### PR TITLE
docs(phase-4): add Phase 4 design + implementation plan

### DIFF
--- a/.claude/skills/wor/SKILL.md
+++ b/.claude/skills/wor/SKILL.md
@@ -17,8 +17,9 @@ Wait for PR reviews (e.g. Copilot), address any feedback, then report back.
    - Run the full test suite (`uv run pytest`) to verify fixes.
    - Format code (`uv run ruff format src tests`).
    - Commit and push the fixes.
-   - **Post replies to each Copilot comment**, then **trigger a fresh Copilot review** with `gh pr comment {n} --body "/copilot review"`. Copilot's default mode only auto-reviews the initial push; the slash command is required to re-review subsequent fix pushes.
-   - Resume polling for the next review round.
+   - Post replies to each Copilot comment.
+   - **Ask the user to click "Re-request review" next to `copilot-pull-request-reviewer` in the PR's Reviewers sidebar.** Copilot only auto-reviews the initial push; subsequent fix-push reviews are UI-only — there is no working API equivalent (the bot rejects both REST `/requested_reviewers` ("not a collaborator") and the `/copilot review` PR comment is treated as plain text).
+   - Resume polling for the next review round once the user confirms they've clicked.
    - Report a summary to the user: what Copilot said, what was changed.
 6. If Copilot approved with no actionable comments, report that to the user.
 7. After reporting, wait for user instructions — do NOT auto-merge.

--- a/.claude/skills/wor/SKILL.md
+++ b/.claude/skills/wor/SKILL.md
@@ -17,6 +17,8 @@ Wait for PR reviews (e.g. Copilot), address any feedback, then report back.
    - Run the full test suite (`uv run pytest`) to verify fixes.
    - Format code (`uv run ruff format src tests`).
    - Commit and push the fixes.
+   - **Post replies to each Copilot comment**, then **trigger a fresh Copilot review** with `gh pr comment {n} --body "/copilot review"`. Copilot's default mode only auto-reviews the initial push; the slash command is required to re-review subsequent fix pushes.
+   - Resume polling for the next review round.
    - Report a summary to the user: what Copilot said, what was changed.
 6. If Copilot approved with no actionable comments, report that to the user.
 7. After reporting, wait for user instructions — do NOT auto-merge.

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -521,7 +521,7 @@ EOF
 - Modify: `src/cancelchain/transaction.py`
 - Modify: `src/cancelchain/payload.py` (remove Marshmallow Schemas and rename `SubjectType` → `Subject`)
 
-This PR replaces the three transaction-related Marshmallow Schemas with Pydantic BaseModels and rewrites the four call sites (`validate`, `validate_coinbase`, `to_json`, `from_dict`, `from_json`). After this PR, the Marshmallow `OutflowSchema`/`InflowSchema`/`Subject` (added by PR-2) are gone.
+This PR replaces the three transaction-related Marshmallow Schemas with Pydantic BaseModels and rewrites the four call sites that directly invoke `TransactionSchema().validate/dumps/load/loads(...)` — `validate`, `to_json`, `from_dict`, `from_json`. `validate_coinbase` is a one-line wrapper around `self.validate(coinbase=True)` and doesn't need a separate update. After this PR, the Marshmallow `OutflowSchema`/`InflowSchema`/`Subject` (added by PR-2) are gone.
 
 - [ ] **Step 1: Branch off main**
 

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -116,7 +116,7 @@ EOF
 - Modify: `pyproject.toml`
 - Modify: `src/cancelchain/schema.py`
 
-This PR introduces Pydantic as a runtime dependency and converts the 5 Marshmallow custom field subclasses (`Address`, `Base64`, `MillHash`, `Timestamp`, `PublicKey`) into `Annotated[str, AfterValidator(...)]` type aliases. The `SansNoneSchema` base class is retired. Marshmallow stays in `[project.dependencies]` for now — PR-6 removes it after the swap is complete.
+This PR introduces Pydantic as a runtime dependency and **adds** 5 Pydantic `Annotated[str, AfterValidator(...)]` aliases under `*Type` suffix names (`AddressType`, `Base64Type`, `MillHashType`, `TimestampType`, `PublicKeyType`) plus a `pydantic_errors_to_messages` adapter. **PR-1 is fully additive on `schema.py`** — the Marshmallow `Address(fields.String)`, `Base64(fields.String)`, `MillHash(Base64)`, `Timestamp(fields.String)`, `PublicKey(Base64)`, and `SansNoneSchema(Schema)` classes are NOT touched; they're still callable as Marshmallow fields by `payload.py` / `transaction.py` / `block.py` until PRs 3 and 4 swap those files. PR-6 deletes the Marshmallow classes after all consumers are gone. Marshmallow stays in `[project.dependencies]` throughout this PR.
 
 - [ ] **Step 1: Branch off main**
 
@@ -211,18 +211,29 @@ def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
     """Convert Pydantic ValidationError to Marshmallow-shaped messages.
 
     Marshmallow's ValidationError.messages is a nested dict keyed by
-    field name; this matches what api.py's make_error_response and the
-    InvalidBlockError({...: e.messages}) re-raise wrappers expect.
+    field name (e.g. {'outflows': {0: {'amount': ['Must be ge 1']}}}).
+    This adapter rebuilds that nested shape from Pydantic's flat
+    err['loc'] tuples so api.py's make_error_response and the
+    InvalidBlockError({...: e.messages}) re-raise wrappers see the
+    same dict layout downstream consumers already render.
     """
     result: dict[str, Any] = {}
     for err in e.errors():
         loc = err.get('loc', ())
         msg = err.get('msg', 'invalid')
-        if loc:
-            key = '.'.join(str(part) for part in loc)
-        else:
-            key = '_schema'
-        result.setdefault(key, []).append(msg)
+        if not loc:
+            result.setdefault('_schema', []).append(msg)
+            continue
+        current = result
+        for part in loc[:-1]:
+            key = str(part)
+            existing = current.get(key)
+            if not isinstance(existing, dict):
+                current[key] = {}
+            current = current[key]
+        last_key = str(loc[-1])
+        bucket = current.setdefault(last_key, [])
+        bucket.append(msg)
     return result
 ```
 
@@ -1365,9 +1376,10 @@ Each of the 5 call sites updated to use Model.model_validate(
 _pydantic_validation_error adapter preserves the .messages attribute
 that make_error_response expects.
 
-Marshmallow import block removed from api.py. The Phase 1 spec's
-"Marshmallow → Pydantic" Phase 4 goal is now complete for src/;
-PR-6 finishes by removing marshmallow from runtime deps.
+Marshmallow import block removed from api.py. After this PR, api.py
+is marshmallow-free; schema.py still imports marshmallow (by design,
+since PR-1 is additive) until PR-6 deletes the Marshmallow classes
+and removes the runtime dep.
 
 Phase 4 / PR 5 of 6.
 
@@ -1387,7 +1399,7 @@ gh pr create --base main --title "feat(deps): API query schemas → Pydantic v2"
 - PendingTxnQueryModel uses \`Annotated[datetime, BeforeValidator(ciso_2_dt), PlainSerializer(dt_2_ciso)]\` to replace \`fields.Function\`.
 - Marshmallow import removed from \`api.py\`.
 
-After this PR, no \`src/cancelchain/\` file imports marshmallow. PR-6 removes the runtime dep + overrides.
+After this PR, \`api.py\` is marshmallow-free. \`schema.py\` still imports marshmallow (by design, since PR-1 is additive) until PR-6 deletes the Marshmallow classes and removes the runtime dep + overrides.
 
 Phase 4 / PR 5 of 6.
 
@@ -1465,7 +1477,7 @@ ignore_missing_imports = true
 ```
 from `[tool.mypy]` overrides.
 
-- [ ] **Step 4: Refresh the lockfile**
+- [ ] **Step 5: Refresh the lockfile**
 
 ```bash
 uv lock
@@ -1473,7 +1485,7 @@ grep -i marshmallow uv.lock
 ```
 Expected: `grep` returns no matches. The lockfile is regenerated without marshmallow.
 
-- [ ] **Step 5: Re-sync and verify**
+- [ ] **Step 6: Re-sync and verify**
 
 ```bash
 uv sync --group dev
@@ -1489,7 +1501,7 @@ uv run pytest
 ```
 All must exit 0.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add pyproject.toml uv.lock src/cancelchain/schema.py
