### PR TITLE
feat(models): materialize longest chain to eliminate recursive-CTE hot reads

### DIFF
--- a/src/cancelchain/chain.py
+++ b/src/cancelchain/chain.py
@@ -557,7 +557,8 @@ class Chain:
 
     def to_db(self) -> None:
         dao = self.to_dao(create=True)
-        dao.commit()
+        db.session.add(dao)
+        db.session.flush()
         self.cid = dao.id
         dao.sync_longest_chain_blocks()
         db.session.commit()

--- a/src/cancelchain/chain.py
+++ b/src/cancelchain/chain.py
@@ -10,6 +10,7 @@ from typing import Any, Self
 from sqlalchemy.exc import SQLAlchemyError
 
 from cancelchain.block import Block
+from cancelchain.database import db
 from cancelchain.exceptions import (
     EmptyChainError,
     FutureBlockError,
@@ -558,6 +559,8 @@ class Chain:
         dao = self.to_dao(create=True)
         dao.commit()
         self.cid = dao.id
+        dao.sync_longest_chain_blocks()
+        db.session.commit()
 
     def __lt__(self, other: Chain) -> bool:
         return self.length < other.length

--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -377,6 +377,92 @@ class BlockDAO(db.Model):
             q = q.filter_by(idx=idx)
         return q.one_or_none()
 
+    @classmethod
+    def longest_chain_blocks_q(cls) -> Query[BlockDAO]:
+        """Blocks in the longest chain, ordered tip→genesis.
+
+        Matches BlockDAO.block_chain's tip-first ordering so consumers
+        that compose on the result (subquery / filter / first) see the
+        same row order.
+        """
+        return (
+            db.session.query(BlockDAO)
+            .join(
+                LongestChainBlockDAO,
+                BlockDAO.id == LongestChainBlockDAO.block_id,
+            )
+            .order_by(LongestChainBlockDAO.position.desc())
+        )
+
+    @classmethod
+    def longest_chain_transactions_q(cls) -> Query[TransactionDAO]:
+        """Transactions in the longest chain, ordered tip→genesis.
+
+        Matches TransactionDAO.transactions_chain's ordering
+        (timestamp.desc, id) within the longest chain's block set.
+        """
+        blocks_subq = cls.longest_chain_blocks_q().subquery()
+        block_alias = db.aliased(BlockDAO, blocks_subq)
+        q = db.session.query(TransactionDAO)
+        q = q.join(block_alias, TransactionDAO.blocks)
+        return q.order_by(TransactionDAO.timestamp.desc(), TransactionDAO.id)
+
+    @classmethod
+    def longest_chain_outflows_q(cls) -> Query[OutflowDAO]:
+        """Outflows in the longest chain, ordered by their parent txn's
+        timestamp desc, then txid, then outflow idx — matching
+        OutflowDAO.outflows_chain's ordering.
+        """
+        txn_subq = cls.longest_chain_transactions_q().subquery()
+        txn_alias = db.aliased(TransactionDAO, txn_subq)
+        q = db.session.query(OutflowDAO)
+        q = q.join(txn_alias, OutflowDAO.transaction)
+        return q.order_by(
+            txn_alias.timestamp.desc(),
+            txn_alias.txid,
+            OutflowDAO.idx,
+        )
+
+    @classmethod
+    def longest_chain_inflows_q(cls) -> Query[InflowDAO]:
+        """Inflows in the longest chain, ordered analogously to
+        InflowDAO.inflows_chain (timestamp desc, txid, inflow idx).
+        """
+        txn_subq = cls.longest_chain_transactions_q().subquery()
+        txn_alias = db.aliased(TransactionDAO, txn_subq)
+        q = db.session.query(InflowDAO)
+        q = q.join(txn_alias, InflowDAO.transaction)
+        return q.order_by(
+            txn_alias.timestamp.desc(),
+            txn_alias.txid,
+            InflowDAO.idx,
+        )
+
+
+class LongestChainBlockDAO(db.Model):
+    """Flat materialization of the canonical chain's block membership.
+
+    One row per block in the currently-longest chain, keyed by block.id
+    with `position` 0 at genesis and increasing toward the tip. Maintained
+    by ChainDAO.sync_longest_chain_blocks() — never written from anywhere
+    else. Phase 6 (2026-05-27) introduced this table to eliminate the
+    recursive `BlockDAO._block_chain` CTE from hot-path reads.
+    """
+
+    __tablename__ = 'longest_chain_block'
+
+    block_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey('block.id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+    position: Mapped[int] = mapped_column(Integer, unique=True, nullable=False)
+    block: Mapped[BlockDAO] = relationship()
+
+    def __init__(self, block_id: int, position: int) -> None:
+        self.block_id = block_id
+        self.position = position
+
 
 class ChainDAO(db.Model):
     __tablename__ = 'chain'
@@ -400,18 +486,26 @@ class ChainDAO(db.Model):
 
     @property
     def blocks(self) -> Query[BlockDAO]:
+        if self._is_longest():
+            return BlockDAO.longest_chain_blocks_q()
         return self.block.block_chain
 
     @property
     def transactions(self) -> Query[TransactionDAO]:
+        if self._is_longest():
+            return BlockDAO.longest_chain_transactions_q()
         return self.block.transactions_chain
 
     @property
     def outflows(self) -> Query[OutflowDAO]:
+        if self._is_longest():
+            return BlockDAO.longest_chain_outflows_q()
         return self.block.outflows_chain
 
     @property
     def inflows(self) -> Query[InflowDAO]:
+        if self._is_longest():
+            return BlockDAO.longest_chain_inflows_q()
         return self.block.inflows_chain
 
     def unspent_outflows(
@@ -503,6 +597,86 @@ class ChainDAO(db.Model):
             q = q.limit(limit)
             return db.session.query(db.aliased(q.subquery()))
         return q
+
+    def _is_longest(self) -> bool:
+        """True iff this ChainDAO row is currently the longest chain.
+
+        Used by the property accessors (blocks, transactions, outflows,
+        inflows) to route hot reads through LongestChainBlockDAO
+        instead of the recursive CTE.
+        """
+        longest = ChainDAO.longest()
+        return longest is not None and longest.id == self.id
+
+    def sync_longest_chain_blocks(self) -> None:
+        """Update the longest_chain_block materialization to reflect
+        this chain — if this chain is currently the longest.
+
+        Three sub-cases:
+        - Bootstrap: table is empty → populate from this chain's
+          recursive CTE walk (one-time cost).
+        - Steady-state extend: table's last entry is our previous tip
+          → INSERT one row at position = max + 1.
+        - Reorg / out-of-order: anything else → full DELETE + rebuild.
+
+        No-op when this chain is not the longest. Called from
+        Chain.to_db() so the materialization update participates in
+        the same SQLAlchemy session/transaction as the chain row save.
+        """
+        if not self._is_longest():
+            return
+
+        current_max = db.session.query(
+            db.func.max(LongestChainBlockDAO.position)
+        ).scalar()
+
+        if current_max is None:
+            self._rebuild_longest_chain_blocks()
+            return
+
+        table_tip_block_id = (
+            db.session.query(LongestChainBlockDAO.block_id)
+            .filter(LongestChainBlockDAO.position == current_max)
+            .scalar()
+        )
+
+        if table_tip_block_id == self.block_id:
+            # Already in sync (defensive — e.g., to_db called twice).
+            return
+
+        if table_tip_block_id == self.block.prev_id:
+            # Normal extend: append one row.
+            db.session.add(
+                LongestChainBlockDAO(
+                    block_id=self.block_id,
+                    position=current_max + 1,
+                )
+            )
+            return
+
+        # Reorg or gap: rebuild.
+        self._rebuild_longest_chain_blocks()
+
+    def _rebuild_longest_chain_blocks(self) -> None:
+        """Wipe and repopulate longest_chain_block from this chain's
+        recursive CTE walk. Used on bootstrap and reorg.
+
+        This is the path that still fires the recursive CTE — see
+        Phase 6 spec 'Risks' for the deferred follow-up (Phase 6.5/7)
+        to replace this with an iterative walk when chain length
+        grows past the CTE's tolerable size.
+        """
+        db.session.query(LongestChainBlockDAO).delete()
+        # block_chain walks tip → genesis; reverse so position 0 is
+        # genesis and the tip ends up at the highest position.
+        blocks = list(self.block.block_chain)
+        for position, block in enumerate(reversed(blocks)):
+            db.session.add(
+                LongestChainBlockDAO(
+                    block_id=block.id,
+                    position=position,
+                )
+            )
 
     def set_block_hash(self, block_hash: str) -> None:
         self.block = BlockDAO.get(block_hash)  # type: ignore[assignment]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,9 +70,11 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         assert dao_b is not None
 
         assert BlockDAO.query.count() == 3
-        # Materialization mirrors the longest chain only; chain_a (length 2)
-        # remains longest because its tip's timestamp is earlier than
-        # chain_b's, so the count is 2 not 3.
+        # Materialization mirrors the longest chain only. chain_a and
+        # chain_b both have length 2 but chain_a wins the (idx DESC,
+        # timestamp ASC) tiebreaker in ChainDAO.chains(), so the
+        # materialization holds chain_a's 2 blocks (not the 3 distinct
+        # BlockDAOs in the database).
         assert LongestChainBlockDAO.query.count() == 2
         assert dao_b.unspent_outflows(wallet.address).count() == 2
         balance = 2 * chain_b.block_reward()
@@ -133,30 +135,63 @@ def test_longest_chain_block_single_extend(app, mill_block, wallet):
         assert rows_after[-1].block_id == BlockDAO.get(b2.block_hash).id
 
 
-def test_longest_chain_block_non_longest_extend_noop(app, mill_block, wallet):
-    """When a chain that is NOT the longest gets a `Chain.to_db()`
-    call, the materialization table must stay aligned with whichever
-    chain IS longest. Simulated here by directly invoking
-    sync_longest_chain_blocks on a fork chain dao that we construct
-    to be shorter than the current longest.
+def test_longest_chain_block_non_longest_extend_noop(app, time_stepper, wallet):
+    """Calling sync on a non-longest chain leaves the materialization
+    aligned with whichever chain IS longest.
+
+    Builds a real fork (chain_a + chain_b sharing block_1) so that a
+    non-longest ChainDAO row genuinely exists, mirroring the pattern
+    in test_unspent_outflows.
     """
     with app.app_context():
-        _m, b1 = mill_block(wallet)
-        _m, _b2 = mill_block(wallet)
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet)
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet)
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet)
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        longest = ChainDAO.longest()
+        assert longest is not None
+        non_longest = next(
+            (d for d in ChainDAO.chains() if d.id != longest.id),
+            None,
+        )
+        assert non_longest is not None, (
+            'fixture did not produce a non-longest ChainDAO row'
+        )
+        assert non_longest._is_longest() is False
+
         longest_rows_before = (
             db.session.query(LongestChainBlockDAO)
             .order_by(LongestChainBlockDAO.position)
             .all()
         )
-        # Look up the chain at the b1 tip (shorter than longest).
-        shorter_dao = ChainDAO.get(block_hash=b1.block_hash)
-        if shorter_dao is None:
-            # The b1 chain may have been replaced by b2's extension —
-            # in that case skip the assertion since a non-longest
-            # chain row doesn't exist in this fixture path.
-            return
-        assert shorter_dao._is_longest() is False
-        shorter_dao.sync_longest_chain_blocks()
+        non_longest.sync_longest_chain_blocks()
         longest_rows_after = (
             db.session.query(LongestChainBlockDAO)
             .order_by(LongestChainBlockDAO.position)
@@ -208,23 +243,58 @@ def test_longest_chain_blocks_q_fast_path_skips_cte(app, mill_block, wallet):
         assert 'longest_chain_block' in compiled_sql.lower()
 
 
-def test_non_longest_chain_blocks_uses_cte(app, mill_block, wallet):
+def test_non_longest_chain_blocks_uses_cte(app, time_stepper, wallet):
     """A non-longest ChainDAO's .blocks still emits the recursive CTE
     (we did not optimize that path). Verified by emitted SQL.
+
+    Builds a real fork (chain_a + chain_b sharing block_1) so that a
+    non-longest ChainDAO row genuinely exists.
     """
     with app.app_context():
-        _m, b1 = mill_block(wallet)
-        _m, _b2 = mill_block(wallet)
-        # Make the b1 chain ChainDAO and explicitly mark not-longest
-        # by checking via _is_longest. If b1's ChainDAO row no longer
-        # exists in this fixture path (b2 extension may have rebound
-        # the same row), skip the SQL check.
-        shorter_dao = ChainDAO.get(block_hash=b1.block_hash)
-        if shorter_dao is None:
-            return
-        assert shorter_dao._is_longest() is False
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet)
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet)
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet)
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        longest = ChainDAO.longest()
+        assert longest is not None
+        non_longest = next(
+            (d for d in ChainDAO.chains() if d.id != longest.id),
+            None,
+        )
+        assert non_longest is not None, (
+            'fixture did not produce a non-longest ChainDAO row'
+        )
+        assert non_longest._is_longest() is False
+
         compiled_sql = str(
-            shorter_dao.blocks.statement.compile(
+            non_longest.blocks.statement.compile(
                 compile_kwargs={'literal_binds': True}
             )
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,8 @@ import datetime
 
 from cancelchain.block import Block
 from cancelchain.chain import Chain
-from cancelchain.models import BlockDAO
+from cancelchain.database import db
+from cancelchain.models import BlockDAO, ChainDAO, LongestChainBlockDAO
 from cancelchain.payload import Inflow, Outflow
 from cancelchain.transaction import Transaction
 
@@ -23,6 +24,7 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         dao_a = chain_a.to_dao()
 
         assert BlockDAO.query.count() == 1
+        assert LongestChainBlockDAO.query.count() == 1
         assert dao_a is not None
         assert dao_a.unspent_outflows(wallet.address).count() == 1
         balance = chain_a.block_reward()
@@ -54,6 +56,7 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         chain_a.to_db()
 
         assert BlockDAO.query.count() == 2
+        assert LongestChainBlockDAO.query.count() == 2
         assert dao_a.unspent_outflows(wallet.address).count() == 2
         balance = int(1.5 * chain_a.block_reward())
         assert dao_a.wallet_balance(wallet.address) == balance
@@ -67,6 +70,10 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         assert dao_b is not None
 
         assert BlockDAO.query.count() == 3
+        # Materialization mirrors the longest chain only; chain_a (length 2)
+        # remains longest because its tip's timestamp is earlier than
+        # chain_b's, so the count is 2 not 3.
+        assert LongestChainBlockDAO.query.count() == 2
         assert dao_b.unspent_outflows(wallet.address).count() == 2
         balance = 2 * chain_b.block_reward()
         assert dao_b.wallet_balance(wallet.address) == balance
@@ -76,3 +83,190 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         balance = int(1.5 * chain_a.block_reward())
         assert dao_a.wallet_balance(wallet.address) == balance
         assert dao_a.subject_balance(subject) == cb_1_amount
+
+
+def test_longest_chain_block_bootstrap(app, mill_block, wallet):
+    """Building the first chain populates the materialization table
+    with one row per block, ordered position 0 (genesis) → N-1 (tip).
+    """
+    with app.app_context():
+        _m, _b1 = mill_block(wallet)
+        _m, b2 = mill_block(wallet)
+        rows = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        assert len(rows) == 2
+        assert rows[0].position == 0
+        assert rows[1].position == 1
+        # Position 1 is the tip (newest block).
+        assert rows[1].block_id == BlockDAO.get(b2.block_hash).id
+
+
+def test_longest_chain_block_single_extend(app, mill_block, wallet):
+    """Each subsequent block inserts exactly one new row at the next
+    position; prior rows are untouched.
+    """
+    with app.app_context():
+        _m, _b1 = mill_block(wallet)
+        rows_before = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        before_count = len(rows_before)
+        before_ids = [r.block_id for r in rows_before]
+
+        _m, b2 = mill_block(wallet)
+
+        rows_after = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        assert len(rows_after) == before_count + 1
+        # First N positions unchanged.
+        assert [r.block_id for r in rows_after[:before_count]] == before_ids
+        # New row at the tail with the new block's id.
+        assert rows_after[-1].position == before_count
+        assert rows_after[-1].block_id == BlockDAO.get(b2.block_hash).id
+
+
+def test_longest_chain_block_non_longest_extend_noop(app, mill_block, wallet):
+    """When a chain that is NOT the longest gets a `Chain.to_db()`
+    call, the materialization table must stay aligned with whichever
+    chain IS longest. Simulated here by directly invoking
+    sync_longest_chain_blocks on a fork chain dao that we construct
+    to be shorter than the current longest.
+    """
+    with app.app_context():
+        _m, b1 = mill_block(wallet)
+        _m, _b2 = mill_block(wallet)
+        longest_rows_before = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        # Look up the chain at the b1 tip (shorter than longest).
+        shorter_dao = ChainDAO.get(block_hash=b1.block_hash)
+        if shorter_dao is None:
+            # The b1 chain may have been replaced by b2's extension —
+            # in that case skip the assertion since a non-longest
+            # chain row doesn't exist in this fixture path.
+            return
+        assert shorter_dao._is_longest() is False
+        shorter_dao.sync_longest_chain_blocks()
+        longest_rows_after = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        assert [(r.block_id, r.position) for r in longest_rows_after] == [
+            (r.block_id, r.position) for r in longest_rows_before
+        ]
+
+
+def test_longest_chain_block_property_matches_cte(app, mill_block, wallet):
+    """After any chain build, the materialization table contents
+    (ordered position DESC, i.e. tip→genesis) must match the recursive
+    CTE walk. Uses block_chain (the CTE) as ground truth.
+    """
+    with app.app_context():
+        for _ in range(5):
+            mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        cte_ids = [b.id for b in longest.block.block_chain]
+        mat_ids = [
+            r.block_id
+            for r in db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position.desc())
+            .all()
+        ]
+        assert cte_ids == mat_ids
+
+
+def test_longest_chain_blocks_q_fast_path_skips_cte(app, mill_block, wallet):
+    """ChainDAO.longest().blocks uses the materialization JOIN, not
+    the recursive CTE. Verified by emitted SQL: the fast-path query
+    should NOT contain a 'WITH RECURSIVE' clause.
+    """
+    with app.app_context():
+        _m, _b1 = mill_block(wallet)
+        _m, _b2 = mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        compiled_sql = str(
+            longest.blocks.statement.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
+        assert 'RECURSIVE' not in compiled_sql.upper(), (
+            f'Expected no recursive CTE in fast-path SQL, got:\n{compiled_sql}'
+        )
+        assert 'longest_chain_block' in compiled_sql.lower()
+
+
+def test_non_longest_chain_blocks_uses_cte(app, mill_block, wallet):
+    """A non-longest ChainDAO's .blocks still emits the recursive CTE
+    (we did not optimize that path). Verified by emitted SQL.
+    """
+    with app.app_context():
+        _m, b1 = mill_block(wallet)
+        _m, _b2 = mill_block(wallet)
+        # Make the b1 chain ChainDAO and explicitly mark not-longest
+        # by checking via _is_longest. If b1's ChainDAO row no longer
+        # exists in this fixture path (b2 extension may have rebound
+        # the same row), skip the SQL check.
+        shorter_dao = ChainDAO.get(block_hash=b1.block_hash)
+        if shorter_dao is None:
+            return
+        assert shorter_dao._is_longest() is False
+        compiled_sql = str(
+            shorter_dao.blocks.statement.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
+        # CTE fallback uses 'WITH RECURSIVE' on SQLite/Postgres.
+        assert 'RECURSIVE' in compiled_sql.upper()
+
+
+def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
+    """Forcing a rebuild (via _rebuild_longest_chain_blocks) wipes
+    the table and repopulates it from the longest chain's CTE walk
+    so the contents match exactly.
+    """
+    with app.app_context():
+        _m, b1 = mill_block(wallet)
+        _m, _b2 = mill_block(wallet)
+        _m, _b3 = mill_block(wallet)
+        # Sanity: table has 3 rows.
+        assert db.session.query(LongestChainBlockDAO).count() == 3
+
+        # Insert junk to simulate a corrupted / out-of-date table.
+        db.session.query(LongestChainBlockDAO).delete()
+        db.session.add(
+            LongestChainBlockDAO(
+                block_id=BlockDAO.get(b1.block_hash).id, position=99
+            )
+        )
+        db.session.commit()
+        assert db.session.query(LongestChainBlockDAO).count() == 1
+
+        # Rebuild from the current longest chain.
+        longest = ChainDAO.longest()
+        assert longest is not None
+        longest._rebuild_longest_chain_blocks()
+        db.session.commit()
+
+        # Table is back to 3 rows in tip→genesis order matching CTE.
+        cte_ids = [b.id for b in longest.block.block_chain]
+        mat_ids = [
+            r.block_id
+            for r in db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position.desc())
+            .all()
+        ]
+        assert cte_ids == mat_ids
+        assert len(mat_ids) == 3


### PR DESCRIPTION
## Summary
- Adds `LongestChainBlockDAO` (table `longest_chain_block`), a flat materialization of the canonical chain's block membership.
- Adds 4 new `BlockDAO` query factories (`longest_chain_blocks_q` / `_transactions_q` / `_outflows_q` / `_inflows_q`) that JOIN through the table instead of running the recursive CTE.
- Adds 3 new `ChainDAO` methods (`_is_longest`, `sync_longest_chain_blocks`, `_rebuild_longest_chain_blocks`).
- Branches the 4 `ChainDAO` property accessors (`blocks`, `transactions`, `outflows`, `inflows`) on `_is_longest()`. The 6 downstream methods (`unspent_outflows`, `wallet_balance`, `unforgiven_outflows`, `subject_balance`, `subject_support`, `wallet_leaderboard`) inherit the fast path through composition.
- Wires `Chain.to_db()` to call `sync_longest_chain_blocks` so the materialization stays in step with chain persistence.

## Why
The recursive `BlockDAO._block_chain` CTE was the project's known perf bottleneck — it once caused the project to be shelved. Phase 6 eliminates the CTE from hot-path reads. The residual CTE in `_rebuild_longest_chain_blocks` only fires on bootstrap and reorg (rare events, not per-read); replacing it with an iterative walk for long chains is queued as Phase 6.5/7.

## Out of scope (per spec)
- SA 2.0 syntax modernization (Phase 7).
- `mypy: disable-error-code` block removal in `models.py` (Phase 7).
- Eliminating the residual CTE in `_rebuild_longest_chain_blocks` (Phase 6.5/7).

## Test plan
- [x] `uv run mypy` exits 0.
- [x] `uv run pytest` passes (220 → 227, +7).
- [x] `uv run ruff check` + `format --check` pass.
- [x] New tests: bootstrap / single-block extend / non-longest extend noop / property-matches-CTE / fast-path-skips-CTE / non-longest-uses-CTE / rebuild-on-reorg.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)