### PR TITLE
feat(ci): make ruff check and mypy hard CI gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,4 +18,4 @@ jobs:
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
       - run: uv run pytest
-      - run: uv run mypy src
+      - run: uv run mypy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,7 @@ jobs:
           enable-cache: true
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --group dev --python ${{ matrix.python-version }}
-      # ruff check is non-blocking in Phase 1 because the codebase carries
-      # ~37 pre-existing lint errors (older ruff did not catch them). Phase 3
-      # cleans them up alongside the type-hint campaign; at that point this
-      # `continue-on-error` is removed and ruff check becomes a hard gate.
       - run: uv run ruff check src tests
-        continue-on-error: true
       - run: uv run ruff format --check src tests
       - run: uv run pytest
-      # mypy is non-blocking in Phase 1; Task 5 introduced the runner but the
-      # codebase isn't typed yet. Phase 3 tightens this to a hard gate.
       - run: uv run mypy src
-        continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,11 +105,11 @@ When `CC_API_ASYNC_PROCESSING=true`, block/txn POSTs return `202` without doing 
 
 ## Style
 
-- `ruff` config in `pyproject.toml`: `[tool.ruff]` holds top-level settings (target Python 3.12, `line-length = 80`), `[tool.ruff.lint]` holds the rule selection — large rule set enabled (`A,B,C,DTZ,E,EM,F,FBT,I,ICN,ISC,N,PLC,PLE,PLR,PLW,Q,RUF,S,SIM,T,TID,UP,W,YTT`). Several rules are ignored project-wide — notably `Q000` (single-quote convention enforced via `[tool.ruff.format] quote-style = "single"`) and `S101` (assert allowed in tests). Both `ruff check` and `ruff format --check` are hard CI gates as of Phase 3 / PR 8.
-- `mypy` runs under `[tool.mypy] strict = true` against `src/cancelchain/` and is a hard CI gate as of Phase 3.
+- `ruff` config in `pyproject.toml`: `[tool.ruff]` holds top-level settings (target Python 3.12, `line-length = 80`), `[tool.ruff.lint]` holds the rule selection — large rule set enabled (`A,B,C,DTZ,E,EM,F,FBT,I,ICN,ISC,N,PLC,PLE,PLR,PLW,Q,RUF,S,SIM,T,TID,UP,W,YTT`). Quote style: `[tool.ruff.lint.flake8-quotes] inline-quotes = "single"` + `[tool.ruff.format] quote-style = "single"` keep linter and formatter aligned. Project-wide ignores include `S101` (assert allowed in tests). Both `ruff check` and `ruff format --check` are hard CI gates as of Phase 3 / PR 8.
+- `mypy` runs under `[tool.mypy] strict = true` and is a hard CI gate as of Phase 3. Target paths come from the `files = ["src/cancelchain"]` setting; invoke with `uv run mypy` (no positional args) so config and CI agree.
 - Python ≥ 3.12 (CI matrix: 3.12, 3.13). 3.13 is the highest actively tested version.
-- SQLAlchemy is pinned `<2.0`; don't import from 2.0-only namespaces. Flask-SQLAlchemy is 3.x (uses `db.Model`, `db.session`, classic `Model.query` style).
-- pymerkle is pinned `>=4,<5` (block Merkle tree). v5 has breaking changes.
+- SQLAlchemy is `>=2.0` with `Mapped[]` annotations on every DAO in `models.py`. Flask-SQLAlchemy 3.1+ preserves the legacy `Model.query` / `db.session.query(...)` API; modernization to `db.session.execute(db.select(...))` is Phase 6 work, not Phase 3.
+- pymerkle is `>=5` (currently resolves to 6.1.0) with the v5/v6 `InmemoryTree` API in `block.py`.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ When `CC_API_ASYNC_PROCESSING=true`, block/txn POSTs return `202` without doing 
 
 ## Style
 
-- `ruff` config in `pyproject.toml`: `[tool.ruff]` holds top-level settings (target Python 3.12, `line-length = 80`), `[tool.ruff.lint]` holds the rule selection — large rule set enabled (`A,B,C,DTZ,E,EM,F,FBT,I,ICN,ISC,N,PLC,PLE,PLR,PLW,Q,RUF,S,SIM,T,TID,UP,W,YTT`). Several rules are ignored project-wide — notably `Q000` (single-quote convention enforced via `[tool.ruff.format] quote-style = "single"`) and `S101` (assert allowed in tests). In Phase 1 CI, `ruff check` is `continue-on-error: true` to allow incremental cleanup of pre-existing debt; only `ruff format --check` is a hard gate. Phase 3 removes the `continue-on-error` once the existing lint is cleaned up.
+- `ruff` config in `pyproject.toml`: `[tool.ruff]` holds top-level settings (target Python 3.12, `line-length = 80`), `[tool.ruff.lint]` holds the rule selection — large rule set enabled (`A,B,C,DTZ,E,EM,F,FBT,I,ICN,ISC,N,PLC,PLE,PLR,PLW,Q,RUF,S,SIM,T,TID,UP,W,YTT`). Several rules are ignored project-wide — notably `Q000` (single-quote convention enforced via `[tool.ruff.format] quote-style = "single"`) and `S101` (assert allowed in tests). Both `ruff check` and `ruff format --check` are hard CI gates as of Phase 3 / PR 8.
+- `mypy` runs under `[tool.mypy] strict = true` against `src/cancelchain/` and is a hard CI gate as of Phase 3.
 - Python ≥ 3.12 (CI matrix: 3.12, 3.13). 3.13 is the highest actively tested version.
 - SQLAlchemy is pinned `<2.0`; don't import from 2.0-only namespaces. Flask-SQLAlchemy is 3.x (uses `db.Model`, `db.session`, classic `Model.query` style).
 - pymerkle is pinned `>=4,<5` (block Merkle tree). v5 has breaking changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,10 +154,10 @@ exclude_lines = [
 # MYPY
 [tool.mypy]
 python_version = "3.12"
+files = ["src/cancelchain"]
+strict = true
 warn_unused_ignores = true
 warn_redundant_casts = true
-strict_optional = true
-files = ["src/cancelchain"]
 
 [[tool.mypy.overrides]]
 module = ["marshmallow", "marshmallow.*"]


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from `ruff check` and `mypy` in `.github/workflows/tests.yml`.
- Sets `[tool.mypy] strict = true` in `pyproject.toml`.
- Updates `CLAUDE.md` Style section prose.

PRs 1-7 (+ PR-7.5 fix) cleared the underlying debt; this is the gate flip.

Phase 3 / PR 8 of 9.

## Test plan
- [x] `uv run ruff check src tests` exits 0.
- [x] `uv run ruff format --check src tests` exits 0.
- [x] `uv run mypy src` exits 0 under `strict = true` (24 files).
- [x] `uv run pytest` passes (177 passed, 1 skipped).
- [ ] CI green on 3.12 and 3.13 (both as hard gates now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)