@@ -1520,7 +1532,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 7: Push and open PR**
+- [ ] **Step 8: Push and open PR**
 
 ```bash
 git push -u origin chore/remove-marshmallow
@@ -1547,7 +1559,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 8: Stop — controller handles wor + mwg + sync**
+- [ ] **Step 9: Stop — controller handles wor + mwg + sync**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -1,0 +1,1883 @@
+# Phase 4 — Marshmallow → Pydantic v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the six-PR train laid out in `docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md`. After this plan completes, `marshmallow` is no longer in `[project.dependencies]` or `uv.lock`, the corresponding `[[tool.mypy.overrides]]` block is gone, and the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directives that Phase 3 added in `schema.py` and `transaction.py` have either been removed or narrowed.
+
+**Architecture:** Path B (swap-in-place). Each Marshmallow `Schema` becomes a Pydantic v2 `BaseModel` used for validation + I/O. The domain dataclasses (`Block`, `Transaction`, `Outflow`, `Inflow`, `Chain`) keep their stdlib `@dataclass` definitions and their staged-construction lifecycle. The six PRs proceed in dependency order: `schema → payload → transaction → block → api → cleanup`, each self-contained with no long-lived dual implementations.
+
+**Tech Stack:** Pydantic v2.10+, with `Annotated[str, AfterValidator(...)]` for custom field types, `@model_validator(mode='after')` for cross-field validation, and `model.model_dump(exclude_none=True)` for None-stripping serialization.
+
+---
+
+## Prerequisites
+
+- Working directory: `/home/gumptionthomas/Development/cancelchain`. Use absolute paths or `cd` once.
+- `uv --version` 0.4.x or newer; `gh --version` works and `gh auth status` shows authenticated.
+- Phase 3 fully merged. `git log --oneline -5` should show `525ccf5 fix(tests): harden FLASK_SECRET_KEY against pyjwt insecure-key warning (#49)` at or near the top.
+- The branch `docs/phase-4-design` exists locally with commit `a644741` (the design spec). This plan adds the second commit on that branch and ships both as the docs PR.
+- CI hard-gates `ruff check` and `mypy` (as of Phase 3 / PR-8). Every PR must keep both clean.
+- Test baseline: **177 passed, 1 skipped**. Phase 4 should preserve that count (no new tests required, no regressions).
+- Each impl PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller (orchestrator) handles those, not the implementer subagent.
+- Never push directly to `main`. Every change goes through a branch + PR.
+
+---
+
+## File Map
+
+| Task | PR | Files |
+|---|---|---|
+| 1 | docs PR | `docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md` (this file) |
+| 2 | PR-1 schema.py | `pyproject.toml`, `src/cancelchain/schema.py` |
+| 3 | PR-2 payload.py | `src/cancelchain/payload.py` |
+| 4 | PR-3 transaction.py | `src/cancelchain/transaction.py` |
+| 5 | PR-4 block.py | `src/cancelchain/block.py` |
+| 6 | PR-5 api.py | `src/cancelchain/api.py` |
+| 7 | PR-6 cleanup | `pyproject.toml`, `src/cancelchain/schema.py`, `src/cancelchain/transaction.py`, `src/cancelchain/payload.py` (verify directive removal) |
+| 8 | acceptance | none (verification only) |
+
+---
+
+## Task 1: Ship the docs PR (spec + plan)
+
+**Files:** Modify: nothing. The design spec is already committed on `docs/phase-4-design` as `a644741`. This task adds the implementation plan and ships them together.
+
+- [ ] **Step 1: Confirm branch state**
+
+Run:
+```bash
+git rev-parse --abbrev-ref HEAD
+git log --oneline main..HEAD
+```
+Expected: branch is `docs/phase-4-design`; one commit above main: `a644741 docs(phase-4): add Phase 4 Marshmallow → Pydantic v2 design spec`.
+
+- [ ] **Step 2: Verify the plan file is present**
+
+Run:
+```bash
+ls -la docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+git status docs/superpowers/plans/
+```
+Expected: file exists, untracked.
+
+- [ ] **Step 3: Stage and commit**
+
+Run:
+```bash
+git add docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+git commit -m "$(cat <<'EOF'
+docs(phase-4): add Phase 4 Marshmallow → Pydantic v2 implementation plan
+
+Spells out the 6 sequential impl PRs (schema, payload, transaction,
+block, api, cleanup) with exact files, commands, and the wor/mwg
+cycle between each PR.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push**
+
+Run:
+```bash
+git push -u origin docs/phase-4-design
+```
+
+- [ ] **Step 5: Open the docs PR**
+
+Run:
+```bash
+gh pr create --base main --head docs/phase-4-design --title "docs(phase-4): add Phase 4 design + implementation plan" --body "$(cat <<'EOF'
+## Summary
+- Adds the Phase 4 design spec (\`docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md\`).
+- Adds the Phase 4 implementation plan (\`docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md\`).
+- No code changes.
+
+Phase 4 ships as six small PRs in sequence: pydantic + schema.py custom types → payload → transaction → block → api → cleanup (remove marshmallow). Path B scope (Schemas → BaseModels; dataclasses preserved).
+
+## Test plan
+- [ ] Spec self-review passes (already done in the brainstorming session).
+- [ ] Plan self-review passes (already done in the planning session).
+- [ ] Reviewer confirms the PR list matches the spec's "Changes" section.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 2: PR-1 — Pydantic v2 + custom types in `schema.py`
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/cancelchain/schema.py`
+
+This PR introduces Pydantic as a runtime dependency and converts the 5 Marshmallow custom field subclasses (`Address`, `Base64`, `MillHash`, `Timestamp`, `PublicKey`) into `Annotated[str, AfterValidator(...)]` type aliases. The `SansNoneSchema` base class is retired. Marshmallow stays in `[project.dependencies]` for now — PR-6 removes it after the swap is complete.
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/pydantic-schema-types
+```
+Expected: new branch from latest main (head should be the docs PR's squash commit).
+
+- [ ] **Step 2: Add `pydantic>=2.10` to runtime dependencies**
+
+Edit `pyproject.toml`. In `[project] dependencies`, insert `"pydantic>=2.10",` in alphabetical position (between `pyjwt` and `pymerkle`).
+
+- [ ] **Step 3: Lock and install**
+
+```bash
+uv lock --upgrade-package pydantic
+uv sync --group dev
+uv run python -c "from importlib.metadata import version; print('pydantic', version('pydantic'))"
+```
+Expected: `pydantic 2.10.x` or newer.
+
+- [ ] **Step 4: Rewrite `schema.py`**
+
+Replace the entire contents of `src/cancelchain/schema.py` with:
+
+```python
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Annotated, Any
+
+from pydantic import AfterValidator, ValidationError
+
+from cancelchain.exceptions import InvalidKeyError
+from cancelchain.util import iso_2_dt
+from cancelchain.wallet import (
+    ADDRESS_TAG,
+    Wallet,
+    b58decode,
+    b64decode,
+    b64encode,
+)
+
+
+def asdict_sans_none(dc: Any) -> dict[str, Any]:
+    return asdict(
+        dc, dict_factory=lambda x: {k: v for (k, v) in x if v is not None}
+    )
+
+
+def validate_address(public_key_b64: str | None, address: str | None) -> bool:
+    try:
+        wallet = Wallet(b64ks=public_key_b64)
+    except InvalidKeyError:
+        return False
+    return bool((wallet is not None) and address == wallet.address)
+
+
+def validate_address_format(address: str) -> bool:
+    try:
+        if (
+            address.startswith(ADDRESS_TAG)
+            and address.endswith(ADDRESS_TAG)
+            and len(
+                b58decode(
+                    address.removeprefix(ADDRESS_TAG).removesuffix(ADDRESS_TAG)
+                )
+            )
+            == 32
+        ):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def validate_base64(s: str) -> bool:
+    try:
+        return bool(b64encode(b64decode(s)) == s)
+    except Exception:
+        pass
+    return False
+
+
+def validate_public_key(public_key_b64: str) -> bool:
+    try:
+        wallet = Wallet(b64ks=public_key_b64)
+    except InvalidKeyError:
+        return False
+    return wallet is not None and wallet.private_key is None
+
+
+def validate_signature(
+    public_key_b64: str | None,
+    signing_data: bytes,
+    signature: str | None,
+) -> bool:
+    try:
+        wallet = Wallet(b64ks=public_key_b64)
+    except InvalidKeyError:
+        return False
+    if wallet is not None:
+        return bool(wallet.validate_signature(signing_data, signature))
+    return False
+
+
+def validate_timestamp(s: str) -> bool:
+    try:
+        _ = iso_2_dt(s)
+        return True
+    except Exception:
+        pass
+    return False
+
+
+# --- Pydantic v2 custom type aliases ---
+# AfterValidator runs after Pydantic's built-in coercion; the callback
+# either returns the value (possibly transformed) or raises ValueError,
+# which Pydantic wraps into a ValidationError for the caller.
+
+
+def _check_address_format(s: str) -> str:
+    if not validate_address_format(s):
+        msg = f'Invalid address format: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_base64(s: str) -> str:
+    if not validate_base64(s):
+        msg = f'Invalid base64 value: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_mill_hash(s: str) -> str:
+    if not validate_base64(s) or len(s) != 64:
+        msg = f'Invalid mill hash: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_timestamp(s: str) -> str:
+    if not validate_timestamp(s):
+        msg = f'Invalid timestamp: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_public_key(s: str) -> str:
+    if not validate_public_key(s):
+        msg = f'Invalid public key: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+Address = Annotated[str, AfterValidator(_check_address_format)]
+Base64 = Annotated[str, AfterValidator(_check_base64)]
+MillHash = Annotated[str, AfterValidator(_check_mill_hash)]
+Timestamp = Annotated[str, AfterValidator(_check_timestamp)]
+PublicKey = Annotated[str, AfterValidator(_check_public_key)]
+
+
+def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
+    """Convert Pydantic ValidationError to Marshmallow-shaped messages.
+
+    Marshmallow's ValidationError.messages is a nested dict keyed by
+    field name; this matches what api.py's make_error_response and the
+    InvalidBlockError({...: e.messages}) re-raise wrappers expect.
+    """
+    result: dict[str, Any] = {}
+    for err in e.errors():
+        loc = err.get('loc', ())
+        msg = err.get('msg', 'invalid')
+        if loc:
+            key = '.'.join(str(part) for part in loc)
+        else:
+            key = '_schema'
+        result.setdefault(key, []).append(msg)
+    return result
+```
+
+Notes on the rewrite:
+- `SansNoneSchema` class removed (lines 121–126 in original).
+- 5 Marshmallow field subclasses removed (lines 91–118 in original).
+- Marshmallow import removed; `pydantic` import added.
+- All validator functions kept verbatim (they're used by both the new `AfterValidator` callbacks AND by `transaction.py:validate_signature`-style direct calls in PR-3).
+- New `pydantic_errors_to_messages` helper for the Pydantic→Marshmallow-shaped error adapter (used in PRs 3, 4, 5).
+- File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports remain).
+
+- [ ] **Step 5: Verify mypy + ruff still clean**
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+```
+All three must exit 0.
+
+If `mypy` reports new errors in `schema.py`, they're likely from removing the file-level directive. The most common cause is `validate_signature` calling `wallet.validate_signature(signing_data, signature)` where the wallet path returns `Any` (pycryptodome). If that surfaces, restore the directive narrowed to `"no-any-return"` only:
+```python
+# mypy: disable-error-code="no-any-return"
+```
+
+- [ ] **Step 6: Test suite**
+
+```bash
+uv run pytest
+```
+Expected: 177 passed, 1 skipped. The schema.py changes alone shouldn't break tests because no caller is using the new Pydantic types yet — but the removed `SansNoneSchema` class WOULD break callers if any imported it. Verify by grep:
+
+```bash
+grep -rn "SansNoneSchema" src/cancelchain/ tests/
+```
+Expected output: the only references are in `payload.py`, `transaction.py`, `block.py`'s import statements. Those will fail tests on this PR. So PR-1 MUST also remove those imports OR PR-1 must keep `SansNoneSchema` as a stub until PR-4.
+
+**Decision: keep `SansNoneSchema` as a no-op `Schema` alias in this PR**, removed in PR-2/3/4 as each file gets converted. Add at the bottom of `schema.py`:
+
+```python
+# Temporary alias for the duration of the Phase 4 migration. Removed
+# in PR-2/3/4 as each downstream file converts to BaseModel.
+from marshmallow import Schema as _MarshmallowSchema
+
+
+class SansNoneSchema(_MarshmallowSchema):
+    """Legacy Marshmallow base — kept only while PR-2/3/4 land."""
+```
+
+This preserves the existing post_dump None-stripping behavior for any file that still uses it during the transition. PR-2/3/4 remove their `SansNoneSchema` import as each one converts.
+
+- [ ] **Step 7: Re-verify tests**
+
+```bash
+uv run pytest
+```
+Expected: 177 passed, 1 skipped.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/cancelchain/schema.py
+git commit -m "$(cat <<'EOF'
+feat(deps): pydantic v2 + custom types as Annotated aliases
+
+Adds pydantic>=2.10 to runtime dependencies. Rewrites schema.py:
+
+- 5 custom Marshmallow field subclasses (Address, Base64, MillHash,
+  Timestamp, PublicKey) become Annotated[str, AfterValidator(...)]
+  type aliases. The existing validator functions (validate_address,
+  validate_base64, etc.) become the AfterValidator callbacks via small
+  _check_* wrappers that raise ValueError on failure (Pydantic re-wraps).
+- Adds pydantic_errors_to_messages helper that converts Pydantic's
+  list-of-dict ValidationError.errors() to the nested-dict shape
+  Marshmallow's e.messages exposes. Used by PRs 3/4/5 at the
+  domain-layer catch sites so the downstream api.make_error_response
+  and InvalidBlockError({...: e.messages}) wrappers don't see a shape
+  change.
+- SansNoneSchema kept as a no-op Marshmallow alias only for the
+  duration of PR-2/3/4 (each removes its own import).
+
+File-level # mypy: disable-error-code directive removed (no Marshmallow
+imports remain in schema.py).
+
+Phase 4 / PR 1 of 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 9: Push and open PR**
+
+```bash
+git push -u origin feat/pydantic-schema-types
+gh pr create --base main --title "feat(deps): pydantic v2 + custom types as Annotated aliases" --body "$(cat <<'EOF'
+## Summary
+- Adds \`pydantic>=2.10\` to runtime deps.
+- Converts schema.py's 5 custom field subclasses (Address, Base64, MillHash, Timestamp, PublicKey) to \`Annotated[str, AfterValidator(...)]\` aliases.
+- Adds \`pydantic_errors_to_messages\` adapter helper for downstream PRs.
+- Drops the file-level mypy disable directive from schema.py.
+- Keeps \`SansNoneSchema\` as a transitional alias (removed by PR-2/3/4 as each downstream file converts).
+
+Phase 4 / PR 1 of 6. Spec: \`docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md\`.
+
+## Test plan
+- [x] \`uv run mypy\` exits 0.
+- [x] \`uv run pytest\` passes (177/178).
+- [x] \`uv run ruff check\` + \`format --check\` pass.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 10: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 3: PR-2 — `payload.py` schemas
+
+**Files:**
+- Modify: `src/cancelchain/payload.py`
+
+Replace `OutflowSchema` and `InflowSchema` (Marshmallow) with `OutflowModel` and `InflowModel` (Pydantic). The `Outflow` and `Inflow` `@dataclass` definitions are unchanged. The `Subject` custom field becomes an `Annotated` alias local to this file.
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/pydantic-payload
+```
+
+- [ ] **Step 2: Rewrite `payload.py`**
+
+Replace the entire contents of `src/cancelchain/payload.py` with:
+
+```python
+from __future__ import annotations
+
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from dataclasses import dataclass
+from typing import Annotated, Any, Self
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from cancelchain.schema import Address, MillHash
+
+MIN_SUBJECT_LENGTH = 1
+MAX_SUBJECT_LENGTH = 79
+INVALID_DESTINATION_MSG = 'Invalid destinations'
+INVALID_PADDING_MSG = 'Invalid padding'
+
+
+def encode_subject(raw_subject: str) -> str:
+    return urlsafe_b64encode(raw_subject.encode()).rstrip(b'=').decode()
+
+
+def decode_subject(subject: str) -> str:
+    if subject.endswith('='):
+        raise TypeError(INVALID_PADDING_MSG)
+    subject_bytes = subject.encode()
+    subject_bytes += b'=' * (-len(subject_bytes) % 4)
+    return urlsafe_b64decode(subject_bytes).decode()
+
+
+def validate_subject(subject: str) -> bool:
+    try:
+        raw_subject = decode_subject(subject)
+        if MIN_SUBJECT_LENGTH <= len(raw_subject) <= MAX_SUBJECT_LENGTH:
+            return encode_subject(raw_subject) == subject
+    except Exception:
+        pass
+    return False
+
+
+def validate_raw_subject(raw_subject: str) -> bool:
+    try:
+        if MIN_SUBJECT_LENGTH <= len(raw_subject) <= MAX_SUBJECT_LENGTH:
+            return decode_subject(encode_subject(raw_subject)) == raw_subject
+    except Exception:
+        pass
+    return False
+
+
+def _check_subject(s: str) -> str:
+    if not validate_subject(s):
+        msg = f'Invalid subject: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+Subject = Annotated[str, AfterValidator(_check_subject)]
+
+
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: Address | None = None
+    subject: Subject | None = None
+    forgive: Subject | None = None
+    support: Subject | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
+        options = [
+            v
+            for v in (self.subject, self.forgive, self.support)
+            if v is not None
+        ]
+        if not (
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
+        ):
+            raise ValueError(INVALID_DESTINATION_MSG)
+        return self
+
+
+@dataclass
+class Outflow:
+    amount: int | None = None
+    address: str | None = None
+    subject: str | None = None
+    forgive: str | None = None
+    support: str | None = None
+
+    @property
+    def data_csv(self) -> str:
+        return ','.join(
+            [
+                str(self.amount),
+                self.address if self.address is not None else '',
+                self.subject if self.subject is not None else '',
+                self.forgive if self.forgive is not None else '',
+                self.support if self.support is not None else '',
+            ]
+        )
+
+    @property
+    def schadenfreude(self) -> int:
+        if self.subject is not None and self.amount is not None:
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def grace(self) -> int:
+        if self.forgive is not None and self.amount is not None:
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def mudita(self) -> int:
+        if self.support is not None and self.amount is not None:
+            return self.amount
+        return 0
+
+
+class InflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    outflow_txid: MillHash
+    outflow_idx: int = Field(ge=0)
+
+
+@dataclass
+class Inflow:
+    outflow_txid: str | None = None
+    outflow_idx: int | None = None
+
+    @property
+    def data_csv(self) -> str:
+        return ','.join([str(self.outflow_txid), str(self.outflow_idx)])
+```
+
+Notes:
+- `OutflowSchema` → `OutflowModel`; `InflowSchema` → `InflowModel`.
+- `Subject(fields.String)` → `Subject = Annotated[str, AfterValidator(_check_subject)]`.
+- `@validates_schema validate_destinations` → `@model_validator(mode='after')` operating on `self` instead of `data`.
+- `@post_load make_outflow` / `make_inflow` removed — callers in PR-3 do `Outflow(**OutflowModel.model_validate(d).model_dump())`.
+- `SansNoneSchema` import removed (file no longer uses it).
+- File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports remain).
+- `Outflow` / `Inflow` dataclasses unchanged.
+
+- [ ] **Step 3: Verify**
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+Expected: tests still 177 passed, 1 skipped. The other files (`transaction.py`, `block.py`) still import `OutflowSchema`/`InflowSchema` — that import will fail at module load. So at this point those files need updating, OR we keep transitional aliases.
+
+**Decision: add transitional aliases at the bottom of `payload.py` and remove them in PR-3:**
+
+```python
+# Temporary aliases for the duration of the Phase 4 migration.
+# PR-3 (transaction.py) drops the OutflowSchema/InflowSchema imports.
+OutflowSchema = OutflowModel
+InflowSchema = InflowModel
+```
+
+This makes the existing `from cancelchain.payload import InflowSchema, OutflowSchema` in `transaction.py` continue to resolve, but the value is now a Pydantic model. Any code that calls `.load()`, `.loads()`, `.dumps()`, etc. will fail — but those calls are only in `transaction.py`'s `TransactionSchema.outflows = fields.List(fields.Nested(OutflowSchema), ...)` and `block.py`'s analogous lines. `fields.Nested` accepts a Marshmallow `Schema` class, not a Pydantic `BaseModel`, so this WILL break.
+
+**Better decision: instead of trying to keep dual compatibility, this PR MUST also be the one that breaks the transaction.py/block.py imports — meaning PR-2 and PR-3 should land together.**
+
+Re-scope: **PR-2 just adds `OutflowModel`/`InflowModel` as NEW names; keep `OutflowSchema`/`InflowSchema` as Marshmallow Schemas for now.** PR-3 swaps `transaction.py`'s `TransactionSchema` to use `OutflowModel`/`InflowModel` in `fields.Nested` — wait, that still doesn't work because Marshmallow's `fields.Nested` requires a Marshmallow Schema.
+
+The fundamental issue: nested schemas can't bridge Marshmallow ↔ Pydantic. So PR-2 must keep `OutflowSchema`/`InflowSchema` working as Marshmallow Schemas (because PR-3 still uses them), and the actual `OutflowModel`/`InflowModel` get introduced as new classes that don't get used until PR-3.
+
+**Final decision: PR-2 ADDS `OutflowModel`/`InflowModel` alongside the existing `OutflowSchema`/`InflowSchema`. No deletion of the Marshmallow classes in PR-2; that happens in PR-3 when `transaction.py` switches.**
+
+Revised plan for Step 2: rewrite `payload.py` to KEEP the existing Marshmallow `OutflowSchema`/`InflowSchema` AND ADD new `OutflowModel`/`InflowModel`. Both work; nothing breaks. PR-3 deletes the Marshmallow classes in the same commit it swaps `transaction.py`.
+
+Replace Step 2 above with: **append to existing `src/cancelchain/payload.py` (keep the existing OutflowSchema, InflowSchema, Subject(fields.String) intact)**, adding only:
+
+```python
+# --- Pydantic v2 models (used by PR-3 onwards). Marshmallow Schemas
+# above are kept until PR-3 swaps transaction.py.
+
+def _check_subject(s: str) -> str:
+    if not validate_subject(s):
+        msg = f'Invalid subject: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+SubjectType = Annotated[str, AfterValidator(_check_subject)]
+
+
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: Address | None = None
+    subject: SubjectType | None = None
+    forgive: SubjectType | None = None
+    support: SubjectType | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
+        options = [
+            v
+            for v in (self.subject, self.forgive, self.support)
+            if v is not None
+        ]
+        if not (
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
+        ):
+            raise ValueError(INVALID_DESTINATION_MSG)
+        return self
+
+
+class InflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    outflow_txid: MillHash
+    outflow_idx: int = Field(ge=0)
+```
+
+Top-of-file imports get the additions:
+```python
+from typing import Annotated, Any, Self
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from cancelchain.schema import Address, MillHash
+```
+
+`SubjectType` (renamed from `Subject` to avoid collision with the existing Marshmallow `Subject(fields.String)` class — PR-3 drops the Marshmallow `Subject` and we can rename `SubjectType` → `Subject` then).
+
+- [ ] **Step 4: Test suite**
+
+```bash
+uv run pytest
+```
+Expected: 177 passed, 1 skipped (no behavior change — the new Models exist but aren't used by anything yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cancelchain/payload.py
+git commit -m "$(cat <<'EOF'
+feat(deps): add Pydantic OutflowModel/InflowModel alongside Marshmallow
+
+Adds Pydantic v2 OutflowModel and InflowModel (with SubjectType
+Annotated alias) alongside the existing Marshmallow OutflowSchema /
+InflowSchema. Both coexist; PR-3 (transaction.py) swaps over and PR-3
+also removes the Marshmallow versions.
+
+This dual-coexistence is necessary because Marshmallow's fields.Nested
+can't bridge to a Pydantic BaseModel — TransactionSchema.outflows uses
+fields.Nested(OutflowSchema), so OutflowSchema must remain a
+Marshmallow Schema until TransactionSchema itself is swapped.
+
+Phase 4 / PR 2 of 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push -u origin feat/pydantic-payload
+gh pr create --base main --title "feat(deps): add Pydantic OutflowModel/InflowModel alongside Marshmallow" --body "$(cat <<'EOF'
+## Summary
+- Adds Pydantic v2 \`OutflowModel\`, \`InflowModel\`, and \`SubjectType\` alongside the existing Marshmallow Schemas.
+- Marshmallow \`OutflowSchema\` / \`InflowSchema\` / \`Subject\` stay in place — \`fields.Nested\` in \`TransactionSchema\` still references them. PR-3 swaps the consumers and removes the Marshmallow versions.
+
+Phase 4 / PR 2 of 6.
+
+## Test plan
+- [x] \`uv run pytest\` passes (177/178; no consumer of the new Models yet).
+- [x] \`uv run mypy\` + ruff clean.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 4: PR-3 — `transaction.py` schemas + call sites
+
+**Files:**
+- Modify: `src/cancelchain/transaction.py`
+- Modify: `src/cancelchain/payload.py` (remove Marshmallow Schemas and rename `SubjectType` → `Subject`)
+
+This PR replaces the three transaction-related Marshmallow Schemas with Pydantic BaseModels and rewrites the four call sites (`validate`, `validate_coinbase`, `to_json`, `from_dict`, `from_json`). After this PR, the Marshmallow `OutflowSchema`/`InflowSchema`/`Subject` (added by PR-2) are gone.
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/pydantic-transaction
+```
+
+- [ ] **Step 2: Remove Marshmallow Schemas from `payload.py`**
+
+Edit `src/cancelchain/payload.py`. Delete:
+- The `class Subject(fields.String):` definition.
+- The `class OutflowSchema(SansNoneSchema):` definition (including `@validates_schema validate_destinations` and `@post_load make_outflow` methods).
+- The `class InflowSchema(SansNoneSchema):` definition (including `@post_load make_inflow`).
+- The `from marshmallow import (...)` import line.
+- The `from cancelchain.schema import Address, MillHash, SansNoneSchema` line — replace with `from cancelchain.schema import Address, MillHash` (drop `SansNoneSchema`).
+
+Rename the `SubjectType` alias to `Subject`:
+```python
+# Before:
+SubjectType = Annotated[str, AfterValidator(_check_subject)]
+# After:
+Subject = Annotated[str, AfterValidator(_check_subject)]
+```
+
+And update `OutflowModel` field annotations from `subject: SubjectType | None` → `subject: Subject | None`, same for `forgive` and `support`.
+
+The file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive can be removed (no Marshmallow imports remain).
+
+- [ ] **Step 3: Rewrite `TransactionSchema` family in `transaction.py`**
+
+Edit `src/cancelchain/transaction.py`. Replace lines 1–101 (imports through `CoinbaseTransactionSchema`) with:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Generator, Iterator, MutableSet
+from dataclasses import dataclass, field
+from datetime import datetime
+from json import JSONDecodeError
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    model_validator,
+)
+
+from cancelchain.exceptions import (
+    InvalidSignatureError,
+    InvalidTransactionError,
+    InvalidTransactionIdError,
+    MissingWalletError,
+    UnsealedTransactionError,
+)
+from cancelchain.milling import mill_hash_str
+from cancelchain.models import (
+    InflowDAO,
+    OutflowDAO,
+    PendingIOflowDAO,
+    PendingTxnDAO,
+    TransactionDAO,
+)
+from cancelchain.payload import Inflow, InflowModel, Outflow, OutflowModel
+from cancelchain.schema import (
+    Address,
+    Base64,
+    MillHash,
+    PublicKey,
+    Timestamp,
+    asdict_sans_none,
+    pydantic_errors_to_messages,
+    validate_address,
+    validate_signature,
+)
+from cancelchain.util import dt_2_iso, iso_2_dt, now_iso
+from cancelchain.wallet import Wallet
+
+VERSION_1 = '1'
+MAX_FLOWS = 50
+ADDRESS_MISMATCH_MSG = 'Address/public key mismatch'
+
+
+class TransactionModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    timestamp: Timestamp
+    txid: MillHash
+    address: Address
+    public_key: PublicKey
+    signature: Base64 | None = None
+    inflows: Annotated[
+        list[InflowModel], Field(min_length=0, max_length=MAX_FLOWS)
+    ]
+    outflows: Annotated[
+        list[OutflowModel], Field(min_length=1, max_length=MAX_FLOWS)
+    ]
+    version: Literal[VERSION_1]
+
+    @model_validator(mode='after')
+    def validate_pk_address(self) -> Self:
+        if not validate_address(self.public_key, self.address):
+            raise ValueError(ADDRESS_MISMATCH_MSG)
+        return self
+
+
+class RegularTransactionModel(TransactionModel):
+    inflows: Annotated[
+        list[InflowModel], Field(min_length=1, max_length=MAX_FLOWS)
+    ]
+
+
+class CoinbaseTransactionModel(TransactionModel):
+    inflows: Annotated[
+        list[InflowModel], Field(min_length=0, max_length=0)
+    ]
+    outflows: Annotated[
+        list[OutflowModel], Field(min_length=1, max_length=4)
+    ]
+```
+
+Notes:
+- Import block reorganized: Marshmallow removed; `pydantic.ValidationError` added; `Annotated`, `Literal`, `Self` to typing; payload imports updated to `InflowModel`, `OutflowModel`; schema imports add `pydantic_errors_to_messages`.
+- `Address`, `Base64`, `MillHash`, `PublicKey`, `Timestamp`, `SansNoneSchema` imports updated to drop `SansNoneSchema`.
+- File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports).
+
+- [ ] **Step 4: Update call sites in `transaction.py`**
+
+Find the `Transaction.validate` method (around line 206 originally):
+
+```python
+    def validate(self, coinbase: bool = False) -> None:  # noqa: FBT001
+        if coinbase:
+            errors = CoinbaseTransactionSchema().validate(self.to_dict())
+        else:
+            errors = RegularTransactionSchema().validate(self.to_dict())
+        if errors:
+            raise InvalidTransactionError(errors)
+        self.validate_signature()
+        self.validate_txid()
+```
+
+Replace with:
+
+```python
+    def validate(self, coinbase: bool = False) -> None:  # noqa: FBT001
+        Model = (
+            CoinbaseTransactionModel if coinbase else RegularTransactionModel
+        )
+        try:
+            Model.model_validate(self.to_dict())
+        except ValidationError as e:
+            raise InvalidTransactionError(
+                pydantic_errors_to_messages(e)
+            ) from e
+        self.validate_signature()
+        self.validate_txid()
+```
+
+Find `Transaction.to_json`:
+
+```python
+    def to_json(self) -> str:
+        return TransactionSchema().dumps(self.to_dict())
+```
+
+Replace with:
+
+```python
+    def to_json(self) -> str:
+        return TransactionModel.model_validate(self.to_dict()).model_dump_json(
+            exclude_none=True
+        )
+```
+
+Find `Transaction.from_dict`:
+
+```python
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Self:
+        try:
+            return TransactionSchema().load(d)
+        except ValidationError as e:
+            raise InvalidTransactionError(e.messages) from e
+```
+
+Replace with:
+
+```python
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Self:
+        try:
+            model = TransactionModel.model_validate(d)
+        except ValidationError as e:
+            raise InvalidTransactionError(
+                pydantic_errors_to_messages(e)
+            ) from e
+        return cls(**model.model_dump())
+```
+
+Find `Transaction.from_json`:
+
+```python
+    @classmethod
+    def from_json(cls, j: str | bytes) -> Self:
+        try:
+            return TransactionSchema().loads(j)
+        except (JSONDecodeError, ValidationError) as e:
+            raise InvalidTransactionError(
+                getattr(e, 'messages', str(e))
+            ) from e
+```
+
+Replace with:
+
+```python
+    @classmethod
+    def from_json(cls, j: str | bytes) -> Self:
+        try:
+            model = TransactionModel.model_validate_json(j)
+        except ValidationError as e:
+            raise InvalidTransactionError(
+                pydantic_errors_to_messages(e)
+            ) from e
+        except JSONDecodeError as e:
+            raise InvalidTransactionError(str(e)) from e
+        return cls(**model.model_dump())
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+Expected:
+- mypy + ruff: 0 errors.
+- pytest: 177 passed, 1 skipped. The key tests are `tests/test_transaction.py` (all 36+ tests including the P3-PR-7.5 regression set) and `tests/test_payload.py`.
+
+If any test fails:
+- `test_txn_from` / `test_db` / `test_pending_txns` — these round-trip JSON through `to_json` / `from_json`. If the JSON output differs from before (e.g., key ordering, integer-vs-string, datetime format), Pydantic vs Marshmallow output isn't byte-equivalent yet. Inspect the diff with `print(repr(txn.to_json()))` before and after.
+- `test_txn_invalid` — exercises the validate error path. If Pydantic's error message wording differs from Marshmallow's, the test assertion needs adjustment (probably matching on `'Address/public key mismatch'` is what we want anyway since that's the constant).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cancelchain/transaction.py src/cancelchain/payload.py
+git commit -m "$(cat <<'EOF'
+feat(deps): transaction schemas → Pydantic v2 BaseModel
+
+Replaces TransactionSchema / RegularTransactionSchema /
+CoinbaseTransactionSchema with TransactionModel and two subclasses.
+
+- @validates_schema validate_pk_address → @model_validator(mode='after').
+- @post_load make_transaction → removed; callers do
+  cls(**Model.model_validate(d).model_dump()) explicitly.
+- validate.Equal(VERSION_1) → Literal[VERSION_1].
+- validate.Length(min=N, max=M) → Field(min_length=N, max_length=M).
+- TransactionSchema().validate(...) → Model.model_validate(...) wrapped
+  in try/except ValidationError; pydantic_errors_to_messages adapter
+  preserves the message-dict shape downstream consumers expect.
+- TransactionSchema().dumps(...) → Model.model_validate(...).model_dump_json(exclude_none=True).
+- TransactionSchema().load(...) → Model.model_validate(d) then dataclass conversion.
+- TransactionSchema().loads(j) → Model.model_validate_json(j) then dataclass conversion.
+
+payload.py: removes the now-unused Marshmallow OutflowSchema /
+InflowSchema / Subject(fields.String); renames the Pydantic SubjectType
+alias to Subject. File-level # mypy: disable-error-code directive
+removed from both files.
+
+Phase 4 / PR 3 of 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/pydantic-transaction
+gh pr create --base main --title "feat(deps): transaction schemas → Pydantic v2" --body "$(cat <<'EOF'
+## Summary
+- TransactionSchema family (3 classes) → TransactionModel family.
+- payload.py: removes Marshmallow OutflowSchema/InflowSchema/Subject; renames Pydantic SubjectType → Subject.
+- @post_load removed — callers do \`cls(**Model.model_validate(d).model_dump())\`.
+- @validates_schema → @model_validator(mode='after').
+- Pydantic ValidationError caught at call sites; \`pydantic_errors_to_messages\` adapter preserves downstream consumers.
+- File-level mypy disable directive removed from \`transaction.py\` and \`payload.py\`.
+
+Phase 4 / PR 3 of 6.
+
+## Test plan
+- [x] \`uv run pytest\` passes (177/178), including round-trip JSON tests (test_txn_from, test_db, test_pending_txns).
+- [x] \`uv run mypy\` + ruff clean.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 5: PR-4 — `block.py` schema + call sites
+
+**Files:**
+- Modify: `src/cancelchain/block.py`
+
+Replace `BlockSchema(SansNoneSchema)` with `BlockModel(BaseModel)`. Rewrite the four call sites in `Block.validate`, `Block.to_json`, `Block.from_dict`, `Block.from_json`.
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/pydantic-block
+```
+
+- [ ] **Step 2: Rewrite `BlockSchema` → `BlockModel` in `block.py`**
+
+Edit `src/cancelchain/block.py`. Replace lines 1–81 (imports through `BlockSchema`) with:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    model_validator,
+)
+from pymerkle import InmemoryTree, InvalidProof, verify_inclusion
+
+from cancelchain.exceptions import (
+    ExpiredTransactionError,
+    FutureTransactionError,
+    InvalidBlockError,
+    InvalidBlockHashError,
+    InvalidCoinbaseError,
+    InvalidMerkleRootError,
+    InvalidProofError,
+    InvalidTransactionError,
+    MissingCoinbaseError,
+    OutOfOrderTransactionError,
+    SealedBlockError,
+    UnlinkedBlockError,
+)
+from cancelchain.milling import mill_hash_str, milling_generator
+from cancelchain.models import BlockDAO
+from cancelchain.schema import (
+    MillHash,
+    Timestamp,
+    asdict_sans_none,
+    pydantic_errors_to_messages,
+)
+from cancelchain.transaction import Transaction, TransactionModel
+from cancelchain.util import dt_2_iso, iso_2_dt, now_iso
+from cancelchain.wallet import Wallet
+
+VERSION_1 = '1'
+MAX_TRANSACTIONS = 100
+TXN_TIMEOUT = timedelta(hours=4)
+MISSED_TARGET_MSG = 'Missed target'
+
+
+def validate_hash_diff(block_hash: str, target: str) -> bool:
+    return int(block_hash, 16) < int(target, 16)
+
+
+class BlockModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    idx: int = Field(ge=0)
+    timestamp: Timestamp
+    block_hash: MillHash
+    prev_hash: MillHash
+    target: MillHash
+    proof_of_work: int = Field(ge=0)
+    merkle_root: MillHash
+    txns: Annotated[
+        list[TransactionModel],
+        Field(min_length=1, max_length=MAX_TRANSACTIONS),
+    ]
+    version: Literal[VERSION_1]
+
+    @model_validator(mode='after')
+    def validate_difficulty(self) -> Self:
+        if not validate_hash_diff(self.block_hash, self.target):
+            raise ValueError(MISSED_TARGET_MSG)
+        return self
+```
+
+Notes:
+- Marshmallow import removed (`from marshmallow import (ValidationError, ...)`).
+- `SansNoneSchema` import removed.
+- `TransactionSchema` import → `TransactionModel`.
+- `pydantic_errors_to_messages` added to schema imports.
+- File-level `# mypy: disable-error-code` directive removed.
+
+- [ ] **Step 3: Update call sites in `block.py`**
+
+Find the validate call in `Block.validate_transactions` (around line 278):
+
+```python
+        if errors := BlockSchema().validate(self.to_dict()):
+            raise InvalidBlockError(errors)
+```
+
+Replace with:
+
+```python
+        try:
+            BlockModel.model_validate(self.to_dict())
+        except ValidationError as e:
+            raise InvalidBlockError(
+                pydantic_errors_to_messages(e)
+            ) from e
+```
+
+Find `Block.to_json`:
+
+```python
+    def to_json(self) -> str:
+        return BlockSchema().dumps(self.to_dict())
+```
+
+Replace with:
+
+```python
+    def to_json(self) -> str:
+        return BlockModel.model_validate(self.to_dict()).model_dump_json(
+            exclude_none=True
+        )
+```
+
+Find `Block.from_dict`:
+
+```python
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Self:
+        try:
+            return BlockSchema().load(d)
+        except ValidationError as e:
+            raise InvalidBlockError(e.messages) from e
+```
+
+Replace with:
+
+```python
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Self:
+        try:
+            model = BlockModel.model_validate(d)
+        except ValidationError as e:
+            raise InvalidBlockError(
+                pydantic_errors_to_messages(e)
+            ) from e
+        return cls(**model.model_dump())
+```
+
+Find `Block.from_json`:
+
+```python
+    @classmethod
+    def from_json(cls, j: str | bytes) -> Self:
+        try:
+            return BlockSchema().loads(j)
+        except (JSONDecodeError, ValidationError) as ve:
+            raise InvalidBlockError(
+                getattr(ve, 'messages', str(ve))
+            ) from ve
+```
+
+Replace with:
+
+```python
+    @classmethod
+    def from_json(cls, j: str | bytes) -> Self:
+        try:
+            model = BlockModel.model_validate_json(j)
+        except ValidationError as e:
+            raise InvalidBlockError(
+                pydantic_errors_to_messages(e)
+            ) from e
+        except JSONDecodeError as e:
+            raise InvalidBlockError(str(e)) from e
+        return cls(**model.model_dump())
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+Expected: 177 passed, 1 skipped. Highest-risk tests: `tests/test_block.py` (13 tests including `test_to_dao_partial_block_raises`), `tests/test_chain.py` (24+ tests that exercise blocks end-to-end).
+
+The `model_dump()` call on a `BlockModel` produces a dict with `txns: list[dict]` (nested `TransactionModel` dumps). The `cls(**model.model_dump())` call passes those nested dicts to `Block.__init__`, which expects `txns: list[Transaction]`. Verify by looking at the original `BlockSchema.@post_load make_block`:
+
+```python
+@post_load
+def make_block(self, data: dict[str, Any], **kwargs: Any) -> Block:
+    return Block(**data)
+```
+
+The original did the same — `Block(**data)` with `data['txns']` being a `list[Transaction]` because Marshmallow's `@post_load` cascades up through `@post_load make_transaction` (which converts each nested dict to a `Transaction`).
+
+With Pydantic, `model.model_dump()` returns plain dicts — `txns` becomes `list[dict]`, not `list[Transaction]`. So `cls(**model.model_dump())` passes `txns=list[dict]` to `Block.__init__`, which won't construct `Transaction` instances.
+
+**Fix:** in `Block.from_dict` and `Block.from_json`, manually convert nested txns:
+
+```python
+@classmethod
+def from_dict(cls, d: dict[str, Any]) -> Self:
+    try:
+        model = BlockModel.model_validate(d)
+    except ValidationError as e:
+        raise InvalidBlockError(pydantic_errors_to_messages(e)) from e
+    data = model.model_dump()
+    data['txns'] = [Transaction(**t) for t in data['txns']]
+    return cls(**data)
+```
+
+Same adjustment in `Block.from_json`. Apply both before Step 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cancelchain/block.py
+git commit -m "$(cat <<'EOF'
+feat(deps): block schema → Pydantic v2 BaseModel
+
+Replaces BlockSchema with BlockModel(BaseModel).
+
+- @validates_schema validate_difficulty → @model_validator(mode='after').
+- @post_load make_block → removed; from_dict/from_json explicitly
+  reconstruct nested Transaction instances from the model_dump() dicts.
+- fields.List(fields.Nested(TransactionSchema), validate=...) →
+  Annotated[list[TransactionModel], Field(min_length=1, max_length=...)].
+- BlockSchema().validate(...) → Model.model_validate(...) +
+  pydantic_errors_to_messages adapter at the catch site.
+- BlockSchema().dumps(...) → Model.model_validate(...).model_dump_json(exclude_none=True).
+
+File-level # mypy: disable-error-code directive removed.
+
+Phase 4 / PR 4 of 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push -u origin feat/pydantic-block
+gh pr create --base main --title "feat(deps): block schema → Pydantic v2" --body "$(cat <<'EOF'
+## Summary
+- BlockSchema → BlockModel.
+- @validates_schema validate_difficulty → @model_validator(mode='after').
+- @post_load removed; from_dict / from_json explicitly reconstruct nested Transaction instances.
+- pydantic_errors_to_messages adapter at catch sites.
+- File-level mypy disable directive removed.
+
+Phase 4 / PR 4 of 6.
+
+## Test plan
+- [x] \`uv run pytest\` passes (177/178), including merkle-tree validation and recursive-CTE-traversal tests.
+- [x] \`uv run mypy\` + ruff clean.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 6: PR-5 — `api.py` query schemas
+
+**Files:**
+- Modify: `src/cancelchain/api.py`
+
+Replace the 3 query schemas (`TransferTxnQuerySchema`, `SubjectTxnQuerySchema`, `PendingTxnQuerySchema`) with Pydantic BaseModels. Update the 5 call sites that invoke `.load(request.args)`.
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/pydantic-api-queries
+```
+
+- [ ] **Step 2: Update `api.py` imports and remove Marshmallow**
+
+Edit `src/cancelchain/api.py`. Find the Marshmallow import block:
+
+```python
+from marshmallow import Schema, ValidationError, fields, validate
+```
+
+Replace with:
+
+```python
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    ValidationError,
+)
+```
+
+Add `pydantic_errors_to_messages` to the existing `from cancelchain.schema import (...)` line.
+
+- [ ] **Step 3: Replace `TransferTxnQuerySchema` (around line 370)**
+
+Replace:
+
+```python
+class TransferTxnQuerySchema(Schema):
+    public_key = fields.String(required=True, validate=validate_public_key)
+    amount = fields.Integer(required=True, validate=validate.Range(min=1))
+    address = fields.String(required=True, validate=validate_address_format)
+```
+
+With:
+
+```python
+def _check_address_format_local(s: str) -> str:
+    if not validate_address_format(s):
+        msg = f'Invalid address format: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_public_key_local(s: str) -> str:
+    if not validate_public_key(s):
+        msg = f'Invalid public key: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+_PublicKeyField = Annotated[str, AfterValidator(_check_public_key_local)]
+_AddressFormatField = Annotated[
+    str, AfterValidator(_check_address_format_local)
+]
+
+
+class TransferTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    public_key: _PublicKeyField
+    amount: int = Field(ge=1)
+    address: _AddressFormatField
+```
+
+Notes:
+- The query schemas use `validate_address_format` (different from `validate_address` which checks pk⇔address match). The custom `_AddressFormatField` reflects that.
+- The `_PublicKeyField` here matches the existing `validate_public_key` behavior in the query context, which is structurally identical to `schema.PublicKey` BUT uses a different validator path — keep them parallel.
+
+Alternative (cleaner): reuse `schema.PublicKey`. But that runs through `validate_public_key(public_key_b64)` which expects a full b64-encoded key. The query schema validates `public_key=...` from URL args which is also a b64 string. So they ARE the same. Use `schema.PublicKey` directly:
+
+```python
+from cancelchain.schema import Address as _AddressType
+from cancelchain.schema import PublicKey as _PublicKeyType
+
+# Note: `schema.Address` validates the CC-tagged address format, which
+# is what `validate_address_format` does here. Reuse.
+
+class TransferTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    public_key: _PublicKeyType
+    amount: int = Field(ge=1)
+    address: _AddressType
+```
+
+**Final decision: reuse `schema.Address` and `schema.PublicKey`** to avoid type duplication. Verify `schema.Address`'s `_check_address_format` matches the existing `validate_address_format` validator — yes, both run `validate_address_format(s)`. Same for `schema.PublicKey` ↔ `validate_public_key`.
+
+- [ ] **Step 4: Replace `SubjectTxnQuerySchema` (around line 405)**
+
+Replace:
+
+```python
+class SubjectTxnQuerySchema(Schema):
+    public_key = fields.String(required=True, validate=validate_public_key)
+    amount = fields.Integer(required=True, validate=validate.Range(min=1))
+    subject = fields.String(required=True, validate=validate_raw_subject)
+```
+
+With:
+
+```python
+def _check_raw_subject(s: str) -> str:
+    if not validate_raw_subject(s):
+        msg = f'Invalid raw subject: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+_RawSubjectField = Annotated[str, AfterValidator(_check_raw_subject)]
+
+
+class SubjectTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    public_key: _PublicKeyType
+    amount: int = Field(ge=1)
+    subject: _RawSubjectField
+```
+
+(`validate_raw_subject` differs from `schema._check_address_format` etc. — it accepts the raw, pre-encoded user-supplied subject string. Keeping the local check makes the intent explicit.)
+
+- [ ] **Step 5: Replace `PendingTxnQuerySchema` (around line 498)**
+
+Replace:
+
+```python
+class PendingTxnQuerySchema(Schema):
+    earliest = fields.Function(
+        lambda obj: dt_2_ciso(obj.earliest),
+        deserialize=ciso_2_dt,
+        required=False,
+    )
+```
+
+With:
+
+```python
+_CisoTimestamp = Annotated[
+    datetime,
+    BeforeValidator(lambda v: ciso_2_dt(v) if isinstance(v, str) else v),
+    PlainSerializer(lambda dt: dt_2_ciso(dt), return_type=str),
+]
+
+
+class PendingTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    earliest: _CisoTimestamp | None = None
+```
+
+This requires `from datetime import datetime` in the imports if it isn't already present (verify; `api.py` already uses datetime elsewhere).
+
+- [ ] **Step 6: Update the 5 call sites**
+
+Find each occurrence of `QuerySchema().load(request.args)` (lines 379, 414, 443, 472, 511). Replace each pattern:
+
+```python
+# Before:
+args = TransferTxnQuerySchema().load(request.args)
+# ... uses args['public_key'], args['amount'], args['address'] ...
+```
+
+With:
+
+```python
+# After:
+try:
+    model = TransferTxnQueryModel.model_validate(
+        request.args.to_dict(flat=True)
+    )
+except ValidationError as e:
+    return make_error_response(_pydantic_validation_error(e))
+args = model.model_dump(exclude_none=True)
+# ... uses args['public_key'], args['amount'], args['address'] ...
+```
+
+Where `_pydantic_validation_error(e)` is a small helper added at the top of `api.py`:
+
+```python
+def _pydantic_validation_error(e: ValidationError) -> Any:
+    """Wrap a Pydantic ValidationError into the shape make_error_response expects."""
+    return type(
+        'AdaptedValidationError',
+        (Exception,),
+        {'messages': pydantic_errors_to_messages(e)},
+    )()
+```
+
+This avoids modifying `make_error_response` itself — the existing function expects `err.messages`; we hand it an object with that attribute.
+
+Apply the same pattern to:
+- `SubjectTxnQuerySchema().load(request.args)` at lines 414, 443, 472 — use `SubjectTxnQueryModel`.
+- `PendingTxnQuerySchema().load(request.args)` at line 511 — use `PendingTxnQueryModel`.
+
+For the `PendingTxnQueryModel` site, the existing code does `args.get('earliest')` which returns a `datetime | None`. The `args = model.model_dump(exclude_none=True)` line works the same way — if `earliest` is None, it's not in the dict; `args.get('earliest')` returns `None` either way.
+
+- [ ] **Step 7: Remove unused imports**
+
+After the swap, `api.py` no longer needs:
+- `from marshmallow import Schema, ValidationError, fields, validate` — already replaced.
+- Verify the existing `from cancelchain.schema import validate_address_format, validate_public_key` is still needed (it IS — for backward compat in the original query schemas; but if all schemas now use the Address/PublicKey types directly, these can come out).
+
+Run:
+```bash
+uv run ruff check src/cancelchain/api.py
+```
+Ruff will flag unused imports. Drop those it identifies.
+
+- [ ] **Step 8: Verify**
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+Expected: 177 passed, 1 skipped. Tests exercising the API endpoints (`tests/test_api.py`, `tests/test_browser.py`) verify the new validation path.
+
+If any test fails:
+- Bad-input rejection tests (e.g., `test_invalid_amount`) — check that Pydantic's error response shape matches what tests assert. They probably assert on HTTP 400 status, not the response body, so should be fine.
+- Endpoint smoke tests — verify `request.args.to_dict(flat=True)` returns dict-like data that Pydantic accepts.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/cancelchain/api.py
+git commit -m "$(cat <<'EOF'
+feat(deps): API query schemas → Pydantic v2
+
+Replaces the 3 Marshmallow query schemas with Pydantic models:
+
+- TransferTxnQuerySchema → TransferTxnQueryModel (reuses
+  schema.Address and schema.PublicKey custom types).
+- SubjectTxnQuerySchema → SubjectTxnQueryModel (with local raw-subject
+  validator).
+- PendingTxnQuerySchema → PendingTxnQueryModel (with
+  Annotated[datetime, BeforeValidator(ciso_2_dt),
+  PlainSerializer(dt_2_ciso)] for the ciso-timestamp parse/format
+  symmetry that fields.Function provided).
+
+Each of the 5 call sites updated to use Model.model_validate(
+  request.args.to_dict(flat=True)) wrapped in try/except. Small
+_pydantic_validation_error adapter preserves the .messages attribute
+that make_error_response expects.
+
+Marshmallow import block removed from api.py. The Phase 1 spec's
+"Marshmallow → Pydantic" Phase 4 goal is now complete for src/;
+PR-6 finishes by removing marshmallow from runtime deps.
+
+Phase 4 / PR 5 of 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 10: Push and open PR**
+
+```bash
+git push -u origin feat/pydantic-api-queries
+gh pr create --base main --title "feat(deps): API query schemas → Pydantic v2" --body "$(cat <<'EOF'
+## Summary
+- 3 Marshmallow query schemas → Pydantic models.
+- 5 call sites updated to use \`Model.model_validate(request.args.to_dict(flat=True))\`.
+- PendingTxnQueryModel uses \`Annotated[datetime, BeforeValidator(ciso_2_dt), PlainSerializer(dt_2_ciso)]\` to replace \`fields.Function\`.
+- Marshmallow import removed from \`api.py\`.
+
+After this PR, no \`src/cancelchain/\` file imports marshmallow. PR-6 removes the runtime dep + overrides.
+
+Phase 4 / PR 5 of 6.
+
+## Test plan
+- [x] \`uv run pytest\` passes (177/178), including API endpoint tests.
+- [x] \`uv run mypy\` + ruff clean.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 11: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 7: PR-6 — Remove `marshmallow` from runtime dependencies
+
+**Files:**
+- Modify: `pyproject.toml`
+- Possibly modify: `src/cancelchain/schema.py` (remove the transitional `SansNoneSchema` alias if PR-1 left it)
+- Possibly modify: `src/cancelchain/transaction.py` (verify directive removal — should already be done in PR-3)
+- Possibly modify: `src/cancelchain/models.py` (review only — directive there is for `db.Model`, not marshmallow)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b chore/remove-marshmallow
+```
+
+- [ ] **Step 2: Verify no Marshmallow imports remain**
+
+```bash
+grep -rn "marshmallow\|Marshmallow" src/cancelchain/
+```
+
+Expected: no matches. If `schema.py` still has the transitional `SansNoneSchema` alias from PR-1 (the `from marshmallow import Schema as _MarshmallowSchema`), remove it now.
+
+- [ ] **Step 3: Edit `pyproject.toml`**
+
+Remove the line:
+```toml
+"marshmallow>=3.19",
+```
+from `[project.dependencies]`.
+
+Remove the block:
+```toml
+[[tool.mypy.overrides]]
+module = ["marshmallow", "marshmallow.*"]
+ignore_missing_imports = true
+```
+from `[tool.mypy]` overrides.
+
+- [ ] **Step 4: Refresh the lockfile**
+
+```bash
+uv lock
+grep -i marshmallow uv.lock
+```
+Expected: `grep` returns no matches. The lockfile is regenerated without marshmallow.
+
+- [ ] **Step 5: Re-sync and verify**
+
+```bash
+uv sync --group dev
+uv run python -c "import marshmallow" 2>&1 | head -2
+```
+Expected: `ModuleNotFoundError: No module named 'marshmallow'`.
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+All must exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/cancelchain/schema.py
+git commit -m "$(cat <<'EOF'
+chore(deps): remove marshmallow from runtime dependencies
+
+After PRs 1-5 swapped every Marshmallow Schema for a Pydantic v2
+BaseModel, no source code under src/cancelchain/ imports marshmallow.
+This PR finishes the migration:
+
+- Removes \`marshmallow>=3.19\` from [project.dependencies].
+- Removes [[tool.mypy.overrides]] module = ["marshmallow", "marshmallow.*"].
+- Removes the transitional SansNoneSchema alias from schema.py (if PR-1
+  added one).
+
+uv lock regenerated; marshmallow no longer in uv.lock.
+
+Phase 4 / PR 6 of 6 (final PR of Phase 4).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin chore/remove-marshmallow
+gh pr create --base main --title "chore(deps): remove marshmallow from runtime dependencies" --body "$(cat <<'EOF'
+## Summary
+- Removes \`marshmallow>=3.19\` from \`[project.dependencies]\`.
+- Removes the \`[[tool.mypy.overrides]]\` block for \`marshmallow.*\`.
+- Removes the transitional \`SansNoneSchema\` alias from \`schema.py\` (if PR-1 left one).
+- \`uv lock\` regenerated; \`marshmallow\` no longer in \`uv.lock\`.
+
+Phase 4 / PR 6 of 6 (final PR).
+
+## Test plan
+- [x] \`grep -rn marshmallow src/\` returns nothing.
+- [x] \`grep marshmallow uv.lock\` returns nothing.
+- [x] \`uv run python -c "import marshmallow"\` raises ModuleNotFoundError.
+- [x] \`uv run pytest\` passes (177/178).
+- [x] \`uv run mypy\` + \`ruff check\` + \`ruff format --check\` all exit 0 (hard CI gates).
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 8: Phase 4 acceptance verification
+
+**Files:** none modified. Final verification after all 6 impl PRs land.
+
+- [ ] **Step 1: Confirm clean main**
+
+```bash
+git checkout main && git pull --ff-only
+git log --oneline -8
+```
+Expected: 6 Phase 4 squash-merge commits visible.
+
+- [ ] **Step 2: Fresh-clone simulation**
+
+```bash
+rm -rf .venv
+uv sync --group dev
+uv run python --version
+```
+Expected: Python 3.12.x.
+
+- [ ] **Step 3: Marshmallow absent**
+
+```bash
+grep -rn marshmallow src/
+echo ""
+grep marshmallow pyproject.toml
+echo ""
+grep marshmallow uv.lock | head
+echo ""
+uv run python -c "import marshmallow" 2>&1 | head -3
+```
+Expected: nothing on first three; ModuleNotFoundError on fourth.
+
+- [ ] **Step 4: Hard CI gates pass**
+
+```bash
+uv run ruff check src tests; echo "exit: $?"
+uv run ruff format --check src tests; echo "exit: $?"
+uv run mypy; echo "exit: $?"
+```
+All three exit 0.
+
+- [ ] **Step 5: Tests pass on 3.12 and 3.13**
+
+```bash
+uv sync --group dev --python 3.12
+uv run pytest 2>&1 | tail -3
+```
+Expected: 177 passed, 1 skipped.
+
+```bash
+UV_PYTHON=3.13 uv sync --group dev --python 3.13 --reinstall
+UV_PYTHON=3.13 uv run --python 3.13 pytest 2>&1 | tail -3
+```
+Expected: same.
+
+- [ ] **Step 6: CLI smoke**
+
+```bash
+uv run cancelchain --help
+```
+Expected: full command tree prints.
+
+- [ ] **Step 7: Docker build smoke**
+
+```bash
+docker build -t cc-phase4-final .
+```
+Expected: build succeeds.
+
+- [ ] **Step 8: Acceptance complete**
+
+If Steps 1–7 all pass, Phase 4 is done. No commit.
+
+---
+
+## Notes on the wor / mwg workflow
+
+Each impl PR (Tasks 2–7) ends with the controller running `wor` and `mwg`:
+
+1. **`wor`:** poll PR until Copilot review completes. Read inline comments. Reply one at a time with verified `in_reply_to_id` (per the user's memory). User manually resolves threads.
+2. **`mwg`:** `gh pr checks <N> --watch`; once green, `gh pr merge <N> --squash --delete-branch`.
+
+Never skip `wor`, even when CI is green and local tests pass. Copilot consistently caught real bugs in Phases 2 and 3.
+
+If Copilot review requests substantive changes, push a new commit to the PR branch (do not amend) and re-run `wor`.
+
+---
+
+## Risk: nested-model `model_dump` returns plain dicts
+
+The biggest pitfall in Tasks 4 (transaction) and 5 (block) is the `cls(**model.model_dump())` pattern when the model has nested fields.
+
+For `Transaction`, `model.model_dump()` returns `{'inflows': [{...}], 'outflows': [{...}], ...}` — those nested lists are `list[dict]`, but `Transaction.__init__` expects `list[Inflow]` / `list[Outflow]`.
+
+For `Block`, same issue with `txns: list[Transaction]`.
+
+The fix at each from_dict / from_json site: explicitly reconstruct the nested dataclasses from their dicts before passing to the outer dataclass constructor:
+
+```python
+data = model.model_dump()
+data['inflows'] = [Inflow(**i) for i in data['inflows']]
+data['outflows'] = [Outflow(**o) for o in data['outflows']]
+return cls(**data)
+```
+
+Plan steps for Tasks 4 and 5 include this fix explicitly. If a test like `test_txn_from` fails with "AttributeError: 'dict' object has no attribute X" on a nested field, this is the cause.
+
+---
+
+## Roll-back posture
+
+Each PR squash-merged independently. Forward-fix is preferred over revert because:
+- Revert would re-introduce Marshmallow + remove Pydantic mid-stream
+- Later PRs depend on earlier ones (PR-3 imports `OutflowModel` introduced in PR-2)
+
+For a defect found post-merge, prefer a `fix(deps): ...` PR. If a structural problem requires reverting a PR, all subsequent PRs need to be reverted too, in reverse order.

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -33,23 +33,24 @@
 | 4 | PR-3 transaction.py | `src/cancelchain/transaction.py` |
 | 5 | PR-4 block.py | `src/cancelchain/block.py` |
 | 6 | PR-5 api.py | `src/cancelchain/api.py` |
-| 7 | PR-6 cleanup | `pyproject.toml`, `src/cancelchain/schema.py`, `src/cancelchain/transaction.py`, `src/cancelchain/payload.py` (verify directive removal) |
+| 7 | PR-6 cleanup | `pyproject.toml`, `src/cancelchain/schema.py` (delete Marshmallow classes); verify-only: `src/cancelchain/transaction.py`, `src/cancelchain/payload.py`, `src/cancelchain/block.py` (PR-3/PR-4 directive removal) |
 | 8 | acceptance | none (verification only) |
 
 ---
 
 ## Task 1: Ship the docs PR (spec + plan)
 
-**Files:** Modify: nothing. The design spec is already committed on `docs/phase-4-design` as `a644741`. This task adds the implementation plan and ships them together.
+**Files:** Modify: nothing. The design spec is already committed on `docs/phase-4-design`. This task adds the implementation plan and ships them together.
 
 - [ ] **Step 1: Confirm branch state**
 
 Run:
 ```bash
 git rev-parse --abbrev-ref HEAD
