### PR TITLE
feat(deps): add pydantic v2 + Annotated *Type aliases (additive)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "millify>=0.1.1",
   "pg8000>=1.31",
   "pycryptodome>=3.20",
+  "pydantic>=2.10",
   "pyjwt>=2.9",
   "pymerkle>=5",
   "python-dotenv>=1.0",

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -191,8 +191,12 @@ def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
     keeps integer keys in-Python; we don't — they're indistinguishable
     on the wire).
 
-    Example output for outflows[0].amount failing Field(ge=1)::
+    When two errors share a prefix such that one path terminates at a
+    node that the other treats as internal (rare but possible with
+    discriminated unions or before-validators), the leaf messages are
+    kept under a '_self' sentinel key so neither error is lost.
 
+    Example output for outflows[0].amount failing Field(ge=1):
         {'outflows': {'0': {'amount': ['Input should be >= 1']}}}
     """
     result: dict[str, Any] = {}
@@ -206,10 +210,19 @@ def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
         for part in loc[:-1]:
             key = str(part)
             existing = current.get(key)
-            if not isinstance(existing, dict):
+            if isinstance(existing, dict):
+                pass  # walk into it
+            elif isinstance(existing, list):
+                # Prior leaf at this position — preserve it under _self.
+                current[key] = {'_self': existing}
+            else:
                 current[key] = {}
             current = current[key]
         last_key = str(loc[-1])
-        bucket = current.setdefault(last_key, [])
-        bucket.append(msg)
+        existing_leaf = current.get(last_key)
+        if isinstance(existing_leaf, dict):
+            # Prior nesting under this key — append msg to _self list.
+            existing_leaf.setdefault('_self', []).append(msg)
+        else:
+            current.setdefault(last_key, []).append(msg)
     return result

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -138,37 +138,49 @@ class SansNoneSchema(Schema):
 # which Pydantic wraps into a ValidationError for the caller.
 
 
+def _truncate(s: str, max_len: int = 32) -> str:
+    """Cap a user-provided value for echo in validation messages.
+
+    Pydantic surfaces these messages in HTTP 400 responses and logs.
+    Echoing unbounded input would let clients bloat responses or leak
+    arbitrary content; cap to a short prefix plus a length indicator.
+    """
+    if len(s) <= max_len:
+        return s
+    return f'{s[:max_len]}... ({len(s)} chars)'
+
+
 def _check_address_format(s: str) -> str:
     if not validate_address_format(s):
-        msg = f'Invalid address format: {s!r}'
+        msg = f'Invalid address format: {_truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_base64(s: str) -> str:
     if not validate_base64(s):
-        msg = f'Invalid base64 value: {s!r}'
+        msg = f'Invalid base64 value: {_truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_mill_hash(s: str) -> str:
     if not validate_base64(s) or len(s) != 64:
-        msg = f'Invalid mill hash: {s!r}'
+        msg = f'Invalid mill hash: {_truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_timestamp(s: str) -> str:
     if not validate_timestamp(s):
-        msg = f'Invalid timestamp: {s!r}'
+        msg = f'Invalid timestamp: {_truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_public_key(s: str) -> str:
     if not validate_public_key(s):
-        msg = f'Invalid public key: {s!r}'
+        msg = f'Invalid public key: {_truncate(s)!r}'
         raise ValueError(msg)
     return s
 

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -5,7 +5,8 @@ from dataclasses import asdict
 from typing import Annotated, Any
 
 from marshmallow import Schema, fields, post_dump, validate
-from pydantic import AfterValidator, ValidationError
+from pydantic import AfterValidator
+from pydantic import ValidationError as PydanticValidationError
 
 from cancelchain.exceptions import InvalidKeyError
 from cancelchain.util import iso_2_dt
@@ -180,7 +181,7 @@ TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
 PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
 
 
-def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
+def pydantic_errors_to_messages(e: PydanticValidationError) -> dict[str, Any]:
     """Convert Pydantic ValidationError to Marshmallow-shaped messages.
 
     Rebuilds a nested dict from Pydantic's flat err['loc'] tuples so

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 # mypy: disable-error-code="no-untyped-call,no-any-return"
 from dataclasses import asdict
-from typing import Any
+from typing import Annotated, Any
 
 from marshmallow import Schema, fields, post_dump, validate
+from pydantic import AfterValidator, ValidationError
 
 from cancelchain.exceptions import InvalidKeyError
 from cancelchain.util import iso_2_dt
