### PR TITLE
chore(ci): align tests.yml setup-uv version with security.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
       - run: uv python install ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Addresses a cross-workflow drift Copilot flagged on PR #29: `tests.yml` was using `astral-sh/setup-uv@v3` (loose tag) while `security.yml` pins `astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b` (v8.1.0, SHA-pinned). That kind of "different uv installer per workflow" is exactly what `CLAUDE.md` "Supply-chain practices" is meant to prevent.

This PR aligns `tests.yml` on the same v8.1.0 SHA pin used in `security.yml`.

## Out of scope (per no-scope-creep)

- `actions/checkout@v4` on line 12 of `tests.yml` is still a loose tag and similarly violates the SHA-pinning convention. Worth a small follow-up PR that tightens it across the file (and any other workflows that appear in the future).

## Test Plan

- [x] YAML still parses
- [ ] Branch CI confirms uv install + sync + pytest still work on 3.10–3.13 (will be green when this PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)