-git log --oneline main..HEAD
+git ls-files docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+git rev-list --count main..HEAD
 ```
-Expected: branch is `docs/phase-4-design`; one commit above main: `a644741 docs(phase-4): add Phase 4 Marshmallow → Pydantic v2 design spec`.
+Expected: current branch is `docs/phase-4-design`; the spec file path is tracked (returned by `git ls-files`); commit count above main is `1` (the design-spec commit). These checks are SHA-independent — they keep working after squash-merges or rebases.
 
 - [ ] **Step 2: Verify the plan file is present**
 

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -151,7 +151,7 @@ from typing import Annotated, Any
 from pydantic import AfterValidator, ValidationError
 ```
 
-Then **append** these blocks to the end of the file (after the existing `PublicKey(Base64)` class definition):
+Then **append** these blocks at the very end of `schema.py` (after the existing `SansNoneSchema(Schema)` class definition — `schema.py` currently ends with `SansNoneSchema`, which itself comes after `PublicKey(Base64)`. Don't insert mid-file between them):
 
 ```python
 # --- Pydantic v2 custom type aliases (introduced in Phase 4 / PR-1).
@@ -210,12 +210,16 @@ PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
 def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
     """Convert Pydantic ValidationError to Marshmallow-shaped messages.
 
-    Marshmallow's ValidationError.messages is a nested dict keyed by
-    field name (e.g. {'outflows': {0: {'amount': ['Must be ge 1']}}}).
-    This adapter rebuilds that nested shape from Pydantic's flat
-    err['loc'] tuples so api.py's make_error_response and the
-    InvalidBlockError({...: e.messages}) re-raise wrappers see the
-    same dict layout downstream consumers already render.
+    Rebuilds a nested dict from Pydantic's flat err['loc'] tuples so
+    api.py's make_error_response and the InvalidBlockError({...: e.messages})
+    re-raise wrappers see the same nested layout downstream consumers
+    already render. List indices in `loc` are stringified, since the
+    resulting dict will be JSON-serialized to clients anyway (Marshmallow
+    keeps integer keys in-Python; we don't — they're indistinguishable
+    on the wire).
+
+    Example output for outflows[0].amount failing Field(ge=1):
+        {'outflows': {'0': {'amount': ['Input should be greater than or equal to 1']}}}
     """
     result: dict[str, Any] = {}
     for err in e.errors():

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -569,7 +569,7 @@ from collections.abc import Generator, Iterator, MutableSet
 from dataclasses import dataclass, field
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Final, Literal, Self
 
 from pydantic import (
     BaseModel,
@@ -609,7 +609,8 @@ from cancelchain.schema import (
 from cancelchain.util import dt_2_iso, iso_2_dt, now_iso
 from cancelchain.wallet import Wallet
 
-VERSION_1 = '1'
+# Final required for `Literal[VERSION_1]` to type-check under mypy strict.
+VERSION_1: Final = '1'
 MAX_FLOWS = 50
 ADDRESS_MISMATCH_MSG = 'Address/public key mismatch'
 
@@ -880,7 +881,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from json import JSONDecodeError
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Final, Literal, Self
 
 from pydantic import (
     BaseModel,
@@ -917,7 +918,8 @@ from cancelchain.transaction import Transaction, TransactionModel
 from cancelchain.util import dt_2_iso, iso_2_dt, now_iso
 from cancelchain.wallet import Wallet
 
-VERSION_1 = '1'
+# Final required for `Literal[VERSION_1]` to type-check under mypy strict.
+VERSION_1: Final = '1'
 MAX_TRANSACTIONS = 100
 TXN_TIMEOUT = timedelta(hours=4)
 MISSED_TARGET_MSG = 'Missed target'
@@ -1168,7 +1170,19 @@ git checkout -b feat/pydantic-api-queries
 
 - [ ] **Step 2: Update `api.py` imports and remove Marshmallow**
 
-Edit `src/cancelchain/api.py`. Find the Marshmallow import block:
+Edit `src/cancelchain/api.py`. The existing typing import line reads:
+
+```python
+from typing import Any, NoReturn
+```
+
+Replace with (add `Annotated` — needed for the local `_RawSubjectField` alias and the `_CisoTimestamp` alias in Step 5):
+
+```python
+from typing import Annotated, Any, NoReturn
+```
+
+Find the Marshmallow import block:
 
 ```python
 from marshmallow import Schema, ValidationError, fields, validate
@@ -1188,7 +1202,7 @@ from pydantic import (
 )
 ```
 
-Add `pydantic_errors_to_messages` to the existing `from cancelchain.schema import (...)` line.
+Add `AddressType`, `PublicKeyType`, and `pydantic_errors_to_messages` to the existing `from cancelchain.schema import (...)` line.
 
 - [ ] **Step 3: Replace `TransferTxnQuerySchema` (around line 370)**
 

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -12,10 +12,10 @@
 
 ## Prerequisites
 
-- Working directory: `/home/gumptionthomas/Development/cancelchain`. Use absolute paths or `cd` once.
+- Working directory: the cancelchain repo root (whatever path it lives at). Run all commands from there.
 - `uv --version` 0.4.x or newer; `gh --version` works and `gh auth status` shows authenticated.
-- Phase 3 fully merged. `git log --oneline -5` should show `525ccf5 fix(tests): harden FLASK_SECRET_KEY against pyjwt insecure-key warning (#49)` at or near the top.
-- The branch `docs/phase-4-design` exists locally with commit `a644741` (the design spec). This plan adds the second commit on that branch and ships both as the docs PR.
+- Phase 3 fully merged. Verify with `gh pr view 49 --json state,mergedAt --jq .state` returning `MERGED`, plus `grep -c 'pydantic' pyproject.toml` returning 0 (Phase 3 left no pydantic dep).
+- The branch `docs/phase-4-design` exists locally with the design spec already committed. This plan adds the second commit on that branch and ships both as the docs PR.
 - CI hard-gates `ruff check` and `mypy` (as of Phase 3 / PR-8). Every PR must keep both clean.
 - Test baseline: **177 passed, 1 skipped**. Phase 4 should preserve that count (no new tests required, no regressions).
 - Each impl PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller (orchestrator) handles those, not the implementer subagent.
@@ -715,7 +715,7 @@ Replace with:
 Add this helper near the top of the file (just below the `*Model` class definitions):
 
 ```python
-def _txn_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
+def txn_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
     """Convert a TransactionModel.model_dump() dict's nested lists from
     list[dict] to list[Inflow] / list[Outflow] before passing to the
     Transaction dataclass constructor.
@@ -747,7 +747,7 @@ Replace with:
             raise InvalidTransactionError(
                 pydantic_errors_to_messages(e)
             ) from e
-        return cls(**_txn_from_model_data(model.model_dump()))
+        return cls(**txn_from_model_data(model.model_dump()))
 ```
 
 Find `Transaction.from_json`:
@@ -776,10 +776,10 @@ Replace with:
             ) from e
         except JSONDecodeError as e:
             raise InvalidTransactionError(str(e)) from e
-        return cls(**_txn_from_model_data(model.model_dump()))
+        return cls(**txn_from_model_data(model.model_dump()))
 ```
 
-Without the `_txn_from_model_data` step, `Transaction.inflows[0].outflow_txid` would raise `AttributeError` because the elements are plain dicts, not `Inflow` instances. Block-level reconstruction (PR-4) imports this helper too — see Task 5 Step 4.
+Without the `txn_from_model_data` step, `Transaction.inflows[0].outflow_txid` would raise `AttributeError` because the elements are plain dicts, not `Inflow` instances. Block-level reconstruction (PR-4) imports this helper too — see Task 5 Step 4.
 
 - [ ] **Step 5: Verify**
 
@@ -999,14 +999,23 @@ Replace with:
         )
 ```
 
-**Nested reconstruction.** `BlockModel.model_dump()` returns `txns` as `list[dict]`, but `Block` expects `list[Transaction]`. Each of those nested dicts in turn has `inflows`/`outflows` as `list[dict]` that need to become `list[Inflow]` / `list[Outflow]`. The `_txn_from_model_data` helper from PR-3 (in `transaction.py`) does the inner conversion; reuse it for the inflow/outflow part and wrap with `Transaction(**...)` for each txn.
+**Nested reconstruction.** `BlockModel.model_dump()` returns `txns` as `list[dict]`, but `Block` expects `list[Transaction]`. Each of those nested dicts in turn has `inflows`/`outflows` as `list[dict]` that need to become `list[Inflow]` / `list[Outflow]`. The `txn_from_model_data` helper from PR-3 (in `transaction.py`) does the inner conversion; reuse it for the inflow/outflow part and wrap with `Transaction(**...)` for each txn.
 
-Add this private helper near the top of `block.py` (just below `BlockModel`):
+**Important:** PR-3 must expose this helper under a **public** name (`txn_from_model_data`, no leading underscore). The Task 4 (PR-3) plan was updated to use the public name precisely so PR-4 can import it normally at the top of `block.py` — avoiding both `noqa: PLC2701` (private-name import) and `ruff E402` (imports not at top of file).
+
+Add `txn_from_model_data` to `block.py`'s existing top-level `from cancelchain.transaction import Transaction, TransactionModel` line:
 
 ```python
-from cancelchain.transaction import _txn_from_model_data  # noqa: PLC2701
+from cancelchain.transaction import (
+    Transaction,
+    TransactionModel,
+    txn_from_model_data,
+)
+```
 
+Then define `_block_from_model_data` as a module-level helper (also at the top of the file, after the imports — placement is the implementer's call as long as it's not interleaved between imports and class definitions):
 
+```python
 def _block_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
     """Convert a BlockModel.model_dump() dict's txns list from
     list[dict] to list[Transaction] (with nested Inflow/Outflow
@@ -1014,12 +1023,10 @@ def _block_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
     dataclass constructor.
     """
     data['txns'] = [
-        Transaction(**_txn_from_model_data(t)) for t in data.get('txns', [])
+        Transaction(**txn_from_model_data(t)) for t in data.get('txns', [])
     ]
     return data
 ```
-
-If `noqa: PLC2701` (private-name import) feels unclean, an acceptable alternative is to expose `_txn_from_model_data` under a public name (e.g., `txn_from_model_data`) in PR-3 by removing the underscore; that's a one-line plan tweak you can do at implementation time.
 
 Find `Block.from_dict`:
 
@@ -1101,7 +1108,7 @@ uv run pytest
 
 Expected: 177 passed, 1 skipped. Highest-risk tests: `tests/test_block.py` (13 tests including `test_to_dao_partial_block_raises`), `tests/test_chain.py` (24+ tests that exercise blocks end-to-end).
 
-If `model_dump()`-related `AttributeError`s appear (e.g., `'dict' object has no attribute 'outflows'`), confirm `_block_from_model_data` is wired into both `from_dict` and `from_json` and that `_txn_from_model_data` was added in PR-3.
+If `model_dump()`-related `AttributeError`s appear (e.g., `'dict' object has no attribute 'outflows'`), confirm `_block_from_model_data` is wired into both `from_dict` and `from_json` and that `txn_from_model_data` was added in PR-3.
 
 - [ ] **Step 5: Commit**
 
@@ -1219,12 +1226,9 @@ class TransferTxnQuerySchema(Schema):
     address = fields.String(required=True, validate=validate_address_format)
 ```
 
-With (reusing the `*Type` aliases from `schema.py` — `AddressType` runs `_check_address_format`, which is `validate_address_format`; `PublicKeyType` runs `_check_public_key`, which is `validate_public_key`):
+With (reusing the `*Type` aliases from `schema.py` — `AddressType` runs `_check_address_format`, which is `validate_address_format`; `PublicKeyType` runs `_check_public_key`, which is `validate_public_key`; `AddressType` and `PublicKeyType` were already added to the top-level schema import in Step 2):
 
 ```python
-from cancelchain.schema import AddressType, PublicKeyType
-
-
 class TransferTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -139,101 +139,27 @@ uv run python -c "from importlib.metadata import version; print('pydantic', vers
 ```
 Expected: `pydantic 2.10.x` or newer.
 
-- [ ] **Step 4: Rewrite `schema.py`**
+- [ ] **Step 4: Add Pydantic aliases to `schema.py` (additive only)**
 
-Replace the entire contents of `src/cancelchain/schema.py` with:
+**Do NOT replace the file's contents.** PR-1 is fully additive — the existing Marshmallow `Address(fields.String)`, `Base64(fields.String)`, `MillHash(Base64)`, `Timestamp(fields.String)`, `PublicKey(Base64)`, and `SansNoneSchema(Schema)` classes are still used as callable Marshmallow field classes by `payload.py` (`address = Address()`, `outflow_txid = MillHash(required=True)`), `transaction.py`, and `block.py`. Replacing them with Pydantic `Annotated` aliases would break 12+ import-time call sites. The file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive also **stays** in PR-1 — the Marshmallow imports are still here.
+
+Edit `src/cancelchain/schema.py`. Add the `Annotated` import and the `pydantic` imports at the top of the file (alongside the existing Marshmallow imports):
 
 ```python
-from __future__ import annotations
-
-from dataclasses import asdict
 from typing import Annotated, Any
 
 from pydantic import AfterValidator, ValidationError
+```
 
-from cancelchain.exceptions import InvalidKeyError
-from cancelchain.util import iso_2_dt
-from cancelchain.wallet import (
-    ADDRESS_TAG,
-    Wallet,
-    b58decode,
-    b64decode,
-    b64encode,
-)
+Then **append** these blocks to the end of the file (after the existing `PublicKey(Base64)` class definition):
 
-
-def asdict_sans_none(dc: Any) -> dict[str, Any]:
-    return asdict(
-        dc, dict_factory=lambda x: {k: v for (k, v) in x if v is not None}
-    )
-
-
-def validate_address(public_key_b64: str | None, address: str | None) -> bool:
-    try:
-        wallet = Wallet(b64ks=public_key_b64)
-    except InvalidKeyError:
-        return False
-    return bool((wallet is not None) and address == wallet.address)
-
-
-def validate_address_format(address: str) -> bool:
-    try:
-        if (
-            address.startswith(ADDRESS_TAG)
-            and address.endswith(ADDRESS_TAG)
-            and len(
-                b58decode(
-                    address.removeprefix(ADDRESS_TAG).removesuffix(ADDRESS_TAG)
-                )
-            )
-            == 32
-        ):
-            return True
-    except Exception:
-        pass
-    return False
-
-
-def validate_base64(s: str) -> bool:
-    try:
-        return bool(b64encode(b64decode(s)) == s)
-    except Exception:
-        pass
-    return False
-
-
-def validate_public_key(public_key_b64: str) -> bool:
-    try:
-        wallet = Wallet(b64ks=public_key_b64)
-    except InvalidKeyError:
-        return False
-    return wallet is not None and wallet.private_key is None
-
-
-def validate_signature(
-    public_key_b64: str | None,
-    signing_data: bytes,
-    signature: str | None,
-) -> bool:
-    try:
-        wallet = Wallet(b64ks=public_key_b64)
-    except InvalidKeyError:
-        return False
-    if wallet is not None:
-        return bool(wallet.validate_signature(signing_data, signature))
-    return False
-
-
-def validate_timestamp(s: str) -> bool:
-    try:
-        _ = iso_2_dt(s)
-        return True
-    except Exception:
-        pass
-    return False
-
-
-# --- Pydantic v2 custom type aliases ---
+```python
+# --- Pydantic v2 custom type aliases (introduced in Phase 4 / PR-1).
+# Names get a *Type suffix to avoid colliding with the Marshmallow
+# field classes above, which are still used as callables by payload.py,
+# transaction.py, and block.py until PRs 3 and 4 swap them out. PR-6
+# deletes the Marshmallow classes; the *Type aliases are permanent.
+#
 # AfterValidator runs after Pydantic's built-in coercion; the callback
 # either returns the value (possibly transformed) or raises ValueError,
 # which Pydantic wraps into a ValidationError for the caller.
@@ -274,11 +200,11 @@ def _check_public_key(s: str) -> str:
     return s
 
 
-Address = Annotated[str, AfterValidator(_check_address_format)]
-Base64 = Annotated[str, AfterValidator(_check_base64)]
-MillHash = Annotated[str, AfterValidator(_check_mill_hash)]
-Timestamp = Annotated[str, AfterValidator(_check_timestamp)]
-PublicKey = Annotated[str, AfterValidator(_check_public_key)]
+AddressType = Annotated[str, AfterValidator(_check_address_format)]
+Base64Type = Annotated[str, AfterValidator(_check_base64)]
+MillHashType = Annotated[str, AfterValidator(_check_mill_hash)]
+TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
+PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
 
 
 def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
@@ -300,13 +226,11 @@ def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
     return result
 ```
 
-Notes on the rewrite:
-- `SansNoneSchema` class removed (lines 121–126 in original).
-- 5 Marshmallow field subclasses removed (lines 91–118 in original).
-- Marshmallow import removed; `pydantic` import added.
-- All validator functions kept verbatim (they're used by both the new `AfterValidator` callbacks AND by `transaction.py:validate_signature`-style direct calls in PR-3).
-- New `pydantic_errors_to_messages` helper for the Pydantic→Marshmallow-shaped error adapter (used in PRs 3, 4, 5).
-- File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports remain).
+Notes:
+- **The existing Marshmallow `Address`, `Base64`, `MillHash`, `Timestamp`, `PublicKey`, and `SansNoneSchema` classes are untouched.** PR-6 deletes them after PRs 3, 4, 5 have removed every Marshmallow Schema in the codebase.
+- The 5 `*Type` aliases are the new Pydantic types. PRs 2, 3, 4, 5 import them under those names. PR-6 does not rename them.
+- `pydantic_errors_to_messages` adapter is used by PRs 3, 4, 5 at the catch sites that previously caught `marshmallow.ValidationError`.
+- File-level `# mypy: disable-error-code` directive **stays** in this PR (Marshmallow imports remain).
 
 - [ ] **Step 5: Verify mypy + ruff still clean**
 
@@ -315,71 +239,44 @@ uv run mypy
 uv run ruff check src tests
 uv run ruff format --check src tests
 ```
-All three must exit 0.
-
-If `mypy` reports new errors in `schema.py`, they're likely from removing the file-level directive. The most common cause is `validate_signature` calling `wallet.validate_signature(signing_data, signature)` where the wallet path returns `Any` (pycryptodome). If that surfaces, restore the directive narrowed to `"no-any-return"` only:
-```python
-# mypy: disable-error-code="no-any-return"
-```
+All three must exit 0. Because schema.py is purely additive in PR-1, no existing call site is affected — pre-existing mypy/ruff clean state should be preserved.
 
 - [ ] **Step 6: Test suite**
 
 ```bash
 uv run pytest
 ```
-Expected: 177 passed, 1 skipped. The schema.py changes alone shouldn't break tests because no caller is using the new Pydantic types yet — but the removed `SansNoneSchema` class WOULD break callers if any imported it. Verify by grep:
+Expected: 177 passed, 1 skipped. Existing Marshmallow Schemas still resolve their `Address(required=True)` etc. references to the unchanged Marshmallow classes. The new `*Type` aliases have no callers yet — they're inert exports.
 
-```bash
-grep -rn "SansNoneSchema" src/cancelchain/ tests/
-```
-Expected output: the only references are in `payload.py`, `transaction.py`, `block.py`'s import statements. Those will fail tests on this PR. So PR-1 MUST also remove those imports OR PR-1 must keep `SansNoneSchema` as a stub until PR-4.
-
-**Decision: keep `SansNoneSchema` as a no-op `Schema` alias in this PR**, removed in PR-2/3/4 as each file gets converted. Add at the bottom of `schema.py`:
-
-```python
-# Temporary alias for the duration of the Phase 4 migration. Removed
-# in PR-2/3/4 as each downstream file converts to BaseModel.
-from marshmallow import Schema as _MarshmallowSchema
-
-
-class SansNoneSchema(_MarshmallowSchema):
-    """Legacy Marshmallow base — kept only while PR-2/3/4 land."""
-```
-
-This preserves the existing post_dump None-stripping behavior for any file that still uses it during the transition. PR-2/3/4 remove their `SansNoneSchema` import as each one converts.
-
-- [ ] **Step 7: Re-verify tests**
-
-```bash
-uv run pytest
-```
-Expected: 177 passed, 1 skipped.
-
-- [ ] **Step 8: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add pyproject.toml uv.lock src/cancelchain/schema.py
 git commit -m "$(cat <<'EOF'
-feat(deps): pydantic v2 + custom types as Annotated aliases
+feat(deps): add pydantic v2 + Annotated *Type aliases (additive)
 
-Adds pydantic>=2.10 to runtime dependencies. Rewrites schema.py:
+Adds pydantic>=2.10 to runtime dependencies. Adds to schema.py:
 
-- 5 custom Marshmallow field subclasses (Address, Base64, MillHash,
-  Timestamp, PublicKey) become Annotated[str, AfterValidator(...)]
-  type aliases. The existing validator functions (validate_address,
-  validate_base64, etc.) become the AfterValidator callbacks via small
-  _check_* wrappers that raise ValueError on failure (Pydantic re-wraps).
-- Adds pydantic_errors_to_messages helper that converts Pydantic's
+- 5 new Pydantic Annotated[str, AfterValidator(...)] aliases under
+  *Type suffix names (AddressType, Base64Type, MillHashType,
+  TimestampType, PublicKeyType). The Marshmallow Address/Base64/
+  MillHash/Timestamp/PublicKey field classes are NOT touched —
+  payload.py, transaction.py, and block.py still use them as
+  callable field classes (e.g., address = Address(required=True)).
+  PR-6 deletes the Marshmallow classes once PRs 3, 4, 5 have removed
+  every Marshmallow Schema. The *Type suffix is permanent.
+- pydantic_errors_to_messages helper that converts Pydantic's
   list-of-dict ValidationError.errors() to the nested-dict shape
   Marshmallow's e.messages exposes. Used by PRs 3/4/5 at the
   domain-layer catch sites so the downstream api.make_error_response
   and InvalidBlockError({...: e.messages}) wrappers don't see a shape
   change.
-- SansNoneSchema kept as a no-op Marshmallow alias only for the
-  duration of PR-2/3/4 (each removes its own import).
+- SansNoneSchema is unchanged (its @post_dump remove_none_values
+  hook still serves payload.py / transaction.py / block.py
+  Marshmallow Schemas).
 
-File-level # mypy: disable-error-code directive removed (no Marshmallow
-imports remain in schema.py).
+File-level # mypy: disable-error-code directive stays — Marshmallow
+imports remain in schema.py.
 
 Phase 4 / PR 1 of 6.
 
@@ -388,23 +285,22 @@ EOF
 )"
 ```
 
-- [ ] **Step 9: Push and open PR**
+- [ ] **Step 8: Push and open PR**
 
 ```bash
 git push -u origin feat/pydantic-schema-types
-gh pr create --base main --title "feat(deps): pydantic v2 + custom types as Annotated aliases" --body "$(cat <<'EOF'
+gh pr create --base main --title "feat(deps): add pydantic v2 + Annotated *Type aliases (additive)" --body "$(cat <<'EOF'
 ## Summary
 - Adds \`pydantic>=2.10\` to runtime deps.
-- Converts schema.py's 5 custom field subclasses (Address, Base64, MillHash, Timestamp, PublicKey) to \`Annotated[str, AfterValidator(...)]\` aliases.
+- Adds Annotated[str, AfterValidator(...)] aliases under *Type suffix names (AddressType, Base64Type, MillHashType, TimestampType, PublicKeyType).
 - Adds \`pydantic_errors_to_messages\` adapter helper for downstream PRs.
-- Drops the file-level mypy disable directive from schema.py.
-- Keeps \`SansNoneSchema\` as a transitional alias (removed by PR-2/3/4 as each downstream file converts).
+- **Fully additive** — Marshmallow Address/Base64/MillHash/Timestamp/PublicKey and SansNoneSchema are untouched (still used by payload.py / transaction.py / block.py until PRs 3 and 4 swap them out). PR-6 deletes the Marshmallow versions.
 
 Phase 4 / PR 1 of 6. Spec: \`docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md\`.
 
 ## Test plan
 - [x] \`uv run mypy\` exits 0.
-- [x] \`uv run pytest\` passes (177/178).
+- [x] \`uv run pytest\` passes (177/178). schema.py changes are purely additive.
 - [x] \`uv run ruff check\` + \`format --check\` pass.
 - [ ] CI green on 3.12 and 3.13.
 
@@ -413,7 +309,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 10: Stop — controller handles wor + mwg + sync**
+- [ ] **Step 9: Stop — controller handles wor + mwg + sync**
 
 ---
 
@@ -500,7 +396,7 @@ class OutflowModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     amount: int = Field(ge=1)
-    address: Address | None = None
+    address: AddressType | None = None
     subject: SubjectType | None = None
     forgive: SubjectType | None = None
     support: SubjectType | None = None
@@ -523,8 +419,23 @@ class OutflowModel(BaseModel):
 class InflowModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    outflow_txid: MillHash
+    outflow_txid: MillHashType
     outflow_idx: int = Field(ge=0)
+```
+
+The `from cancelchain.schema import Address, MillHash, SansNoneSchema` line above stays unchanged (the Marshmallow `OutflowSchema(SansNoneSchema)` still uses `address = Address()` etc.). The Pydantic models reference `AddressType` and `MillHashType` instead — add them to the schema import:
+
+```python
+# Before:
+from cancelchain.schema import Address, MillHash, SansNoneSchema
+# After:
+from cancelchain.schema import (
+    Address,
+    AddressType,
+    MillHash,
+    MillHashType,
+    SansNoneSchema,
+)
 ```
 
 Notes:
@@ -610,9 +521,21 @@ Edit `src/cancelchain/payload.py`. Delete:
 - The `class OutflowSchema(SansNoneSchema):` definition (including `@validates_schema validate_destinations` and `@post_load make_outflow` methods).
 - The `class InflowSchema(SansNoneSchema):` definition (including `@post_load make_inflow`).
 - The `from marshmallow import (...)` import line.
-- The `from cancelchain.schema import Address, MillHash, SansNoneSchema` line — replace with `from cancelchain.schema import Address, MillHash` (drop `SansNoneSchema`).
+- From the schema import, drop `Address`, `MillHash`, and `SansNoneSchema` (no longer needed — `OutflowModel` / `InflowModel` use `AddressType` / `MillHashType` exclusively):
+  ```python
+  # Before:
+  from cancelchain.schema import (
+      Address,
+      AddressType,
+      MillHash,
+      MillHashType,
+      SansNoneSchema,
+  )
+  # After:
+  from cancelchain.schema import AddressType, MillHashType
+  ```
 
-Rename the `SubjectType` alias to `Subject`:
+Rename the local `SubjectType` alias to `Subject` now that the Marshmallow `Subject(fields.String)` is gone:
 ```python
 # Before:
 SubjectType = Annotated[str, AfterValidator(_check_subject)]
@@ -662,11 +585,11 @@ from cancelchain.models import (
 )
 from cancelchain.payload import Inflow, InflowModel, Outflow, OutflowModel
 from cancelchain.schema import (
-    Address,
-    Base64,
-    MillHash,
-    PublicKey,
-    Timestamp,
+    AddressType,
+    Base64Type,
+    MillHashType,
+    PublicKeyType,
+    TimestampType,
     asdict_sans_none,
     pydantic_errors_to_messages,
     validate_address,
@@ -683,11 +606,11 @@ ADDRESS_MISMATCH_MSG = 'Address/public key mismatch'
 class TransactionModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    timestamp: Timestamp
-    txid: MillHash
-    address: Address
-    public_key: PublicKey
-    signature: Base64 | None = None
+    timestamp: TimestampType
+    txid: MillHashType
+    address: AddressType
+    public_key: PublicKeyType
+    signature: Base64Type | None = None
     inflows: Annotated[
         list[InflowModel], Field(min_length=0, max_length=MAX_FLOWS)
     ]
@@ -719,8 +642,7 @@ class CoinbaseTransactionModel(TransactionModel):
 ```
 
 Notes:
-- Import block reorganized: Marshmallow removed; `pydantic.ValidationError` added; `Annotated`, `Literal`, `Self` to typing; payload imports updated to `InflowModel`, `OutflowModel`; schema imports add `pydantic_errors_to_messages`.
-- `Address`, `Base64`, `MillHash`, `PublicKey`, `Timestamp`, `SansNoneSchema` imports updated to drop `SansNoneSchema`.
+- Import block reorganized: Marshmallow removed; `pydantic.ValidationError` added; `Annotated`, `Literal`, `Self` to typing; payload imports updated to `InflowModel`, `OutflowModel`; schema imports switched to the `*Type` Pydantic aliases plus `pydantic_errors_to_messages`.
 - File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports).
 
 - [ ] **Step 4: Update call sites in `transaction.py`**
