### PR TITLE
feat(wallet): tighten Wallet.key types from Any to RSAPrivateKey | RSAPublicKey

### DIFF
--- a/src/cancelchain/wallet.py
+++ b/src/cancelchain/wallet.py
@@ -19,6 +19,8 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cancelchain.exceptions import InvalidKeyError, NoPrivateKeyError
 from cancelchain.milling import mill_hash_bin
 
+RSAKey = RSAPrivateKey | RSAPublicKey
+
 ADDRESS_TAG = 'CC'
 KEY_SIZE = 2048
 GCM_NONCE_SIZE = 12
@@ -41,26 +43,26 @@ def b64encode(b: bytes) -> str:
     return standard_b64encode(b).decode()
 
 
-def export_binary_key(key: Any, passphrase: str | None = None) -> bytes:
+def export_binary_key(key: RSAKey, passphrase: str | None = None) -> bytes:
     if isinstance(key, RSAPublicKey):
         return key.public_bytes(
             encoding=serialization.Encoding.DER,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-    # RSAPrivateKey
+    # RSAPrivateKey (narrowed by exclusion)
     encryption: serialization.KeySerializationEncryption
     if passphrase is None:
         encryption = serialization.NoEncryption()
     else:
         encryption = serialization.BestAvailableEncryption(passphrase.encode())
-    return key.private_bytes(  # type: ignore[no-any-return]
+    return key.private_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=encryption,
     )
 
 
-def import_key(ks: bytes | str, passphrase: str | None = None) -> Any | None:
+def import_key(ks: bytes | str, passphrase: str | None = None) -> RSAKey | None:
     """Load an RSA key from PEM or DER bytes. Accepts both private and
     public keys (api.py / schema.py / models.py construct Wallet with
     a peer's public key alone for signature verification).
@@ -74,26 +76,32 @@ def import_key(ks: bytes | str, passphrase: str | None = None) -> Any | None:
         # Private-key path first (the common case for wallet load flows)
         try:
             if is_pem:
-                return serialization.load_pem_private_key(ks, password)
-            return serialization.load_der_private_key(ks, password)
+                key = serialization.load_pem_private_key(ks, password)
+            else:
+                key = serialization.load_der_private_key(ks, password)
+            if isinstance(key, RSAPrivateKey):
+                return key
         except Exception:
             pass
         # Public-key fallback (peer-public-key wrap path)
-        if is_pem:
-            return serialization.load_pem_public_key(ks)
-        return serialization.load_der_public_key(ks)
+        pub = (
+            serialization.load_pem_public_key(ks)
+            if is_pem
+            else serialization.load_der_public_key(ks)
+        )
+        return pub if isinstance(pub, RSAPublicKey) else None
     except Exception:
         return None
 
 
-def import_b58_key(ks: str, passphrase: str | None = None) -> Any | None:
+def import_b58_key(ks: str, passphrase: str | None = None) -> RSAKey | None:
     try:
         return import_key(b58decode(ks), passphrase=passphrase)
     except Exception:
         return None
 
 
-def import_b64_key(ks: str, passphrase: str | None = None) -> Any | None:
+def import_b64_key(ks: str, passphrase: str | None = None) -> RSAKey | None:
     try:
         return import_key(b64decode(ks), passphrase=passphrase)
     except Exception:
@@ -108,33 +116,32 @@ class Wallet:
         ks: bytes | str | None = None,
         passphrase: str | None = None,
     ) -> None:
+        key: RSAKey | None
         if b64ks is not None:
-            self.key: Any = import_b64_key(b64ks, passphrase=passphrase)
+            key = import_b64_key(b64ks, passphrase=passphrase)
         elif b58ks is not None:
-            self.key = import_b58_key(b58ks, passphrase=passphrase)
+            key = import_b58_key(b58ks, passphrase=passphrase)
         elif ks is not None:
-            self.key = import_key(ks, passphrase=passphrase)
+            key = import_key(ks, passphrase=passphrase)
         else:
-            self.key = rsa.generate_private_key(
+            key = rsa.generate_private_key(
                 public_exponent=65537, key_size=KEY_SIZE
             )
-        if not (
-            isinstance(self.key, (RSAPrivateKey, RSAPublicKey))
-            and self.key.key_size == KEY_SIZE
-        ):
+        if not isinstance(key, (RSAPrivateKey, RSAPublicKey)):
             raise InvalidKeyError()
+        if key.key_size != KEY_SIZE:
+            raise InvalidKeyError()
+        self.key: RSAKey = key
 
     @property
-    def private_key(self) -> Any | None:
+    def private_key(self) -> RSAPrivateKey | None:
         return self.key if isinstance(self.key, RSAPrivateKey) else None
 
     @property
-    def public_key(self) -> Any:
-        return (
-            self.private_key.public_key()
-            if self.private_key is not None
-            else self.key
-        )
+    def public_key(self) -> RSAPublicKey:
+        if isinstance(self.key, RSAPrivateKey):
+            return self.key.public_key()
+        return self.key
 
     @property
     def private_key_b58(self) -> str:
@@ -159,7 +166,7 @@ class Wallet:
             encryption = serialization.BestAvailableEncryption(
                 passphrase.encode()
             )
-        return self.private_key.private_bytes(  # type: ignore[no-any-return]
+        return self.private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=encryption,


### PR DESCRIPTION
## Summary
- Tightens \`Wallet.key\` / \`.private_key\` / \`.public_key\` annotations from \`Any\` to concrete pyca/cryptography types (\`RSAPrivateKey | RSAPublicKey\` / \`RSAPrivateKey | None\` / \`RSAPublicKey\`).
- Tightens \`import_key\` / \`import_b58_key\` / \`import_b64_key\` return types from \`Any | None\` to \`RSAKey | None\` (new module-level type alias \`RSAKey = RSAPrivateKey | RSAPublicKey\`).
- Restructures \`Wallet.__init__\` validation so mypy can narrow the local key through the isinstance + key_size checks.
- Restructures \`Wallet.public_key\` property body to use a direct isinstance check, narrowing via exclusion.
- Removes 2 now-stale \`# type: ignore[no-any-return]\` comments (\`export_binary_key.private_bytes\` and \`Wallet.export_private_key_pem.private_bytes\`).

## Why
Deferred from Phase 5a (pycryptodome → cryptography swap). The Phase 5a spec explicitly called this out as a non-goal: *"Tightening to \`rsa.RSAPrivateKey\` / \`rsa.RSAPublicKey\` would force callers to import from \`cryptography\` to satisfy mypy strict at every consumer. Deferred to a separate refactor."*

The audit-the-callers turned up that the concern was overstated: every external \`.private_key\` / \`.public_key\` caller (in \`schema.py\`, \`test_wallet.py\`) only does \`is None\` checks. None of them call methods on the key objects. So the tightening is genuinely contained to \`wallet.py\` — zero external imports of pyca types needed.

## Test plan
- [x] \`uv run mypy\` exits 0 (strict).
- [x] \`uv run ruff check\` + \`format --check\` pass.
- [x] \`uv run pytest\` passes (227 → 227, no test count change).
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)