### PR TITLE
docs(phase-5a): Phase 5a pycryptodome → cryptography design + plan

### DIFF
--- a/.claude/skills/wor/SKILL.md
+++ b/.claude/skills/wor/SKILL.md
@@ -7,8 +7,9 @@ Wait for PR reviews (e.g. Copilot), address any feedback, then report back.
 1. Determine the PR number — use the current branch's open PR (`gh pr view --json number --jq .number`), or accept a PR number as an argument.
 2. Determine the repository (`gh repo view --json nameWithOwner --jq .nameWithOwner`).
 3. Launch a background polling loop (~30s interval, up to 10 minutes) checking for reviews and review comments:
-   - `gh api repos/{owner/repo}/pulls/{n}/reviews`
-   - `gh api repos/{owner/repo}/pulls/{n}/comments`
+   - `gh api --paginate repos/{owner/repo}/pulls/{n}/reviews`
+   - `gh api --paginate repos/{owner/repo}/pulls/{n}/comments`
+   - **Always use `--paginate`.** Without it, `gh api` returns at most ~30 items, and the OLDEST items get returned first — so newer review comments after multiple rounds will be silently hidden, making it look like no new review came in. This caused a confused state on PR #58 round 4. Use `--paginate` even on small PRs.
    - Use `gh pr checks {n} --watch` (or poll) to detect when CI has passed.
    - After CI passes, continue polling until the review is in.
 4. When reviews or comments appear, read them all carefully.

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace `pycryptodome` with `cryptography` (pyca) in `src/cancelchain/wallet.py`. After this plan completes, no `Crypto.*` imports remain anywhere in the codebase and `pycryptodome` is removed from `[project.dependencies]` and `uv.lock`.
 
-**Architecture:** Single-file swap — every `pycryptodome` consumer lives in `wallet.py` (207 lines). Public `Wallet` API surface stays identical; internal RSA / AES / hash primitives swap out. Greenfield posture (per `[[project-no-legacy-chain]]`): no backward-compat shims, no migration tool, no preservation of pycryptodome's PKCS#1 DER format. The four downstream wire-shape commitments — public-key DER, address mill_hash, signature determinism, and JWT challenge in-flight only — are preserved by choosing standard cryptographic primitives (SubjectPublicKeyInfo DER, PKCS1v1.5+SHA384) that produce byte-identical output to pycryptodome for the same input.
+**Architecture:** Single-file swap — every `pycryptodome` consumer lives in `wallet.py` (207 lines). Public `Wallet` API surface stays identical; internal RSA / AES / hash primitives swap out. Greenfield posture: no backward-compat shims, no migration tool, no preservation of pycryptodome's PKCS#1 DER format. The four downstream wire-shape commitments — public-key DER, address mill_hash, signature determinism, and JWT challenge in-flight only — are preserved by choosing standard cryptographic primitives (SubjectPublicKeyInfo DER, PKCS1v1.5+SHA384) that produce byte-identical output to pycryptodome for the same input.
 
 **Tech Stack:** `cryptography>=44` (pyca, Rust-backed), `os.urandom` for nonces/session keys, `AES-GCM` for the symmetric AEAD (replaces pycryptodome's `AES-EAX`), `OAEP-SHA256` for asymmetric session-key wrapping (replaces pycryptodome's `OAEP-SHA1` default).
 
@@ -563,7 +563,7 @@ Expected: `OK — all 4 fixture invariants hold`. If any assertion fails, the re
 
 ### Step 8: Add new tests to `tests/test_wallet.py`
 
-The existing test file has 11 tests; we append 8 more.
+The existing test file has 12 tests; we append 8 more.
 
 Read the current end of `tests/test_wallet.py`:
 