@@ -975,8 +897,8 @@ from cancelchain.exceptions import (
 from cancelchain.milling import mill_hash_str, milling_generator
 from cancelchain.models import BlockDAO
 from cancelchain.schema import (
-    MillHash,
-    Timestamp,
+    MillHashType,
+    TimestampType,
     asdict_sans_none,
     pydantic_errors_to_messages,
 )
@@ -998,12 +920,12 @@ class BlockModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     idx: int = Field(ge=0)
-    timestamp: Timestamp
-    block_hash: MillHash
-    prev_hash: MillHash
-    target: MillHash
+    timestamp: TimestampType
+    block_hash: MillHashType
+    prev_hash: MillHashType
+    target: MillHashType
     proof_of_work: int = Field(ge=0)
-    merkle_root: MillHash
+    merkle_root: MillHashType
     txns: Annotated[
         list[TransactionModel],
         Field(min_length=1, max_length=MAX_TRANSACTIONS),
@@ -1268,59 +1190,21 @@ class TransferTxnQuerySchema(Schema):
     address = fields.String(required=True, validate=validate_address_format)
 ```
 
-With:
+With (reusing the `*Type` aliases from `schema.py` — `AddressType` runs `_check_address_format`, which is `validate_address_format`; `PublicKeyType` runs `_check_public_key`, which is `validate_public_key`):
 
 ```python
-def _check_address_format_local(s: str) -> str:
-    if not validate_address_format(s):
-        msg = f'Invalid address format: {s!r}'
-        raise ValueError(msg)
-    return s
-
-
-def _check_public_key_local(s: str) -> str:
-    if not validate_public_key(s):
-        msg = f'Invalid public key: {s!r}'
-        raise ValueError(msg)
-    return s
-
-
-_PublicKeyField = Annotated[str, AfterValidator(_check_public_key_local)]
-_AddressFormatField = Annotated[
-    str, AfterValidator(_check_address_format_local)
-]
+from cancelchain.schema import AddressType, PublicKeyType
 
 
 class TransferTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    public_key: _PublicKeyField
+    public_key: PublicKeyType
     amount: int = Field(ge=1)
-    address: _AddressFormatField
+    address: AddressType
 ```
 
-Notes:
-- The query schemas use `validate_address_format` (different from `validate_address` which checks pk⇔address match). The custom `_AddressFormatField` reflects that.
-- The `_PublicKeyField` here matches the existing `validate_public_key` behavior in the query context, which is structurally identical to `schema.PublicKey` BUT uses a different validator path — keep them parallel.
-
-Alternative (cleaner): reuse `schema.PublicKey`. But that runs through `validate_public_key(public_key_b64)` which expects a full b64-encoded key. The query schema validates `public_key=...` from URL args which is also a b64 string. So they ARE the same. Use `schema.PublicKey` directly:
-
-```python
-from cancelchain.schema import Address as _AddressType
-from cancelchain.schema import PublicKey as _PublicKeyType
-
-# Note: `schema.Address` validates the CC-tagged address format, which
-# is what `validate_address_format` does here. Reuse.
-
-class TransferTxnQueryModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    public_key: _PublicKeyType
-    amount: int = Field(ge=1)
-    address: _AddressType
-```
-
-**Final decision: reuse `schema.Address` and `schema.PublicKey`** to avoid type duplication. Verify `schema.Address`'s `_check_address_format` matches the existing `validate_address_format` validator — yes, both run `validate_address_format(s)`. Same for `schema.PublicKey` ↔ `validate_public_key`.
+Note: the query schemas use `validate_address_format` (different from `validate_address`, which checks pk⇔address match). `schema.AddressType` runs exactly `validate_address_format` — same validator, reused.
 
 - [ ] **Step 4: Replace `SubjectTxnQuerySchema` (around line 405)**
 
@@ -1349,7 +1233,7 @@ _RawSubjectField = Annotated[str, AfterValidator(_check_raw_subject)]
 class SubjectTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    public_key: _PublicKeyType
+    public_key: PublicKeyType
     amount: int = Field(ge=1)
     subject: _RawSubjectField
 ```
@@ -1468,7 +1352,7 @@ feat(deps): API query schemas → Pydantic v2
 Replaces the 3 Marshmallow query schemas with Pydantic models:
 
 - TransferTxnQuerySchema → TransferTxnQueryModel (reuses
-  schema.Address and schema.PublicKey custom types).
+  schema.AddressType and schema.PublicKeyType custom types).
 - SubjectTxnQuerySchema → SubjectTxnQueryModel (with local raw-subject
   validator).
 - PendingTxnQuerySchema → PendingTxnQueryModel (with
@@ -1521,13 +1405,13 @@ EOF
 
 ---
 
-## Task 7: PR-6 — Remove `marshmallow` from runtime dependencies
+## Task 7: PR-6 — Delete Marshmallow classes and the `marshmallow` dependency
 
 **Files:**
+- Modify: `src/cancelchain/schema.py` (delete the now-orphaned Marshmallow classes)
 - Modify: `pyproject.toml`
-- Possibly modify: `src/cancelchain/schema.py` (remove the transitional `SansNoneSchema` alias if PR-1 left it)
-- Possibly modify: `src/cancelchain/transaction.py` (verify directive removal — should already be done in PR-3)
-- Possibly modify: `src/cancelchain/models.py` (review only — directive there is for `db.Model`, not marshmallow)
+- Verify: `src/cancelchain/transaction.py`, `src/cancelchain/payload.py`, `src/cancelchain/block.py` (file-level mypy directives — PR-3/PR-4 already removed them)
+- Don't touch: `src/cancelchain/models.py` (its mypy directive covers SA `db.Model` Any leaks, unrelated to Marshmallow; Phase 6 revisits)
 
 - [ ] **Step 1: Branch off main**
 
@@ -1536,15 +1420,36 @@ git checkout main && git pull --ff-only
 git checkout -b chore/remove-marshmallow
 ```
 
-- [ ] **Step 2: Verify no Marshmallow imports remain**
+- [ ] **Step 2: Confirm no Marshmallow imports remain outside `schema.py`**
 
 ```bash
 grep -rn "marshmallow\|Marshmallow" src/cancelchain/
 ```
 
-Expected: no matches. If `schema.py` still has the transitional `SansNoneSchema` alias from PR-1 (the `from marshmallow import Schema as _MarshmallowSchema`), remove it now.
+Expected: matches only inside `schema.py` itself (the Marshmallow `Address(fields.String)`, `Base64(fields.String)`, `MillHash(Base64)`, `Timestamp(fields.String)`, `PublicKey(Base64)`, and `SansNoneSchema(Schema)` classes plus their `from marshmallow import ...` line). All other source files should be Marshmallow-free.
 
-- [ ] **Step 3: Edit `pyproject.toml`**
+- [ ] **Step 3: Delete the Marshmallow classes from `schema.py`**
+
+Edit `src/cancelchain/schema.py`. Delete:
+- The `from marshmallow import Schema, fields, post_dump, validate` line.
+- The `class Address(fields.String):` block.
+- The `class Base64(fields.String):` block.
+- The `class MillHash(Base64):` block.
+- The `class Timestamp(fields.String):` block.
+- The `class PublicKey(Base64):` block.
+- The `class SansNoneSchema(Schema):` block (including its `@post_dump remove_none_values` method).
+- The file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive at the top of the file (the suppressions covered Marshmallow Any leaks, which no longer apply).
+
+Keep everything else:
+- The `asdict_sans_none` utility.
+- The validator functions (`validate_address`, `validate_address_format`, `validate_base64`, `validate_public_key`, `validate_signature`, `validate_timestamp`).
+- The `_check_*` Pydantic wrappers.
+- The `AddressType`, `Base64Type`, `MillHashType`, `TimestampType`, `PublicKeyType` Annotated aliases (no rename — `*Type` suffix is permanent).
+- The `pydantic_errors_to_messages` adapter.
+
+After this edit, `schema.py` imports only from `dataclasses`, `typing`, `pydantic`, and `cancelchain.*` (no Marshmallow).
+
+- [ ] **Step 4: Edit `pyproject.toml`**
 
 Remove the line:
 ```toml
@@ -1589,18 +1494,24 @@ All must exit 0.
 ```bash
 git add pyproject.toml uv.lock src/cancelchain/schema.py
 git commit -m "$(cat <<'EOF'
-chore(deps): remove marshmallow from runtime dependencies
+chore(deps): delete Marshmallow classes and remove the runtime dep
 
-After PRs 1-5 swapped every Marshmallow Schema for a Pydantic v2
-BaseModel, no source code under src/cancelchain/ imports marshmallow.
-This PR finishes the migration:
+After PRs 1-5 swapped every Marshmallow Schema in src/cancelchain/
+for a Pydantic v2 BaseModel, the Marshmallow Address(fields.String),
+Base64(fields.String), MillHash(Base64), Timestamp(fields.String),
+PublicKey(Base64), and SansNoneSchema(Schema) classes in schema.py
+became orphans. This PR:
 
-- Removes \`marshmallow>=3.19\` from [project.dependencies].
+- Deletes those 6 Marshmallow classes from schema.py and the
+  from marshmallow import Schema, fields, post_dump, validate line.
+- Drops the file-level # mypy: disable-error-code directive from
+  schema.py (no Marshmallow Any leaks remain to suppress).
+- Removes marshmallow>=3.19 from [project.dependencies].
 - Removes [[tool.mypy.overrides]] module = ["marshmallow", "marshmallow.*"].
-- Removes the transitional SansNoneSchema alias from schema.py (if PR-1
-  added one).
 
-uv lock regenerated; marshmallow no longer in uv.lock.
+The Pydantic *Type aliases (AddressType, Base64Type, MillHashType,
+TimestampType, PublicKeyType) and the validator functions are kept
+unchanged. uv lock regenerated; marshmallow no longer in uv.lock.
 
 Phase 4 / PR 6 of 6 (final PR of Phase 4).
 
@@ -1613,11 +1524,12 @@ EOF
 
 ```bash
 git push -u origin chore/remove-marshmallow
-gh pr create --base main --title "chore(deps): remove marshmallow from runtime dependencies" --body "$(cat <<'EOF'
+gh pr create --base main --title "chore(deps): delete Marshmallow classes and remove the runtime dep" --body "$(cat <<'EOF'
 ## Summary
-- Removes \`marshmallow>=3.19\` from \`[project.dependencies]\`.
-- Removes the \`[[tool.mypy.overrides]]\` block for \`marshmallow.*\`.
-- Removes the transitional \`SansNoneSchema\` alias from \`schema.py\` (if PR-1 left one).
+- Deletes 6 Marshmallow classes from \`schema.py\` (\`Address\`, \`Base64\`, \`MillHash\`, \`Timestamp\`, \`PublicKey\`, \`SansNoneSchema\`) along with the \`from marshmallow import ...\` line. All callers were retired by PRs 3 / 4 / 5.
+- Drops the file-level mypy disable directive from \`schema.py\`.
+- Removes \`marshmallow>=3.19\` from \`[project.dependencies]\` and the \`[[tool.mypy.overrides]]\` block for \`marshmallow.*\`.
+- The Pydantic \`*Type\` aliases stay (no rename to bare names).
 - \`uv lock\` regenerated; \`marshmallow\` no longer in \`uv.lock\`.
 
 Phase 4 / PR 6 of 6 (final PR).

--- a/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
+++ b/docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md
@@ -128,7 +128,7 @@ Expected: new branch from latest main (head should be the docs PR's squash commi
 
 - [ ] **Step 2: Add `pydantic>=2.10` to runtime dependencies**
 
-Edit `pyproject.toml`. In `[project] dependencies`, insert `"pydantic>=2.10",` in alphabetical position (between `pyjwt` and `pymerkle`).
+Edit `pyproject.toml`. In `[project] dependencies`, insert `"pydantic>=2.10",` in alphabetical position — between `"pycryptodome>=3.20"` and `"pyjwt>=2.9"` (pycryptodome < pydantic < pyjwt).
 
 - [ ] **Step 3: Lock and install**
 
@@ -417,12 +417,14 @@ EOF
 
 ---
 
-## Task 3: PR-2 — `payload.py` schemas
+## Task 3: PR-2 — `payload.py` schemas (additive)
 
 **Files:**
 - Modify: `src/cancelchain/payload.py`
 
-Replace `OutflowSchema` and `InflowSchema` (Marshmallow) with `OutflowModel` and `InflowModel` (Pydantic). The `Outflow` and `Inflow` `@dataclass` definitions are unchanged. The `Subject` custom field becomes an `Annotated` alias local to this file.
+**This PR adds Pydantic models alongside the existing Marshmallow schemas — it does NOT delete the Marshmallow versions.** The Marshmallow `OutflowSchema`, `InflowSchema`, and `Subject(fields.String)` classes stay in place because `TransactionSchema.outflows = fields.List(fields.Nested(OutflowSchema), ...)` in `transaction.py` still needs them — `fields.Nested` requires a Marshmallow `Schema` subclass and cannot bridge to a Pydantic `BaseModel`. PR-3 swaps `TransactionSchema` to `TransactionModel` AND deletes the Marshmallow `OutflowSchema` / `InflowSchema` / `Subject` in the same commit.
+
+To avoid a name collision with the existing Marshmallow `Subject(fields.String)`, the new Pydantic subject alias is named **`SubjectType`** in this PR. PR-3 deletes the Marshmallow `Subject` class and renames `SubjectType` → `Subject` in the same commit.
 
 - [ ] **Step 1: Branch off main**
 
@@ -431,17 +433,39 @@ git checkout main && git pull --ff-only
 git checkout -b feat/pydantic-payload
 ```
 
-- [ ] **Step 2: Rewrite `payload.py`**
+- [ ] **Step 2: Add new imports at the top of `payload.py`**
 
-Replace the entire contents of `src/cancelchain/payload.py` with:
+The existing imports look like:
+```python
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from dataclasses import dataclass
+from typing import Any
+
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates_schema,
+)
+
+from cancelchain.schema import Address, MillHash, SansNoneSchema
+```
+
+Add `Annotated` and `Self` to the typing import, and add the Pydantic block alongside (do NOT remove the Marshmallow imports):
 
 ```python
-from __future__ import annotations
-
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
 from typing import Annotated, Any, Self
 
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates_schema,
+)
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -450,181 +474,17 @@ from pydantic import (
     model_validator,
 )
 
-from cancelchain.schema import Address, MillHash
-
-MIN_SUBJECT_LENGTH = 1
-MAX_SUBJECT_LENGTH = 79
-INVALID_DESTINATION_MSG = 'Invalid destinations'
-INVALID_PADDING_MSG = 'Invalid padding'
-
-
-def encode_subject(raw_subject: str) -> str:
-    return urlsafe_b64encode(raw_subject.encode()).rstrip(b'=').decode()
-
-
-def decode_subject(subject: str) -> str:
-    if subject.endswith('='):
-        raise TypeError(INVALID_PADDING_MSG)
-    subject_bytes = subject.encode()
-    subject_bytes += b'=' * (-len(subject_bytes) % 4)
-    return urlsafe_b64decode(subject_bytes).decode()
-
-
-def validate_subject(subject: str) -> bool:
-    try:
-        raw_subject = decode_subject(subject)
-        if MIN_SUBJECT_LENGTH <= len(raw_subject) <= MAX_SUBJECT_LENGTH:
-            return encode_subject(raw_subject) == subject
-    except Exception:
-        pass
-    return False
-
-
-def validate_raw_subject(raw_subject: str) -> bool:
-    try:
-        if MIN_SUBJECT_LENGTH <= len(raw_subject) <= MAX_SUBJECT_LENGTH:
-            return decode_subject(encode_subject(raw_subject)) == raw_subject
-    except Exception:
-        pass
-    return False
-
-
-def _check_subject(s: str) -> str:
-    if not validate_subject(s):
-        msg = f'Invalid subject: {s!r}'
-        raise ValueError(msg)
-    return s
-
-
-Subject = Annotated[str, AfterValidator(_check_subject)]
-
-
-class OutflowModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    amount: int = Field(ge=1)
-    address: Address | None = None
-    subject: Subject | None = None
-    forgive: Subject | None = None
-    support: Subject | None = None
-
-    @model_validator(mode='after')
-    def validate_destinations(self) -> Self:
-        options = [
-            v
-            for v in (self.subject, self.forgive, self.support)
-            if v is not None
-        ]
-        if not (
-            (self.address and not options)
-            or (options and len(options) == 1 and not self.address)
-        ):
-            raise ValueError(INVALID_DESTINATION_MSG)
-        return self
-
-
-@dataclass
-class Outflow:
-    amount: int | None = None
-    address: str | None = None
-    subject: str | None = None
-    forgive: str | None = None
-    support: str | None = None
-
-    @property
-    def data_csv(self) -> str:
-        return ','.join(
-            [
-                str(self.amount),
-                self.address if self.address is not None else '',
-                self.subject if self.subject is not None else '',
-                self.forgive if self.forgive is not None else '',
-                self.support if self.support is not None else '',
-            ]
-        )
-
-    @property
-    def schadenfreude(self) -> int:
-        if self.subject is not None and self.amount is not None:
-            return int(self.amount / 2)
-        return 0
-
-    @property
-    def grace(self) -> int:
-        if self.forgive is not None and self.amount is not None:
-            return int(self.amount / 2)
-        return 0
-
-    @property
-    def mudita(self) -> int:
-        if self.support is not None and self.amount is not None:
-            return self.amount
-        return 0
-
-
-class InflowModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    outflow_txid: MillHash
-    outflow_idx: int = Field(ge=0)
-
-
-@dataclass
-class Inflow:
-    outflow_txid: str | None = None
-    outflow_idx: int | None = None
-
-    @property
-    def data_csv(self) -> str:
-        return ','.join([str(self.outflow_txid), str(self.outflow_idx)])
+from cancelchain.schema import Address, MillHash, SansNoneSchema
 ```
 
-Notes:
-- `OutflowSchema` → `OutflowModel`; `InflowSchema` → `InflowModel`.
-- `Subject(fields.String)` → `Subject = Annotated[str, AfterValidator(_check_subject)]`.
-- `@validates_schema validate_destinations` → `@model_validator(mode='after')` operating on `self` instead of `data`.
-- `@post_load make_outflow` / `make_inflow` removed — callers in PR-3 do `Outflow(**OutflowModel.model_validate(d).model_dump())`.
-- `SansNoneSchema` import removed (file no longer uses it).
-- File-level `# mypy: disable-error-code` directive removed (no Marshmallow imports remain).
-- `Outflow` / `Inflow` dataclasses unchanged.
+- [ ] **Step 3: Append the Pydantic models at the end of `payload.py`**
 
-- [ ] **Step 3: Verify**
-
-```bash
-uv run mypy
-uv run ruff check src tests
-uv run ruff format --check src tests
-uv run pytest
-```
-
-Expected: tests still 177 passed, 1 skipped. The other files (`transaction.py`, `block.py`) still import `OutflowSchema`/`InflowSchema` — that import will fail at module load. So at this point those files need updating, OR we keep transitional aliases.
-
-**Decision: add transitional aliases at the bottom of `payload.py` and remove them in PR-3:**
+After the existing `Inflow` dataclass at the bottom of the file, add:
 
 ```python
-# Temporary aliases for the duration of the Phase 4 migration.
-# PR-3 (transaction.py) drops the OutflowSchema/InflowSchema imports.
-OutflowSchema = OutflowModel
-InflowSchema = InflowModel
-```
+# --- Pydantic v2 models (used by PR-3 onwards). The Marshmallow
+# Schemas above stay in place until PR-3 swaps transaction.py.
 
-This makes the existing `from cancelchain.payload import InflowSchema, OutflowSchema` in `transaction.py` continue to resolve, but the value is now a Pydantic model. Any code that calls `.load()`, `.loads()`, `.dumps()`, etc. will fail — but those calls are only in `transaction.py`'s `TransactionSchema.outflows = fields.List(fields.Nested(OutflowSchema), ...)` and `block.py`'s analogous lines. `fields.Nested` accepts a Marshmallow `Schema` class, not a Pydantic `BaseModel`, so this WILL break.
-
-**Better decision: instead of trying to keep dual compatibility, this PR MUST also be the one that breaks the transaction.py/block.py imports — meaning PR-2 and PR-3 should land together.**
-
-Re-scope: **PR-2 just adds `OutflowModel`/`InflowModel` as NEW names; keep `OutflowSchema`/`InflowSchema` as Marshmallow Schemas for now.** PR-3 swaps `transaction.py`'s `TransactionSchema` to use `OutflowModel`/`InflowModel` in `fields.Nested` — wait, that still doesn't work because Marshmallow's `fields.Nested` requires a Marshmallow Schema.
-
-The fundamental issue: nested schemas can't bridge Marshmallow ↔ Pydantic. So PR-2 must keep `OutflowSchema`/`InflowSchema` working as Marshmallow Schemas (because PR-3 still uses them), and the actual `OutflowModel`/`InflowModel` get introduced as new classes that don't get used until PR-3.
-
-**Final decision: PR-2 ADDS `OutflowModel`/`InflowModel` alongside the existing `OutflowSchema`/`InflowSchema`. No deletion of the Marshmallow classes in PR-2; that happens in PR-3 when `transaction.py` switches.**
-
-Revised plan for Step 2: rewrite `payload.py` to KEEP the existing Marshmallow `OutflowSchema`/`InflowSchema` AND ADD new `OutflowModel`/`InflowModel`. Both work; nothing breaks. PR-3 deletes the Marshmallow classes in the same commit it swaps `transaction.py`.
-
-Replace Step 2 above with: **append to existing `src/cancelchain/payload.py` (keep the existing OutflowSchema, InflowSchema, Subject(fields.String) intact)**, adding only:
-
-```python
-# --- Pydantic v2 models (used by PR-3 onwards). Marshmallow Schemas
-# above are kept until PR-3 swaps transaction.py.
 
 def _check_subject(s: str) -> str:
     if not validate_subject(s):
@@ -667,24 +527,12 @@ class InflowModel(BaseModel):
     outflow_idx: int = Field(ge=0)
 ```
 
-Top-of-file imports get the additions:
-```python
-from typing import Annotated, Any, Self
+Notes:
+- Marshmallow `OutflowSchema`, `InflowSchema`, `Subject(fields.String)`, `SansNoneSchema` import are all **kept** — PR-3 deletes them.
+- `SubjectType` is named with the `Type` suffix to avoid colliding with the existing Marshmallow `Subject(fields.String)` class. PR-3 renames it to `Subject` once the Marshmallow class is gone.
+- The file-level `# mypy: disable-error-code` directive **stays** in this PR (Marshmallow imports still present). PR-3 removes it.
 
-from pydantic import (
-    AfterValidator,
-    BaseModel,
-    ConfigDict,
-    Field,
-    model_validator,
-)
-
-from cancelchain.schema import Address, MillHash
-```
-
-`SubjectType` (renamed from `Subject` to avoid collision with the existing Marshmallow `Subject(fields.String)` class — PR-3 drops the Marshmallow `Subject` and we can rename `SubjectType` → `Subject` then).
-
-- [ ] **Step 4: Test suite**
+- [ ] **Step 4: Verify and test**
 
 ```bash
 uv run pytest
@@ -924,6 +772,21 @@ Replace with:
         )
 ```
 
+**Nested reconstruction is required for `from_dict` and `from_json`.** `TransactionModel.model_dump()` returns `inflows`/`outflows` as `list[dict]`, but the `Transaction` dataclass expects `list[Inflow]` / `list[Outflow]`. Marshmallow's `@post_load` cascade did the conversion implicitly; Pydantic does not, so we do it explicitly with a private helper.
+
+Add this helper near the top of the file (just below the `*Model` class definitions):
+
+```python
+def _txn_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert a TransactionModel.model_dump() dict's nested lists from
+    list[dict] to list[Inflow] / list[Outflow] before passing to the
+    Transaction dataclass constructor.
+    """
+    data['inflows'] = [Inflow(**i) for i in data.get('inflows', [])]
+    data['outflows'] = [Outflow(**o) for o in data.get('outflows', [])]
+    return data
+```
+
 Find `Transaction.from_dict`:
 
 ```python
@@ -946,7 +809,7 @@ Replace with:
             raise InvalidTransactionError(
                 pydantic_errors_to_messages(e)
             ) from e
-        return cls(**model.model_dump())
+        return cls(**_txn_from_model_data(model.model_dump()))
 ```
 
 Find `Transaction.from_json`:
@@ -975,8 +838,10 @@ Replace with:
             ) from e
         except JSONDecodeError as e:
             raise InvalidTransactionError(str(e)) from e
-        return cls(**model.model_dump())
+        return cls(**_txn_from_model_data(model.model_dump()))
 ```
+
+Without the `_txn_from_model_data` step, `Transaction.inflows[0].outflow_txid` would raise `AttributeError` because the elements are plain dicts, not `Inflow` instances. Block-level reconstruction (PR-4) imports this helper too — see Task 5 Step 4.
 
 - [ ] **Step 5: Verify**
 
@@ -1195,6 +1060,28 @@ Replace with:
         )
 ```
 
+**Nested reconstruction.** `BlockModel.model_dump()` returns `txns` as `list[dict]`, but `Block` expects `list[Transaction]`. Each of those nested dicts in turn has `inflows`/`outflows` as `list[dict]` that need to become `list[Inflow]` / `list[Outflow]`. The `_txn_from_model_data` helper from PR-3 (in `transaction.py`) does the inner conversion; reuse it for the inflow/outflow part and wrap with `Transaction(**...)` for each txn.
+
+Add this private helper near the top of `block.py` (just below `BlockModel`):
+
+```python
+from cancelchain.transaction import _txn_from_model_data  # noqa: PLC2701
+
+
+def _block_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert a BlockModel.model_dump() dict's txns list from
+    list[dict] to list[Transaction] (with nested Inflow/Outflow
+    instances already reconstructed) before passing to the Block
+    dataclass constructor.
+    """
+    data['txns'] = [
+        Transaction(**_txn_from_model_data(t)) for t in data.get('txns', [])
+    ]
+    return data
+```
+
+If `noqa: PLC2701` (private-name import) feels unclean, an acceptable alternative is to expose `_txn_from_model_data` under a public name (e.g., `txn_from_model_data`) in PR-3 by removing the underscore; that's a one-line plan tweak you can do at implementation time.
+
 Find `Block.from_dict`:
 
 ```python
@@ -1217,7 +1104,7 @@ Replace with:
             raise InvalidBlockError(
                 pydantic_errors_to_messages(e)
             ) from e
-        return cls(**model.model_dump())
+        return cls(**_block_from_model_data(model.model_dump()))
 ```
 
 Find `Block.from_json`:
@@ -1246,8 +1133,23 @@ Replace with:
             ) from e
         except JSONDecodeError as e:
             raise InvalidBlockError(str(e)) from e
-        return cls(**model.model_dump())
+        return cls(**_block_from_model_data(model.model_dump()))
 ```
+
+Also update the test at `tests/test_block.py:158` — Pydantic phrases the txn-overflow violation differently:
+
+```python
+# Before:
+with pytest.raises(
+    InvalidBlockError, match='Length must be between 1 and 100'
+):
+# After:
+with pytest.raises(
+    InvalidBlockError, match='List should have at most 100 items'
+):
+```
+
+Plus any other Marshmallow-specific message assertions surfaced by the test run (see the spec's "Test-message risk" note). Run pytest first and fix message matches one at a time.
 
 - [ ] **Step 4: Verify**
 
@@ -1260,33 +1162,7 @@ uv run pytest
 
 Expected: 177 passed, 1 skipped. Highest-risk tests: `tests/test_block.py` (13 tests including `test_to_dao_partial_block_raises`), `tests/test_chain.py` (24+ tests that exercise blocks end-to-end).
 
-The `model_dump()` call on a `BlockModel` produces a dict with `txns: list[dict]` (nested `TransactionModel` dumps). The `cls(**model.model_dump())` call passes those nested dicts to `Block.__init__`, which expects `txns: list[Transaction]`. Verify by looking at the original `BlockSchema.@post_load make_block`:
-
-```python
-@post_load
-def make_block(self, data: dict[str, Any], **kwargs: Any) -> Block:
-    return Block(**data)
-```
-
-The original did the same — `Block(**data)` with `data['txns']` being a `list[Transaction]` because Marshmallow's `@post_load` cascades up through `@post_load make_transaction` (which converts each nested dict to a `Transaction`).
-
-With Pydantic, `model.model_dump()` returns plain dicts — `txns` becomes `list[dict]`, not `list[Transaction]`. So `cls(**model.model_dump())` passes `txns=list[dict]` to `Block.__init__`, which won't construct `Transaction` instances.
-
-**Fix:** in `Block.from_dict` and `Block.from_json`, manually convert nested txns:
-
-```python
-@classmethod
-def from_dict(cls, d: dict[str, Any]) -> Self:
-    try:
-        model = BlockModel.model_validate(d)
-    except ValidationError as e:
-        raise InvalidBlockError(pydantic_errors_to_messages(e)) from e
-    data = model.model_dump()
-    data['txns'] = [Transaction(**t) for t in data['txns']]
-    return cls(**data)
-```
-
-Same adjustment in `Block.from_json`. Apply both before Step 5.
+If `model_dump()`-related `AttributeError`s appear (e.g., `'dict' object has no attribute 'outflows'`), confirm `_block_from_model_data` is wired into both `from_dict` and `from_json` and that `_txn_from_model_data` was added in PR-3.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -27,7 +27,7 @@ Concretely: after Phase 4, `[project.dependencies]` no longer contains `marshmal
 - **Scope: Path B (swap-in-place).** Considered Path A (replace dataclasses with `BaseModel`) and Path C (`pydantic.dataclasses.dataclass`); both conflict with the staged-construction lifecycle the domain types use. Path B is the minimum scope change that achieves the stated Phase 4 goal.
 - **PR strategy: bottom-up by dependency.** 6 PRs in `schema → payload → transaction → block → api → cleanup` order. Each PR is self-contained — no long-lived dual implementations.
 - **Pydantic version: `>=2.10`**. Pydantic v2.10 (2024-Q4) added the model-validator return-type contract and `Annotated[..., AfterValidator(...)]` ergonomics this design relies on.
-- **`@post_load` removal.** Marshmallow's `@post_load` makes `Schema().load(d)` return a domain instance. Pydantic v2 doesn't have a clean equivalent (a `@model_validator(mode='after')` that returns a different type would be confusing). Callers do the conversion explicitly: `Transaction(**TransactionModel.model_validate(d).model_dump())`. 3-4 call sites total; the explicit conversion clarifies the boundary.
+- **`@post_load` removal.** Marshmallow's `@post_load` makes `Schema().load(d)` return a domain instance. Pydantic v2 doesn't have a clean equivalent (a `@model_validator(mode='after')` that returns a different type would be confusing). Callers do the conversion explicitly. **Important:** when the model has nested-list fields (`inflows`, `outflows`, `txns`), `model_dump()` returns those as `list[dict]` — they need explicit reconstruction into `Inflow` / `Outflow` / `Transaction` dataclasses before being passed to the outer constructor. PR-3 introduces a `_txn_from_model_data` helper for this; PR-4 wraps it for the Block case. See the PR-3 and PR-4 sections below for the concrete patterns.
 - **`SansNoneSchema` retirement.** The "drop None on dump" behavior moves to the call site via `model.model_dump(exclude_none=True)` where needed; the existing `asdict_sans_none(dc)` utility (for dataclass `.to_dict()`) is unchanged.
 - **No long-lived parallel Marshmallow + Pydantic.** Each PR swaps its file's Schema(s) for Model(s) in one step; the file goes from "all Marshmallow" to "all Pydantic" in one commit. No transient "both work" gap.
 
@@ -298,10 +298,10 @@ try:
         request.args.to_dict(flat=True)
     ).model_dump(exclude_none=True)
 except ValidationError as e:
-    abort(make_error_response(e))
+    return make_error_response(_pydantic_validation_error(e))
 ```
 
-The `request.args.to_dict(flat=True)` flattens the `MultiDict` to a plain dict (each key's first value). None of the existing query schemas have list-valued fields (verified by grep), so flattening is safe.
+This matches the existing `return make_error_response(err)` pattern in `api.py` (the function expects an object with a `.messages` attribute, which is why we hand it the small `_pydantic_validation_error(e)` adapter — see PR-5 plan task for the helper definition). `request.args.to_dict(flat=True)` flattens the `MultiDict` to a plain dict (each key's first value). None of the existing query schemas have list-valued fields (verified by grep), so flattening is safe.
 
 For `PendingTxnQueryModel.earliest` (originally `fields.Function(serialize=lambda o: dt_2_ciso(o.earliest), deserialize=ciso_2_dt)`):
 
@@ -323,7 +323,7 @@ class PendingTxnQueryModel(BaseModel):
 
 The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs `dt_2_ciso` on output. Same parse/format symmetry as `fields.Function` provided.
 
-`make_error_response(e)` is the existing api.py helper. It currently expects a `marshmallow.ValidationError` with `.messages`. Update it (or add a sibling) to format Pydantic `ValidationError.errors()` output into the same response shape.
+`make_error_response(err)` is the existing api.py helper. It expects an object with a `.messages` attribute. Rather than modifying `make_error_response`, PR-5 introduces a small `_pydantic_validation_error(e)` adapter that wraps a Pydantic `ValidationError` into an object with `.messages = pydantic_errors_to_messages(e)`. Same response shape; no Marshmallow API surface inside `api.py`.
 
 **Acceptance:** API endpoint tests pass; query-parameter validation rejects bad inputs with the same status codes (400) as before.
 

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -1,0 +1,450 @@
+# Phase 4 — Marshmallow → Pydantic v2
+
+**Status:** Draft for review
+**Date:** 2026-05-25
+**Scope:** Replace the Marshmallow-based validation and serialization layer with Pydantic v2. The dataclass domain layer (`Block`, `Transaction`, `Outflow`, `Inflow`, `Chain`) is unchanged; only the `Schema` subclasses get rewritten as `BaseModel` subclasses. After Phase 4, `marshmallow` is no longer a runtime dependency and Phase 3's Marshmallow-related mypy workarounds come out.
+
+## Goal
+
+Modernize the validation/serialization layer onto Pydantic v2, the de-facto Python standard for typed data validation. Removes a runtime dependency, eliminates the untyped-boundary leaks that forced file-level `# mypy: disable-error-code` directives in `schema.py` and `transaction.py`, and aligns the project with the broader Python ecosystem.
+
+Concretely: after Phase 4, `[project.dependencies]` no longer contains `marshmallow`, `[[tool.mypy.overrides]]` for `marshmallow.*` is gone, and the existing test suite (177 passing) still passes byte-for-byte through the same JSON round-trips.
+
+## Non-goals (deferred to Phase 5+)
+
+- **No changes to the dataclass domain layer.** `Block`, `Transaction`, `Outflow`, `Inflow`, `Chain` keep their stdlib `@dataclass` definitions. They retain their staged-construction lifecycle (`Block` starts mostly-empty, fills in over `link` → `add_txn` → `seal` → `mill` → `solve`). Pydantic v2's strict-on-construction model would conflict with that flow without a deeper architectural change; the two-layer dataclass-domain + Pydantic-IO split is preserved deliberately.
+- **No changes to API URLs, request shapes, or wire formats.** JSON output before and after must be byte-equivalent for the round-trip tests to pass.
+- **No introduction of `pydantic.dataclasses.dataclass`.** Same staged-construction conflict.
+- **No `requests` → `httpx` swap** (Phase 5).
+- **No `pycryptodome` → `cryptography` swap** (Phase 5).
+- **No SA `.query.X()` → `db.session.execute(...)` modernization** (Phase 6).
+- **No Alembic** (Phase 7).
+
+## Decisions taken during brainstorming
+
+- **Scope: Path B (swap-in-place).** Considered Path A (replace dataclasses with `BaseModel`) and Path C (`pydantic.dataclasses.dataclass`); both conflict with the staged-construction lifecycle the domain types use. Path B is the minimum scope change that achieves the stated Phase 4 goal.
+- **PR strategy: bottom-up by dependency.** 6 PRs in `schema → payload → transaction → block → api → cleanup` order. Each PR is self-contained — no long-lived dual implementations.
+- **Pydantic version: `>=2.10`**. Pydantic v2.10 (2024-Q4) added the model-validator return-type contract and `Annotated[..., AfterValidator(...)]` ergonomics this design relies on.
+- **`@post_load` removal.** Marshmallow's `@post_load` makes `Schema().load(d)` return a domain instance. Pydantic v2 doesn't have a clean equivalent (a `@model_validator(mode='after')` that returns a different type would be confusing). Callers do the conversion explicitly: `Transaction(**TransactionModel.model_validate(d).model_dump())`. 3-4 call sites total; the explicit conversion clarifies the boundary.
+- **`SansNoneSchema` retirement.** The "drop None on dump" behavior moves to the call site via `model.model_dump(exclude_none=True)` where needed; the existing `asdict_sans_none(dc)` utility (for dataclass `.to_dict()`) is unchanged.
+- **No long-lived parallel Marshmallow + Pydantic.** Each PR swaps its file's Schema(s) for Model(s) in one step; the file goes from "all Marshmallow" to "all Pydantic" in one commit. No transient "both work" gap.
+
+## Changes — the PR train
+
+Phase 4 ships as **six sequential PRs**, each squash-mergeable and individually revertible. Order is dictated by the dependency chain (`schema.py` defines custom types used by every later file).
+
+### PR-1. Pydantic v2 + custom types in `schema.py`
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.dependencies]`)
+- Modify: `src/cancelchain/schema.py`
+
+**Changes:**
+
+In `pyproject.toml`, add to `[project.dependencies]`:
+```toml
+"pydantic>=2.10",
+```
+Keep `marshmallow>=3.19` for now — it's still imported by `payload.py`, `transaction.py`, `block.py`, `api.py` at this point. PR-6 removes it after the swap is complete.
+
+In `schema.py`:
+- Drop the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive (no Marshmallow imports remain in this file after the swap — but only if PR-1 actually removes all of them; if some validator function still touches Marshmallow types, defer the directive removal to PR-6).
+- Remove the Marshmallow imports (`from marshmallow import Schema, fields, post_dump, validate`).
+- Remove the `SansNoneSchema(Schema)` class entirely. The "drop None on dump" semantic moves to call sites that need it via `model.model_dump(exclude_none=True)`.
+- Replace the 5 custom field-type subclasses with `Annotated` type aliases:
+
+  ```python
+  from __future__ import annotations
+  from dataclasses import asdict
+  from typing import Annotated, Any
+
+  from pydantic import AfterValidator
+
+  from cancelchain.util import iso_2_dt
+  from cancelchain.wallet import (
+      ADDRESS_TAG,
+      Wallet,
+      b58decode,
+      b64decode,
+      b64encode,
+  )
+
+  # `asdict_sans_none` stays — used by domain dataclasses' to_dict methods.
+  def asdict_sans_none(dc: Any) -> dict[str, Any]:
+      return asdict(
+          dc,
+          dict_factory=lambda x: {k: v for (k, v) in x if v is not None},
+      )
+
+  # ... validate_address, validate_base64, validate_signature, etc. — unchanged ...
+
+  def _check_address_format(s: str) -> str:
+      if not validate_address_format(s):
+          msg = f'Invalid address format: {s!r}'
+          raise ValueError(msg)
+      return s
+
+  def _check_base64(s: str) -> str:
+      if not validate_base64(s):
+          msg = f'Invalid base64 value: {s!r}'
+          raise ValueError(msg)
+      return s
+
+  def _check_mill_hash(s: str) -> str:
+      if not validate_base64(s) or len(s) != 64:
+          msg = f'Invalid mill hash: {s!r}'
+          raise ValueError(msg)
+      return s
+
+  def _check_timestamp(s: str) -> str:
+      if not validate_timestamp(s):
+          msg = f'Invalid timestamp: {s!r}'
+          raise ValueError(msg)
+      return s
+
+  def _check_public_key(s: str) -> str:
+      if not validate_public_key(s):
+          msg = f'Invalid public key: {s!r}'
+          raise ValueError(msg)
+      return s
+
+  Address = Annotated[str, AfterValidator(_check_address_format)]
+  Base64 = Annotated[str, AfterValidator(_check_base64)]
+  MillHash = Annotated[str, AfterValidator(_check_mill_hash)]
+  Timestamp = Annotated[str, AfterValidator(_check_timestamp)]
+  PublicKey = Annotated[str, AfterValidator(_check_public_key)]
+  ```
+
+  Pydantic's `AfterValidator` callback receives the post-coercion value and either returns it unchanged or raises `ValueError`. Pydantic wraps the `ValueError` into a `ValidationError` for the caller.
+
+- The base validator functions (`validate_address`, `validate_address_format`, `validate_base64`, `validate_public_key`, `validate_signature`, `validate_timestamp`) stay untouched — they're used by code outside the Marshmallow path (e.g., the transaction schema validation hook in PR-3).
+
+**Acceptance:** `uv run mypy` exit 0; `uv run pytest` exit 0 (existing tests unchanged because no callers are using the new types yet). `pydantic` is in `uv.lock`. `marshmallow` is still in `uv.lock` (used by other files).
+
+### PR-2. `payload.py`: `Outflow`/`Inflow` schemas
+
+**Files:**
+- Modify: `src/cancelchain/payload.py`
+
+**Changes:**
+
+Replace `OutflowSchema(SansNoneSchema)` and `InflowSchema(SansNoneSchema)` with `OutflowModel(BaseModel)` and `InflowModel(BaseModel)`.
+
+Pattern (illustrative — the actual code follows existing field/validator constraints):
+
+```python
+from __future__ import annotations
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cancelchain.schema import Address, MillHash
+# Subject is defined locally below as an `Annotated` alias (it stays in
+# payload.py for the same reason it was a `fields.String` subclass here
+# in the Marshmallow version — it's specific to payload validation).
+
+
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: Address | None = None
+    subject: Subject | None = None
+    forgive: Subject | None = None
+    support: Subject | None = None
+    # ... whatever the existing OutflowSchema has ...
+
+
+class InflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    outflow_txid: MillHash
+    outflow_idx: int = Field(ge=0)
+```
+
+- `validate.Range(min=N)` → `Field(ge=N)`.
+- `validate.Length(equal=N)` → `Field(min_length=N, max_length=N)`.
+- `validate.Length(min=N, max=M)` → `Field(min_length=N, max_length=M)`.
+- `validate.Equal(value)` → `Literal[value]`.
+- Marshmallow's `required=True` becomes "no default" in Pydantic.
+- Marshmallow's `required=False` becomes `Field(default=None)` or `... | None = None`.
+- `extra='forbid'` matches Marshmallow's default of rejecting unknown fields.
+
+Drop the `@post_load make_outflow` / `make_inflow` hooks. The `Outflow` / `Inflow` dataclasses stay; no caller in PR-2 needs to convert from the model yet (the conversion happens at higher layers in later PRs).
+
+**Acceptance:** `mypy` + `ruff` clean; tests green. `OutflowSchema` / `InflowSchema` no longer exist in `payload.py`; `OutflowModel` / `InflowModel` are exported.
+
+### PR-3. `transaction.py`: txn schemas + call sites
+
+**Files:**
+- Modify: `src/cancelchain/transaction.py`
+
+**Changes:**
+
+Replace `TransactionSchema(SansNoneSchema)`, `RegularTransactionSchema(TransactionSchema)`, and `CoinbaseTransactionSchema(TransactionSchema)` with corresponding `BaseModel` subclasses:
+
+```python
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from cancelchain.payload import Inflow, InflowModel, Outflow, OutflowModel
+from cancelchain.schema import Address, Base64, MillHash, PublicKey, Timestamp
+
+
+class TransactionModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    timestamp: Timestamp
+    txid: MillHash
+    address: Address
+    public_key: PublicKey
+    signature: Base64 | None = None
+    inflows: Annotated[list[InflowModel], Field(min_length=0, max_length=MAX_FLOWS)]
+    outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=MAX_FLOWS)]
+    version: Literal[VERSION_1]
+
+    @model_validator(mode='after')
+    def validate_pk_address(self) -> Self:
+        if not validate_address(self.public_key, self.address):
+            raise ValueError(ADDRESS_MISMATCH_MSG)
+        return self
+
+
+class RegularTransactionModel(TransactionModel):
+    inflows: Annotated[list[InflowModel], Field(min_length=1, max_length=MAX_FLOWS)]
+
+
+class CoinbaseTransactionModel(TransactionModel):
+    inflows: Annotated[list[InflowModel], Field(min_length=0, max_length=0)]
+    outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=4)]
+```
+
+Updates to call sites within `transaction.py`:
+
+- `errors = CoinbaseTransactionSchema().validate(self.to_dict())` →
+  ```python
+  try:
+      CoinbaseTransactionModel.model_validate(self.to_dict())
+  except ValidationError as e:
+      raise InvalidTransactionError(_pydantic_errors(e)) from e
+  ```
+  where `_pydantic_errors(e)` is a small helper that converts Pydantic's `e.errors()` list-of-dicts into the dict-shape that `InvalidTransactionError(message=...)` already expects (matching the Marshmallow behavior the downstream consumers like `api.py:make_error_response` rely on).
+
+- `TransactionSchema().dumps(self.to_dict())` → `TransactionModel(**self.to_dict()).model_dump_json(exclude_none=True)`. The `exclude_none=True` replicates `SansNoneSchema`'s old `@post_dump`.
+
+- `TransactionSchema().load(d)` → `Transaction(**TransactionModel.model_validate(d).model_dump())`. The explicit dataclass construction at the call site replaces the old `@post_load make_transaction` hook.
+
+- `TransactionSchema().loads(j)` → `TransactionModel.model_validate_json(j)` then same dataclass construction.
+
+- `from marshmallow import ...` import line is removed; `from pydantic import ...` replaces it.
+
+- File-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive: leave it for now. PR-6 verifies whether the directive can be removed entirely or narrowed.
+
+**Acceptance:** all existing Transaction tests pass (including the regression tests added in P3 PR-7.5 for `Transaction.to_dao()`'s fail-fast paths and PendingTxnSet.add). `tests/test_schema.py`'s validators (validate_address, validate_signature, validate_public_key) still work — they're called by both the new Pydantic boundary and by Transaction.validate_signature.
+
+### PR-4. `block.py`: Block schema + call sites
+
+**Files:**
+- Modify: `src/cancelchain/block.py`
+
+**Changes:**
+
+Replace `BlockSchema(SansNoneSchema)` with `BlockModel(BaseModel)`:
+
+```python
+class BlockModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    idx: int = Field(ge=0)
+    timestamp: Timestamp
+    block_hash: MillHash
+    prev_hash: MillHash
+    target: MillHash
+    proof_of_work: int = Field(ge=0, le=2**64 - 1)
+    merkle_root: MillHash
+    txns: list[TransactionModel] = Field(min_length=1, max_length=MAX_TRANSACTIONS)
+    version: Literal[VERSION_1]
+
+    @model_validator(mode='after')
+    def check_proof(self) -> Self:
+        # Validates proof-of-work satisfies target (the existing @validates_schema body).
+        if not validate_hash_diff(self.block_hash, self.target):
+            raise ValueError(MISSED_TARGET_MSG)
+        return self
+```
+
+The `txns` field's `list[TransactionModel]` inheritance — pick either `TransactionModel`, `RegularTransactionModel`, or a discriminated union. Current Marshmallow code uses `fields.Nested(TransactionSchema)` which is the base form; replicate with `TransactionModel` here. Subtype enforcement happens at `Block.add_txn(txn, is_coinbase=...)` runtime, not at schema-load time.
+
+Call-site updates in `block.py`:
+- `BlockSchema().validate(self.to_dict())` → `BlockModel.model_validate(self.to_dict())` in try/except.
+- `BlockSchema().dumps(self.to_dict())` → `BlockModel(**self.to_dict()).model_dump_json(exclude_none=True)`.
+- `BlockSchema().load(d)` → `Block(**BlockModel.model_validate(d).model_dump())`.
+- `BlockSchema().loads(j)` → `BlockModel.model_validate_json(j)` then same.
+
+Drop `from marshmallow import ValidationError`. Catch sites use `pydantic.ValidationError`.
+
+**Acceptance:** all Block tests pass (`tests/test_block.py`'s 13 tests including the P3 PR-7.5 `test_to_dao_partial_block_raises` regression). Merkle root validation still works.
+
+### PR-5. `api.py`: query schemas
+
+**Files:**
+- Modify: `src/cancelchain/api.py`
+
+**Changes:**
+
+Three query schemas (`TransferTxnQuerySchema`, `SubjectTxnQuerySchema`, `PendingTxnQuerySchema`) become Pydantic models. These differ from the domain schemas above because they:
+- Read from `flask.request.args` (a `MultiDict`)
+- Have no `@post_load` (callers just use the validated dict, never a domain object)
+- One of them (`PendingTxnQuerySchema.earliest`) uses `fields.Function` for symmetric ciso-datetime parse/format — see translation note below.
+
+Pattern:
+
+```python
+class TransferTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    address: Address
+    limit: int | None = Field(default=None, ge=1)
+    # ... existing fields ...
+
+
+# at the call site (was: `args = TransferTxnQuerySchema().load(request.args)`):
+try:
+    args = TransferTxnQueryModel.model_validate(
+        request.args.to_dict(flat=True)
+    ).model_dump(exclude_none=True)
+except ValidationError as e:
+    abort(make_error_response(e))
+```
+
+The `request.args.to_dict(flat=True)` flattens the `MultiDict` to a plain dict (each key's first value). None of the existing query schemas have list-valued fields (verified by grep), so flattening is safe.
+
+For `PendingTxnQueryModel.earliest` (originally `fields.Function(serialize=lambda o: dt_2_ciso(o.earliest), deserialize=ciso_2_dt)`):
+
+```python
+from datetime import datetime
+from pydantic import BeforeValidator, PlainSerializer
+
+CisoTimestamp = Annotated[
+    datetime,
+    BeforeValidator(lambda v: ciso_2_dt(v) if isinstance(v, str) else v),
+    PlainSerializer(lambda dt: dt_2_ciso(dt), return_type=str),
+]
+
+
+class PendingTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    earliest: CisoTimestamp | None = None
+```
+
+The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs `dt_2_ciso` on output. Same parse/format symmetry as `fields.Function` provided.
+
+`make_error_response(e)` is the existing api.py helper. It currently expects a `marshmallow.ValidationError` with `.messages`. Update it (or add a sibling) to format Pydantic `ValidationError.errors()` output into the same response shape.
+
+**Acceptance:** API endpoint tests pass; query-parameter validation rejects bad inputs with the same status codes (400) as before.
+
+### PR-6. Remove `marshmallow` from runtime dependencies
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.dependencies]`, `[[tool.mypy.overrides]]`)
+- Modify: `src/cancelchain/schema.py` (if not already done in PR-1)
+- Modify: `src/cancelchain/transaction.py` (mypy directive)
+- Possibly modify: `src/cancelchain/models.py` (verify mypy directive scope)
+
+**Changes:**
+
+- Remove `"marshmallow>=3.19",` from `[project.dependencies]`.
+- Remove the `[[tool.mypy.overrides]]` block for `module = ["marshmallow", "marshmallow.*"]`.
+- Drop any stale `from marshmallow import ...` lines (should be none after PRs 1–5 but verify).
+- Drop the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directives in `schema.py` and `transaction.py` — verify each removal individually with `uv run mypy`. If `transaction.py`'s directive is still needed for non-Marshmallow Any leaks (e.g., a pycryptodome-typed call), narrow it (e.g., `"no-any-return"` only) rather than dropping entirely.
+- Verify `models.py`'s directive — currently `"no-untyped-call,no-any-return,name-defined,misc"`. The Marshmallow portions don't apply there (it's the SA `db.Model` portion). Leave that file as-is; Phase 6 revisits when query modernization happens.
+- Run `uv lock --upgrade-package marshmallow` to confirm Marshmallow is fully removed from the lockfile (the resolver should drop it once no `[project.dependencies]` constraint pulls it in).
+
+**Acceptance:** `grep -r marshmallow src/` returns nothing. `marshmallow` no longer in `uv.lock`. `uv run mypy` exit 0. `uv run ruff check src tests` exit 0. `uv run pytest` exit 0. `uv run cancelchain --help` works.
+
+## Non-source changes summary
+
+| File | Touched by |
+|---|---|
+| `pyproject.toml` | PR-1 (add pydantic), PR-6 (drop marshmallow + overrides) |
+| `uv.lock` | PR-1, PR-6 |
+
+## Source files touched
+
+| File | Touched by |
+|---|---|
+| `src/cancelchain/schema.py` | PR-1 (custom types), PR-6 (directive cleanup verification) |
+| `src/cancelchain/payload.py` | PR-2 |
+| `src/cancelchain/transaction.py` | PR-3, PR-6 (directive cleanup) |
+| `src/cancelchain/block.py` | PR-4 |
+| `src/cancelchain/api.py` | PR-5 |
+| `src/cancelchain/models.py` | none — Phase 6 |
+
+## Translation reference (Marshmallow → Pydantic v2)
+
+| Marshmallow | Pydantic v2 |
+|---|---|
+| `class X(Schema):` | `class X(BaseModel):` |
+| `class X(SansNoneSchema):` | `class X(BaseModel):` + `.model_dump(exclude_none=True)` at use site |
+| `fields.String(required=True)` | `field: str` |
+| `fields.String(required=False)` | `field: str \| None = None` |
+| `fields.Integer(validate=validate.Range(min=N))` | `field: int = Field(ge=N)` |
+| `fields.String(validate=validate.Length(equal=N))` | `field: str = Field(min_length=N, max_length=N)` |
+| `fields.String(validate=validate.Equal(value))` | `field: Literal[value]` |
+| `fields.List(fields.Nested(X), validate=validate.Length(min=N, max=M))` | `field: list[X] = Field(min_length=N, max_length=M)` |
+| `fields.Nested(X)` | `field: X` |
+| Custom field class (`MillHash(Base64)`) | `Annotated[str, AfterValidator(...)]` type alias |
+| `fields.Function(serialize=f_dump, deserialize=f_load)` | `Annotated[X, BeforeValidator(f_load), PlainSerializer(f_dump)]` |
+| `@validates_schema def f(self, data, **kw):` | `@model_validator(mode='after') def f(self) -> Self:` |
+| `@post_load def make_x(self, data, **kw):` | **Removed** — caller does `X(**Model.model_validate(data).model_dump())` |
+| `@post_dump def remove_none_values(self, data, **kw):` | **Removed** — caller does `model.model_dump(exclude_none=True)` |
+| `Schema().load(d)` | `Model.model_validate(d)` |
+| `Schema().loads(j)` | `Model.model_validate_json(j)` |
+| `Schema().dumps(obj)` | `Model(**obj).model_dump_json(exclude_none=True)` |
+| `Schema().validate(d)` | `try: Model.model_validate(d) except ValidationError: ...` |
+| `marshmallow.ValidationError` (caught) | `pydantic.ValidationError` (caught) |
+| `e.messages` (Marshmallow) | `e.errors()` (Pydantic) — different shape; adapter helper recommended |
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Pydantic vs Marshmallow JSON output drift (field order, datetime format, integer-as-string). | Each PR runs the full test suite, which round-trips JSON through `from_json` / `to_json`. The `Timestamp` and `MillHash` custom types preserve string formats because they're declared as `str`-based. Any drift surfaces immediately in `test_from`, `test_db`, `test_pending_txns` etc. |
+| `e.messages` (Marshmallow) → `e.errors()` (Pydantic) shape difference cascades to `api.py:make_error_response` and `InvalidBlockError({...: e.messages})` wrappers. | Add a small `_pydantic_errors_to_messages(e)` adapter that converts Pydantic's list-of-dicts to Marshmallow's nested-dict shape. Apply at every catch site in PR-3 / PR-4 / PR-5. Existing API consumers don't see a change. |
+| `@post_load` removal changes the call surface from `Schema().load(d) → Transaction` to `Transaction(**Model.model_validate(d).model_dump())`. | The 3-4 call sites are all in the same PR as the schema swap (PR-3 for txn, PR-4 for block). Pre-existing tests exercise the call sites and would fail if conversion is wrong. |
+| `request.args.to_dict(flat=True)` discards repeated query parameters. | Verified by grep that no query schema currently uses list-valued fields. If a future query schema adds one, switch its specific call site to `request.args.to_dict(flat=False)` and accept the list value type. |
+| `extra='forbid'` rejects unknown fields (matching Marshmallow's default). If a peer sends an extra field, it would now fail. | This is the *current* Marshmallow behavior; PR-1's swap preserves it. If we discover peer messages sneaking in extras, switch specific Models to `extra='ignore'` with a clear comment. |
+| Pydantic strict-vs-coercive parsing differs from Marshmallow. E.g., Marshmallow accepts `"10"` for an int field; Pydantic v2 with `strict=False` (default) also coerces. | Use Pydantic's default mode (lax/coercive) — `model_config = ConfigDict(strict=False)` is implicit. If a specific field needs strict typing (e.g., reject strings in int fields), use `Field(strict=True)` per-field. |
+| Removing the `marshmallow.*` mypy override might re-surface a non-Marshmallow Any leak. | PR-6 verifies removal one directive at a time and runs full mypy. If a directive is still needed for a non-Marshmallow reason, narrow it rather than dropping entirely. |
+| `Annotated[str, AfterValidator(...)]` type aliases may have subtle type-checker behavior under mypy strict (e.g., aliases not recognized as proper types in all contexts). | Phase 3 verified mypy strict on the existing custom-type usage. The new aliases are simpler (no field subclassing) so this is a lower risk, but PR-1 verifies under strict before merging. |
+| Pydantic v2 ecosystem moves quickly (subtle behavior changes between minor versions). | Pin `>=2.10` with no upper bound. Dependabot's Monday cadence will surface major-version bumps; we revisit if v3 ships. |
+
+## Acceptance criteria for Phase 4 as a whole
+
+- [ ] All six PRs squash-merged to `main`.
+- [ ] `grep -rn "marshmallow" src/` returns no matches.
+- [ ] `grep marshmallow uv.lock` returns no matches.
+- [ ] `grep marshmallow pyproject.toml` returns no matches in `[project.dependencies]` or `[[tool.mypy.overrides]]`.
+- [ ] `uv run pytest` passes (177/178 — same as post-Phase-3).
+- [ ] `uv run mypy` exits 0 under `[tool.mypy] strict = true` (hard CI gate).
+- [ ] `uv run ruff check src tests` exits 0 (hard CI gate).
+- [ ] `uv run cancelchain --help` prints the full command tree.
+- [ ] `docker build .` succeeds.
+- [ ] JSON round-trip tests (`test_from`, `test_db`, `test_pending_txns`) pass — wire format byte-equivalent before/after.
+
+## Open decisions (resolve at PR time)
+
+- PR-1: where exactly to put the `Annotated` type aliases (in `schema.py`, or a new `schema_types.py`?). Default: `schema.py`.
+- PR-3 / PR-4 / PR-5: format of the Pydantic `ValidationError` → Marshmallow-shaped error adapter. Default: build a small `_pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]` helper in `schema.py` and import at catch sites.
+- PR-4: whether `BlockModel.txns` uses `list[TransactionModel]` (base, matches current Marshmallow `fields.Nested(TransactionSchema)`) or a discriminated union of `RegularTransactionModel` + `CoinbaseTransactionModel`. Default: base model — matches existing behavior, no semantic change.
+- PR-6: whether the file-level mypy directive in `transaction.py` can be removed entirely, or must be narrowed to e.g. `"no-any-return"` only. Decided after running `uv run mypy` with the directive removed.
+
+## What comes next (Phase 5+)
+
+- **Phase 5 — Supply-chain swaps.** `requests` → `httpx` and `pycryptodome` → `cryptography`. The `cryptography` swap removes the broad `[[tool.mypy.overrides]] module = ["Crypto", "Crypto.*"]` directive added in Phase 3.
+- **Phase 6 — SA query-style modernization.** `.query.filter_by(...)` → `db.session.execute(db.select(...))` across `models.py` and call sites. Removes the SA 2.0 legacy-API deprecation warning suppression and the `models.py` file-level mypy directive. Pairs with tightening `Chain.to_dao() -> ChainDAO | None` (deferred from Phase 3 PR-7.5).
+- **Phase 7 — Alembic.** Introduce migration framework.
+- **Future — Observability.** OpenTelemetry, Sentry, structured logging.
+
+Each subsequent phase gets its own design doc and implementation plan.

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -201,9 +201,9 @@ Updates to call sites within `transaction.py`:
   try:
       CoinbaseTransactionModel.model_validate(self.to_dict())
   except ValidationError as e:
-      raise InvalidTransactionError(_pydantic_errors(e)) from e
+      raise InvalidTransactionError(pydantic_errors_to_messages(e)) from e
   ```
-  where `_pydantic_errors(e)` is a small helper that converts Pydantic's `e.errors()` list-of-dicts into the dict-shape that `InvalidTransactionError(message=...)` already expects (matching the Marshmallow behavior the downstream consumers like `api.py:make_error_response` rely on).
+  where `pydantic_errors_to_messages(e)` is the shared helper introduced in PR-1 (in `schema.py`) that converts Pydantic's `e.errors()` list-of-dicts into the nested-dict shape `InvalidTransactionError(message=...)` already expects (matching what Marshmallow's `e.messages` produces — downstream consumers like `api.py:make_error_response` don't see a change).
 
 - `TransactionSchema().dumps(self.to_dict())` → `TransactionModel(**self.to_dict()).model_dump_json(exclude_none=True)`. The `exclude_none=True` replicates `SansNoneSchema`'s old `@post_dump`.
 
@@ -400,7 +400,7 @@ The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs 
 | Risk | Mitigation |
 |---|---|
 | Pydantic vs Marshmallow JSON output drift (field order, datetime format, integer-as-string). | Each PR runs the full test suite, which round-trips JSON through `from_json` / `to_json`. The `Timestamp` and `MillHash` custom types preserve string formats because they're declared as `str`-based. Any drift surfaces immediately in `test_from`, `test_db`, `test_pending_txns` etc. |
-| `e.messages` (Marshmallow) → `e.errors()` (Pydantic) shape difference cascades to `api.py:make_error_response` and `InvalidBlockError({...: e.messages})` wrappers. | Add a small `_pydantic_errors_to_messages(e)` adapter that converts Pydantic's list-of-dicts to Marshmallow's nested-dict shape. Apply at every catch site in PR-3 / PR-4 / PR-5. Existing API consumers don't see a change. |
+| `e.messages` (Marshmallow) → `e.errors()` (Pydantic) shape difference cascades to `api.py:make_error_response` and `InvalidBlockError({...: e.messages})` wrappers. | Add a small `pydantic_errors_to_messages(e)` adapter (introduced in PR-1, in `schema.py`) that converts Pydantic's list-of-dicts to Marshmallow's nested-dict shape. Apply at every catch site in PR-3 / PR-4 / PR-5. Existing API consumers don't see a change. |
 | `@post_load` removal changes the call surface from `Schema().load(d) → Transaction` to `Transaction(**Model.model_validate(d).model_dump())`. | The 3-4 call sites are all in the same PR as the schema swap (PR-3 for txn, PR-4 for block). Pre-existing tests exercise the call sites and would fail if conversion is wrong. |
 | `request.args.to_dict(flat=True)` discards repeated query parameters. | Verified by grep that no query schema currently uses list-valued fields. If a future query schema adds one, switch its specific call site to `request.args.to_dict(flat=False)` and accept the list value type. |
 | `extra='forbid'` rejects unknown fields (matching Marshmallow's default). If a peer sends an extra field, it would now fail. | This is the *current* Marshmallow behavior; PR-1's swap preserves it. If we discover peer messages sneaking in extras, switch specific Models to `extra='ignore'` with a clear comment. |
@@ -425,7 +425,7 @@ The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs 
 ## Open decisions (resolve at PR time)
 
 - PR-1: where exactly to put the `Annotated` type aliases (in `schema.py`, or a new `schema_types.py`?). Default: `schema.py`.
-- PR-3 / PR-4 / PR-5: format of the Pydantic `ValidationError` → Marshmallow-shaped error adapter. Default: build a small `_pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]` helper in `schema.py` and import at catch sites.
+- PR-3 / PR-4 / PR-5: format of the Pydantic `ValidationError` → Marshmallow-shaped error adapter. Default: build a small `pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]` helper in `schema.py` (introduced in PR-1) and import at catch sites.
 - PR-4: whether `BlockModel.txns` uses `list[TransactionModel]` (base, matches current Marshmallow `fields.Nested(TransactionSchema)`) or a discriminated union of `RegularTransactionModel` + `CoinbaseTransactionModel`. Default: base model — matches existing behavior, no semantic change.
 - PR-6: whether the file-level mypy directive in `transaction.py` can be removed entirely, or must be narrowed to e.g. `"no-any-return"` only. Decided after running `uv run mypy` with the directive removed.
 

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -152,7 +152,7 @@ Drop the `@post_load make_outflow` / `make_inflow` hooks. The `Outflow` / `Inflo
 Replace `TransactionSchema(SansNoneSchema)`, `RegularTransactionSchema(TransactionSchema)`, and `CoinbaseTransactionSchema(TransactionSchema)` with corresponding `BaseModel` subclasses:
 
 ```python
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Final, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
@@ -160,6 +160,10 @@ from cancelchain.payload import Inflow, InflowModel, Outflow, OutflowModel
 from cancelchain.schema import (
     AddressType, Base64Type, MillHashType, PublicKeyType, TimestampType,
 )
+
+# Required for `Literal[VERSION_1]` to type-check under mypy --strict —
+# a plain str = '1' constant is not a Literal type.
+VERSION_1: Final = '1'
 
 
 class TransactionModel(BaseModel):
@@ -238,7 +242,7 @@ class BlockModel(BaseModel):
     block_hash: MillHashType
     prev_hash: MillHashType
     target: MillHashType
-    proof_of_work: int = Field(ge=0, le=2**64 - 1)
+    proof_of_work: int = Field(ge=0)
     merkle_root: MillHashType
     txns: list[TransactionModel] = Field(min_length=1, max_length=MAX_TRANSACTIONS)
     version: Literal[VERSION_1]

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -27,7 +27,7 @@ Concretely: after Phase 4, `[project.dependencies]` no longer contains `marshmal
 - **Scope: Path B (swap-in-place).** Considered Path A (replace dataclasses with `BaseModel`) and Path C (`pydantic.dataclasses.dataclass`); both conflict with the staged-construction lifecycle the domain types use. Path B is the minimum scope change that achieves the stated Phase 4 goal.
 - **PR strategy: bottom-up by dependency.** 6 PRs in `schema → payload → transaction → block → api → cleanup` order. Each PR is self-contained — no long-lived dual implementations.
 - **Pydantic version: `>=2.10`**. Pydantic v2.10 (2024-Q4) added the model-validator return-type contract and `Annotated[..., AfterValidator(...)]` ergonomics this design relies on.
