### PR TITLE
feat(models): iterative chain walk + cached _is_longest()

### DIFF
--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -636,8 +636,9 @@ class ChainDAO(db.Model):
         this chain — if this chain is currently the longest.
 
         Three sub-cases:
-        - Bootstrap: table is empty → populate from this chain's
-          recursive CTE walk (one-time cost).
+        - Bootstrap: table is empty → populate via the iterative
+          tip→genesis walk in _rebuild_longest_chain_blocks
+          (one-time cost).
         - Steady-state extend: table's last entry is our previous tip
           → INSERT one row at position = max + 1.
         - Reorg / out-of-order: anything else → full DELETE + rebuild.

--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
@@ -478,6 +478,16 @@ class ChainDAO(db.Model):
     )
     block: Mapped[BlockDAO] = relationship(back_populates='chains')
 
+    # Bumped on any longest_chain_block mutation; invalidates all
+    # ChainDAO instances' cached _is_longest values within this
+    # process. Cross-worker invalidation is out of scope — see
+    # the Phase 6.5 spec's Risks section.
+    _chain_generation: ClassVar[int] = 0
+
+    @classmethod
+    def _bump_generation(cls) -> None:
+        cls._chain_generation += 1
+
     def __init__(
         self, block_hash: str, block_dao: BlockDAO | None = None
     ) -> None:
@@ -604,9 +614,22 @@ class ChainDAO(db.Model):
         Used by the property accessors (blocks, transactions, outflows,
         inflows) to route hot reads through LongestChainBlockDAO
         instead of the recursive CTE.
+
+        Cached per instance and invalidated by class-level generation
+        bumps inside sync_longest_chain_blocks / rebuild paths. The
+        cross-worker case (another process reorged the chain) is a
+        known stale-cache risk — bounded to one held instance's
+        lifetime within this worker; see the Phase 6.5 spec's Risks.
         """
+        cached: tuple[int, bool] | None = getattr(
+            self, '_is_longest_cache', None
+        )
+        if cached is not None and cached[0] == ChainDAO._chain_generation:
+            return cached[1]
         longest = ChainDAO.longest()
-        return longest is not None and longest.id == self.id
+        result = longest is not None and longest.id == self.id
+        self._is_longest_cache = (ChainDAO._chain_generation, result)
+        return result
 
     def sync_longest_chain_blocks(self) -> None:
         """Update the longest_chain_block materialization to reflect
@@ -652,24 +675,28 @@ class ChainDAO(db.Model):
                     position=current_max + 1,
                 )
             )
+            ChainDAO._bump_generation()
             return
 
         # Reorg or gap: rebuild.
         self._rebuild_longest_chain_blocks()
 
     def _rebuild_longest_chain_blocks(self) -> None:
-        """Wipe and repopulate longest_chain_block from this chain's
-        recursive CTE walk. Used on bootstrap and reorg.
+        """Wipe and repopulate longest_chain_block by walking the
+        chain iteratively from tip → genesis via BlockDAO.prev links.
 
