### PR TITLE
Add additional auth data for views

### DIFF
--- a/src/cancelchain/api.py
+++ b/src/cancelchain/api.py
@@ -192,6 +192,8 @@ def authorize(required_role=Role.READER):
                 current_app.logger.exception(e)
                 abort(401)
             if authorized:
+                kwargs['_address'] = address
+                kwargs['_role'] = role
                 return func(*args, **kwargs)
             abort(401)
         return wrapper


### PR DESCRIPTION
Add `_address` and `_role` authorization `kwarg` parameters for views to use.