-- **`@post_load` removal.** Marshmallow's `@post_load` makes `Schema().load(d)` return a domain instance. Pydantic v2 doesn't have a clean equivalent (a `@model_validator(mode='after')` that returns a different type would be confusing). Callers do the conversion explicitly. **Important:** when the model has nested-list fields (`inflows`, `outflows`, `txns`), `model_dump()` returns those as `list[dict]` — they need explicit reconstruction into `Inflow` / `Outflow` / `Transaction` dataclasses before being passed to the outer constructor. PR-3 introduces a `_txn_from_model_data` helper for this; PR-4 wraps it for the Block case. See the PR-3 and PR-4 sections below for the concrete patterns.
+- **`@post_load` removal.** Marshmallow's `@post_load` makes `Schema().load(d)` return a domain instance. Pydantic v2 doesn't have a clean equivalent (a `@model_validator(mode='after')` that returns a different type would be confusing). Callers do the conversion explicitly. **Important:** when the model has nested-list fields (`inflows`, `outflows`, `txns`), `model_dump()` returns those as `list[dict]` — they need explicit reconstruction into `Inflow` / `Outflow` / `Transaction` dataclasses before being passed to the outer constructor. PR-3 introduces a public `txn_from_model_data` helper for this; PR-4 imports it and wraps it for the Block case. See the PR-3 and PR-4 sections below for the concrete patterns.
 - **`SansNoneSchema` retirement.** The "drop None on dump" behavior moves to the call site via `model.model_dump(exclude_none=True)` where needed; the existing `asdict_sans_none(dc)` utility (for dataclass `.to_dict()`) is unchanged.
 - **No long-lived parallel Marshmallow + Pydantic.** Each PR swaps its file's Schema(s) for Model(s) in one step; the file goes from "all Marshmallow" to "all Pydantic" in one commit. No transient "both work" gap.
 