@@ -124,3 +125,91 @@ class SansNoneSchema(Schema):
         self, data: dict[str, Any], **kwargs: Any
     ) -> dict[str, Any]:
         return {k: v for k, v in data.items() if v is not None}
+
+
+# --- Pydantic v2 custom type aliases (introduced in Phase 4 / PR-1).
+# Names get a *Type suffix to avoid colliding with the Marshmallow
+# field classes above, which are still used as callables by payload.py,
+# transaction.py, and block.py until PRs 3 and 4 swap them out. PR-6
+# deletes the Marshmallow classes; the *Type aliases are permanent.
+#
+# AfterValidator runs after Pydantic's built-in coercion; the callback
+# either returns the value (possibly transformed) or raises ValueError,
+# which Pydantic wraps into a ValidationError for the caller.
+
+
+def _check_address_format(s: str) -> str:
+    if not validate_address_format(s):
+        msg = f'Invalid address format: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_base64(s: str) -> str:
+    if not validate_base64(s):
+        msg = f'Invalid base64 value: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_mill_hash(s: str) -> str:
+    if not validate_base64(s) or len(s) != 64:
+        msg = f'Invalid mill hash: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_timestamp(s: str) -> str:
+    if not validate_timestamp(s):
+        msg = f'Invalid timestamp: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+def _check_public_key(s: str) -> str:
+    if not validate_public_key(s):
+        msg = f'Invalid public key: {s!r}'
+        raise ValueError(msg)
+    return s
+
+
+AddressType = Annotated[str, AfterValidator(_check_address_format)]
+Base64Type = Annotated[str, AfterValidator(_check_base64)]
+MillHashType = Annotated[str, AfterValidator(_check_mill_hash)]
+TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
+PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
+
+
+def pydantic_errors_to_messages(e: ValidationError) -> dict[str, Any]:
+    """Convert Pydantic ValidationError to Marshmallow-shaped messages.
+
+    Rebuilds a nested dict from Pydantic's flat err['loc'] tuples so
+    api.py's make_error_response and the InvalidBlockError({...: e.messages})
+    re-raise wrappers see the same nested layout downstream consumers
+    already render. List indices in `loc` are stringified, since the
+    resulting dict will be JSON-serialized to clients anyway (Marshmallow
+    keeps integer keys in-Python; we don't — they're indistinguishable
+    on the wire).
+
+    Example output for outflows[0].amount failing Field(ge=1)::
+
+        {'outflows': {'0': {'amount': ['Input should be >= 1']}}}
+    """
+    result: dict[str, Any] = {}
+    for err in e.errors():
+        loc = err.get('loc', ())
+        msg = err.get('msg', 'invalid')
+        if not loc:
+            result.setdefault('_schema', []).append(msg)
+            continue
+        current = result
+        for part in loc[:-1]:
+            key = str(part)
+            existing = current.get(key)
+            if not isinstance(existing, dict):
+                current[key] = {}
+            current = current[key]
+        last_key = str(loc[-1])
+        bucket = current.setdefault(last_key, [])
+        bucket.append(msg)
+    return result

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 # mypy: disable-error-code="no-untyped-call,no-any-return"
 from dataclasses import asdict
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol
 
 from marshmallow import Schema, fields, post_dump, validate
 from pydantic import AfterValidator
-from pydantic import ValidationError as PydanticValidationError
+from pydantic import ValidationError as PydanticValidationError  # noqa: F401
 
 from cancelchain.exceptions import InvalidKeyError
 from cancelchain.util import iso_2_dt
@@ -181,8 +181,21 @@ TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
 PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
 
 
