### PR TITLE
docs(urls): update repo location to gumptionthomas/cancelchain ahead of transfer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,19 +89,19 @@ Open `http://localhost:5000 <http://localhost:5000>`_ in a browser to explore th
 Home Page (Current Chain)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: https://github.com/cancelchain/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-chain.png?raw=true
+.. image:: https://github.com/gumptionthomas/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-chain.png?raw=true
    :width: 500pt
 
 Block Page
 ^^^^^^^^^^
 
-.. image:: https://github.com/cancelchain/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-block.png?raw=true
+.. image:: https://github.com/gumptionthomas/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-block.png?raw=true
    :width: 500pt
 
 Transaction Page
 ^^^^^^^^^^^^^^^^
 
-.. image:: https://github.com/cancelchain/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-txn.png?raw=true
+.. image:: https://github.com/gumptionthomas/cancelchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-txn.png?raw=true
    :width: 500pt
 
 Running the ``cancelchain`` application also exposes a set of web service endpoints that comprise the communications layer of the blockchain. See the  `API Documentation`_ for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ cancelchain = "cancelchain:cli"
 [project.urls]
 Homepage = "https://cancelchain.org"
 Documentation = "https://docs.cancelchain.org"
-Source = "https://github.com/cancelchain/cancelchain"
-Tracker = "https://github.com/cancelchain/cancelchain/issues"
+Source = "https://github.com/gumptionthomas/cancelchain"
+Tracker = "https://github.com/gumptionthomas/cancelchain/issues"
 
 # HATCH
 [tool.hatch.version]


### PR DESCRIPTION
## Summary

Pre-transfer URL housekeeping. Updates the five GitHub URLs in `pyproject.toml` and `README.rst` to point at `gumptionthomas/cancelchain` ahead of moving the repo from the `cancelchain` org to the personal account. GitHub's transfer redirect handles old URLs indefinitely, but updating them in place gives correct PyPI metadata for the next release, avoids the README-image-redirect chain on PyPI's renderer, and keeps long-tail readers from wondering which location is canonical.

### Changes

- `pyproject.toml`: `[project.urls]` — `Source` and `Tracker`
- `README.rst`: three `readme-assets` image URLs (Home Page / Block / Transaction screenshots)

External URLs (`cancelchain.org`, `docs.cancelchain.org`) are unchanged.

### Not in scope here

- The `git clone <url>` command in the dev-workflow paragraph that Phase 1 PR #17 introduces (and that chore PR #18 inherits via stacking). I'll land that as a one-line follow-up commit on the chore branch.
- `CLAUDE.md` — verified clean of `cancelchain/cancelchain` references.

### Merge order before transfer

1. Self-merge this PR to `main` (you, manually — `wor` is blocked while Copilot signups are paused for Free/Team-plan orgs)
2. Transfer the repo via `cancelchain/cancelchain/settings` → Danger Zone → Transfer ownership
3. After transfer, update the local git remote: `git remote set-url origin https://github.com/gumptionthomas/cancelchain.git`
4. PRs #17 (Phase 1) and #18 (chore) ride along with the transfer; their URLs become `gumptionthomas/cancelchain/pull/{17,18}` and old URLs redirect

## Test Plan

- [x] `pyproject.toml` parses as valid TOML (`tomllib.loads` succeeds)
- [x] All five URL references flipped (`git grep cancelchain/cancelchain` returns nothing under `pyproject.toml` and `README.rst`)
- [x] Diff is 5 lines changed, 5 lines added — pure URL swap, no other content

🤖 Generated with [Claude Code](https://claude.com/claude-code)