### PR TITLE
chore(lint): clear tests/ ruff findings

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,13 +36,13 @@ def test_post_token_invalid(app, host, requests_proxy, wallet):
 def test_no_role(app, host, mill_block, requests_proxy, subject, wallet):
     with app.app_context():
         w = Wallet()
-        m, b = mill_block(w)
+        m, _b = mill_block(w)
         lc = m.longest_chain
         txn = lc.create_subject(w, lc.balance(w.address), subject)
         txn.sign()
         response = ApiClient(host, wallet).post_transaction(txn)
         assert response.status_code == requests.codes.created
-        _, b2 = mill_block(wallet)
+        _, _b2 = mill_block(wallet)
         with pytest.raises(requests.exceptions.HTTPError, match='403'):
             ApiClient(host, w).get_block()
 
@@ -99,7 +99,7 @@ def test_regex_roles(
 ):
     with app.app_context():
         w = Wallet()
-        m, b = mill_block(w)
+        _m, _b = mill_block(w)
         with pytest.raises(requests.exceptions.HTTPError, match='403'):
             _ = ApiClient(host, w).get_block()
         app.config['READER_ADDRESSES'] = ['.*']
@@ -152,7 +152,7 @@ def test_last_block(app, host, mill_block, requests_proxy, wallet):
 
 def test_get_invalid_block(app, host, mill_block, requests_proxy, wallet):
     with app.app_context():
-        m, b = mill_block(wallet)
+        _m, _b = mill_block(wallet)
         with pytest.raises(requests.exceptions.HTTPError, match='404'):
             ApiClient(host, wallet).get_block(block_hash='foo')
 
@@ -186,7 +186,7 @@ def test_post_invalid_block(app, host, requests_proxy, wallet):
 
 def test_post_txn(app, host, mill_block, requests_proxy, subject, wallet):
     with app.app_context():
-        m, b = mill_block(wallet)
+        m, _b = mill_block(wallet)
         txn = m.longest_chain.create_subject(wallet, 1, subject)
         txn.sign()
         response = ApiClient(host, wallet).post_transaction(txn)
@@ -198,7 +198,7 @@ def test_post_invalid_txn(
     app, host, mill_block, requests_proxy, subject, wallet
 ):
     with app.app_context():
-        m, b = mill_block(wallet)
+        m, _b = mill_block(wallet)
         txn = m.longest_chain.create_subject(wallet, 1, subject)
         with pytest.raises(requests.exceptions.HTTPError, match='400'):
             ApiClient(host, wallet).post_transaction(txn)