-def pydantic_errors_to_messages(e: PydanticValidationError) -> dict[str, Any]:
+class _ErrorsAware(Protocol):
+    """Anything with an .errors() method returning Pydantic-shaped error dicts.
+
+    Pydantic's ValidationError implements this; synthetic test fakes can
+    satisfy it without subclassing.
+    """
+
+    def errors(self) -> list[dict[str, Any]]: ...
+
+
+def pydantic_errors_to_messages(e: _ErrorsAware) -> dict[str, Any]:
     """Convert Pydantic ValidationError to Marshmallow-shaped messages.
+
+    Accepts any object that satisfies the _ErrorsAware Protocol (duck-typed),
+    so synthetic test fakes work without subclassing PydanticValidationError.
 
     Rebuilds a nested dict from Pydantic's flat err['loc'] tuples so
     api.py's make_error_response and the InvalidBlockError({...: e.messages})

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -6,7 +6,6 @@ from typing import Annotated, Any, Protocol
 
 from marshmallow import Schema, fields, post_dump, validate
 from pydantic import AfterValidator
-from pydantic import ValidationError as PydanticValidationError  # noqa: F401
 
 from cancelchain.exceptions import InvalidKeyError
 from cancelchain.util import iso_2_dt

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -247,3 +247,21 @@ def test_public_key_type_rejects_invalid():
 
     with pytest.raises(PydanticValidationError):
         M(pk='not-a-key')
+
+
+def test_base64_type_truncates_long_invalid_input_in_message():
+    """ValueError message caps long invalid input to keep responses bounded."""
+    # 501 chars: not a multiple of 4, so base64 decode will fail/not round-trip.
+    long_input = 'x' * 501  # invalid base64, definitely > 32 chars
+
+    class M(BaseModel):
+        value: Base64Type
+
+    with pytest.raises(PydanticValidationError) as exc_info:
+        M(value=long_input)
+    # The full input must NOT appear verbatim in any error message;
+    # the truncation marker should.
+    messages = pydantic_errors_to_messages(exc_info.value)
+    flat = str(messages)
+    assert long_input not in flat
+    assert '... (501 chars)' in flat

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,16 +7,24 @@ that exception would propagate through marshmallow's validation pipeline
 and surface as a 500 instead of a structured 400.
 """
 
+from base64 import b64encode
+
 import pytest
 from pydantic import BaseModel, Field, model_validator
 from pydantic import ValidationError as PydanticValidationError
 
 from cancelchain.schema import (
+    AddressType,
+    Base64Type,
+    MillHashType,
+    PublicKeyType,
+    TimestampType,
     pydantic_errors_to_messages,
     validate_address,
     validate_public_key,
     validate_signature,
 )
+from cancelchain.util import now_iso
 
 
 def test_validate_address_returns_false_on_malformed_key():
@@ -148,3 +156,94 @@ def test_pydantic_errors_to_messages_nested_then_leaf_overlap():
     assert isinstance(result['a'], dict)
     assert result['a']['x'] == ['nested error']
     assert result['a']['_self'] == ['leaf error']
+
+
+# ---------------------------------------------------------------------------
+# *Type alias AfterValidator tests
+# ---------------------------------------------------------------------------
+
+
+def test_address_type_accepts_valid(wallet):
+    class M(BaseModel):
+        address: AddressType
+
+    m = M(address=wallet.address)
+    assert m.address == wallet.address
+
+
+def test_address_type_rejects_invalid():
+    class M(BaseModel):
+        address: AddressType
+
+    with pytest.raises(PydanticValidationError):
+        M(address='not-an-address')
+
+
+def test_base64_type_accepts_valid():
+    class M(BaseModel):
+        value: Base64Type
+
+    m = M(value='aGVsbG8=')  # 'hello' in base64
+    assert m.value == 'aGVsbG8='
+
+
+def test_base64_type_rejects_invalid():
+    class M(BaseModel):
+        value: Base64Type
+
+    with pytest.raises(PydanticValidationError):
+        M(value='not_valid_base64!@#')
+
+
+def test_mill_hash_type_accepts_valid():
+    # MillHashType requires valid base64 AND exactly 64 chars.
+    # 48 raw bytes → 64 base64 chars.
+    valid_hash = b64encode(b'A' * 48).decode()
+    assert len(valid_hash) == 64
+
+    class M(BaseModel):
+        h: MillHashType
+
+    m = M(h=valid_hash)
+    assert m.h == valid_hash
+
+
+def test_mill_hash_type_rejects_wrong_length():
+    class M(BaseModel):
+        h: MillHashType
+
+    with pytest.raises(PydanticValidationError):
+        M(h='aGVsbG8=')  # valid base64 but not 64 chars
+
+
+def test_timestamp_type_accepts_valid():
+    class M(BaseModel):
+        t: TimestampType
+
+    ts = now_iso()
+    m = M(t=ts)
+    assert m.t == ts
+
+
+def test_timestamp_type_rejects_invalid():
+    class M(BaseModel):
+        t: TimestampType
+
+    with pytest.raises(PydanticValidationError):
+        M(t='not-a-timestamp')
+
+
+def test_public_key_type_accepts_valid(wallet):
+    class M(BaseModel):
+        pk: PublicKeyType
+
+    m = M(pk=wallet.public_key_b64)
+    assert m.pk == wallet.public_key_b64
+
+
+def test_public_key_type_rejects_invalid():
+    class M(BaseModel):
+        pk: PublicKeyType
+
+    with pytest.raises(PydanticValidationError):
+        M(pk='not-a-key')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,3 +36,126 @@ def test_validate_signature_returns_false_on_malformed_key():
 
 def test_validate_signature_returns_false_on_empty_key():
     assert validate_signature('', b'data', 'sig') is False