-        This is the path that still fires the recursive CTE — see
-        Phase 6 spec 'Risks' for the deferred follow-up (Phase 6.5/7)
-        to replace this with an iterative walk when chain length
-        grows past the CTE's tolerable size.
+        Each step is one indexed PK lookup (block.id). Avoids the
+        recursive CTE's planner overhead on long chains — the cost
+        that caused the project to be shelved in the past. Bumps
+        ChainDAO._chain_generation at the end so cached _is_longest
+        values on any in-process ChainDAO instance are invalidated.
         """
         db.session.query(LongestChainBlockDAO).delete()
-        # block_chain walks tip → genesis; reverse so position 0 is
-        # genesis and the tip ends up at the highest position.
-        blocks = list(self.block.block_chain)
+        blocks: list[BlockDAO] = []
+        current: BlockDAO | None = self.block
+        while current is not None:
+            blocks.append(current)
+            current = current.prev
         for position, block in enumerate(reversed(blocks)):
             db.session.add(
                 LongestChainBlockDAO(
@@ -677,6 +704,7 @@ class ChainDAO(db.Model):
                     position=position,
                 )
             )
+        ChainDAO._bump_generation()
 
     def set_block_hash(self, block_hash: str) -> None:
         self.block = BlockDAO.get(block_hash)  # type: ignore[assignment]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 from cancelchain.block import Block
 from cancelchain.chain import Chain
@@ -340,3 +341,111 @@ def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
         ]
         assert cte_ids == mat_ids
         assert len(mat_ids) == 3
+
+
+def test_iterative_walk_matches_cte(app, mill_block, wallet):
+    """_rebuild_longest_chain_blocks via current.prev produces the
+    same block ordering as the prior recursive-CTE walk would have.
+    Uses self.block.block_chain (still defined; used as fallback)
+    as ground truth.
+    """
+    with app.app_context():
+        for _ in range(10):
+            mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+
+        # Capture CTE ground truth before rebuild.
+        cte_ids = [b.id for b in longest.block.block_chain]
+
+        # Force a rebuild via the iterative walk (also runs on bootstrap
+        # by sync_longest_chain_blocks; here we exercise it directly).
+        longest._rebuild_longest_chain_blocks()
+        db.session.commit()
+
+        mat_ids = [
+            r.block_id
+            for r in db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position.desc())
+            .all()
+        ]
+        assert cte_ids == mat_ids
+        assert len(mat_ids) == 10
+
+
+def test_iterative_walk_long_chain(app, mill_block, wallet):
+    """Iterative walk handles a longer chain (50 blocks) and produces
+    the right count with no exceptions. Primarily a smoke test that
+    the walk terminates and the materialization stays consistent.
+    """
+    with app.app_context():
+        for _ in range(50):
+            mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        longest._rebuild_longest_chain_blocks()
+        db.session.commit()
+        count = db.session.query(LongestChainBlockDAO).count()
+        assert count == 50
+
+
+def test_is_longest_cache_hit_avoids_query(app, mill_block, wallet):
+    """Calling _is_longest twice on the same instance hits the cache
+    on the second call and does NOT re-issue ChainDAO.longest().
+    """
+    with app.app_context():
+        mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        # Reset cache state and bump generation so the next call is a miss.
+        if hasattr(longest, '_is_longest_cache'):
+            delattr(longest, '_is_longest_cache')
+        with patch.object(ChainDAO, 'longest', wraps=ChainDAO.longest) as spy:
+            assert longest._is_longest() is True
+            assert longest._is_longest() is True
+            assert spy.call_count == 1, (
+                f'expected one ChainDAO.longest() call (cache hit on '
+                f'2nd), got {spy.call_count}'
+            )
+
+
+def test_is_longest_cache_invalidated_by_bump(app, mill_block, wallet):
+    """Calling ChainDAO._bump_generation() after a cached _is_longest
+    call forces a recomputation on the next access.
+    """
+    with app.app_context():
+        mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        if hasattr(longest, '_is_longest_cache'):
+            delattr(longest, '_is_longest_cache')
+        with patch.object(ChainDAO, 'longest', wraps=ChainDAO.longest) as spy:
+            assert longest._is_longest() is True
+            ChainDAO._bump_generation()
+            assert longest._is_longest() is True
+            assert spy.call_count == 2, (
+                f'expected two ChainDAO.longest() calls (miss, then '
+                f'miss after bump), got {spy.call_count}'
+            )
+
+
+def test_is_longest_cache_survives_across_method_calls(app, mill_block, wallet):
+    """One ChainDAO.longest() call total across a wallet_balance read
+    that internally accesses self.outflows AND self.inflows. Without
+    caching this would be 2+ calls.
+    """
+    with app.app_context():
+        _m, _b = mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+        if hasattr(longest, '_is_longest_cache'):
+            delattr(longest, '_is_longest_cache')
+        with patch.object(ChainDAO, 'longest', wraps=ChainDAO.longest) as spy:
+            # wallet_balance reads self.outflows and self.inflows;
+            # each property accessor calls _is_longest.
+            longest.wallet_balance(wallet.address)
+            assert spy.call_count == 1, (
+                f'expected one ChainDAO.longest() call across the '
+                f'wallet_balance method (cached after the first '
+                f'property access), got {spy.call_count}'
+            )


### PR DESCRIPTION
## Summary
- Replaces the recursive CTE inside `ChainDAO._rebuild_longest_chain_blocks` with an iterative `current = current.prev` walk; each step is one indexed PK lookup. Bootstrap / reorg rebuilds no longer depend on the CTE planner.
- Adds a class-level generation-counter cache to `ChainDAO._is_longest()` (`_chain_generation: ClassVar[int]` + `_bump_generation()` classmethod). The cache invalidates whenever the materialized table mutates (two bump sites: inside `_rebuild_longest_chain_blocks` after the bulk INSERT, inside `sync_longest_chain_blocks` after the single-row extend INSERT).
- 5 new tests: iterative-walk correctness against the CTE walk; 50-block walk smoke; cache hit; cache invalidation on bump; cache across multiple property accesses within `wallet_balance`.

## Why
Closes the two Phase 6 deferrals documented in the Phase 6 spec's "Risks" section:
- The CTE inside `_rebuild_longest_chain_blocks` was the residual perf risk on long chains.
- Copilot flagged the `_is_longest()` query cost on PR #65; spec deferred caching to Phase 6.5.

## Out of scope (per spec)
- SA 2.0 syntax modernization (Phase 7).
- DeclarativeBase migration + `mypy: disable-error-code` removal in `models.py` (Phase 7).
- Removing the CTE-backed `block_chain` / `transactions_chain` / etc. on `BlockDAO` (still used as the non-longest-chain fallback in `ChainDAO`'s property branches).
- Cross-worker cache invalidation (multi-process coordination).
- Batched-fetch walk for very long chains (if profiling later shows the single-row walk is the new bottleneck).

## Test plan
- [x] `uv run mypy` exits 0.
- [x] `uv run pytest` passes (227 → 232, +5).
- [x] `uv run ruff check` + `format --check` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)