@@ -211,9 +211,9 @@ def test_pending_transactions(
     with app.app_context():
         time_step = time_stepper()
         _ = next(time_step)
-        m, b = mill_block(wallet)
+        m, _b = mill_block(wallet)
         _ = next(time_step)
-        m, b = mill_block(wallet)
+        m, _b = mill_block(wallet)
         response = ApiClient(host, wallet).get_pending_transactions()
         assert response.status_code == requests.codes.ok
         assert response.json() == []

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -9,7 +9,7 @@ from cancelchain.wallet import Wallet
 
 def test_invalid_wallet(app, host, mill_block, requests_proxy, wallet):
     with app.app_context():
-        m, b = mill_block(wallet)
+        _m, _b = mill_block(wallet)
         w = Wallet()
         with pytest.raises(requests.exceptions.HTTPError, match='401'):
             ApiClient(host, w).get_block()
@@ -32,7 +32,7 @@ def test_expired_token(
         time_step = time_stepper(delta=API_TOKEN_SECONDS + 1)
         _ = next(time_step)
         client = ApiClient(host, wallet)
-        m, b = mill_block(wallet)
+        _m, b = mill_block(wallet)
         response = client.get_block()
         assert response.status_code == requests.codes.ok
         _ = next(time_step)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -8,7 +8,7 @@ def test_index(app, mill_block, test_client, wallet):
         response = test_client.get('/')
         assert response.status_code == requests.codes.ok
         assert 'No chain' in str(response.data)
-        m, b = mill_block(wallet)
+        _m, b = mill_block(wallet)
         response = test_client.get('/')
         assert response.status_code == requests.codes.ok
         assert b.block_hash in str(response.data)
@@ -19,7 +19,7 @@ def test_chains(app, mill_block, test_client, wallet):
         response = test_client.get('/chains')
         assert response.status_code == requests.codes.ok
         assert 'No chains' in str(response.data)
-        m, b = mill_block(wallet)
+        _m, b = mill_block(wallet)
         response = test_client.get('/chains')
         assert response.status_code == requests.codes.ok
         assert b.block_hash in str(response.data)
@@ -29,7 +29,7 @@ def test_block(app, mill_block, test_client, wallet):
     with app.app_context():
         response = test_client.get('/block')
         assert response.status_code == requests.codes.not_found
-        m, b = mill_block(wallet)
+        _m, b = mill_block(wallet)
         response = test_client.get('/block')
         assert response.status_code == requests.codes.ok
         assert b.block_hash in str(response.data)

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -244,7 +244,7 @@ def test_db(add_chain_block, app, time_machine, wallet):
         block_copy = Block.from_db(block.block_hash)
         assert block == block_copy
         cb = block.coinbase
-        cb_amount = list(block.coinbase.outflows)[0].amount
+        cb_amount = next(iter(block.coinbase.outflows)).amount
         remit = 2 * CURMUDGEON_PER_GRUMBLE
         then_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(then_dt)
@@ -348,7 +348,7 @@ def test_dao(add_chain_block, app, time_machine, time_stepper, wallet):
 
 def test_validate_block(add_chain_block, app, time_machine, wallet):
     with app.app_context():
-        chain, block = add_chain_block()
+        chain, _block = add_chain_block()
         now_dt = now()
         then_dt = now_dt + datetime.timedelta(hours=1)
         time_machine.move_to(then_dt)
@@ -386,7 +386,7 @@ def test_validate_block_txn(add_chain_block, app, time_machine, wallet):
 
         _, block = add_chain_block(chain=chain)
         cb = block.coinbase
-        cb_amount = list(cb.outflows)[0].amount
+        cb_amount = next(iter(cb.outflows)).amount
 
         block2 = Block()
         chain.link_block(block2)
@@ -444,7 +444,7 @@ def test_validate_txn_inflow(add_chain_block, app, time_machine, txid, wallet):
         time_machine.move_to(then_dt)
         chain, block = add_chain_block()
         cb = block.coinbase
-        cb_amount = list(block.coinbase.outflows)[0].amount
+        cb_amount = next(iter(block.coinbase.outflows)).amount
         then_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(then_dt)
         t = Transaction()
@@ -514,7 +514,7 @@ def test_validate_block_coinbase(add_chain_block, app, subject, txid, wallet):
 
         _, block = add_chain_block(chain=chain)
         cb = block.coinbase
-        cb_amount = list(cb.outflows)[0].amount
+        cb_amount = next(iter(cb.outflows)).amount
 
         t = Transaction()
         t.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
@@ -583,7 +583,7 @@ def test_validate_io_address_mismatch(app, wallet):
         block.mill()
         chain.add_block(block)
         cb = block.coinbase
-        cb_amount = list(cb.outflows)[0].amount
+        cb_amount = next(iter(cb.outflows)).amount
 
         block2 = Block()
         chain.link_block(block2)
@@ -609,7 +609,7 @@ def test_validate_subject_ioflows(app, subject, wallet):
         block.mill()
         chain.add_block(block)
         cb = block.coinbase
-        cb_amount = list(cb.outflows)[0].amount
+        cb_amount = next(iter(cb.outflows)).amount
 
         block2 = Block()
         chain.link_block(block2)

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -31,7 +31,7 @@ def test_miller_create_block(app, time_machine, time_stepper, wallet):
         assert m.longest_chain.length == 2
         assert m.longest_chain.balance(wallet.address) == 2 * REWARD
         cb0 = b0.coinbase
-        cb0_amount = list(cb0.outflows)[0].amount
+        cb0_amount = next(iter(cb0.outflows)).amount
         w2 = Wallet()
         remit = 2 * CPG
         t0 = Transaction()
@@ -86,7 +86,7 @@ def test_duplicate_transaction(app, time_machine, wallet):
         b0 = m.create_block()
         m.mill_block(b0)
         cb0 = b0.coinbase
-        cb0_amount = list(cb0.outflows)[0].amount
+        cb0_amount = next(iter(cb0.outflows)).amount
         when_dt = when_dt + datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
         t0 = Transaction()
@@ -150,7 +150,7 @@ def test_max_txns(app, time_machine, wallet):
         cb0 = b0.coinbase
         prev_t = cb0
         for _i in range(max_txns + 3):
-            amount = list(prev_t.outflows)[0].amount
+            amount = next(iter(prev_t.outflows)).amount
             when_dt += datetime.timedelta(seconds=1)
             time_machine.move_to(when_dt)
             t = Transaction()


### PR DESCRIPTION
## Summary
Auto-fixable cleanups in tests/:
- RUF059 ×16: unused-variable renames to `_<name>`.
- RUF015 ×9: `list(x)[0]` → `next(iter(x))`.

Mechanical, no behavior changes.

Phase 3 / PR 3 of 9.

## Test plan
- [x] `uv run ruff check tests` exits 0.
- [x] `uv run pytest` passes (162 passed, 1 skipped).
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)