### PR TITLE
chore(ruff): align flake8-quotes config with formatter quote-style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,13 @@ ignore = [
   "PLR0913",
   "PLR0915",
   "PLR2004",
-  "Q000",
   "S101",
   "S105",
   "S110",
 ]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
 
 [tool.ruff.format]
 quote-style = "single"


### PR DESCRIPTION
## Summary
Adds `[tool.ruff.lint.flake8-quotes] inline-quotes = "single"` to silence the persistent config-mismatch warning. Removes the now-redundant Q000 ignore.

Phase 3 / PR 1 of 9.

## Test plan
- [x] `uv run ruff check src tests` no longer emits the config-mismatch warning.
- [x] `uv run pytest` passes (162 passed, 1 skipped).
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)