### PR TITLE
chore(claude): add workflow skills + Dependabot config

### DIFF
--- a/.claude/skills/mwg/SKILL.md
+++ b/.claude/skills/mwg/SKILL.md
@@ -1,0 +1,14 @@
+# Merge When Green (mwg)
+
+Wait for CI to pass on the current PR, then squash merge and delete the branch.
+
+## Steps
+
+1. Determine the PR number — use the current branch's open PR (`gh pr view --json number --jq .number`), or accept a PR number as an argument.
+2. Wait for CI checks to pass: `gh pr checks {n} --watch`
+3. Squash merge and delete branch: `gh pr merge {n} --squash --delete-branch`
+
+## Important
+- Do NOT merge if CI fails — report the failure to the user instead.
+- Always use `--squash --delete-branch` (never regular merge or rebase).
+- If the merge fails (e.g., conflicts, branch protection), report the error to the user.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,5 @@
+# Create PR
+1. Ask user to confirm: which GitHub issue, which UI component/area, and branch name
+2. Run tests locally before creating PR: `python -m pytest`
+3. Create PR with issue reference in description
+4. List all files changed for user review

--- a/.claude/skills/wor/SKILL.md
+++ b/.claude/skills/wor/SKILL.md
@@ -1,0 +1,26 @@
+# Wait On Review (wor)
+
+Wait for PR reviews (e.g. Copilot), address any feedback, then report back.
+
+## Steps
+
+1. Determine the PR number — use the current branch's open PR (`gh pr view --json number --jq .number`), or accept a PR number as an argument.
+2. Determine the repository (`gh repo view --json nameWithOwner --jq .nameWithOwner`).
+3. Launch a background polling loop (~30s interval, up to 10 minutes) checking for reviews and review comments:
+   - `gh api repos/{owner/repo}/pulls/{n}/reviews`
+   - `gh api repos/{owner/repo}/pulls/{n}/comments`
+   - Use `gh pr checks {n} --watch` (or poll) to detect when CI has passed.
+   - After CI passes, continue polling until the review is in.
+4. When reviews or comments appear, read them all carefully.
+5. If Copilot left actionable feedback:
+   - Address each comment (fix code, update tests if needed).
+   - Run the full test suite (`uv run pytest`) to verify fixes.
+   - Format code (`uv run isort src/ tests/ && uv run pyink src/ tests/`).
+   - Commit and push the fixes.
+   - Report a summary to the user: what Copilot said, what was changed.
+6. If Copilot approved with no actionable comments, report that to the user.
+7. After reporting, wait for user instructions — do NOT auto-merge.
+
+## Important
+- Do NOT merge the PR. Only the user decides when to merge (they will say "merge it" or "mwg").
+- Use background polling to avoid blocking the conversation.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "python"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
+    labels: ["dependencies", "docker"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 3
+    groups:
+      actions-minor-and-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "ci"]


### PR DESCRIPTION
## Summary

Bifurcation of the original chore/claude-bootstrap PR (#18) to land the main-compatible bootstrap pieces **ahead of** the Phase 1 modernization PR (#17). The remaining bootstrap items all depend on Phase 1 artifacts and will land as a small follow-up PR after #17 merges.

### What lands here

- **`.claude/skills/pr/SKILL.md`** — Create PR skill (issue ref + file list)
- **`.claude/skills/wor/SKILL.md`** — Wait On Review (Copilot polling). Note: non-functional on this repo while Copilot signups are paused for Free/Team-plan orgs, but the file ships so it activates once Copilot is available.
- **`.claude/skills/mwg/SKILL.md`** — Merge When Green (CI watch + `--squash --delete-branch`)
- **`.github/dependabot.yml`** — Weekly Monday updates for pip / docker / github-actions; minor+patch grouped per ecosystem; majors as individual PRs; 3-day cooldown.

### What's deferred to a follow-up after #17 merges

- `.github/workflows/security.yml` — Its `pip-audit` job runs `uv export` from `uv.lock`, which Phase 1 introduces. Adding it to main now would make the first scheduled (and PR-triggered) run fail.
- `CLAUDE.md` "Conventions" and "Supply-chain practices" sections — `CLAUDE.md` itself only exists on the Phase 1 branch.
- README dev-workflow `git clone` URL flip — That line is added by Phase 1 Task 9.
- `wor` skill internals reference `pyink`/`isort` (its acquire-llm origin) instead of `uv run ruff`. Small adaptation also rides in the follow-up PR after Phase 1 establishes ruff as the project formatter on main.

## Disposition of #18

After this PR merges, **close #18** rather than retarget it. Its remaining unique content (CLAUDE.md sections + the `git clone` URL fix) will be re-opened as a small fresh PR after Phase 1 lands. Closing avoids carrying Phase 1's commits in the chore PR's history once they're already on main via #17.

## Test Plan

- [x] `.github/dependabot.yml` parses as valid YAML (`yaml.safe_load` succeeds)
- [x] Branch builds from main with no conflicts
- [N/A] No Python source changes; pytest behavior unchanged
- [Note] `main`'s existing `tests.yml` CI is broken by an unrelated pre-existing YAML scalar bug in the `Install dependencies` step. Phase 1 PR rewrites that workflow entirely; CI on this PR will be red for the same reason as PR #19 was. Merge anyway (no required status checks; no scope creep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)