@@ -220,7 +220,7 @@ Updates to call sites within `transaction.py`:
 
 - `from marshmallow import ...` import line is removed; `from pydantic import ...` replaces it.
 
-- File-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive: leave it for now. PR-6 verifies whether the directive can be removed entirely or narrowed.
+- Remove the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive — the Marshmallow imports it was masking are gone (this PR drops `from marshmallow import ...` from `transaction.py`). If `mypy --strict` reveals a non-Marshmallow Any-leak (e.g., a pycryptodome-typed call), narrow the directive rather than dropping it (e.g., `"no-any-return"` only) instead of restoring the original two-error suppression. PR-6 verifies the file is clean.
 
 **Acceptance:** all existing Transaction tests pass (including the regression tests added in P3 PR-7.5 for `Transaction.to_dao()`'s fail-fast paths and PendingTxnSet.add). `tests/test_schema.py`'s validators (validate_address, validate_signature, validate_public_key) still work — they're called by both the new Pydantic boundary and by Transaction.validate_signature.
 
@@ -263,10 +263,10 @@ Call-site updates in `block.py`:
 - `BlockSchema().load(d)` → explicit reconstruction. `BlockModel.model_dump()` returns `txns` as `list[dict]`, but `Block` expects `list[Transaction]`. Reconstruct nested `Transaction` instances (which in turn reconstruct their nested `Inflow`/`Outflow` — share the helper from PR-3) before passing to `Block(**data)`:
   ```python
   data = BlockModel.model_validate(d).model_dump()
-  data['txns'] = [_txn_from_dump(t) for t in data['txns']]
+  data['txns'] = [Transaction(**txn_from_model_data(t)) for t in data['txns']]
   return Block(**data)
   ```
-  where `_txn_from_dump(t)` rebuilds the `Inflow`/`Outflow` lists and constructs a `Transaction`. Without this, downstream `block.txns[0].sign()` / `txn.outflows[0].amount` access breaks at runtime.
+  where `txn_from_model_data` is the public helper PR-3 introduces in `transaction.py` (it rebuilds the `Inflow`/`Outflow` lists from the dumped dicts). Without this, downstream `block.txns[0].sign()` / `txn.outflows[0].amount` access breaks at runtime.
 - `BlockSchema().loads(j)` → `BlockModel.model_validate_json(j)` then same nested reconstruction.
 
 Drop `from marshmallow import ValidationError`. Catch sites use `pydantic.ValidationError`.
@@ -336,7 +336,7 @@ The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs 
 **Files:**
 - Modify: `pyproject.toml` (`[project.dependencies]`, `[[tool.mypy.overrides]]`)
 - Modify: `src/cancelchain/schema.py` (if not already done in PR-1)
-- Modify: `src/cancelchain/transaction.py` (mypy directive)
+- Verify only: `src/cancelchain/transaction.py` (PR-3 already removed its mypy directive)
 - Possibly modify: `src/cancelchain/models.py` (verify mypy directive scope)
 
 **Changes:**

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -50,78 +50,44 @@ In `pyproject.toml`, add to `[project.dependencies]`:
 Keep `marshmallow>=3.19` for now — it's still imported by `payload.py`, `transaction.py`, `block.py`, `api.py` at this point. PR-6 removes it after the swap is complete.
 
 In `schema.py`:
-- Drop the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive (no Marshmallow imports remain in this file after the swap — but only if PR-1 actually removes all of them; if some validator function still touches Marshmallow types, defer the directive removal to PR-6).
-- Remove the Marshmallow imports (`from marshmallow import Schema, fields, post_dump, validate`).
-- Remove the `SansNoneSchema(Schema)` class entirely. The "drop None on dump" semantic moves to call sites that need it via `model.model_dump(exclude_none=True)`.
-- Replace the 5 custom field-type subclasses with `Annotated` type aliases:
 
-  ```python
-  from __future__ import annotations
-  from dataclasses import asdict
-  from typing import Annotated, Any
+**PR-1 is fully additive.** The existing Marshmallow `Address(fields.String)`, `Base64(fields.String)`, `MillHash(Base64)`, `Timestamp(fields.String)`, `PublicKey(Base64)`, and `SansNoneSchema(Schema)` classes are **not modified or removed** in this PR. They are still used by Marshmallow Schemas in `payload.py` (`address = Address()`, `outflow_txid = MillHash(required=True)`), `transaction.py` (`timestamp = Timestamp(required=True)`, etc.), and `block.py` — touching them now would break those files at import time. PR-6 deletes them after PRs 3, 4, 5 have removed every Marshmallow Schema in the codebase.
 
-  from pydantic import AfterValidator
+The file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive **stays** in PR-1 (Marshmallow imports are still here). PR-6 removes it.
 
-  from cancelchain.util import iso_2_dt
-  from cancelchain.wallet import (
-      ADDRESS_TAG,
-      Wallet,
-      b58decode,
-      b64decode,
-      b64encode,
-  )
+What PR-1 **adds**:
 
-  # `asdict_sans_none` stays — used by domain dataclasses' to_dict methods.
-  def asdict_sans_none(dc: Any) -> dict[str, Any]:
-      return asdict(
-          dc,
-          dict_factory=lambda x: {k: v for (k, v) in x if v is not None},
-      )
+1. New Pydantic type aliases under a `*Type` naming convention (chosen to avoid name collisions with the existing Marshmallow field classes during the overlap window):
 
-  # ... validate_address, validate_base64, validate_signature, etc. — unchanged ...
+   ```python
+   from typing import Annotated
+   from pydantic import AfterValidator, ValidationError
 
-  def _check_address_format(s: str) -> str:
-      if not validate_address_format(s):
-          msg = f'Invalid address format: {s!r}'
-          raise ValueError(msg)
-      return s
+   def _check_address_format(s: str) -> str:
+       if not validate_address_format(s):
+           msg = f'Invalid address format: {s!r}'
+           raise ValueError(msg)
+       return s
 
-  def _check_base64(s: str) -> str:
-      if not validate_base64(s):
-          msg = f'Invalid base64 value: {s!r}'
-          raise ValueError(msg)
-      return s
+   # _check_base64, _check_mill_hash, _check_timestamp, _check_public_key
+   # follow the same shape.
 
-  def _check_mill_hash(s: str) -> str:
-      if not validate_base64(s) or len(s) != 64:
-          msg = f'Invalid mill hash: {s!r}'
-          raise ValueError(msg)
-      return s
+   AddressType = Annotated[str, AfterValidator(_check_address_format)]
+   Base64Type = Annotated[str, AfterValidator(_check_base64)]
+   MillHashType = Annotated[str, AfterValidator(_check_mill_hash)]
+   TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
+   PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
+   ```
 
-  def _check_timestamp(s: str) -> str:
-      if not validate_timestamp(s):
-          msg = f'Invalid timestamp: {s!r}'
-          raise ValueError(msg)
-      return s
+   Pydantic's `AfterValidator` callback receives the post-coercion value and either returns it unchanged or raises `ValueError`. Pydantic wraps the `ValueError` into a `ValidationError` for the caller.
 
-  def _check_public_key(s: str) -> str:
-      if not validate_public_key(s):
-          msg = f'Invalid public key: {s!r}'
-          raise ValueError(msg)
-      return s
+2. A `pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]` adapter that converts Pydantic's list-of-dict `e.errors()` to the nested-dict `e.messages` shape that downstream consumers (`api.make_error_response`, `InvalidBlockError({...: e.messages})`) already expect for Marshmallow errors. PRs 3, 4, 5 use it at their catch sites.
 
-  Address = Annotated[str, AfterValidator(_check_address_format)]
-  Base64 = Annotated[str, AfterValidator(_check_base64)]
-  MillHash = Annotated[str, AfterValidator(_check_mill_hash)]
-  Timestamp = Annotated[str, AfterValidator(_check_timestamp)]
-  PublicKey = Annotated[str, AfterValidator(_check_public_key)]
-  ```
+The base validator functions (`validate_address`, `validate_address_format`, `validate_base64`, `validate_public_key`, `validate_signature`, `validate_timestamp`) stay untouched — they're used by code outside the Marshmallow path (e.g., the transaction schema validation hook in PR-3).
 
