### PR TITLE
feat(deps): upgrade to Flask 3 + Werkzeug 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
   "blinker>=1.6",
   "celery>=5.3",
   "click>=8.1",
-  "Flask>=2.3",
-  "Flask-Caching>=2.0",
+  "Flask>=3.0",
+  "Flask-Caching>=2.3",
   "Flask-SQLAlchemy>=3.0",
   "gunicorn>=20.1",
   "humanfriendly>=10.0",
@@ -47,6 +47,7 @@ dependencies = [
   "requests>=2.31",
   "rich>=13.4",
   "sqlalchemy<2.0",
+  "werkzeug>=3.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "sqlalchemy" },
+    { name = "werkzeug" },
 ]
 
 [package.dev-dependencies]
@@ -193,8 +194,8 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.6" },
     { name = "celery", specifier = ">=5.3" },
     { name = "click", specifier = ">=8.1" },
-    { name = "flask", specifier = ">=2.3" },
-    { name = "flask-caching", specifier = ">=2.0" },
+    { name = "flask", specifier = ">=3.0" },
+    { name = "flask-caching", specifier = ">=2.3" },
     { name = "flask-sqlalchemy", specifier = ">=3.0" },
     { name = "gunicorn", specifier = ">=20.1" },
     { name = "humanfriendly", specifier = ">=10.0" },
@@ -209,6 +210,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "rich", specifier = ">=13.4" },
     { name = "sqlalchemy", specifier = "<2.0" },
+    { name = "werkzeug", specifier = ">=3.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- `Flask>=3.0` (was `>=2.3`).
- `Flask-Caching>=2.3` (was `>=2.0`).
- Pin `werkzeug>=3.0` explicitly.

Phase 2 / PR 2 of 7.

## Test plan
- [x] `uv lock --upgrade-package flask …` resolves cleanly.
- [x] `uv run pytest` passes.
- [x] `uv run ruff format --check` passes.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)