### PR TITLE
feat(payload): add OutflowModel/InflowModel/SubjectType alongside Marshmallow

### DIFF
--- a/src/cancelchain/payload.py
+++ b/src/cancelchain/payload.py
@@ -26,7 +26,7 @@ from cancelchain.schema import (
     MillHash,
     MillHashType,
     SansNoneSchema,
-    _truncate,
+    truncate,
 )
 
 MIN_SUBJECT_LENGTH = 1
@@ -164,7 +164,7 @@ class Inflow:
 
 def _check_subject(s: str) -> str:
     if not validate_subject(s):
-        msg = f'Invalid subject: {_truncate(s)!r}'
+        msg = f'Invalid subject: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 

--- a/src/cancelchain/payload.py
+++ b/src/cancelchain/payload.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # mypy: disable-error-code="no-untyped-call,no-any-return"
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any, Self
 
 from marshmallow import (
     ValidationError,
@@ -12,8 +12,22 @@ from marshmallow import (
     validate,
     validates_schema,
 )
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 
-from cancelchain.schema import Address, MillHash, SansNoneSchema
+from cancelchain.schema import (
+    Address,
+    AddressType,
+    MillHash,
+    MillHashType,
+    SansNoneSchema,
+    _truncate,
+)
 
 MIN_SUBJECT_LENGTH = 1
 MAX_SUBJECT_LENGTH = 79
@@ -142,3 +156,48 @@ class Inflow:
     @property
     def data_csv(self) -> str:
         return ','.join([str(self.outflow_txid), str(self.outflow_idx)])
+
+
+# --- Pydantic v2 models (used by PR-3 onwards). The Marshmallow
+# Schemas above stay in place until PR-3 swaps transaction.py.
+
+
+def _check_subject(s: str) -> str:
+    if not validate_subject(s):
+        msg = f'Invalid subject: {_truncate(s)!r}'
+        raise ValueError(msg)
+    return s
+
+
+SubjectType = Annotated[str, AfterValidator(_check_subject)]
+
+
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: AddressType | None = None
+    subject: SubjectType | None = None
+    forgive: SubjectType | None = None
+    support: SubjectType | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
+        options = [
+            v
+            for v in (self.subject, self.forgive, self.support)
+            if v is not None
+        ]
+        if not (
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
+        ):
+            raise ValueError(INVALID_DESTINATION_MSG)
+        return self
+
+
+class InflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    outflow_txid: MillHashType
+    outflow_idx: int = Field(ge=0)

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -138,7 +138,7 @@ class SansNoneSchema(Schema):
 # which Pydantic wraps into a ValidationError for the caller.
 
 
-def _truncate(s: str, max_len: int = 32) -> str:
+def truncate(s: str, max_len: int = 32) -> str:
     """Cap a user-provided value for echo in validation messages.
 
     Pydantic surfaces these messages in HTTP 400 responses and logs.
@@ -152,35 +152,35 @@ def _truncate(s: str, max_len: int = 32) -> str:
 
 def _check_address_format(s: str) -> str:
     if not validate_address_format(s):
-        msg = f'Invalid address format: {_truncate(s)!r}'
+        msg = f'Invalid address format: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_base64(s: str) -> str:
     if not validate_base64(s):
-        msg = f'Invalid base64 value: {_truncate(s)!r}'
+        msg = f'Invalid base64 value: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_mill_hash(s: str) -> str:
     if not validate_base64(s) or len(s) != 64:
-        msg = f'Invalid mill hash: {_truncate(s)!r}'
+        msg = f'Invalid mill hash: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_timestamp(s: str) -> str:
     if not validate_timestamp(s):
-        msg = f'Invalid timestamp: {_truncate(s)!r}'
+        msg = f'Invalid timestamp: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 
 
 def _check_public_key(s: str) -> str:
     if not validate_public_key(s):
-        msg = f'Invalid public key: {_truncate(s)!r}'
+        msg = f'Invalid public key: {truncate(s)!r}'
         raise ValueError(msg)
     return s
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -93,23 +93,26 @@ def test_outflow_model_rejects_address_and_subject(wallet):
     subject = encode_subject('test')
     with pytest.raises(PydanticValidationError) as exc_info:
         OutflowModel(amount=5, address=wallet.address, subject=subject)
-    messages = str(exc_info.value)
-    assert INVALID_DESTINATION_MSG in messages
+    assert any(
+        INVALID_DESTINATION_MSG in err['msg'] for err in exc_info.value.errors()
+    )
 
 
 def test_outflow_model_rejects_two_subject_options():
     subj = encode_subject('test')
     with pytest.raises(PydanticValidationError) as exc_info:
         OutflowModel(amount=5, subject=subj, forgive=subj)
-    messages = str(exc_info.value)
-    assert INVALID_DESTINATION_MSG in messages
+    assert any(
+        INVALID_DESTINATION_MSG in err['msg'] for err in exc_info.value.errors()
+    )
 
 
 def test_outflow_model_rejects_no_destination(wallet):
     with pytest.raises(PydanticValidationError) as exc_info:
         OutflowModel(amount=5)
-    messages = str(exc_info.value)
-    assert INVALID_DESTINATION_MSG in messages
+    assert any(
+        INVALID_DESTINATION_MSG in err['msg'] for err in exc_info.value.errors()
+    )
 
 
 def test_outflow_model_rejects_zero_amount(wallet):

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,6 +1,17 @@
-from base64 import urlsafe_b64encode
+from base64 import b64encode, urlsafe_b64encode
 
-from cancelchain.payload import Inflow, Outflow, validate_subject
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from cancelchain.payload import (
+    INVALID_DESTINATION_MSG,
+    Inflow,
+    InflowModel,
+    Outflow,
+    OutflowModel,
+    encode_subject,
+    validate_subject,
+)
 
 
 def test_outflow_data_csv(subject, wallet):
@@ -39,3 +50,84 @@ def test_validate_subject(subject_raw, subject):
     subject_urlsafe = urlsafe_b64encode(subject_raw.encode()).decode()
     assert subject_urlsafe.endswith('=')
     assert not validate_subject(subject_urlsafe)
+
+
+# ---------------------------------------------------------------------------
+# OutflowModel / InflowModel Pydantic v2 tests
+# ---------------------------------------------------------------------------
+
+VALID_MILL_HASH = b64encode(b'A' * 48).decode()  # 48 bytes → 64 base64 chars
+
+
+def test_outflow_model_accepts_address_only(wallet):
+    m = OutflowModel(amount=10, address=wallet.address)
+    assert m.amount == 10
+    assert m.address == wallet.address
+    assert m.subject is None
+    assert m.forgive is None
+    assert m.support is None
+
+
+def test_outflow_model_accepts_subject_only():
+    subject = encode_subject('cancel me')
+    m = OutflowModel(amount=5, subject=subject)
+    assert m.subject == subject
+    assert m.address is None
+
+
+def test_outflow_model_accepts_forgive_only():
+    subject = encode_subject('forgiven one')
+    m = OutflowModel(amount=3, forgive=subject)
+    assert m.forgive == subject
+    assert m.address is None
+
+
+def test_outflow_model_accepts_support_only():
+    subject = encode_subject('supported one')
+    m = OutflowModel(amount=7, support=subject)
+    assert m.support == subject
+    assert m.address is None
+
+
+def test_outflow_model_rejects_address_and_subject(wallet):
+    subject = encode_subject('test')
+    with pytest.raises(PydanticValidationError) as exc_info:
+        OutflowModel(amount=5, address=wallet.address, subject=subject)
+    messages = str(exc_info.value)
+    assert INVALID_DESTINATION_MSG in messages
+
+
+def test_outflow_model_rejects_two_subject_options():
+    subj = encode_subject('test')
+    with pytest.raises(PydanticValidationError) as exc_info:
+        OutflowModel(amount=5, subject=subj, forgive=subj)
+    messages = str(exc_info.value)
+    assert INVALID_DESTINATION_MSG in messages
+
+
+def test_outflow_model_rejects_no_destination(wallet):
+    with pytest.raises(PydanticValidationError) as exc_info:
+        OutflowModel(amount=5)
+    messages = str(exc_info.value)
+    assert INVALID_DESTINATION_MSG in messages
+
+
+def test_outflow_model_rejects_zero_amount(wallet):
+    with pytest.raises(PydanticValidationError):
+        OutflowModel(amount=0, address=wallet.address)
+
+
+def test_inflow_model_accepts_valid():
+    m = InflowModel(outflow_txid=VALID_MILL_HASH, outflow_idx=0)
+    assert m.outflow_txid == VALID_MILL_HASH
+    assert m.outflow_idx == 0
+
+
+def test_inflow_model_rejects_negative_idx():
+    with pytest.raises(PydanticValidationError):
+        InflowModel(outflow_txid=VALID_MILL_HASH, outflow_idx=-1)
+
+
+def test_inflow_model_rejects_invalid_mill_hash():
+    with pytest.raises(PydanticValidationError):
+        InflowModel(outflow_txid='not-a-hash', outflow_idx=0)


### PR DESCRIPTION
## Summary
- Adds `OutflowModel`, `InflowModel`, and a `SubjectType` Annotated alias to `src/cancelchain/payload.py` alongside the existing Marshmallow `OutflowSchema` / `InflowSchema` / `Subject(fields.String)`.
- New Pydantic models reference `AddressType` / `MillHashType` from `schema.py` (added in PR-1) and a local `SubjectType` whose AfterValidator runs the existing `validate_subject` function.
- The Marshmallow classes are NOT touched — `TransactionSchema.outflows = fields.List(fields.Nested(OutflowSchema), ...)` in `transaction.py` still requires Marshmallow Schemas. PR-3 deletes them.
- 11 new tests in `tests/test_payload.py` for the new Pydantic models.

Phase 4 / PR 2 of 6. Spec/plan merged in #50.

## Test plan
- [x] `uv run mypy` exits 0.
- [x] `uv run pytest` passes (193 → 204, 11 new tests).
- [x] `uv run ruff check` + `format --check` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)