-  Pydantic's `AfterValidator` callback receives the post-coercion value and either returns it unchanged or raises `ValueError`. Pydantic wraps the `ValueError` into a `ValidationError` for the caller.
+**Naming convention note.** The `*Type` suffix is permanent — PR-6 doesn't rename `AddressType` back to `Address`. After PR-6, `schema.py` contains only `AddressType`, `Base64Type`, `MillHashType`, `TimestampType`, `PublicKeyType`, `pydantic_errors_to_messages`, the validator functions, and `asdict_sans_none`.
 
-- The base validator functions (`validate_address`, `validate_address_format`, `validate_base64`, `validate_public_key`, `validate_signature`, `validate_timestamp`) stay untouched — they're used by code outside the Marshmallow path (e.g., the transaction schema validation hook in PR-3).
-
-**Acceptance:** `uv run mypy` exit 0; `uv run pytest` exit 0 (existing tests unchanged because no callers are using the new types yet). `pydantic` is in `uv.lock`. `marshmallow` is still in `uv.lock` (used by other files).
+**Acceptance:** `uv run mypy` exit 0; `uv run pytest` exit 0 (existing tests unchanged — Marshmallow classes still present and behave identically; new Pydantic aliases are not yet used by any caller). `pydantic` is in `uv.lock`. `marshmallow` is still in `uv.lock` and `[project.dependencies]`.
 
 ### PR-2. `payload.py`: `Outflow`/`Inflow` schemas
 