@@ -878,7 +878,7 @@ Each PR (Tasks 1 and 2) ends with the controller running `wor` and `mwg`:
 1. **`wor`:** poll PR until Copilot review completes. Read inline comments. Reply one at a time with verified `in_reply_to_id` (per the user's memory).
 2. **`mwg`:** `gh pr checks <N> --watch`; once green, `gh pr merge <N> --squash --delete-branch`.
 
-If Copilot review requests substantive changes, push a new commit (do not amend) and ask the user to click "Re-request review" in the PR sidebar (per `[[feedback-copilot-rereview-trigger]]` — Copilot's auto-review doesn't fire on subsequent fix pushes consistently).
+If Copilot review requests substantive changes, push a new commit (do not amend) and ask the user to click "Re-request review" in the PR sidebar — Copilot's auto-review doesn't fire on subsequent fix pushes consistently; the UI click is the only reliable trigger.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -187,6 +187,7 @@ Replace the entire contents of `src/cancelchain/wallet.py` with:
 ```python
 from __future__ import annotations
 
+import binascii
 import json
 import os
 from base64 import standard_b64decode, standard_b64encode
@@ -382,9 +383,13 @@ class Wallet:
                 padding.PKCS1v15(),
                 hashes.SHA384(),
             )
-        except (InvalidSignature, ValueError, TypeError):
+        except (InvalidSignature, binascii.Error, ValueError, TypeError):
             # InvalidSignature: pyca raises this on a bad signature.
-            # ValueError: bad b64 padding, malformed signature bytes.
+            # binascii.Error: malformed base64 (bad padding, non-b64
+            #   chars). It's a subclass of ValueError in Python 3 so
+            #   the ValueError catch alone would suffice — explicit
+            #   listing makes the b64 failure path obvious.
+            # ValueError: bad-length signature bytes after b64decode.
             # TypeError: wrong types from caller.
             return False
         return True
@@ -689,8 +694,10 @@ src/cancelchain/wallet.py:
 - PKCS1_v1_5+SHA384 sign/verify → private_key.sign(data,
   padding.PKCS1v15(), hashes.SHA384()) / public_key.verify(...). The
   verify path raises InvalidSignature on failure; wrap in try/except
-  (InvalidSignature, ValueError, TypeError) to preserve the
-  return-bool contract.
+  (InvalidSignature, binascii.Error, ValueError, TypeError) to
+  preserve the return-bool contract. binascii.Error covers malformed
+  base64 input to b64decode (it's a subclass of ValueError in Python
+  3 but listed explicitly for reader clarity).
 - PKCS1_OAEP (SHA-1 default) → padding.OAEP(mgf=MGF1(SHA256()),
   algorithm=SHA256(), label=None). Stronger hash; no compat constraint.
 - AES.MODE_EAX → AESGCM. EAX is not in pyca/cryptography. JWT

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -474,10 +474,11 @@ Notes:
 
 ```bash
 grep -n 'Crypto' src/cancelchain/wallet.py
-grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/
+grep -rn 'pycryptodome' src/cancelchain/
+grep -rn 'Crypto\.' src/cancelchain/
 ```
 
-Expected: both return empty.
+Expected: all three return empty. Two separate `grep`s because POSIX `grep` treats `\b` as a literal backspace, not a word boundary — `Crypto\.` (with a literal dot) catches the import shapes pycryptodome uses (`from Crypto.Cipher`, `from Crypto.PublicKey`, etc.) without false positives on unrelated strings containing "Crypto".
 
 ### Step 6: Regenerate `WALLET_PRIVATE_KEY_B58` in `tests/conftest.py`
 
@@ -756,7 +757,7 @@ Phase 5a. Spec/plan merged in the preceding docs PR.
 - [x] \`uv run pytest\` passes (205 → ~213).
 - [x] \`uv run ruff check\` + \`format --check\` pass.
 - [x] \`uv run python -c "import Crypto"\` raises ModuleNotFoundError.
-- [x] \`grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/\` returns nothing.
+- [x] \`grep -rn 'pycryptodome' src/cancelchain/\` and \`grep -rn 'Crypto\.' src/cancelchain/\` both return nothing.
 - [ ] CI green on 3.12 and 3.13.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
@@ -794,13 +795,14 @@ Expected: Python 3.12.x and a fresh venv.
 - [ ] **Step 3: pycryptodome absent**
 
 ```bash
-grep -rn 'pycryptodome\|Crypto\b' src/cancelchain/
+grep -rn 'pycryptodome' src/cancelchain/
+grep -rn 'Crypto\.' src/cancelchain/
 grep -c pycryptodome pyproject.toml
 grep -ci pycryptodome uv.lock
 uv run python -c "import Crypto" 2>&1 | head -3
 ```
 
-Expected: first three grep checks return nothing / 0; the import attempt raises `ModuleNotFoundError`.
+Expected: first four grep checks return nothing / 0; the import attempt raises `ModuleNotFoundError`. Two separate `grep`s because POSIX `grep` treats `\b` as a literal backspace, not a word boundary.
 
 - [ ] **Step 4: cryptography present**
 

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -1,0 +1,938 @@
+# Phase 5a — `pycryptodome` → `cryptography` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `pycryptodome` with `cryptography` (pyca) in `src/cancelchain/wallet.py`. After this plan completes, no `Crypto.*` imports remain anywhere in the codebase and `pycryptodome` is removed from `[project.dependencies]` and `uv.lock`.
+
+**Architecture:** Single-file swap — every `pycryptodome` consumer lives in `wallet.py` (207 lines). Public `Wallet` API surface stays identical; internal RSA / AES / hash primitives swap out. Greenfield posture (per `[[project-no-legacy-chain]]`): no backward-compat shims, no migration tool, no preservation of pycryptodome's PKCS#1 DER format. The four downstream wire-shape commitments — public-key DER, address mill_hash, signature determinism, and JWT challenge in-flight only — are preserved by choosing standard cryptographic primitives (SubjectPublicKeyInfo DER, PKCS1v1.5+SHA384) that produce byte-identical output to pycryptodome for the same input.
+
+**Tech Stack:** `cryptography>=44` (pyca, Rust-backed), `os.urandom` for nonces/session keys, `AES-GCM` for the symmetric AEAD (replaces pycryptodome's `AES-EAX`), `OAEP-SHA256` for asymmetric session-key wrapping (replaces pycryptodome's `OAEP-SHA1` default).
+
+---
+
+## Prerequisites
+
+- Working directory: the cancelchain repo root (whatever path it lives at). Run all commands from there.
+- `uv --version` 0.4.x or newer; `gh --version` works and `gh auth status` shows authenticated.
+- Phase 4 fully merged. Verify with `gh pr view 57 --json state --jq .state` → `MERGED`, and `grep -c 'marshmallow' pyproject.toml` → `0`.
+- The branch `docs/phase-5a-design` exists locally with the design spec already committed. This plan adds the second commit on that branch and ships both as the docs PR.
+- CI hard-gates `ruff check`, `ruff format --check`, and `mypy --strict`.
+- Test baseline: **205 passed, 1 skipped**. Phase 5a adds ~8-9 new tests, so the final count is ~213-214 passed, 1 skipped.
+- Each PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller handles those, not the implementer subagent.
+- Never push directly to `main`.
+
+---
+
+## File Map
+
+| Task | PR | Files |
+|---|---|---|
+| 1 | docs PR | `docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md` (this file) |
+| 2 | impl PR | `pyproject.toml`, `src/cancelchain/wallet.py`, `tests/conftest.py`, `tests/test_wallet.py`, `uv.lock` |
+| 3 | acceptance | none (verification only) |
+
+---
+
+## Task 1: Ship the docs PR (spec + plan)
+
+**Files:** Modify: nothing tracked yet. The design spec is already committed on `docs/phase-5a-design`. This task adds the implementation plan and ships them together.
+
+- [ ] **Step 1: Confirm branch state**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git ls-files docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+git rev-list --count main..HEAD
+```
+
+Expected: branch is `docs/phase-5a-design`; spec file is tracked (the path is echoed back by `git ls-files`); commit count above main is `1`.
+
+- [ ] **Step 2: Verify the plan file is present and untracked**
+
+```bash
+ls -la docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+git status docs/superpowers/plans/
+```
+
+Expected: file exists, shows as untracked.
+
+- [ ] **Step 3: Stage and commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+git commit -m "$(cat <<'EOF'
+docs(phase-5a): add Phase 5a pycryptodome → cryptography implementation plan
+
+Spells out the single-PR impl: branch off main, swap wallet.py
+internals, regenerate WALLET_PRIVATE_KEY_B58 fixture, add 8 new
+round-trip / public-key-only tests, drop pycryptodome from deps +
+mypy overrides + uv.lock.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin docs/phase-5a-design
+```
+
+- [ ] **Step 5: Open the docs PR**
+
+```bash
+gh pr create --base main --head docs/phase-5a-design --title "docs(phase-5a): Phase 5a pycryptodome → cryptography design + plan" --body "$(cat <<'EOF'
+## Summary
+- Adds the Phase 5a design spec (\`docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md\`).
+- Adds the Phase 5a implementation plan (\`docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md\`).
+- No code changes.
+
+Phase 5a ships as a single implementation PR after this docs PR lands. Single-file swap contained to \`src/cancelchain/wallet.py\` (greenfield posture — no backward-compat shims).
+
+## Test plan
+- [x] Spec self-review passed.
+- [x] Plan self-review passed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 2: Phase 5a impl — swap `wallet.py` to `cryptography`
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/cancelchain/wallet.py`
+- Modify: `tests/conftest.py` (regenerate `WALLET_PRIVATE_KEY_B58`)
+- Modify: `tests/test_wallet.py` (add 8 new tests)
+- Modify: `uv.lock` (regenerated)
+
+### Step 1: Branch off main
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/cryptography-swap
+```
+
+### Step 2: Update `pyproject.toml` dependencies
+
+Edit `pyproject.toml`. In `[project] dependencies`, replace `"pycryptodome>=3.20",` with `"cryptography>=44",`. Position alphabetically — between `"celery>=5.4"` and `"click>=8.1.7"` (cryptography sorts before click).
+
+Before:
+```toml
+  "celery>=5.4",
+  "click>=8.1.7",
+  ...
+  "pg8000>=1.31",
+  "pycryptodome>=3.20",
+  "pydantic>=2.10",
+```
+
+After:
+```toml
+  "celery>=5.4",
+  "cryptography>=44",
+  "click>=8.1.7",
+  ...
+  "pg8000>=1.31",
+  "pydantic>=2.10",
+```
+
+Drop the `[[tool.mypy.overrides]]` block at line 162-164:
+
+Before:
+```toml
+[[tool.mypy.overrides]]
+module = ["Crypto", "Crypto.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["base58check", "pymerkle", "pymerkle.*"]
+ignore_missing_imports = true
+```
+
+After:
+```toml
+[[tool.mypy.overrides]]
+module = ["base58check", "pymerkle", "pymerkle.*"]
+ignore_missing_imports = true
+```
+
+(`cryptography` ships its own type stubs in the package — no override needed.)
+
+### Step 3: Lock and install
+
+```bash
+uv lock --upgrade-package pycryptodome --upgrade-package cryptography
+uv sync --group dev
+uv run python -c "from importlib.metadata import version; print('cryptography', version('cryptography'))"
+uv run python -c "import Crypto" 2>&1 | head -3
+```
+
+Expected:
+- `cryptography 44.x.x` or newer.
+- `ModuleNotFoundError: No module named 'Crypto'`.
+
+If `uv lock` keeps pycryptodome around (because something else still depends on it), STOP and investigate — nothing else in this codebase should pull it in.
+
+### Step 4: Rewrite `src/cancelchain/wallet.py`
+
+Replace the entire contents of `src/cancelchain/wallet.py` with:
+
+```python
+from __future__ import annotations
+
+import json
+import os
+from base64 import standard_b64decode, standard_b64encode
+from collections.abc import Generator
+from typing import Any
+
+import base58check
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    RSAPublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from cancelchain.exceptions import InvalidKeyError, NoPrivateKeyError
+from cancelchain.milling import mill_hash_bin
+
+ADDRESS_TAG = 'CC'
+KEY_SIZE = 2048
+GCM_NONCE_SIZE = 12
+AES_SESSION_KEY_SIZE = 16
+
+
+def b58decode(s: str) -> bytes:
+    return base58check.b58decode(s.encode())  # type: ignore[no-any-return]
+
+
+def b58encode(b: bytes) -> str:
+    return base58check.b58encode(b).decode()  # type: ignore[no-any-return]
+
+
+def b64decode(s: str) -> bytes:
+    return standard_b64decode(s.encode())
+
+
+def b64encode(b: bytes) -> str:
+    return standard_b64encode(b).decode()
+
+
+def export_binary_key(key: Any, passphrase: str | None = None) -> bytes:
+    if isinstance(key, RSAPublicKey):
+        return key.public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    # RSAPrivateKey
+    encryption: serialization.KeySerializationEncryption
+    if passphrase is None:
+        encryption = serialization.NoEncryption()
+    else:
+        encryption = serialization.BestAvailableEncryption(
+            passphrase.encode()
+        )
+    return key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+
+
+def import_key(ks: bytes | str, passphrase: str | None = None) -> Any | None:
+    """Load an RSA key from PEM or DER bytes. Accepts both private and
+    public keys (api.py / schema.py / models.py construct Wallet with
+    a peer's public key alone for signature verification).
+    """
+    try:
+        if isinstance(ks, str):
+            ks = ks.encode()
+        password = passphrase.encode() if passphrase is not None else None
+        is_pem = b'-----BEGIN' in ks[:30]
+        # Private-key path first (the common case for wallet load flows)
+        try:
+            if is_pem:
+                return serialization.load_pem_private_key(ks, password)
+            return serialization.load_der_private_key(ks, password)
+        except Exception:
+            pass
+        # Public-key fallback (peer-public-key wrap path)
+        if is_pem:
+            return serialization.load_pem_public_key(ks)
+        return serialization.load_der_public_key(ks)
+    except Exception:
+        return None
+
+
+def import_b58_key(ks: str, passphrase: str | None = None) -> Any | None:
+    try:
+        return import_key(b58decode(ks), passphrase=passphrase)
+    except Exception:
+        return None
+
+
+def import_b64_key(ks: str, passphrase: str | None = None) -> Any | None:
+    try:
+        return import_key(b64decode(ks), passphrase=passphrase)
+    except Exception:
+        return None
+
+
+class Wallet:
+    def __init__(
+        self,
+        b64ks: str | None = None,
+        b58ks: str | None = None,
+        ks: bytes | str | None = None,
+        passphrase: str | None = None,
+    ) -> None:
+        if b64ks is not None:
+            self.key: Any = import_b64_key(b64ks, passphrase=passphrase)
+        elif b58ks is not None:
+            self.key = import_b58_key(b58ks, passphrase=passphrase)
+        elif ks is not None:
+            self.key = import_key(ks, passphrase=passphrase)
+        else:
+            self.key = rsa.generate_private_key(
+                public_exponent=65537, key_size=KEY_SIZE
+            )
+        if not (
+            isinstance(self.key, (RSAPrivateKey, RSAPublicKey))
+            and self.key.key_size == KEY_SIZE
+        ):
+            raise InvalidKeyError()
+
+    @property
+    def private_key(self) -> Any | None:
+        return self.key if isinstance(self.key, RSAPrivateKey) else None
+
+    @property
+    def public_key(self) -> Any:
+        return (
+            self.private_key.public_key()
+            if self.private_key is not None
+            else self.key
+        )
+
+    @property
+    def private_key_b58(self) -> str:
+        return self.export_private_key_b58()
+
+    @property
+    def public_key_b64(self) -> str:
+        return b64encode(export_binary_key(self.public_key))
+
+    @property
+    def address(self) -> str:
+        aks = b58encode(
+            mill_hash_bin(export_binary_key(self.public_key))
+        )
+        return f'{ADDRESS_TAG}{aks}{ADDRESS_TAG}'
+
+    def export_private_key_pem(self, passphrase: str | None = None) -> bytes:
+        if self.private_key is None:
+            raise NoPrivateKeyError()
+        encryption: serialization.KeySerializationEncryption
+        if passphrase is None:
+            encryption = serialization.NoEncryption()
+        else:
+            encryption = serialization.BestAvailableEncryption(
+                passphrase.encode()
+            )
+        return self.private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=encryption,
+        )
+
+    def export_private_key_b58(self, passphrase: str | None = None) -> str:
+        if self.private_key is None:
+            raise NoPrivateKeyError()
+        return b58encode(
+            export_binary_key(self.private_key, passphrase=passphrase)
+        )
+
+    def sign(self, data: bytes) -> str:
+        if self.private_key is None:
+            raise NoPrivateKeyError()
+        sig = self.private_key.sign(
+            data, padding.PKCS1v15(), hashes.SHA384()
+        )
+        return b64encode(sig)
+
+    def validate_signature(
+        self, data: bytes, signature: str | None
+    ) -> bool:
+        if not (data and signature):
+            return False
+        try:
+            self.public_key.verify(
+                b64decode(signature),
+                data,
+                padding.PKCS1v15(),
+                hashes.SHA384(),
+            )
+        except (InvalidSignature, ValueError, TypeError):
+            # InvalidSignature: pyca raises this on a bad signature.
+            # ValueError: bad b64 padding, malformed signature bytes.
+            # TypeError: wrong types from caller.
+            return False
+        return True
+
+    def encrypt(self, data: bytes) -> str:
+        session_key = os.urandom(AES_SESSION_KEY_SIZE)
+        enc_session_key = self.public_key.encrypt(
+            session_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        nonce = os.urandom(GCM_NONCE_SIZE)
+        ciphertext_with_tag = AESGCM(session_key).encrypt(
+            nonce, data, None
+        )
+        return b64encode(enc_session_key + nonce + ciphertext_with_tag)
+
+    def decrypt(self, msg: str) -> bytes:
+        if self.private_key is None:
+            raise NoPrivateKeyError()
+        raw = b64decode(msg)
+        key_size_bytes = self.private_key.key_size // 8
+        enc_session_key = raw[:key_size_bytes]
+        nonce = raw[key_size_bytes : key_size_bytes + GCM_NONCE_SIZE]
+        ciphertext = raw[key_size_bytes + GCM_NONCE_SIZE :]
+        session_key = self.private_key.decrypt(
+            enc_session_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        return AESGCM(session_key).decrypt(nonce, ciphertext, None)
+
+    def to_dict(self) -> dict[str, str]:
+        return {'private_key': self.private_key_b58}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    def to_file(
+        self, walletdir: str | None = None, passphrase: str | None = None
+    ) -> str:
+        filename = f'{self.address}.pem'
+        if walletdir:
+            filename = os.path.join(walletdir, filename)
+        with open(filename, 'wb') as f:
+            f.write(self.export_private_key_pem(passphrase=passphrase))
+        return filename
+
+    def __repr__(self) -> str:
+        return f'Wallet({self.address})'
+
+    __hash__: None = None  # type: ignore[assignment]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Wallet):
+            return NotImplemented
+        return bool(self.key == other.key)
+
+    @classmethod
+    def from_dict(cls, wallet_dict: dict[str, Any]) -> Wallet:
+        return cls(b58ks=wallet_dict.get('private_key'))
+
+    @classmethod
+    def from_json(cls, wallet_json: str) -> Wallet:
+        return cls.from_dict(json.loads(wallet_json))
+
+    @classmethod
+    def from_file(
+        cls, filename: str, passphrase: str | None = None
+    ) -> Wallet:
+        with open(filename, 'rb') as f:
+            return cls(ks=f.read(), passphrase=passphrase)
+```
+
+Notes:
+- The `Generator` import is no longer used (the old `decrypt` had an inner `msg_parts` generator helper; the new `decrypt` uses straight slicing). Keep the import only if other code in the file references `Generator`. Check with `grep Generator src/cancelchain/wallet.py` after pasting — if no other references, ruff will flag it as unused and the formatter will remove it; or remove it manually. Same for any other unused imports (`base58check` IS still used; double-check).
+- The `Crypto.*` imports are gone.
+- `Wallet.key` is now an `Any` typed attribute that may hold either `RSAPrivateKey` or `RSAPublicKey`. The constructor's isinstance check validates both forms.
+
+### Step 5: Verify the swap is clean
+
+```bash
+grep -n 'Crypto' src/cancelchain/wallet.py
+grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/
+```
+
+Expected: both return empty.
+
+### Step 6: Regenerate `WALLET_PRIVATE_KEY_B58` in `tests/conftest.py`
+
+The fixture's b58-encoded private key was generated under pycryptodome's PKCS#1 DER format. The new code reads PKCS#1 DER input fine (cryptography's `load_der_private_key` handles both PKCS#1 and PKCS#8), but exports as PKCS#8 DER, so a round-trip through `Wallet.private_key_b58` produces a different string. To keep `test_create_from_key` passing, the constant in conftest.py must be regenerated to the new PKCS#8 DER b58 of the same underlying RSA key.
+
+Run this one-shot script in the venv:
+
+```bash
+uv run python <<'PY'
+from base58check import b58decode, b58encode
+from cryptography.hazmat.primitives import serialization
+
+# The OLD pycryptodome-era b58 (copy from current conftest.py).
+# Open tests/conftest.py and read the multi-line string WALLET_PRIVATE_KEY_B58 = (...).
+import re, pathlib
+src = pathlib.Path('tests/conftest.py').read_text()
+m = re.search(r'WALLET_PRIVATE_KEY_B58 = \((.+?)\)', src, re.DOTALL)
+assert m, 'could not locate WALLET_PRIVATE_KEY_B58 literal'
+literal = m.group(1)
+old_b58 = ''.join(re.findall(r"'([^']+)'", literal))
+print(f'old_b58 length: {len(old_b58)}')
+
+# Decode to the old PKCS#1 DER bytes
+old_der = b58decode(old_b58.encode())
+
+# Load that key under cryptography (handles PKCS#1 DER fine)
+key = serialization.load_der_private_key(old_der, password=None)
+
+# Re-export as PKCS#8 DER
+new_der = key.private_bytes(
+    encoding=serialization.Encoding.DER,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+
+# Re-encode b58
+new_b58 = b58encode(new_der).decode()
+print(f'new_b58 length: {len(new_b58)}')
+print('---')
+print(new_b58)
+PY
+```
+
+Expected: prints two lengths and the new b58 string. Copy that new b58 string.
+
+Open `tests/conftest.py`. Find the `WALLET_PRIVATE_KEY_B58 = (...)` literal. Replace its contents with the new b58 string, formatted as a multi-line concatenation in the same style as the original (split into ~60-character chunks if you want to match the existing formatting; or one single string — ruff will reformat as needed).
+
+### Step 7: Verify the fixture regeneration is correct
+
+```bash
+uv run python <<'PY'
+from cancelchain.wallet import Wallet
+import sys
+sys.path.insert(0, 'tests')
+from conftest import (
+    WALLET_PRIVATE_KEY_B58,
+    WALLET_PUBLIC_KEY_B64,
+    WALLET_ADDRESS,
+    WALLET_SIGNATURE_DATA,
+    WALLET_SIGNATURE,
+)
+
+w = Wallet(b58ks=WALLET_PRIVATE_KEY_B58)
+assert w.public_key_b64 == WALLET_PUBLIC_KEY_B64, (
+    f'public_key_b64 mismatch:\n  got: {w.public_key_b64}\n  exp: {WALLET_PUBLIC_KEY_B64}'
+)
+assert w.address == WALLET_ADDRESS, (
+    f'address mismatch:\n  got: {w.address}\n  exp: {WALLET_ADDRESS}'
+)
+sig = w.sign(WALLET_SIGNATURE_DATA.encode())
+assert sig == WALLET_SIGNATURE, (
+    f'signature mismatch:\n  got: {sig}\n  exp: {WALLET_SIGNATURE}'
+)
+# Round-trip the new b58 → re-export should match
+assert w.private_key_b58 == WALLET_PRIVATE_KEY_B58, (
+    'private_key_b58 round-trip mismatch'
+)
+print('OK — all 4 fixture invariants hold')
+PY
+```
+
+Expected: `OK — all 4 fixture invariants hold`. If any assertion fails, the regeneration script in Step 6 went wrong — STOP and debug.
+
+### Step 8: Add new tests to `tests/test_wallet.py`
+
+The existing test file has 11 tests; we append 8 more.
+
+Read the current end of `tests/test_wallet.py`:
+
+```bash
+tail -20 tests/test_wallet.py
+```
+
+Append the following test functions to the end of `tests/test_wallet.py`. Match the existing style (top-level functions, no class wrapping, fixtures from conftest where available):
+
+```python
+
+
+def test_wallet_address_round_trips_through_pem(tmp_path):
+    """Freshly generated wallet → write PEM → read back → same address."""
+    w1 = Wallet()
+    path = w1.to_file(walletdir=str(tmp_path))
+    w2 = Wallet.from_file(path)
+    assert w1.address == w2.address
+
+
+def test_wallet_address_round_trips_through_b58():
+    """Freshly generated wallet → b58 → read back → same address."""
+    w1 = Wallet()
+    w2 = Wallet(b58ks=w1.private_key_b58)
+    assert w1.address == w2.address
+
+
+def test_wallet_sign_verify_happy_path():
+    w = Wallet()
+    sig = w.sign(b'hello world')
+    assert w.validate_signature(b'hello world', sig) is True
+
+
+def test_wallet_verify_rejects_mutated_payload():
+    w = Wallet()
+    sig = w.sign(b'hello world')
+    assert w.validate_signature(b'hello WORLD', sig) is False
+
+
+def test_wallet_verify_rejects_garbage_signature():
+    w = Wallet()
+    assert w.validate_signature(b'data', 'garbagebase64==') is False
+
+
+def test_wallet_encrypt_decrypt_round_trip():
+    w = Wallet()
+    plaintext = b'session-challenge-payload'
+    ciphertext = w.encrypt(plaintext)
+    assert w.decrypt(ciphertext) == plaintext
+
+
+def test_wallet_encrypted_pem_round_trip(tmp_path):
+    """Encrypted PEM with a passphrase round-trips."""
+    w1 = Wallet()
+    path = w1.to_file(walletdir=str(tmp_path), passphrase='hunter2')
+    w2 = Wallet.from_file(path, passphrase='hunter2')
+    assert w1.address == w2.address
+
+
+def test_wallet_public_key_only_constructs(wallet):
+    """Wallet(b64ks=public_key_b64) accepts a peer's public key alone.
+
+    Used by api.py / schema.py / models.py to wrap a remote party's
+    public key for signature verification. Private operations
+    (sign, decrypt, export_private_key_*) raise NoPrivateKeyError.
+    """
+    from cancelchain.exceptions import NoPrivateKeyError
+
+    w = Wallet(b64ks=wallet.public_key_b64)
+    assert w.private_key is None
+    assert w.public_key is not None
+    assert w.address == wallet.address
+    # Public verify should still work
+    sig = wallet.sign(b'data')
+    assert w.validate_signature(b'data', sig) is True
+    # Private operations raise
+    with pytest.raises(NoPrivateKeyError):
+        w.sign(b'data')
+```
+
+If the `from cancelchain.exceptions import NoPrivateKeyError` line is needed at module level (i.e., `NoPrivateKeyError` isn't already imported at the top of `tests/test_wallet.py`), hoist it to the top alongside the existing `from cancelchain.exceptions import InvalidKeyError` line. Verify with `grep -n 'NoPrivateKeyError' tests/test_wallet.py` before deciding — if it shows up only inside the new function, hoist it.
+
+### Step 9: Verify all gates
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+All four must exit 0. Test count: 205 → ~213 (8 new tests).
+
+If `mypy` reports new errors in `wallet.py`, the most common cause is the `Any`-typed `self.key` attribute interacting with method calls. The intent is that `Wallet.key` is `Any` throughout so callers don't need to import RSAPrivateKey/RSAPublicKey types. If a specific line type-errors, add a narrow `# type: ignore` rather than tightening the type. Aim for ≤1 ignore in the new code; if you need more, something's wrong — investigate before suppressing.
+
+If `pytest` fails on:
+- `test_create_from_key` — the fixture regeneration was wrong. Re-run Step 7's assertion script and inspect the mismatch.
+- `test_crypto` (decrypt with wrong wallet) — that test asserts `with pytest.raises(ValueError)`. AES-GCM's `AESGCM.decrypt` on a wrong key raises `InvalidTag`, which is a subclass of `cryptography.exceptions.InvalidTag` (NOT `ValueError`). The test may need its `pytest.raises` argument widened. Check with `uv run pytest tests/test_wallet.py::test_crypto -v` and inspect the error; if it raises `InvalidTag`, update the test to `pytest.raises((ValueError, InvalidTag))` and add `from cryptography.exceptions import InvalidTag` to the test file imports. Document this in the commit message.
+
+### Step 10: Commit
+
+```bash
+git add pyproject.toml uv.lock src/cancelchain/wallet.py tests/conftest.py tests/test_wallet.py
+git commit -m "$(cat <<'EOF'
+feat(deps): swap pycryptodome → cryptography in wallet.py
+
+Phase 5a. Single-file swap. Greenfield posture (per
+project-no-legacy-chain memory): no backward-compat shims, no
+migration tool.
+
+src/cancelchain/wallet.py:
+- 5 Crypto.* imports replaced with cryptography hazmat primitives:
+  rsa, padding, hashes, serialization, AESGCM, InvalidSignature.
+- RSA.generate(2048) → rsa.generate_private_key(public_exponent=65537,
+  key_size=2048).
+- RSA.import_key auto-detect → explicit PEM-vs-DER sniff (bytes
+  startswith '-----BEGIN' in first 30B) followed by private-key
+  loader fallthrough to public-key loader (callers in api.py,
+  schema.py, models.py construct Wallet(b64ks=public_key_b64) for
+  signature verification against peer keys).
+- PKCS1_v1_5+SHA384 sign/verify → private_key.sign(data,
+  padding.PKCS1v15(), hashes.SHA384()) / public_key.verify(...). The
+  verify path raises InvalidSignature on failure; wrap in try/except
+  (InvalidSignature, ValueError, TypeError) to preserve the
+  return-bool contract.
+- PKCS1_OAEP (SHA-1 default) → padding.OAEP(mgf=MGF1(SHA256()),
+  algorithm=SHA256(), label=None). Stronger hash; no compat constraint.
+- AES.MODE_EAX → AESGCM. EAX is not in pyca/cryptography. JWT
+  challenge ciphertexts are alive for seconds during the handshake
+  and never persisted, so the wire-format change is safe. New layout:
+  enc_session_key (256B) || nonce (12B) || ciphertext_with_appended_tag.
+- Crypto.Random.get_random_bytes(N) → os.urandom(N).
+- Private-key DER and PEM serialization both switch to PKCS#8.
+- Encrypted PEM uses BestAvailableEncryption (PBKDF2-SHA256/AES-256-CBC).
+
+pyproject.toml:
+- "pycryptodome>=3.20" removed from [project.dependencies].
+- "cryptography>=44" added in alphabetical position.
+- [[tool.mypy.overrides]] block for module = ["Crypto", "Crypto.*"]
+  removed (cryptography ships type stubs).
+
+tests/conftest.py:
+- WALLET_PRIVATE_KEY_B58 regenerated under the new PKCS#8 DER format
+  (the underlying RSA key value is unchanged). The other four WALLET_*
+  constants (WALLET_PUBLIC_KEY_B64, WALLET_ADDRESS, WALLET_SIGNATURE_DATA,
+  WALLET_SIGNATURE) stay byte-identical — SubjectPublicKeyInfo DER and
+  PKCS1v1.5+SHA384 are deterministic across both libraries.
+
+tests/test_wallet.py:
+- 8 new tests cover address/PEM/b58 round-trips, sign-verify happy and
+  tamper-rejection paths, encrypt-decrypt round-trip, encrypted-PEM
+  round-trip, and the public-key-only construct path (verifies that
+  Wallet(b64ks=peer_pub_b64) accepts the input, exposes public_key,
+  returns None for private_key, and raises NoPrivateKeyError on
+  sign/decrypt while still verifying peer signatures).
+
+Test count: 205 → ~213.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Step 11: Push and open PR
+
+```bash
+git push -u origin feat/cryptography-swap
+gh pr create --base main --title "feat(deps): swap pycryptodome → cryptography in wallet.py" --body "$(cat <<'EOF'
+## Summary
+- Replaces pycryptodome with pyca/cryptography in \`src/cancelchain/wallet.py\` (single-file swap).
+- Drops \`pycryptodome>=3.20\` from \`[project.dependencies]\`, adds \`cryptography>=44\`.
+- Drops the \`[[tool.mypy.overrides]]\` block for the \`Crypto\` module (cryptography ships type stubs).
+- AES-EAX → AES-GCM (pyca doesn't support EAX; JWT challenge ciphertexts aren't persisted so wire-format change is safe).
+- OAEP hash defaults switch from SHA-1 to SHA-256.
+- Private-key DER and PEM serialization both switch to PKCS#8 standard format.
+- Encrypted PEM uses BestAvailableEncryption (PBKDF2-SHA256 + AES-256-CBC).
+- 8 new tests in \`tests/test_wallet.py\` covering round-trips, sign/verify happy + reject paths, encrypt/decrypt, encrypted-PEM, and public-key-only Wallet construction.
+- \`WALLET_PRIVATE_KEY_B58\` fixture regenerated under PKCS#8 DER (the underlying RSA key is unchanged; the other 4 WALLET_* fixtures stay byte-identical).
+
+**Greenfield posture** (per \`project-no-legacy-chain\` memory): no backward-compat shims, no migration tool. No persisted wallet \`.pem\` files or in-flight JWT challenges to preserve.
+
+Phase 5a. Spec/plan merged in the preceding docs PR.
+
+## Test plan
+- [x] \`uv run mypy\` exits 0.
+- [x] \`uv run pytest\` passes (205 → ~213).
+- [x] \`uv run ruff check\` + \`format --check\` pass.
+- [x] \`uv run python -c "import Crypto"\` raises ModuleNotFoundError.
+- [x] \`grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/\` returns nothing.
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 12: Stop — controller handles wor + mwg + sync
+
+---
+
+## Task 3: Phase 5a acceptance verification
+
+**Files:** none modified. Final verification after the impl PR lands.
+
+- [ ] **Step 1: Confirm clean main**
+
+```bash
+git checkout main && git pull --ff-only
+git log --oneline -3
+```
+
+Expected: top two commits are the docs PR squash and the impl PR squash.
+
+- [ ] **Step 2: Fresh sync**
+
+```bash
+rm -rf .venv
+uv sync --group dev
+uv run python --version
+```
+
+Expected: Python 3.12.x and a fresh venv.
+
+- [ ] **Step 3: pycryptodome absent**
+
+```bash
+grep -rn 'pycryptodome\|Crypto\b' src/cancelchain/
+grep -c pycryptodome pyproject.toml
+grep -ci pycryptodome uv.lock
+uv run python -c "import Crypto" 2>&1 | head -3
+```
+
+Expected: first three grep checks return nothing / 0; the import attempt raises `ModuleNotFoundError`.
+
+- [ ] **Step 4: cryptography present**
+
+```bash
+uv run python -c "from importlib.metadata import version; print('cryptography', version('cryptography'))"
+uv run python -c "from cryptography.hazmat.primitives.asymmetric import rsa; print(rsa)"
+```
+
+Expected: prints `cryptography 44.x.x` and the rsa module repr.
+
+- [ ] **Step 5: Hard CI gates pass**
+
+```bash
+uv run ruff check src tests; echo "ruff check exit: $?"
+uv run ruff format --check src tests; echo "ruff format exit: $?"
+uv run mypy; echo "mypy exit: $?"
+```
+
+All three exit 0.
+
+- [ ] **Step 6: Tests pass on 3.12 and 3.13**
+
+```bash
+uv run --python 3.12 pytest 2>&1 | tail -3
+uv run --python 3.13 pytest 2>&1 | tail -3
+```
+
+Expected: both print `213 passed, 1 skipped` (or whatever the new count is — should be 8 more than 205).
+
+- [ ] **Step 7: CLI smoke**
+
+```bash
+uv run cancelchain --help
+```
+
+Expected: prints the full command tree.
+
+- [ ] **Step 8: Wallet round-trip smoke**
+
+```bash
+uv run python <<'PY'
+from cancelchain.wallet import Wallet
+w1 = Wallet()
+print('generated address:', w1.address)
+b58 = w1.private_key_b58
+w2 = Wallet(b58ks=b58)
+assert w1.address == w2.address
+print('b58 round-trip OK')
+sig = w1.sign(b'hello')
+assert w1.validate_signature(b'hello', sig) is True
+assert w1.validate_signature(b'world', sig) is False
+print('sign/verify OK')
+ct = w1.encrypt(b'secret')
+assert w1.decrypt(ct) == b'secret'
+print('encrypt/decrypt OK')
+PY
+```
+
+Expected: prints `generated address: CC...CC`, then `b58 round-trip OK`, then `sign/verify OK`, then `encrypt/decrypt OK`.
+
+- [ ] **Step 9: Docker build smoke**
+
+```bash
+docker build --target builder -t cc-phase5a-final .
+```
+
+Expected: succeeds.
+
+- [ ] **Step 10: Acceptance complete**
+
+If Steps 1–9 all pass, Phase 5a is done. No commit.
+
+---
+
+## Notes on the wor / mwg workflow
+
+Each PR (Tasks 1 and 2) ends with the controller running `wor` and `mwg`:
+
+1. **`wor`:** poll PR until Copilot review completes. Read inline comments. Reply one at a time with verified `in_reply_to_id` (per the user's memory).
+2. **`mwg`:** `gh pr checks <N> --watch`; once green, `gh pr merge <N> --squash --delete-branch`.
+
+If Copilot review requests substantive changes, push a new commit (do not amend) and ask the user to click "Re-request review" in the PR sidebar (per `[[feedback-copilot-rereview-trigger]]` — Copilot's auto-review doesn't fire on subsequent fix pushes consistently).
+
+---
+
+## Risks and watchpoints
+
+### Risk: `test_crypto` may break on the AES-GCM exception type
+
+The existing `tests/test_wallet.py::test_crypto` does:
+```python
+with pytest.raises(ValueError):
+    wallet2.decrypt(msg)
+```
+
+Under pycryptodome's AES-EAX, `decrypt_and_verify` raised `ValueError` on a bad tag (wrong key). Under cryptography's AES-GCM, `AESGCM.decrypt` raises `cryptography.exceptions.InvalidTag` — which is NOT a subclass of `ValueError`. This test will fail.
+
+Fix in Step 9: widen the `pytest.raises` to a tuple:
+```python
+from cryptography.exceptions import InvalidTag
+
+with pytest.raises((ValueError, InvalidTag)):
+    wallet2.decrypt(msg)
+```
+
+Or, even cleaner: change to `with pytest.raises(InvalidTag):` since we now know the precise exception type. Document the change in the commit message under "tests/test_wallet.py:".
+
+### Risk: AES-GCM wire-layout offset off-by-one
+
+The `decrypt` slicing in Step 4's code assumes:
+- `enc_session_key`: first `key_size_bytes` (256) bytes
+- `nonce`: next 12 bytes (`raw[256:268]`)
+- `ciphertext_with_tag`: everything from byte 268 onward
+
+`AESGCM.encrypt(nonce, data, None)` returns `ciphertext || tag` (16-byte GCM tag appended). `AESGCM.decrypt` takes the same ciphertext-plus-tag blob and the original nonce. So the slicing is correct *only if* `encrypt` returns the same layout I'm slicing for in `decrypt`. Verify with the round-trip test in Step 9 (`test_wallet_encrypt_decrypt_round_trip`); if it fails, inspect the actual byte lengths via `len(raw)`, `key_size_bytes`, etc.
+
+### Risk: `Generator` import becomes unused
+
+The old `decrypt` had an inner `msg_parts(key_size, raw) -> Generator[bytes, None, None]` helper. The new `decrypt` uses straight slicing. Remove `from collections.abc import Generator` if no other code in `wallet.py` uses it. Ruff will flag this and `uv run ruff check` will fail — fix by removing the import.
+
+### Risk: hardcoded `Wallet.size_in_bytes()` reference somewhere outside wallet.py
+
+`grep -rn 'size_in_bytes\|size_in_bits' src/ tests/` — should return empty (these are pycryptodome methods that don't exist on cryptography keys). If any external code accessed `wallet.private_key.size_in_bytes()`, it would break silently with a `AttributeError`. Verify pre-implementation.
+
+### Risk: `Wallet.__eq__` uses `self.key == other.key`
+
+pyca/cryptography RSA key objects implement `__eq__` against same-type keys. For `RSAPrivateKey == RSAPrivateKey`, equality compares the underlying key material — preserves the existing contract. For `RSAPrivateKey == RSAPublicKey` (mixed-type), pyca returns NotImplemented and Python falls back to identity comparison (False). This matches the spirit of the prior pycryptodome behavior; verify with `test_eq` from the existing test file (passes if the contract holds).
+
+### Risk: `mypy --strict` complaining about `Any`-typed key
+
+The `self.key: Any` declaration plus the `isinstance` runtime check at the constructor satisfies strict mypy for most uses. The properties `private_key: Any | None` and `public_key: Any` keep the broad type at the boundary so external callers don't have to import pyca types. If mypy still complains on a specific method (e.g., `sign` calling `self.private_key.sign(...)`), the issue is that mypy can't narrow `Any | None` after the `if self.private_key is None: raise` check — assign to a local first:
+```python
+key = self.private_key
+if key is None:
+    raise NoPrivateKeyError()
+sig = key.sign(data, padding.PKCS1v15(), hashes.SHA384())
+```
+
+If mypy still complains, narrow with `# type: ignore[no-any-return]` or similar at the specific call site. ≤2 ignores in the new code is acceptable; more than that and the type design needs rethinking.

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace `pycryptodome` with `cryptography` (pyca) in `src/cancelchain/wallet.py`. After this plan completes, no `Crypto.*` imports remain anywhere in the codebase and `pycryptodome` is removed from `[project.dependencies]` and `uv.lock`.
 
-**Architecture:** Single-file swap — every `pycryptodome` consumer lives in `wallet.py` (207 lines). Public `Wallet` API surface stays identical; internal RSA / AES / hash primitives swap out. Greenfield posture: no backward-compat shims, no migration tool, no preservation of pycryptodome's PKCS#1 DER format. The four downstream wire-shape commitments — public-key DER, address mill_hash, signature determinism, and JWT challenge in-flight only — are preserved by choosing standard cryptographic primitives (SubjectPublicKeyInfo DER, PKCS1v1.5+SHA384) that produce byte-identical output to pycryptodome for the same input.
+**Architecture:** Single-file swap — every `pycryptodome` consumer lives in `wallet.py` (208 lines). Public `Wallet` API surface stays identical; internal RSA / AES / hash primitives swap out. Greenfield posture: no backward-compat shims, no migration tool, no preservation of pycryptodome's PKCS#1 DER format. The four downstream wire-shape commitments — public-key DER, address mill_hash, signature determinism, and JWT challenge ciphertext (persisted briefly in `ApiToken.cipher`, auto-refreshed every 60s on expiry, no production deploy to migrate) — are preserved by choosing standard cryptographic primitives (SubjectPublicKeyInfo DER, PKCS1v1.5+SHA384) that produce byte-identical output to pycryptodome for the same input.
 
 **Tech Stack:** `cryptography>=44` (pyca, Rust-backed), `os.urandom` for nonces/session keys, `AES-GCM` for the symmetric AEAD (replaces pycryptodome's `AES-EAX`), `OAEP-SHA256` for asymmetric session-key wrapping (replaces pycryptodome's `OAEP-SHA1` default).
 
@@ -16,7 +16,7 @@
 - `uv --version` 0.4.x or newer; `gh --version` works and `gh auth status` shows authenticated.
 - Phase 4 fully merged. Verify with `gh pr view 57 --json state --jq .state` → `MERGED`, and `grep -c 'marshmallow' pyproject.toml` → `0`.
 - The branch `docs/phase-5a-design` exists locally with the design spec already committed. This plan adds the second commit on that branch and ships both as the docs PR.
-- CI hard-gates `ruff check`, `ruff format --check`, and `mypy --strict`.
+- CI hard-gates `ruff check`, `ruff format --check`, and `mypy` (strict via `[tool.mypy] strict = true` in pyproject.toml; no CLI flag needed — `uv run mypy` honors the config).
 - Test baseline: **205 passed, 1 skipped**. Phase 5a adds ~8-9 new tests, so the final count is ~213-214 passed, 1 skipped.
 - Each PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller handles those, not the implementer subagent.
 - Never push directly to `main`.
@@ -692,9 +692,13 @@ src/cancelchain/wallet.py:
 - PKCS1_OAEP (SHA-1 default) → padding.OAEP(mgf=MGF1(SHA256()),
   algorithm=SHA256(), label=None). Stronger hash; no compat constraint.
 - AES.MODE_EAX → AESGCM. EAX is not in pyca/cryptography. JWT
-  challenge ciphertexts are alive for seconds during the handshake
-  and never persisted, so the wire-format change is safe. New layout:
-  enc_session_key (256B) || nonce (12B) || ciphertext_with_appended_tag.
+  challenge ciphertexts ARE persisted in ApiToken.cipher (DB column)
+  but only for up to 60s, after which ApiToken.expired triggers
+  refreshed_cipher() to regenerate. Greenfield (no production DB),
+  so the persistence window is irrelevant for migration; even if
+  deployed, the cleanup is automatic on the next handshake. The
+  wire-format change is safe. New layout: enc_session_key (256B) ||
+  nonce (12B) || ciphertext_with_appended_tag.
 - Crypto.Random.get_random_bytes(N) → os.urandom(N).
 - Private-key DER and PEM serialization both switch to PKCS#8.
 - Encrypted PEM uses BestAvailableEncryption (PBKDF2-SHA256/AES-256-CBC).

--- a/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
+++ b/docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md
@@ -17,7 +17,7 @@
 - Phase 4 fully merged. Verify with `gh pr view 57 --json state --jq .state` → `MERGED`, and `grep -c 'marshmallow' pyproject.toml` → `0`.
 - The branch `docs/phase-5a-design` exists locally with the design spec already committed. This plan adds the second commit on that branch and ships both as the docs PR.
 - CI hard-gates `ruff check`, `ruff format --check`, and `mypy` (strict via `[tool.mypy] strict = true` in pyproject.toml; no CLI flag needed — `uv run mypy` honors the config).
-- Test baseline: **205 passed, 1 skipped**. Phase 5a adds ~8-9 new tests, so the final count is ~213-214 passed, 1 skipped.
+- Test baseline: **205 passed, 1 skipped**. Phase 5a adds 8 new tests, so the final count is 213 passed, 1 skipped.
 - Each PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller handles those, not the implementer subagent.
 - Never push directly to `main`.
 
@@ -656,13 +656,13 @@ uv run ruff format --check src tests
 uv run pytest
 ```
 
-All four must exit 0. Test count: 205 → ~213 (8 new tests).
+All four must exit 0. Test count: 205 → 213 (8 new tests).
 
 If `mypy` reports new errors in `wallet.py`, the most common cause is the `Any`-typed `self.key` attribute interacting with method calls. The intent is that `Wallet.key` is `Any` throughout so callers don't need to import RSAPrivateKey/RSAPublicKey types. If a specific line type-errors, add a narrow `# type: ignore` rather than tightening the type. Aim for ≤1 ignore in the new code; if you need more, something's wrong — investigate before suppressing.
 
 If `pytest` fails on:
 - `test_create_from_key` — the fixture regeneration was wrong. Re-run Step 7's assertion script and inspect the mismatch.
-- `test_crypto` (decrypt with wrong wallet) — that test asserts `with pytest.raises(ValueError)`. AES-GCM's `AESGCM.decrypt` on a wrong key raises `InvalidTag`, which is a subclass of `cryptography.exceptions.InvalidTag` (NOT `ValueError`). The test may need its `pytest.raises` argument widened. Check with `uv run pytest tests/test_wallet.py::test_crypto -v` and inspect the error; if it raises `InvalidTag`, update the test to `pytest.raises((ValueError, InvalidTag))` and add `from cryptography.exceptions import InvalidTag` to the test file imports. Document this in the commit message.
+- `test_crypto` (decrypt with wrong wallet) — that test asserts `with pytest.raises(ValueError)`. `AESGCM.decrypt` raises `cryptography.exceptions.InvalidTag` (NOT `ValueError`). The test must be updated. Check with `uv run pytest tests/test_wallet.py::test_crypto -v`; update the assertion to `pytest.raises(InvalidTag)` and add `from cryptography.exceptions import InvalidTag` to the test file imports. Document this in the commit message.
 
 ### Step 10: Commit
 
@@ -671,9 +671,10 @@ git add pyproject.toml uv.lock src/cancelchain/wallet.py tests/conftest.py tests
 git commit -m "$(cat <<'EOF'
 feat(deps): swap pycryptodome → cryptography in wallet.py
 
-Phase 5a. Single-file swap. Greenfield posture (per
-project-no-legacy-chain memory): no backward-compat shims, no
-migration tool.
+Phase 5a. Single-file swap. Greenfield posture (no production
+cancelchain deploy, no legacy wallet .pem files in the wild, no
+existing DB rows holding old-format ApiToken.cipher): no
+backward-compat shims, no migration tool.
 
 src/cancelchain/wallet.py:
 - 5 Crypto.* imports replaced with cryptography hazmat primitives:
@@ -725,7 +726,7 @@ tests/test_wallet.py:
   returns None for private_key, and raises NoPrivateKeyError on
   sign/decrypt while still verifying peer signatures).
 
-Test count: 205 → ~213.
+Test count: 205 → 213.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -741,20 +742,20 @@ gh pr create --base main --title "feat(deps): swap pycryptodome → cryptography
 - Replaces pycryptodome with pyca/cryptography in \`src/cancelchain/wallet.py\` (single-file swap).
 - Drops \`pycryptodome>=3.20\` from \`[project.dependencies]\`, adds \`cryptography>=44\`.
 - Drops the \`[[tool.mypy.overrides]]\` block for the \`Crypto\` module (cryptography ships type stubs).
-- AES-EAX → AES-GCM (pyca doesn't support EAX; JWT challenge ciphertexts aren't persisted so wire-format change is safe).
+- AES-EAX → AES-GCM (pyca doesn't support EAX; JWT challenge ciphertexts ARE persisted briefly in ApiToken.cipher for up to 60s but greenfield project means no existing DB rows to migrate — the wire-format change is safe).
 - OAEP hash defaults switch from SHA-1 to SHA-256.
 - Private-key DER and PEM serialization both switch to PKCS#8 standard format.
 - Encrypted PEM uses BestAvailableEncryption (PBKDF2-SHA256 + AES-256-CBC).
 - 8 new tests in \`tests/test_wallet.py\` covering round-trips, sign/verify happy + reject paths, encrypt/decrypt, encrypted-PEM, and public-key-only Wallet construction.
 - \`WALLET_PRIVATE_KEY_B58\` fixture regenerated under PKCS#8 DER (the underlying RSA key is unchanged; the other 4 WALLET_* fixtures stay byte-identical).
 
-**Greenfield posture** (per \`project-no-legacy-chain\` memory): no backward-compat shims, no migration tool. No persisted wallet \`.pem\` files or in-flight JWT challenges to preserve.
+**Greenfield posture**: no production deploy, no legacy wallet \`.pem\` files in the wild, no existing DB rows holding old-format ApiToken.cipher to migrate. No backward-compat shims; no migration tool.
 
 Phase 5a. Spec/plan merged in the preceding docs PR.
 
 ## Test plan
 - [x] \`uv run mypy\` exits 0.
-- [x] \`uv run pytest\` passes (205 → ~213).
+- [x] \`uv run pytest\` passes (205 → 213).
 - [x] \`uv run ruff check\` + \`format --check\` pass.
 - [x] \`uv run python -c "import Crypto"\` raises ModuleNotFoundError.
 - [x] \`grep -rn 'pycryptodome' src/cancelchain/\` and \`grep -rn 'Crypto\.' src/cancelchain/\` both return nothing.

--- a/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
@@ -8,7 +8,7 @@
 
 Modernize the cryptographic primitives onto pyca/`cryptography` — the Rust-backed library at the center of the Python crypto ecosystem. Drops `pycryptodome` (less actively maintained, no longer the de facto standard), and aligns the project with the broader Python ecosystem.
 
-The user has confirmed greenfield posture: no legacy wallet `.pem` files exist that need to round-trip across this swap, no existing JWT-handshake ciphertexts need to be readable, no addresses need to match what pycryptodome would have produced for the same RSA key. Same-version determinism still applies (a freshly generated wallet must round-trip in this codebase; the existing test suite must still pass).
+**Greenfield posture.** No legacy wallet `.pem` files exist that need to round-trip across this swap, no existing JWT-handshake ciphertexts need to be readable, no addresses need to match what pycryptodome would have produced for the same RSA key. Library swaps can pick the modern format/algorithm freely. Same-version determinism still applies — a freshly generated wallet must round-trip in this codebase, and the existing test suite must still pass.
 
 ## Non-goals
 
@@ -17,7 +17,7 @@ The user has confirmed greenfield posture: no legacy wallet `.pem` files exist t
 - **No changing `KEY_SIZE = 2048`.** RSA-2048 stays.
 - **No typing the `Wallet.key` / `.public_key` / `.private_key` attributes beyond `Any`.** Tightening to `rsa.RSAPrivateKey` / `rsa.RSAPublicKey` would force callers to import from `cryptography` to satisfy mypy strict at every consumer. Deferred to a separate refactor (Phase 6 or later).
 - **No `__hash__` / `__eq__` cleanup.** The current `__hash__: None = None` ergonomics and the `__eq__` that compares the underlying key object both stay as-is. pyca/cryptography's RSA key objects implement `__eq__` against other key objects, so the equality semantic is preserved.
-- **No backward compatibility shims.** Greenfield (see [[project-no-legacy-chain]]). No migration tool, no encrypted-PEM compat reader, no AES-EAX fallback for old in-flight challenges (they don't exist).
+- **No backward compatibility shims.** Greenfield project (no production deploy, no legacy chain, no shipped wallets). No migration tool, no encrypted-PEM compat reader, no AES-EAX fallback for old in-flight challenges (they don't exist).
 - **No `Wallet.to_dict` / `Wallet.from_dict` JSON-shape change.** The b58-encoded private key payload stays the same wire shape (binary key bytes → base58check), though the binary key bytes themselves shift from pycryptodome's DER serialization to cryptography's PKCS#8 DER serialization.
 
 ## Decisions taken during brainstorming
@@ -37,8 +37,8 @@ The user has confirmed greenfield posture: no legacy wallet `.pem` files exist t
 - Modify: `src/cancelchain/wallet.py`
 - Modify: `pyproject.toml` (drop `pycryptodome>=3.20`, add `cryptography>=44`)
 - Modify: `uv.lock` (regenerated)
-- Possibly modify: `tests/conftest.py` if any test wallet fixture depends on pycryptodome behavior (verify; the fixture generates keys at session start through `Wallet()` so it should be transparent)
-- Add: `tests/test_wallet.py` round-trip tests if the file doesn't exist (or append if it does)
+- Modify: `tests/conftest.py` (regenerate the hardcoded `WALLET_PRIVATE_KEY_B58` constant — see "Test fixture regeneration" below)
+- Modify: `tests/test_wallet.py` (already exists with 12 tests; append 8 new round-trip / public-key-only tests)
 
 ### New imports in `wallet.py`
 
@@ -288,15 +288,15 @@ The `[[tool.mypy.overrides]]` block for `Crypto`/`Crypto.*` becomes unused — `
 | `WALLET_SIGNATURE` | b64 of `PKCS1v1.5(SHA384(data))` signature | No (PKCS1v1.5 + SHA384 is deterministic given the same private key). |
 
 Implementer regenerates `WALLET_PRIVATE_KEY_B58` by:
-1. Loading the **old** WALLET_PRIVATE_KEY_B58 string through the new cryptography-based `Wallet(b58ks=...)` — **this will fail** because the old b58 decodes to PKCS#1 DER, which the new `Wallet` could read but would re-export as PKCS#8 with a different b58.
-2. Better: take the old b58 → b58-decode → load as PKCS#1 DER using `serialization.load_der_private_key` (this works because `cryptography` can read PKCS#1 DER on input even though it writes PKCS#8 by default) → re-export via `private_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())` → base58check-encode → that's the new WALLET_PRIVATE_KEY_B58.
+1. Loading the **old** WALLET_PRIVATE_KEY_B58 string through the new cryptography-based `Wallet(b58ks=...)` actually succeeds (cryptography reads PKCS#1 DER fine — it just writes PKCS#8 by default). The failure mode is round-trip mismatch: `Wallet(b58ks=OLD).private_key_b58 != OLD` because the re-export writes PKCS#8. The fixture assertion `wallet.private_key_b58 == wallet_private_key_b58` is what fails, not the constructor.
+2. Cleanest path: take the old b58 → b58-decode → load as PKCS#1 DER using `serialization.load_der_private_key` → re-export via `private_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())` → base58check-encode → that's the new WALLET_PRIVATE_KEY_B58.
 3. Verify: `Wallet(b58ks=NEW_WALLET_PRIVATE_KEY_B58).public_key_b64 == WALLET_PUBLIC_KEY_B64` and `.address == WALLET_ADDRESS` and `.sign('helloworld'.encode()) == WALLET_SIGNATURE` all hold. If any of these don't hold, the regeneration is wrong.
 
 A small inline script in the implementer's terminal does this regeneration once; the resulting string is hardcoded into `tests/conftest.py`. The other 4 WALLET_* constants stay untouched.
 
 ### Tests
 
-Add to `tests/test_wallet.py` (already exists, 11 tests):
+Add to `tests/test_wallet.py` (already exists with 12 tests):
 
 ```python
 def test_wallet_address_round_trips_through_pem(tmp_path):
@@ -387,7 +387,7 @@ Test count: 205 → ~214.
 
 - **AES-GCM-vs-EAX semantic difference.** The output ciphertext layout differs (12-byte nonce vs 16-byte nonce; integrated tag vs separate). Internal callers in `api.py` (encrypts challenge) and `api_client.py` (decrypts challenge) both call through `Wallet.encrypt` / `Wallet.decrypt`, which both move atomically in this PR. Server and client never speak across versions.
 - **`InvalidSignature` exception type.** The `validate_signature` catch needs to catch the right exception. Mirroring the old "return False on any failure" behavior with `except Exception` is broad — narrow to `except (InvalidSignature, ValueError, TypeError)` if mypy complains; the broad form is acceptable since the function's documented contract is "return True iff valid."
-- **Address mismatch from a DER format wobble.** Vanishingly unlikely — `SubjectPublicKeyInfo` DER is a deterministic ASN.1 sequence; both pycryptodome and pyca produce byte-identical output for the same RSA key. But the test suite's address-dependent assertions (e.g., wallet fixture loaded → address compared to a hardcoded value somewhere?) need to be inspected. Verify with `grep -n 'CC.*CC' tests/` and similar; if there are any hardcoded address strings, regenerate them when the test fixtures regenerate keys (which they do at every session via `tmp_path`).
+- **Address mismatch from a DER format wobble.** Vanishingly unlikely — `SubjectPublicKeyInfo` DER is a deterministic ASN.1 sequence; both pycryptodome and pyca produce byte-identical output for the same RSA key. `tests/conftest.py` hardcodes `WALLET_ADDRESS` (the b58 of `mill_hash(public_key_der)` for a specific stored RSA key); since the public-DER format is invariant across libraries, `WALLET_ADDRESS` should NOT need regeneration. Verify by running the Step 7 fixture-invariant script (see the plan) before declaring done — it asserts `Wallet(b58ks=NEW_WALLET_PRIVATE_KEY_B58).address == WALLET_ADDRESS`. If that assertion fails, the public-DER format DID drift and the address constant needs updating too; investigate before regenerating blindly.
 
 ## Open decisions
 

--- a/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
@@ -1,0 +1,419 @@
+# Phase 5a — `pycryptodome` → `cryptography`
+
+**Status:** Draft for review
+**Date:** 2026-05-26
+**Scope:** Replace the pycryptodome RSA / AES / hash primitives in `src/cancelchain/wallet.py` with their pyca/`cryptography` equivalents. After this phase: no `Crypto.*` imports anywhere in the codebase, and `pycryptodome` is no longer in `[project.dependencies]` or `uv.lock`.
+
+## Goal
+
+Modernize the cryptographic primitives onto pyca/`cryptography` — the Rust-backed library at the center of the Python crypto ecosystem. Drops `pycryptodome` (less actively maintained, no longer the de facto standard), and aligns the project with the broader Python ecosystem.
+
+The user has confirmed greenfield posture: no legacy wallet `.pem` files exist that need to round-trip across this swap, no existing JWT-handshake ciphertexts need to be readable, no addresses need to match what pycryptodome would have produced for the same RSA key. Same-version determinism still applies (a freshly generated wallet must round-trip in this codebase; the existing test suite must still pass).
+
+## Non-goals
+
+- **No async crypto.** RSA + AES are CPU-bound and the per-call latency doesn't warrant an async API.
+- **No replacing `base58check`.** Unrelated dep, used for address-tag encoding.
+- **No changing `KEY_SIZE = 2048`.** RSA-2048 stays.
+- **No typing the `Wallet.key` / `.public_key` / `.private_key` attributes beyond `Any`.** Tightening to `rsa.RSAPrivateKey` / `rsa.RSAPublicKey` would force callers to import from `cryptography` to satisfy mypy strict at every consumer. Deferred to a separate refactor (Phase 6 or later).
+- **No `__hash__` / `__eq__` cleanup.** The current `__hash__: None = None` ergonomics and the `__eq__` that compares the underlying key object both stay as-is. pyca/cryptography's RSA key objects implement `__eq__` against other key objects, so the equality semantic is preserved.
+- **No backward compatibility shims.** Greenfield (see [[project-no-legacy-chain]]). No migration tool, no encrypted-PEM compat reader, no AES-EAX fallback for old in-flight challenges (they don't exist).
+- **No `Wallet.to_dict` / `Wallet.from_dict` JSON-shape change.** The b58-encoded private key payload stays the same wire shape (binary key bytes → base58check), though the binary key bytes themselves shift from pycryptodome's DER serialization to cryptography's PKCS#8 DER serialization.
+
+## Decisions taken during brainstorming
+
+- **Scope: single-file swap.** All pycryptodome usage lives in `wallet.py` (207 lines). No other source consumer. One PR.
+- **Symmetric cipher: AES-GCM** replaces pycryptodome's AES-EAX. pyca/cryptography does not support EAX. The in-flight JWT challenge ciphertext is never persisted (alive for seconds during the handshake), so the wire-format change is safe.
+- **OAEP hash: SHA-256.** pycryptodome's `PKCS1_OAEP.new` defaulted to SHA-1 for both MGF1 and the algorithm. With no compat constraint, use SHA-256 — stronger, modern, no downside.
+- **Private-key PEM format: PKCS#8.** pycryptodome wrote PKCS#1 TraditionalOpenSSL for unencrypted private keys (the `pkcs=1` default in `export_private_key_pem`). Switch to PKCS#8 universally — the modern standard. The wire shape on disk changes from `-----BEGIN RSA PRIVATE KEY-----` to `-----BEGIN PRIVATE KEY-----` (or `-----BEGIN ENCRYPTED PRIVATE KEY-----` when a passphrase is supplied).
+- **Encrypted PEM uses `BestAvailableEncryption`.** pyca/cryptography's wrapper picks PBKDF2-SHA256 + AES-256-CBC (PKCS#8 standard). Stronger than pycryptodome's `scryptAndAES128-CBC` default (scrypt KDF was nice; AES-128 was the weak link).
+- **Random bytes: `os.urandom`.** pycryptodome's `Crypto.Random.get_random_bytes(16)` becomes the stdlib `os.urandom(16)`. Same security guarantees (both backed by `/dev/urandom` on Linux, `BCryptGenRandom` on Windows). Drops one library function.
+- **Format sniffing on `import_key`.** pycryptodome's `RSA.import_key` auto-detected PEM vs DER. pyca/cryptography requires the caller to pick: `load_pem_private_key(data, password)` vs `load_der_private_key(data, password)`. Sniff: if `b'-----BEGIN'` appears within the first 30 bytes of input, route to PEM; else DER. On any exception (including format mismatch), return None — preserves the `import_key` contract.
+
+## Changes
+
+### Files
+
+- Modify: `src/cancelchain/wallet.py`
+- Modify: `pyproject.toml` (drop `pycryptodome>=3.20`, add `cryptography>=44`)
+- Modify: `uv.lock` (regenerated)
+- Possibly modify: `tests/conftest.py` if any test wallet fixture depends on pycryptodome behavior (verify; the fixture generates keys at session start through `Wallet()` so it should be transparent)
+- Add: `tests/test_wallet.py` round-trip tests if the file doesn't exist (or append if it does)
+
+### New imports in `wallet.py`
+
+```python
+import os
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    RSAPublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.exceptions import InvalidSignature
+```
+
+Drop:
+```python
+import Crypto.Random
+from Crypto.Cipher import AES, PKCS1_OAEP
+from Crypto.Hash import SHA384
+from Crypto.PublicKey import RSA
+from Crypto.Signature import PKCS1_v1_5
+```
+
+### Function-by-function mapping
+
+#### Key generation (constructor's `else` branch)
+
+```python
+# Before:
+self.key = RSA.generate(KEY_SIZE)
+# After:
+self.key = rsa.generate_private_key(
+    public_exponent=65537, key_size=KEY_SIZE
+)
+```
+
+#### `import_key(ks, passphrase)` — format-sniffing helper
+
+Must accept **both private and public** keys. `api.py`, `schema.py`, and `models.py` all call `Wallet(b64ks=public_key_b64)` to wrap a remote party's public key for signature verification. Strategy: try the private-key loaders first (since they're the common case in CLI / wallet-load flows); on failure, fall back to public-key loaders. Return None if neither path works.
+
+```python
+def import_key(ks: bytes | str, passphrase: str | None = None) -> Any | None:
+    try:
+        if isinstance(ks, str):
+            ks = ks.encode()
+        password = passphrase.encode() if passphrase is not None else None
+        is_pem = b'-----BEGIN' in ks[:30]
+        # Private-key path first
+        try:
+            if is_pem:
+                return serialization.load_pem_private_key(ks, password)
+            return serialization.load_der_private_key(ks, password)
+        except Exception:
+            pass
+        # Public-key fallback (used by api.py / schema.py callers that
+        # only have a peer's public key in hand)
+        if is_pem:
+            return serialization.load_pem_public_key(ks)
+        return serialization.load_der_public_key(ks)
+    except Exception:
+        return None
+```
+
+The passphrase is only meaningful on the private path; public keys aren't encrypted at rest in this codebase.
+
+#### `export_binary_key(key, passphrase)`
+
+```python
+def export_binary_key(key: Any, passphrase: str | None = None) -> bytes:
+    if isinstance(key, RSAPublicKey):
+        return key.public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    # else RSAPrivateKey
+    encryption: serialization.KeySerializationEncryption
+    if passphrase is None:
+        encryption = serialization.NoEncryption()
+    else:
+        encryption = serialization.BestAvailableEncryption(passphrase.encode())
+    return key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+```
+
+#### `Wallet.public_key` / `Wallet.private_key`
+
+```python
+@property
+def private_key(self) -> Any | None:
+    return self.key if isinstance(self.key, RSAPrivateKey) else None
+
+@property
+def public_key(self) -> Any:
+    return (
+        self.private_key.public_key() if self.private_key is not None
+        else self.key
+    )
+```
+
+(pyca keys don't have `has_private()`. Check isinstance instead.)
+
+#### `Wallet.export_private_key_pem(passphrase)`
+
+```python
+def export_private_key_pem(self, passphrase: str | None = None) -> bytes:
+    if self.private_key is None:
+        raise NoPrivateKeyError()
+    encryption: serialization.KeySerializationEncryption
+    if passphrase is None:
+        encryption = serialization.NoEncryption()
+    else:
+        encryption = serialization.BestAvailableEncryption(passphrase.encode())
+    return self.private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+```
+
+#### `Wallet.sign(data)`
+
+```python
+def sign(self, data: bytes) -> str:
+    if self.private_key is None:
+        raise NoPrivateKeyError()
+    sig = self.private_key.sign(data, padding.PKCS1v15(), hashes.SHA384())
+    return b64encode(sig)
+```
+
+#### `Wallet.validate_signature(data, signature)`
+
+```python
+def validate_signature(self, data: bytes, signature: str | None) -> bool:
+    if not (data and signature):
+        return False
+    try:
+        self.public_key.verify(
+            b64decode(signature),
+            data,
+            padding.PKCS1v15(),
+            hashes.SHA384(),
+        )
+    except (InvalidSignature, ValueError, TypeError):
+        # InvalidSignature: pyca raises this on a bad signature.
+        # ValueError: bad b64 padding, malformed signature bytes.
+        # TypeError: wrong types from caller.
+        return False
+    return True
+```
+
+`cryptography`'s `verify` raises on failure rather than returning False — translate at the call site. The catch narrows to the documented failure modes; an unexpected exception (e.g., system-level) propagates so we don't accidentally swallow real bugs.
+
+#### `Wallet.encrypt(data)`
+
+```python
+def encrypt(self, data: bytes) -> str:
+    session_key = os.urandom(16)
+    enc_session_key = self.public_key.encrypt(
+        session_key,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    nonce = os.urandom(12)
+    ciphertext_with_tag = AESGCM(session_key).encrypt(nonce, data, None)
+    return b64encode(enc_session_key + nonce + ciphertext_with_tag)
+```
+
+Wire layout: `enc_session_key (256B) || nonce (12B) || ciphertext_with_appended_tag`.
+
+#### `Wallet.decrypt(msg)`
+
+```python
+def decrypt(self, msg: str) -> bytes:
+    if self.private_key is None:
+        raise NoPrivateKeyError()
+    raw = b64decode(msg)
+    key_size_bytes = self.private_key.key_size // 8
+    enc_session_key = raw[:key_size_bytes]
+    nonce = raw[key_size_bytes:key_size_bytes + 12]
+    ciphertext = raw[key_size_bytes + 12:]
+    session_key = self.private_key.decrypt(
+        enc_session_key,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    return AESGCM(session_key).decrypt(nonce, ciphertext, None)
+```
+
+Note: pycryptodome had `private_key.size_in_bytes()` returning 256 for RSA-2048. pyca uses `key_size // 8`.
+
+#### Constructor validation
+
+The check must accept **both** private and public keys at the requested size. Multiple call sites (api.py, schema.py, models.py) construct `Wallet(b64ks=public_key_b64)` to wrap a remote party's public key for verification.
+
+```python
+# Before:
+if not (self.key and self.key.size_in_bits() == KEY_SIZE):
+    raise InvalidKeyError()
+# After:
+if not (
+    isinstance(self.key, (RSAPrivateKey, RSAPublicKey))
+    and self.key.key_size == KEY_SIZE
+):
+    raise InvalidKeyError()
+```
+
+Both `RSAPrivateKey` and `RSAPublicKey` expose `.key_size` as an `int` (matches pycryptodome's `size_in_bits()` semantics).
+
+### `pyproject.toml` changes
+
+```diff
+-  "pycryptodome>=3.20",
++  "cryptography>=44",
+```
+
+The `[[tool.mypy.overrides]]` block for `Crypto`/`Crypto.*` becomes unused — `cryptography` ships type stubs. Drop it:
+
+```diff
+-[[tool.mypy.overrides]]
+-module = ["Crypto", "Crypto.*"]
+-ignore_missing_imports = true
+```
+
+(Verify by reading the current pyproject.toml — there may or may not be such a block.)
+
+### Test fixture regeneration
+
+`tests/conftest.py` has 5 hardcoded `WALLET_*` constants used by `tests/test_wallet.py`'s `test_create_from_key`, `test_sign`, etc. The relationship:
+
+| Constant | What | Changes under cryptography? |
+|---|---|---|
+| `WALLET_PRIVATE_KEY_B58` | b58check encoding of `export_binary_key(private)` | **Yes** — PKCS#1 DER → PKCS#8 DER. The underlying RSA key value stays the same; only the DER envelope changes. **Regenerate.** |
+| `WALLET_PUBLIC_KEY_B64` | b64 of `export_binary_key(public)` (SubjectPublicKeyInfo DER) | No — both libraries produce byte-identical SubjectPublicKeyInfo DER. |
+| `WALLET_ADDRESS` | `'CC' + b58(mill_hash(public_key_der)) + 'CC'` | No (depends only on public DER, unchanged). |
+| `WALLET_SIGNATURE_DATA` | `'helloworld'` literal | No. |
+| `WALLET_SIGNATURE` | b64 of `PKCS1v1.5(SHA384(data))` signature | No (PKCS1v1.5 + SHA384 is deterministic given the same private key). |
+
+Implementer regenerates `WALLET_PRIVATE_KEY_B58` by:
+1. Loading the **old** WALLET_PRIVATE_KEY_B58 string through the new cryptography-based `Wallet(b58ks=...)` — **this will fail** because the old b58 decodes to PKCS#1 DER, which the new `Wallet` could read but would re-export as PKCS#8 with a different b58.
+2. Better: take the old b58 → b58-decode → load as PKCS#1 DER using `serialization.load_der_private_key` (this works because `cryptography` can read PKCS#1 DER on input even though it writes PKCS#8 by default) → re-export via `private_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())` → base58check-encode → that's the new WALLET_PRIVATE_KEY_B58.
+3. Verify: `Wallet(b58ks=NEW_WALLET_PRIVATE_KEY_B58).public_key_b64 == WALLET_PUBLIC_KEY_B64` and `.address == WALLET_ADDRESS` and `.sign('helloworld'.encode()) == WALLET_SIGNATURE` all hold. If any of these don't hold, the regeneration is wrong.
+
+A small inline script in the implementer's terminal does this regeneration once; the resulting string is hardcoded into `tests/conftest.py`. The other 4 WALLET_* constants stay untouched.
+
+### Tests
+
+Add to `tests/test_wallet.py` (already exists, 11 tests):
+
+```python
+def test_wallet_address_round_trips_through_pem(tmp_path):
+    """Freshly generated wallet → write PEM → read back → same address."""
+    w1 = Wallet()
+    path = w1.to_file(walletdir=str(tmp_path))
+    w2 = Wallet.from_file(path)
+    assert w1.address == w2.address
+
+
+def test_wallet_address_round_trips_through_b58(tmp_path):
+    """Freshly generated wallet → b58 → read back → same address."""
+    w1 = Wallet()
+    w2 = Wallet(b58ks=w1.private_key_b58)
+    assert w1.address == w2.address
+
+
+def test_wallet_sign_verify_happy_path():
+    w = Wallet()
+    sig = w.sign(b'hello world')
+    assert w.validate_signature(b'hello world', sig) is True
+
+
+def test_wallet_verify_rejects_mutated_payload():
+    w = Wallet()
+    sig = w.sign(b'hello world')
+    assert w.validate_signature(b'hello WORLD', sig) is False
+
+
+def test_wallet_verify_rejects_garbage_signature():
+    w = Wallet()
+    assert w.validate_signature(b'data', 'garbagebase64==') is False
+
+
+def test_wallet_encrypt_decrypt_round_trip():
+    w = Wallet()
+    plaintext = b'session-challenge-payload'
+    ciphertext = w.encrypt(plaintext)
+    assert w.decrypt(ciphertext) == plaintext
+
+
+def test_wallet_encrypted_pem_round_trip(tmp_path):
+    """Encrypted PEM with a passphrase round-trips."""
+    w1 = Wallet()
+    path = w1.to_file(walletdir=str(tmp_path), passphrase='hunter2')
+    w2 = Wallet.from_file(path, passphrase='hunter2')
+    assert w1.address == w2.address
+
+
+def test_wallet_invalid_key_raises():
+    with pytest.raises(InvalidKeyError):
+        Wallet(b64ks='not-a-key')
+
+
+def test_wallet_public_key_only_constructs(wallet):
+    """Wallet(b64ks=public_key_b64) accepts a peer's public key alone.
+
+    Used by api.py / schema.py / models.py to wrap a remote party's
+    public key for signature verification. Private operations
+    (sign, decrypt, export_private_key_*) raise NoPrivateKeyError.
+    """
+    w = Wallet(b64ks=wallet.public_key_b64)
+    assert w.private_key is None
+    assert w.public_key is not None
+    assert w.address == wallet.address
+    # Public verify should still work
+    sig = wallet.sign(b'data')
+    assert w.validate_signature(b'data', sig) is True
+    # Private operations raise
+    with pytest.raises(NoPrivateKeyError):
+        w.sign(b'data')
+```
+
+Test count: 205 → ~214.
+
+## Acceptance
+
+- `grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/` returns nothing (or only docstring references).
+- `grep -i pycryptodome uv.lock` returns nothing.
+- `uv run python -c "import Crypto"` raises `ModuleNotFoundError`.
+- `uv run mypy` exits 0.
+- `uv run ruff check src tests` + `ruff format --check src tests` exit 0.
+- `uv run pytest` exits 0; test count grows by 7-8.
+- `uv run cancelchain --help` works.
+- `docker build --target builder -t cc-phase5a .` succeeds.
+
+## Risks
+
+- **AES-GCM-vs-EAX semantic difference.** The output ciphertext layout differs (12-byte nonce vs 16-byte nonce; integrated tag vs separate). Internal callers in `api.py` (encrypts challenge) and `api_client.py` (decrypts challenge) both call through `Wallet.encrypt` / `Wallet.decrypt`, which both move atomically in this PR. Server and client never speak across versions.
+- **`InvalidSignature` exception type.** The `validate_signature` catch needs to catch the right exception. Mirroring the old "return False on any failure" behavior with `except Exception` is broad — narrow to `except (InvalidSignature, ValueError, TypeError)` if mypy complains; the broad form is acceptable since the function's documented contract is "return True iff valid."
+- **Address mismatch from a DER format wobble.** Vanishingly unlikely — `SubjectPublicKeyInfo` DER is a deterministic ASN.1 sequence; both pycryptodome and pyca produce byte-identical output for the same RSA key. But the test suite's address-dependent assertions (e.g., wallet fixture loaded → address compared to a hardcoded value somewhere?) need to be inspected. Verify with `grep -n 'CC.*CC' tests/` and similar; if there are any hardcoded address strings, regenerate them when the test fixtures regenerate keys (which they do at every session via `tmp_path`).
+
+## Open decisions
+
+None at design time. The brainstorming round resolved:
+- Single vs split PRs → single (contained to one file).
+- EAX → GCM is acceptable.
+- Encrypted PEM backward compat → no constraint.
+
+## Translation reference (quick lookup for the implementer)
+
+| Concept | pycryptodome | cryptography (pyca) |
+|---|---|---|
+| Generate RSA key | `RSA.generate(2048)` | `rsa.generate_private_key(public_exponent=65537, key_size=2048)` |
+| Has private? | `key.has_private()` | `isinstance(key, RSAPrivateKey)` |
+| Public key from private | `private.public_key()` | `private.public_key()` (same name!) |
+| Key size (bits) | `key.size_in_bits()` | `key.key_size` |
+| Key size (bytes) | `key.size_in_bytes()` | `key.key_size // 8` |
+| Random bytes | `Crypto.Random.get_random_bytes(N)` | `os.urandom(N)` |
+| Sign RSA-PKCS1v1.5-SHA384 | `PKCS1_v1_5.new(k).sign(SHA384.new(d))` | `k.sign(d, padding.PKCS1v15(), hashes.SHA384())` |
+| Verify (bool) | `PKCS1_v1_5.new(k).verify(SHA384.new(d), sig)` | `try: k.verify(sig, d, padding.PKCS1v15(), hashes.SHA384()); except InvalidSignature: ...` |
+| Encrypt RSA-OAEP | `PKCS1_OAEP.new(k).encrypt(data)` | `k.encrypt(data, padding.OAEP(mgf=MGF1(hashes.SHA256()), algorithm=hashes.SHA256(), label=None))` |
+| Decrypt RSA-OAEP | `PKCS1_OAEP.new(k).decrypt(ct)` | `k.decrypt(ct, padding.OAEP(...))` (same OAEP() instance shape) |
+| AES-GCM encrypt | `AES.new(key, MODE_EAX); ciphertext, tag = aes.encrypt_and_digest(data); nonce = aes.nonce` | `nonce = os.urandom(12); ct_with_tag = AESGCM(key).encrypt(nonce, data, None)` |
+| AES-GCM decrypt | `AES.new(key, MODE_EAX, nonce).decrypt_and_verify(ct, tag)` | `AESGCM(key).decrypt(nonce, ct_with_tag, None)` |
+| Load PEM private key | `RSA.import_key(pem_bytes, passphrase=...)` | `serialization.load_pem_private_key(pem_bytes, password)` |
+| Load DER private key | `RSA.import_key(der_bytes, passphrase=...)` | `serialization.load_der_private_key(der_bytes, password)` |
+| Export DER public | `key.export_key(format='DER')` | `key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)` |
+| Export PEM private (PKCS#8, unencrypted) | `key.export_key(pkcs=1)` (Trad. OpenSSL — but we switch to PKCS#8) | `key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())` |
+| Export PEM private (PKCS#8, encrypted) | `key.export_key(pkcs=8, passphrase=..., protection='scryptAndAES128-CBC')` | `key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, BestAvailableEncryption(passphrase.encode()))` |

--- a/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
@@ -22,11 +22,11 @@ Modernize the cryptographic primitives onto pyca/`cryptography` — the Rust-bac
 
 ## Decisions taken during brainstorming
 
-- **Scope: single-file swap.** All pycryptodome usage lives in `wallet.py` (207 lines). No other source consumer. One PR.
-- **Symmetric cipher: AES-GCM** replaces pycryptodome's AES-EAX. pyca/cryptography does not support EAX. The in-flight JWT challenge ciphertext is never persisted (alive for seconds during the handshake), so the wire-format change is safe.
-- **OAEP hash: SHA-256.** pycryptodome's `PKCS1_OAEP.new` defaulted to SHA-1 for both MGF1 and the algorithm. With no compat constraint, use SHA-256 — stronger, modern, no downside.
+- **Scope: single-file swap.** All pycryptodome usage lives in `wallet.py` (208 lines). No other source consumer. One PR.
+- **Symmetric cipher: AES-GCM** replaces pycryptodome's AES-EAX. pyca/cryptography does not support EAX. The JWT challenge ciphertext IS persisted briefly in `ApiToken.cipher` (DB column) — up to 60 seconds, since `ApiToken.expired` triggers `refreshed_cipher()` to regenerate a fresh challenge after that timeout. Greenfield project (no production deploy, no existing DB), so the persistence window is irrelevant for migration purposes; even in a hypothetical deployed scenario the worst case is 60s of unreadable challenges that auto-resolve on the next refresh. The wire-format change is safe.
+- **OAEP hash: SHA-256.** pycryptodome's `PKCS1_OAEP.new` defaulted to SHA-1 for both MGF1 and the algorithm. With no compat constraint, use SHA-256 — stronger, modern.
 - **Private-key PEM format: PKCS#8.** pycryptodome wrote PKCS#1 TraditionalOpenSSL for unencrypted private keys (the `pkcs=1` default in `export_private_key_pem`). Switch to PKCS#8 universally — the modern standard. The wire shape on disk changes from `-----BEGIN RSA PRIVATE KEY-----` to `-----BEGIN PRIVATE KEY-----` (or `-----BEGIN ENCRYPTED PRIVATE KEY-----` when a passphrase is supplied).
-- **Encrypted PEM uses `BestAvailableEncryption`.** pyca/cryptography's wrapper picks PBKDF2-SHA256 + AES-256-CBC (PKCS#8 standard). Stronger than pycryptodome's `scryptAndAES128-CBC` default (scrypt KDF was nice; AES-128 was the weak link).
+- **Encrypted PEM uses `BestAvailableEncryption`.** pyca/cryptography's wrapper picks PBKDF2-SHA256 + AES-256-CBC (the recommended PKCS#8 default). The current `wallet.py` explicitly configures `protection='scryptAndAES128-CBC'` (scrypt KDF + AES-128). AES-128 is still cryptographically strong; switching to AES-256 just gives a larger security margin and uses cryptography's recommended default scheme.
 - **Random bytes: `os.urandom`.** pycryptodome's `Crypto.Random.get_random_bytes(16)` becomes the stdlib `os.urandom(16)`. Same security guarantees (both backed by `/dev/urandom` on Linux, `BCryptGenRandom` on Windows). Drops one library function.
 - **Format sniffing on `import_key`.** pycryptodome's `RSA.import_key` auto-detected PEM vs DER. pyca/cryptography requires the caller to pick: `load_pem_private_key(data, password)` vs `load_der_private_key(data, password)`. Sniff: if `b'-----BEGIN'` appears within the first 30 bytes of input, route to PEM; else DER. On any exception (including format mismatch), return None — preserves the `import_key` contract.
 
@@ -265,15 +265,13 @@ Both `RSAPrivateKey` and `RSAPublicKey` expose `.key_size` as an `int` (matches 
 +  "cryptography>=44",
 ```
 
-The `[[tool.mypy.overrides]]` block for `Crypto`/`Crypto.*` becomes unused — `cryptography` ships type stubs. Drop it:
+The `[[tool.mypy.overrides]]` block for `Crypto`/`Crypto.*` is present in `pyproject.toml` at lines 162–164 (confirmed via grep). It becomes unused — `cryptography` ships type stubs — and should be deleted:
 
 ```diff
 -[[tool.mypy.overrides]]
 -module = ["Crypto", "Crypto.*"]
 -ignore_missing_imports = true
 ```
-
-(Verify by reading the current pyproject.toml — there may or may not be such a block.)
 
 ### Test fixture regeneration
 
@@ -307,7 +305,7 @@ def test_wallet_address_round_trips_through_pem(tmp_path):
     assert w1.address == w2.address
 
 
-def test_wallet_address_round_trips_through_b58(tmp_path):
+def test_wallet_address_round_trips_through_b58():
     """Freshly generated wallet → b58 → read back → same address."""
     w1 = Wallet()
     w2 = Wallet(b58ks=w1.private_key_b58)
@@ -346,17 +344,16 @@ def test_wallet_encrypted_pem_round_trip(tmp_path):
     assert w1.address == w2.address
 
 
-def test_wallet_invalid_key_raises():
-    with pytest.raises(InvalidKeyError):
-        Wallet(b64ks='not-a-key')
-
-
 def test_wallet_public_key_only_constructs(wallet):
     """Wallet(b64ks=public_key_b64) accepts a peer's public key alone.
 
     Used by api.py / schema.py / models.py to wrap a remote party's
     public key for signature verification. Private operations
     (sign, decrypt, export_private_key_*) raise NoPrivateKeyError.
+
+    Requires `from cancelchain.exceptions import NoPrivateKeyError`
+    in the test file's imports (hoist alongside the existing
+    InvalidKeyError import if not already present).
     """
     w = Wallet(b64ks=wallet.public_key_b64)
     assert w.private_key is None
@@ -370,7 +367,9 @@ def test_wallet_public_key_only_constructs(wallet):
         w.sign(b'data')
 ```
 
-Test count: 205 → ~214.
+(The existing `tests/test_wallet.py::test_create_invalid_key` already covers the `Wallet(b64ks='foo')` / `Wallet(b58ks='foo')` / `Wallet(ks='foo')` error paths — no extra invalid-key test needed in PR-5a.)
+
+Test count: 205 → 213 (8 new tests). The existing `test_crypto` may also need its `pytest.raises(ValueError)` widened to accept `cryptography.exceptions.InvalidTag` — see Risks below.
 
 ## Acceptance
 
@@ -379,7 +378,7 @@ Test count: 205 → ~214.
 - `uv run python -c "import Crypto"` raises `ModuleNotFoundError`.
 - `uv run mypy` exits 0.
 - `uv run ruff check src tests` + `ruff format --check src tests` exit 0.
-- `uv run pytest` exits 0; test count grows by 7-8.
+- `uv run pytest` exits 0; test count grows by 8 (205 → 213).
 - `uv run cancelchain --help` works.
 - `docker build --target builder -t cc-phase5a .` succeeds.
 

--- a/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
@@ -373,11 +373,11 @@ Test count: 205 → 213 (8 new tests). The existing `test_crypto` may also need 
 
 ## Acceptance
 
-- `grep -rn 'Crypto\b\|pycryptodome' src/cancelchain/` returns nothing (or only docstring references).
+- `grep -rn 'pycryptodome' src/cancelchain/` returns nothing AND `grep -rn 'Crypto\.' src/cancelchain/` returns nothing (or only docstring references). Two greps because `\b` isn't a portable word-boundary in POSIX grep.
 - `grep -i pycryptodome uv.lock` returns nothing.
 - `uv run python -c "import Crypto"` raises `ModuleNotFoundError`.
 - `uv run mypy` exits 0.
-- `uv run ruff check src tests` + `ruff format --check src tests` exit 0.
+- `uv run ruff check src tests` + `uv run ruff format --check src tests` exit 0.
 - `uv run pytest` exits 0; test count grows by 8 (205 → 213).
 - `uv run cancelchain --help` works.
 - `docker build --target builder -t cc-phase5a .` succeeds.

--- a/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md
@@ -186,13 +186,19 @@ def validate_signature(self, data: bytes, signature: str | None) -> bool:
             padding.PKCS1v15(),
             hashes.SHA384(),
         )
-    except (InvalidSignature, ValueError, TypeError):
+    except (InvalidSignature, binascii.Error, ValueError, TypeError):
         # InvalidSignature: pyca raises this on a bad signature.
-        # ValueError: bad b64 padding, malformed signature bytes.
+        # binascii.Error: malformed base64 (bad padding, non-b64 chars).
+        #   It's a subclass of ValueError in Python 3 so the ValueError
+        #   catch would cover it too — listing it explicitly clarifies
+        #   intent for readers.
+        # ValueError: bad-length signature bytes after b64decode.
         # TypeError: wrong types from caller.
         return False
     return True
 ```
+
+(Add `import binascii` at the top of `wallet.py` alongside the other stdlib imports.)
 
 `cryptography`'s `verify` raises on failure rather than returning False — translate at the call site. The catch narrows to the documented failure modes; an unexpected exception (e.g., system-level) propagates so we don't accidentally swallow real bugs.
 
@@ -385,7 +391,7 @@ Test count: 205 → 213 (8 new tests). The existing `test_crypto` may also need 
 ## Risks
 
 - **AES-GCM-vs-EAX semantic difference.** The output ciphertext layout differs (12-byte nonce vs 16-byte nonce; integrated tag vs separate). Internal callers in `api.py` (encrypts challenge) and `api_client.py` (decrypts challenge) both call through `Wallet.encrypt` / `Wallet.decrypt`, which both move atomically in this PR. Server and client never speak across versions.
-- **`InvalidSignature` exception type.** The `validate_signature` catch needs to catch the right exception. Mirroring the old "return False on any failure" behavior with `except Exception` is broad — narrow to `except (InvalidSignature, ValueError, TypeError)` if mypy complains; the broad form is acceptable since the function's documented contract is "return True iff valid."
+- **`InvalidSignature` exception type.** The `validate_signature` catch needs to catch the right exception. The new code uses `except (InvalidSignature, binascii.Error, ValueError, TypeError)` — narrow and explicit. `binascii.Error` is technically a subclass of `ValueError` in Python 3 (so the `ValueError` catch would suffice), but listing it explicitly makes the b64-decode failure path obvious to readers. The function's documented contract is "return True iff valid".
 - **Address mismatch from a DER format wobble.** Vanishingly unlikely — `SubjectPublicKeyInfo` DER is a deterministic ASN.1 sequence; both pycryptodome and pyca produce byte-identical output for the same RSA key. `tests/conftest.py` hardcodes `WALLET_ADDRESS` (the b58 of `mill_hash(public_key_der)` for a specific stored RSA key); since the public-DER format is invariant across libraries, `WALLET_ADDRESS` should NOT need regeneration. Verify by running the Step 7 fixture-invariant script (see the plan) before declaring done — it asserts `Wallet(b58ks=NEW_WALLET_PRIVATE_KEY_B58).address == WALLET_ADDRESS`. If that assertion fails, the public-DER format DID drift and the address constant needs updating too; investigate before regenerating blindly.
 
 ## Open decisions


### PR DESCRIPTION
## Summary
- Adds the Phase 5a design spec (\`docs/superpowers/specs/2026-05-26-phase-5a-pycryptodome-to-cryptography-design.md\`).
- Adds the Phase 5a implementation plan (\`docs/superpowers/plans/2026-05-26-phase-5a-pycryptodome-to-cryptography.md\`).
- No code changes.

Phase 5a ships as a single implementation PR after this docs PR lands. Single-file swap contained to \`src/cancelchain/wallet.py\` (greenfield posture — no backward-compat shims).

## Test plan
- [x] Spec self-review passed.
- [x] Plan self-review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)