### PR TITLE
feat(block): swap BlockSchema → BlockModel + Marshmallow purge

### DIFF
--- a/src/cancelchain/block.py
+++ b/src/cancelchain/block.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-# mypy: disable-error-code="no-untyped-call,no-any-return"
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from json import JSONDecodeError
-from typing import Any, Self
+from typing import Annotated, Any, Literal, Self
 
-from marshmallow import (
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
     ValidationError,
-    fields,
-    post_load,
-    validate,
-    validates_schema,
+    model_validator,
 )
 from pymerkle import InmemoryTree, InvalidProof, verify_inclusion
 
@@ -32,12 +32,16 @@ from cancelchain.exceptions import (
 from cancelchain.milling import mill_hash_str, milling_generator
 from cancelchain.models import BlockDAO
 from cancelchain.schema import (
-    MillHash,
-    SansNoneSchema,
-    Timestamp,
+    MillHashType,
+    TimestampType,
     asdict_sans_none,
+    pydantic_errors_to_messages,
 )
-from cancelchain.transaction import Transaction, TransactionSchema
+from cancelchain.transaction import (
+    Transaction,
+    TransactionModel,
+    txn_from_model_data,
+)
 from cancelchain.util import dt_2_iso, iso_2_dt, now_iso
 from cancelchain.wallet import Wallet
 
@@ -51,33 +55,41 @@ def validate_hash_diff(block_hash: str, target: str) -> bool:
     return int(block_hash, 16) < int(target, 16)
 
 
-class BlockSchema(SansNoneSchema):
-    idx = fields.Integer(required=True, validate=validate.Range(min=0))
-    timestamp = Timestamp(required=True)
-    block_hash = MillHash(required=True)
-    prev_hash = MillHash(required=True)
-    target = MillHash(required=True)
-    proof_of_work = fields.Integer(
-        required=True, validate=validate.Range(min=0)
-    )
-    merkle_root = MillHash(required=True)
-    txns = fields.List(
-        fields.Nested(TransactionSchema),
-        required=True,
-        validate=validate.Length(min=1, max=MAX_TRANSACTIONS),
-    )
-    version = fields.String(required=True, validate=validate.Equal(VERSION_1))
+def _block_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert a BlockModel.model_dump() dict's txns list from list[dict]
+    to list[Transaction] (with nested Inflow/Outflow instances already
+    reconstructed via txn_from_model_data) before passing to the Block
+    dataclass constructor.
+    """
+    return {
+        **data,
+        'txns': [
+            Transaction(**txn_from_model_data(t)) for t in data.get('txns', [])
+        ],
+    }
 
-    @validates_schema
-    def validate_difficulty(self, data: dict[str, Any], **kwargs: Any) -> None:
-        block_hash: str = data.get('block_hash', '')
-        target: str = data.get('target', '')
-        if not validate_hash_diff(block_hash, target):
-            raise ValidationError(MISSED_TARGET_MSG)
 
-    @post_load
-    def make_block(self, data: dict[str, Any], **kwargs: Any) -> Block:
-        return Block(**data)
+class BlockModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    idx: int = Field(ge=0)
+    timestamp: TimestampType
+    block_hash: MillHashType
+    prev_hash: MillHashType
+    target: MillHashType
+    proof_of_work: int = Field(ge=0)
+    merkle_root: MillHashType
+    txns: Annotated[
+        list[TransactionModel],
+        Field(min_length=1, max_length=MAX_TRANSACTIONS),
+    ]
+    version: Literal['1']
+
+    @model_validator(mode='after')
+    def validate_difficulty(self) -> Self:
+        if not validate_hash_diff(self.block_hash, self.target):
+            raise ValueError(MISSED_TARGET_MSG)
+        return self
 
 
 @dataclass(order=True)
@@ -275,8 +287,10 @@ class Block:
             raise InvalidCoinbaseError()
 
     def validate(self) -> None:
-        if errors := BlockSchema().validate(self.to_dict()):
-            raise InvalidBlockError(errors)
+        try:
+            BlockModel.model_validate(self.to_dict())
+        except ValidationError as e:
+            raise InvalidBlockError(pydantic_errors_to_messages(e)) from e
         self.validate_block_hash()
         self.validate_merkle_root()
         prev_txn = None
@@ -295,7 +309,7 @@ class Block:
         return asdict_sans_none(self)
 
     def to_json(self) -> str:
-        return BlockSchema().dumps(self.to_dict())
+        return json.dumps(self.to_dict())
 
     def to_dao(self) -> BlockDAO:
         # to_dao() is only meaningful after the block is sealed: all
@@ -331,18 +345,20 @@ class Block:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> Self:
         try:
-            return BlockSchema().load(d)
+            model = BlockModel.model_validate(d)
         except ValidationError as e:
-            raise InvalidBlockError(e.messages)
+            raise InvalidBlockError(pydantic_errors_to_messages(e)) from e
+        return cls(**_block_from_model_data(model.model_dump()))
 
     @classmethod
-    def from_json(cls, j: str) -> Self:
+    def from_json(cls, j: str | bytes) -> Self:
         try:
-            return BlockSchema().loads(j)
-        except JSONDecodeError as je:
-            raise InvalidBlockError(je.msg)
-        except ValidationError as ve:
-            raise InvalidBlockError(ve.messages)
+            model = BlockModel.model_validate_json(j)
+        except ValidationError as e:
+            raise InvalidBlockError(pydantic_errors_to_messages(e)) from e
+        except JSONDecodeError as e:
+            raise InvalidBlockError(e.msg) from e
+        return cls(**_block_from_model_data(model.model_dump()))
 
     @classmethod
     def from_dao(cls, dao: Any) -> Self:

--- a/src/cancelchain/payload.py
+++ b/src/cancelchain/payload.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-# mypy: disable-error-code="no-untyped-call,no-any-return"
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
-from typing import Annotated, Any, Self
+from typing import Annotated, Self
 
-from marshmallow import (
-    ValidationError,
-    fields,
-    post_load,
-    validate,
-    validates_schema,
-)
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -21,11 +13,8 @@ from pydantic import (
 )
 
 from cancelchain.schema import (
-    Address,
     AddressType,
-    MillHash,
     MillHashType,
-    SansNoneSchema,
     truncate,
 )
 
@@ -66,38 +55,45 @@ def validate_raw_subject(raw_subject: str) -> bool:
     return False
 
 
-class Subject(fields.String):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate_subject)
+def _check_subject(s: str) -> str:
+    if not validate_subject(s):
+        msg = f'Invalid subject: {truncate(s)!r}'
+        raise ValueError(msg)
+    return s
 
 
-class OutflowSchema(SansNoneSchema):
-    amount = fields.Integer(required=True, validate=validate.Range(min=1))
-    address = Address()
-    subject = Subject()
-    forgive = Subject()
-    support = Subject()
+Subject = Annotated[str, AfterValidator(_check_subject)]
 
-    @validates_schema
-    def validate_destinations(
-        self, data: dict[str, Any], **kwargs: Any
-    ) -> None:
-        address = data.get('address')
+
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: AddressType | None = None
+    subject: Subject | None = None
+    forgive: Subject | None = None
+    support: Subject | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
         options = [
             v
-            for v in [data.get(n) for n in ('subject', 'forgive', 'support')]
+            for v in (self.subject, self.forgive, self.support)
             if v is not None
         ]
         if not (
-            (address and not options)
-            or (options and len(options) == 1 and not address)
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
         ):
-            raise ValidationError(INVALID_DESTINATION_MSG)
+            raise ValueError(INVALID_DESTINATION_MSG)
+        return self
 
-    @post_load
-    def make_outflow(self, data: dict[str, Any], **kwargs: Any) -> Outflow:
-        return Outflow(**data)
+
+class InflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    outflow_txid: MillHashType
+    outflow_idx: int = Field(ge=0)
 
 
 @dataclass
@@ -139,15 +135,6 @@ class Outflow:
         return 0
 
 
-class InflowSchema(SansNoneSchema):
-    outflow_txid = MillHash(required=True)
-    outflow_idx = fields.Integer(required=True, validate=validate.Range(min=0))
-
-    @post_load
-    def make_inflow(self, data: dict[str, Any], **kwargs: Any) -> Inflow:
-        return Inflow(**data)
-
-
 @dataclass
 class Inflow:
     outflow_txid: str | None = None
@@ -156,48 +143,3 @@ class Inflow:
     @property
     def data_csv(self) -> str:
         return ','.join([str(self.outflow_txid), str(self.outflow_idx)])
-
-
-# --- Pydantic v2 models (used by PR-3 onwards). The Marshmallow
-# Schemas above stay in place until PR-3 swaps transaction.py.
-
-
-def _check_subject(s: str) -> str:
-    if not validate_subject(s):
-        msg = f'Invalid subject: {truncate(s)!r}'
-        raise ValueError(msg)
-    return s
-
-
-SubjectType = Annotated[str, AfterValidator(_check_subject)]
-
-
-class OutflowModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    amount: int = Field(ge=1)
-    address: AddressType | None = None
-    subject: SubjectType | None = None
-    forgive: SubjectType | None = None
-    support: SubjectType | None = None
-
-    @model_validator(mode='after')
-    def validate_destinations(self) -> Self:
-        options = [
-            v
-            for v in (self.subject, self.forgive, self.support)
-            if v is not None
-        ]
-        if not (
-            (self.address and not options)
-            or (options and len(options) == 1 and not self.address)
-        ):
-            raise ValueError(INVALID_DESTINATION_MSG)
-        return self
-
-
-class InflowModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    outflow_txid: MillHashType
-    outflow_idx: int = Field(ge=0)

--- a/src/cancelchain/schema.py
+++ b/src/cancelchain/schema.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-# mypy: disable-error-code="no-untyped-call,no-any-return"
 from collections.abc import Sequence
 from dataclasses import asdict
 from typing import Annotated, Any, Protocol
 
-from marshmallow import Schema, fields, post_dump, validate
 from pydantic import AfterValidator
 from pydantic_core import ErrorDetails
 
@@ -91,50 +89,7 @@ def validate_timestamp(s: str) -> bool:
     return False
 
 
-class Address(fields.String):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate_address_format)
-
-
-class Base64(fields.String):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate_base64)
-
-
-class MillHash(Base64):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate.Length(equal=64))
-
-
-class Timestamp(fields.String):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate_timestamp)
-
-
-class PublicKey(Base64):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.validators.insert(0, validate_public_key)
-
-
-class SansNoneSchema(Schema):
-    @post_dump
-    def remove_none_values(
-        self, data: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        return {k: v for k, v in data.items() if v is not None}
-
-
 # --- Pydantic v2 custom type aliases (introduced in Phase 4 / PR-1).
-# Names get a *Type suffix to avoid colliding with the Marshmallow
-# field classes above, which are still used as callables by payload.py,
-# transaction.py, and block.py until PRs 3 and 4 swap them out. PR-6
-# deletes the Marshmallow classes; the *Type aliases are permanent.
-#
 # AfterValidator runs after Pydantic's built-in coercion; the callback
 # either returns the value (possibly transformed) or raises ValueError,
 # which Pydantic wraps into a ValidationError for the caller.

--- a/src/cancelchain/transaction.py
+++ b/src/cancelchain/transaction.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# mypy: disable-error-code="no-untyped-call,no-any-return"
 import json
 from collections.abc import Generator, Iterator, MutableSet
 from dataclasses import dataclass, field
@@ -8,9 +7,6 @@ from datetime import datetime
 from json import JSONDecodeError
 from typing import Annotated, Any, Literal, Self
 
-from marshmallow import ValidationError as MarshmallowValidationError
-from marshmallow import fields as ma_fields
-from marshmallow import post_load, validate, validates_schema
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -37,22 +33,14 @@ from cancelchain.models import (
 from cancelchain.payload import (
     Inflow,
     InflowModel,
-    InflowSchema,
     Outflow,
     OutflowModel,
-    OutflowSchema,
 )
 from cancelchain.schema import (
-    Address,
     AddressType,
-    Base64,
     Base64Type,
-    MillHash,
     MillHashType,
-    PublicKey,
     PublicKeyType,
-    SansNoneSchema,
-    Timestamp,
     TimestampType,
     asdict_sans_none,
     pydantic_errors_to_messages,
@@ -67,40 +55,8 @@ MAX_FLOWS = 50
 ADDRESS_MISMATCH_MSG = 'Address/public key mismatch'
 
 
-class TransactionSchema(SansNoneSchema):
-    timestamp = Timestamp(required=True)
-    txid = MillHash(required=True)
-    address = Address(required=True)
-    public_key = PublicKey(required=True)
-    signature = Base64(required=False)
-    inflows = ma_fields.List(
-        ma_fields.Nested(InflowSchema),
-        required=True,
-        validate=validate.Length(min=0, max=MAX_FLOWS),
-    )
-    outflows = ma_fields.List(
-        ma_fields.Nested(OutflowSchema),
-        required=True,
-        validate=validate.Length(min=1, max=MAX_FLOWS),
-    )
-    version = ma_fields.String(
-        required=True, validate=validate.Equal(VERSION_1)
-    )
-
-    @validates_schema
-    def validate_pk_address(self, data: dict[str, Any], **kwargs: Any) -> None:
-        if not validate_address(data.get('public_key'), data.get('address')):
-            raise MarshmallowValidationError(ADDRESS_MISMATCH_MSG)
-
-    @post_load
-    def make_transaction(
-        self, data: dict[str, Any], **kwargs: Any
-    ) -> Transaction:
-        return Transaction(**data)
-
-
 # ---------------------------------------------------------------------------
-# Pydantic v2 models — canonical validators for all new callers.
+# Pydantic v2 models — canonical validators for all callers.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -155,7 +155,7 @@ def test_too_many_txns(reward, subject, txid, wallet):
     block.seal(wallet, reward)
     block.mill()
     with pytest.raises(
-        InvalidBlockError, match='Length must be between 1 and 100'
+        InvalidBlockError, match='List should have at most 100 items'
     ):
         block.validate()
 


### PR DESCRIPTION
## Summary
- Replaces \`BlockSchema(SansNoneSchema)\` with \`BlockModel(BaseModel)\` in \`src/cancelchain/block.py\`.
- Updates the 4 \`Block\` call sites: \`validate_transactions\`, \`to_json\`, \`from_dict\`, \`from_json\`. \`to_json\` switches to \`json.dumps(self.to_dict())\` so it doesn't validate on dump.
- Private \`_block_from_model_data(data)\` helper wraps PR-3's public \`txn_from_model_data\` to reconstruct nested \`Transaction\` instances from \`BlockModel.model_dump()\` output. Returns a fresh dict (no mutation).
- Updates one \`test_block.py\` message-match assertion from Marshmallow's \`'Length must be between 1 and 100'\` wording to Pydantic's \`'List should have at most 100 items'\`.

**Marshmallow purge** — \`BlockSchema\` was the last upstream consumer of \`TransactionSchema\` / \`InflowSchema\` / \`OutflowSchema\` / \`Subject\` / the 5 custom field classes / \`SansNoneSchema\`. With \`BlockSchema\` gone, the rest become reachable orphans and are deleted in this PR across \`transaction.py\`, \`payload.py\`, and \`schema.py\`. File-level \`# mypy: disable-error-code\` directives drop from each file as the Marshmallow imports go away. \`SubjectType\` renames → \`Subject\` in \`payload.py\` (collision is gone).

After this PR, the only remaining Marshmallow consumer in \`src/cancelchain/\` is \`api.py\`'s three query schemas (\`TransferTxnQuerySchema\`, \`SubjectTxnQuerySchema\`, \`PendingTxnQuerySchema\`). PR-5 swaps those. PR-6 removes the runtime dep.

Phase 4 / PR 4 of 6.

## Test plan
- [x] \`uv run mypy\` exits 0 (success: no issues found in 24 source files).
- [x] \`uv run pytest\` passes (204 passed, 1 skipped).
- [x] \`uv run ruff check\` + \`format --check\` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)