@@ -140,27 +106,27 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from cancelchain.schema import Address, MillHash
-# Subject is defined locally below as an `Annotated` alias (it stays in
-# payload.py for the same reason it was a `fields.String` subclass here
-# in the Marshmallow version — it's specific to payload validation).
+from cancelchain.schema import AddressType, MillHashType
+# SubjectType is defined locally below as an `Annotated` alias (the Marshmallow
+# `Subject(fields.String)` class stays in payload.py until PR-3 deletes it; the
+# Type suffix avoids a name collision during the overlap window).
 
 
 class OutflowModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     amount: int = Field(ge=1)
-    address: Address | None = None
-    subject: Subject | None = None
-    forgive: Subject | None = None
-    support: Subject | None = None
+    address: AddressType | None = None
+    subject: SubjectType | None = None
+    forgive: SubjectType | None = None
+    support: SubjectType | None = None
     # ... whatever the existing OutflowSchema has ...
 
 
 class InflowModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    outflow_txid: MillHash
+    outflow_txid: MillHashType
     outflow_idx: int = Field(ge=0)
 ```
 
@@ -191,17 +157,19 @@ from typing import Annotated, Any, Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from cancelchain.payload import Inflow, InflowModel, Outflow, OutflowModel
-from cancelchain.schema import Address, Base64, MillHash, PublicKey, Timestamp
+from cancelchain.schema import (
+    AddressType, Base64Type, MillHashType, PublicKeyType, TimestampType,
+)
 
 
 class TransactionModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    timestamp: Timestamp
-    txid: MillHash
-    address: Address
-    public_key: PublicKey
-    signature: Base64 | None = None
+    timestamp: TimestampType
+    txid: MillHashType
+    address: AddressType
+    public_key: PublicKeyType
+    signature: Base64Type | None = None
     inflows: Annotated[list[InflowModel], Field(min_length=0, max_length=MAX_FLOWS)]
     outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=MAX_FLOWS)]
     version: Literal[VERSION_1]
@@ -266,12 +234,12 @@ class BlockModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     idx: int = Field(ge=0)
-    timestamp: Timestamp
-    block_hash: MillHash
-    prev_hash: MillHash
-    target: MillHash
+    timestamp: TimestampType
+    block_hash: MillHashType
+    prev_hash: MillHashType
+    target: MillHashType
     proof_of_work: int = Field(ge=0, le=2**64 - 1)
-    merkle_root: MillHash
+    merkle_root: MillHashType
     txns: list[TransactionModel] = Field(min_length=1, max_length=MAX_TRANSACTIONS)
     version: Literal[VERSION_1]
 
@@ -319,7 +287,7 @@ Pattern:
 class TransferTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    address: Address
+    address: AddressType
     limit: int | None = Field(default=None, ge=1)
     # ... existing fields ...
 
@@ -369,12 +337,14 @@ The `BeforeValidator` runs `ciso_2_dt` on input strings; `PlainSerializer` runs 
 
 **Changes:**
 
+- In `schema.py`: delete the Marshmallow field classes `Address(fields.String)`, `Base64(fields.String)`, `MillHash(Base64)`, `Timestamp(fields.String)`, `PublicKey(Base64)`, and `SansNoneSchema(Schema)`. After PRs 3, 4, 5 these have no callers — `payload.py`'s `Subject(fields.String)` was already deleted by PR-3. Drop `from marshmallow import Schema, fields, post_dump, validate` and the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directive (no Marshmallow imports remain, so the suppressions are no longer load-bearing).
+- The `*Type` Pydantic aliases (`AddressType`, `Base64Type`, `MillHashType`, `TimestampType`, `PublicKeyType`) and the validator functions (`validate_address`, `validate_address_format`, etc.) stay. No renaming back to bare names — the `*Type` suffix is permanent.
 - Remove `"marshmallow>=3.19",` from `[project.dependencies]`.
 - Remove the `[[tool.mypy.overrides]]` block for `module = ["marshmallow", "marshmallow.*"]`.
-- Drop any stale `from marshmallow import ...` lines (should be none after PRs 1–5 but verify).
-- Drop the file-level `# mypy: disable-error-code="no-untyped-call,no-any-return"` directives in `schema.py` and `transaction.py` — verify each removal individually with `uv run mypy`. If `transaction.py`'s directive is still needed for non-Marshmallow Any leaks (e.g., a pycryptodome-typed call), narrow it (e.g., `"no-any-return"` only) rather than dropping entirely.
-- Verify `models.py`'s directive — currently `"no-untyped-call,no-any-return,name-defined,misc"`. The Marshmallow portions don't apply there (it's the SA `db.Model` portion). Leave that file as-is; Phase 6 revisits when query modernization happens.
-- Run `uv lock --upgrade-package marshmallow` to confirm Marshmallow is fully removed from the lockfile (the resolver should drop it once no `[project.dependencies]` constraint pulls it in).
+- Verify no stale `from marshmallow import ...` lines remain anywhere (should be none after PRs 1–5).
+- Verify `transaction.py`'s file-level mypy directive — PR-3 already removed it. Same for `payload.py` (removed by PR-3) and `block.py` (removed by PR-4).
+- Leave `models.py`'s directive (`"no-untyped-call,no-any-return,name-defined,misc"`) untouched — it covers SA `db.Model` Any leaks, unrelated to Marshmallow. Phase 6 revisits when query modernization lands.
+- Run `uv lock` to confirm Marshmallow is fully removed from the lockfile (the resolver drops it once no `[project.dependencies]` constraint pulls it in).
 
 **Acceptance:** `grep -r marshmallow src/` returns nothing. `marshmallow` no longer in `uv.lock`. `uv run mypy` exit 0. `uv run ruff check src tests` exit 0. `uv run pytest` exit 0. `uv run cancelchain --help` works.
 

--- a/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
+++ b/docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md
@@ -8,7 +8,9 @@
 
 Modernize the validation/serialization layer onto Pydantic v2, the de-facto Python standard for typed data validation. Removes a runtime dependency, eliminates the untyped-boundary leaks that forced file-level `# mypy: disable-error-code` directives in `schema.py` and `transaction.py`, and aligns the project with the broader Python ecosystem.
 
-Concretely: after Phase 4, `[project.dependencies]` no longer contains `marshmallow`, `[[tool.mypy.overrides]]` for `marshmallow.*` is gone, and the existing test suite (177 passing) still passes byte-for-byte through the same JSON round-trips.
+Concretely: after Phase 4, `[project.dependencies]` no longer contains `marshmallow`, `[[tool.mypy.overrides]]` for `marshmallow.*` is gone, and the existing test suite (177 passing) still passes through the same JSON round-trips.
+
+**Test-message risk.** A small number of negative-path tests assert on Marshmallow-specific error message text (e.g., `tests/test_block.py:158` checks `match='Length must be between 1 and 100'`). The Pydantic→messages adapter (`pydantic_errors_to_messages` in PR-1) preserves the dict *shape* downstream consumers expect, but it does not normalize message *text* — Pydantic phrases length violations as `'List should have at most 100 items after validation, not 101'`. These assertions must be updated to the equivalent Pydantic wording in the PR that introduces the swap for their domain object (PR-3 for transaction tests, PR-4 for block tests). Tests that match on stable application-level constants (e.g., `'Address/public key mismatch'`, `'Invalid destinations'`, `'Missed target'`) are unaffected.
 
 ## Non-goals (deferred to Phase 5+)
 
@@ -128,7 +130,7 @@ In `schema.py`:
 
 **Changes:**
 
-Replace `OutflowSchema(SansNoneSchema)` and `InflowSchema(SansNoneSchema)` with `OutflowModel(BaseModel)` and `InflowModel(BaseModel)`.
+**Add** `OutflowModel(BaseModel)` and `InflowModel(BaseModel)` alongside the existing `OutflowSchema(SansNoneSchema)` and `InflowSchema(SansNoneSchema)`. The Marshmallow versions stay in place for this PR because `TransactionSchema.outflows = fields.List(fields.Nested(OutflowSchema), ...)` in `transaction.py` requires a Marshmallow `Schema` subclass — `fields.Nested` cannot bridge to a Pydantic `BaseModel`. PR-3 deletes the Marshmallow versions (and the `Subject(fields.String)` local class) in the same commit it swaps `TransactionSchema` over.
 
 Pattern (illustrative — the actual code follows existing field/validator constraints):
 
@@ -172,7 +174,7 @@ class InflowModel(BaseModel):
 
 Drop the `@post_load make_outflow` / `make_inflow` hooks. The `Outflow` / `Inflow` dataclasses stay; no caller in PR-2 needs to convert from the model yet (the conversion happens at higher layers in later PRs).
 
-**Acceptance:** `mypy` + `ruff` clean; tests green. `OutflowSchema` / `InflowSchema` no longer exist in `payload.py`; `OutflowModel` / `InflowModel` are exported.
+**Acceptance:** `mypy` + `ruff` clean; tests green. `OutflowModel` / `InflowModel` are exported. The Marshmallow `OutflowSchema` / `InflowSchema` / `Subject(fields.String)` are still present (deleted by PR-3).
 
 ### PR-3. `transaction.py`: txn schemas + call sites
 
@@ -233,9 +235,16 @@ Updates to call sites within `transaction.py`:
 
 - `TransactionSchema().dumps(self.to_dict())` → `TransactionModel(**self.to_dict()).model_dump_json(exclude_none=True)`. The `exclude_none=True` replicates `SansNoneSchema`'s old `@post_dump`.
 
-- `TransactionSchema().load(d)` → `Transaction(**TransactionModel.model_validate(d).model_dump())`. The explicit dataclass construction at the call site replaces the old `@post_load make_transaction` hook.
+- `TransactionSchema().load(d)` → explicit dataclass construction that replaces the old `@post_load make_transaction` hook. **Nested reconstruction is required:** `TransactionModel.model_dump()` returns `inflows`/`outflows` as `list[dict]`, but the `Transaction` dataclass expects `list[Inflow]` / `list[Outflow]`. Marshmallow's `@post_load` cascade did the conversion implicitly; in Pydantic we do it explicitly:
+  ```python
+  data = TransactionModel.model_validate(d).model_dump()
+  data['inflows'] = [Inflow(**i) for i in data['inflows']]
+  data['outflows'] = [Outflow(**o) for o in data['outflows']]
+  return Transaction(**data)
+  ```
+  Without this, attribute access (`outflow.amount`, `inflow.outflow_txid`) breaks at runtime because the list elements are plain dicts.
 
-- `TransactionSchema().loads(j)` → `TransactionModel.model_validate_json(j)` then same dataclass construction.
+- `TransactionSchema().loads(j)` → `TransactionModel.model_validate_json(j)` then the same nested-reconstruction conversion.
 
 - `from marshmallow import ...` import line is removed; `from pydantic import ...` replaces it.
 
@@ -279,8 +288,14 @@ The `txns` field's `list[TransactionModel]` inheritance — pick either `Transac
 Call-site updates in `block.py`:
 - `BlockSchema().validate(self.to_dict())` → `BlockModel.model_validate(self.to_dict())` in try/except.
 - `BlockSchema().dumps(self.to_dict())` → `BlockModel(**self.to_dict()).model_dump_json(exclude_none=True)`.
-- `BlockSchema().load(d)` → `Block(**BlockModel.model_validate(d).model_dump())`.
-- `BlockSchema().loads(j)` → `BlockModel.model_validate_json(j)` then same.
+- `BlockSchema().load(d)` → explicit reconstruction. `BlockModel.model_dump()` returns `txns` as `list[dict]`, but `Block` expects `list[Transaction]`. Reconstruct nested `Transaction` instances (which in turn reconstruct their nested `Inflow`/`Outflow` — share the helper from PR-3) before passing to `Block(**data)`:
+  ```python
+  data = BlockModel.model_validate(d).model_dump()
+  data['txns'] = [_txn_from_dump(t) for t in data['txns']]
+  return Block(**data)
+  ```
+  where `_txn_from_dump(t)` rebuilds the `Inflow`/`Outflow` lists and constructs a `Transaction`. Without this, downstream `block.txns[0].sign()` / `txn.outflows[0].amount` access breaks at runtime.
+- `BlockSchema().loads(j)` → `BlockModel.model_validate_json(j)` then same nested reconstruction.
 
 Drop `from marshmallow import ValidationError`. Catch sites use `pydantic.ValidationError`.
 


### PR DESCRIPTION
## Summary
- Adds the Phase 4 design spec (`docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md`).
- Adds the Phase 4 implementation plan (`docs/superpowers/plans/2026-05-25-phase-4-marshmallow-to-pydantic.md`).
- No code changes.

Phase 4 ships as six small PRs in sequence: pydantic + schema.py custom types → payload → transaction → block → api → cleanup (remove marshmallow). Path B scope (Schemas → BaseModels; dataclasses preserved due to the staged-construction lifecycle).

## Test plan
- [x] Spec self-review passed during brainstorming.
- [x] Plan self-review passed during planning.
- [ ] Reviewer confirms the PR list matches the spec's "Changes" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)