### PR TITLE
chore(deps): remove marshmallow from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "Flask-SQLAlchemy>=3.1",
   "gunicorn>=23",
   "humanfriendly>=10.0",
-  "marshmallow>=3.19",
   "millify>=0.1.1",
   "pg8000>=1.31",
   "pycryptodome>=3.20",
@@ -159,10 +158,6 @@ files = ["src/cancelchain"]
 strict = true
 warn_unused_ignores = true
 warn_redundant_casts = true
-
-[[tool.mypy.overrides]]
-module = ["marshmallow", "marshmallow.*"]
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["Crypto", "Crypto.*"]

--- a/uv.lock
+++ b/uv.lock
@@ -180,7 +180,6 @@ dependencies = [
     { name = "flask-sqlalchemy" },
     { name = "gunicorn" },
     { name = "humanfriendly" },
-    { name = "marshmallow" },
     { name = "millify" },
     { name = "pg8000" },
     { name = "pycryptodome" },
@@ -219,7 +218,6 @@ requires-dist = [
     { name = "flask-sqlalchemy", specifier = ">=3.1" },
     { name = "gunicorn", specifier = ">=23" },
     { name = "humanfriendly", specifier = ">=10.0" },
-    { name = "marshmallow", specifier = ">=3.19" },
     { name = "millify", specifier = ">=0.1.1" },
     { name = "pg8000", specifier = ">=1.31" },
     { name = "pycryptodome", specifier = ">=3.20" },
@@ -892,15 +890,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "marshmallow"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Removes \`marshmallow>=3.19\` from \`[project.dependencies]\`.
- Removes the \`[[tool.mypy.overrides]]\` block for \`marshmallow\` / \`marshmallow.*\`.
- \`uv lock\` regenerated; \`marshmallow\` no longer in \`uv.lock\`.

After PRs 1-5 swapped every Marshmallow consumer to Pydantic v2, the
runtime dep is unreachable. This PR completes Phase 4.

Phase 4 / PR 6 of 6 (final).

## Test plan
- [x] \`grep -rn marshmallow src/cancelchain/\` returns comment-only matches (no real imports).
- [x] \`grep -rn marshmallow tests/\` returns nothing.
- [x] \`grep -i marshmallow uv.lock\` returns nothing after \`uv lock\`.
- [x] \`uv run python -c "import marshmallow"\` raises ModuleNotFoundError.
- [x] \`uv run mypy\` exits 0 (no issues found in 24 source files).
- [x] \`uv run pytest\` passes (205 passed, 1 skipped — unchanged).
- [x] \`uv run ruff check\` + \`format --check\` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)