+
+
+# ---------------------------------------------------------------------------
+# pydantic_errors_to_messages
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel, Field, model_validator  # noqa: E402
+
+from cancelchain.schema import pydantic_errors_to_messages  # noqa: E402
+
+
+def test_pydantic_errors_to_messages_simple_field():
+    """Single field error produces a flat dict with a list of messages."""
+
+    class M(BaseModel):
+        amount: int = Field(ge=1)
+
+    try:
+        M.model_validate({'amount': 0})
+        raise AssertionError
+    except AssertionError:
+        raise
+    except Exception as exc:
+        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+
+    assert 'amount' in result
+    assert isinstance(result['amount'], list)
+    assert len(result['amount']) == 1
+
+
+def test_pydantic_errors_to_messages_nested():
+    """Nested model field produces a nested dict."""
+
+    class Inner(BaseModel):
+        amount: int = Field(ge=1)
+
+    class Outer(BaseModel):
+        outflows: list[Inner]
+
+    try:
+        Outer.model_validate({'outflows': [{'amount': 0}]})
+        raise AssertionError
+    except AssertionError:
+        raise
+    except Exception as exc:
+        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+
+    assert 'outflows' in result
+    assert '0' in result['outflows']
+    assert 'amount' in result['outflows']['0']
+    assert isinstance(result['outflows']['0']['amount'], list)
+
+
+def test_pydantic_errors_to_messages_whole_model_error():
+    """@model_validator raising ValueError with empty loc → '_schema' bucket."""
+
+    class M(BaseModel):
+        a: int
+        b: int
+
+        @model_validator(mode='after')
+        def check_a_lt_b(self) -> 'M':
+            msg = 'a must be less than b'
+            if self.a >= self.b:
+                raise ValueError(msg)
+            return self
+
+    try:
+        M.model_validate({'a': 5, 'b': 1})
+        raise AssertionError
+    except AssertionError:
+        raise
+    except Exception as exc:
+        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+
+    assert '_schema' in result
+    assert isinstance(result['_schema'], list)
+    assert any('a must be less than b' in m for m in result['_schema'])
+
+
+class _FakeValidationError:
+    """Synthetic ValidationError-like object for overlap tests.
+
+    Pydantic schemas don't reliably emit overlapping loc paths on their
+    own; this helper lets us construct exactly the edge-case inputs that
+    exercise the _self sentinel and the nested-then-leaf rewrite branch.
+    """
+
+    def __init__(self, errs: list[dict]) -> None:
+        self._errs = errs
+
+    def errors(self) -> list[dict]:
+        return self._errs
+
+
+def test_pydantic_errors_to_messages_leaf_then_nested_overlap():
+    """loc=('a',) then loc=('a','x') — leaf preserved under _self."""
+    fake = _FakeValidationError(
+        [
+            {'loc': ('a',), 'msg': 'leaf error'},
+            {'loc': ('a', 'x'), 'msg': 'nested error'},
+        ]
+    )
+    result = pydantic_errors_to_messages(fake)  # type: ignore[arg-type]
+
+    assert isinstance(result['a'], dict)
+    assert result['a']['_self'] == ['leaf error']
+    assert result['a']['x'] == ['nested error']
+
+
+def test_pydantic_errors_to_messages_nested_then_leaf_overlap():
+    """loc=('a','x') then loc=('a',) — both preserved; no AttributeError."""
+    fake = _FakeValidationError(
+        [
+            {'loc': ('a', 'x'), 'msg': 'nested error'},
+            {'loc': ('a',), 'msg': 'leaf error'},
+        ]
+    )
+    result = pydantic_errors_to_messages(fake)  # type: ignore[arg-type]
+
+    assert isinstance(result['a'], dict)
+    assert result['a']['x'] == ['nested error']
+    assert result['a']['_self'] == ['leaf error']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,12 @@ that exception would propagate through marshmallow's validation pipeline
 and surface as a 500 instead of a structured 400.
 """
 
+import pytest
+from pydantic import BaseModel, Field, model_validator
+from pydantic import ValidationError as PydanticValidationError
+
 from cancelchain.schema import (
+    pydantic_errors_to_messages,
     validate_address,
     validate_public_key,
     validate_signature,
@@ -42,10 +47,6 @@ def test_validate_signature_returns_false_on_empty_key():
 # pydantic_errors_to_messages
 # ---------------------------------------------------------------------------
 
-from pydantic import BaseModel, Field, model_validator  # noqa: E402
-
-from cancelchain.schema import pydantic_errors_to_messages  # noqa: E402
-
 
 def test_pydantic_errors_to_messages_simple_field():
     """Single field error produces a flat dict with a list of messages."""
@@ -53,13 +54,9 @@ def test_pydantic_errors_to_messages_simple_field():
     class M(BaseModel):
         amount: int = Field(ge=1)
 
-    try:
+    with pytest.raises(PydanticValidationError) as exc_info:
         M.model_validate({'amount': 0})
-        raise AssertionError
-    except AssertionError:
-        raise
-    except Exception as exc:
-        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+    result = pydantic_errors_to_messages(exc_info.value)
 
     assert 'amount' in result
     assert isinstance(result['amount'], list)
@@ -75,13 +72,9 @@ def test_pydantic_errors_to_messages_nested():
     class Outer(BaseModel):
         outflows: list[Inner]
 
-    try:
+    with pytest.raises(PydanticValidationError) as exc_info:
         Outer.model_validate({'outflows': [{'amount': 0}]})
-        raise AssertionError
-    except AssertionError:
-        raise
-    except Exception as exc:
-        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+    result = pydantic_errors_to_messages(exc_info.value)
 
     assert 'outflows' in result
     assert '0' in result['outflows']
@@ -103,13 +96,9 @@ def test_pydantic_errors_to_messages_whole_model_error():
                 raise ValueError(msg)
             return self
 
-    try:
+    with pytest.raises(PydanticValidationError) as exc_info:
         M.model_validate({'a': 5, 'b': 1})
-        raise AssertionError
-    except AssertionError:
-        raise
-    except Exception as exc:
-        result = pydantic_errors_to_messages(exc)  # type: ignore[arg-type]
+    result = pydantic_errors_to_messages(exc_info.value)
 
     assert '_schema' in result
     assert isinstance(result['_schema'], list)
@@ -139,7 +128,7 @@ def test_pydantic_errors_to_messages_leaf_then_nested_overlap():
             {'loc': ('a', 'x'), 'msg': 'nested error'},
         ]
     )
-    result = pydantic_errors_to_messages(fake)  # type: ignore[arg-type]
+    result = pydantic_errors_to_messages(fake)
 
     assert isinstance(result['a'], dict)
     assert result['a']['_self'] == ['leaf error']
@@ -154,7 +143,7 @@ def test_pydantic_errors_to_messages_nested_then_leaf_overlap():
             {'loc': ('a',), 'msg': 'leaf error'},
         ]
     )
-    result = pydantic_errors_to_messages(fake)  # type: ignore[arg-type]
+    result = pydantic_errors_to_messages(fake)
 
     assert isinstance(result['a'], dict)
     assert result['a']['x'] == ['nested error']

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +184,7 @@ dependencies = [
     { name = "millify" },
     { name = "pg8000" },
     { name = "pycryptodome" },
+    { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pymerkle" },
     { name = "python-dotenv" },
@@ -213,6 +223,7 @@ requires-dist = [
     { name = "millify", specifier = ">=0.1.1" },
     { name = "pg8000", specifier = ">=1.31" },
     { name = "pycryptodome", specifier = ">=3.20" },
+    { name = "pydantic", specifier = ">=2.10" },
     { name = "pyjwt", specifier = ">=2.9" },
     { name = "pymerkle", specifier = ">=5" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -1086,6 +1097,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1444,6 +1545,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds \`pydantic>=2.10\` to runtime deps (resolves to 2.13.4).
- Adds Annotated[str, AfterValidator(...)] aliases under *Type suffix names (AddressType, Base64Type, MillHashType, TimestampType, PublicKeyType).
- Adds \`pydantic_errors_to_messages\` adapter helper for downstream PRs.
- **Fully additive** — Marshmallow Address/Base64/MillHash/Timestamp/PublicKey and SansNoneSchema are untouched (still used by payload.py / transaction.py / block.py until PRs 3 and 4 swap them out). PR-6 deletes the Marshmallow versions.

Phase 4 / PR 1 of 6. Spec: \`docs/superpowers/specs/2026-05-25-phase-4-marshmallow-to-pydantic-design.md\`.

## Test plan
- [x] \`uv run mypy\` exits 0.
- [x] \`uv run pytest\` passes (177 passed, 1 skipped). schema.py changes are purely additive.
- [x] \`uv run ruff check\` + \`format --check\` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)