### PR TITLE
feat(models): smart-reorg rebuild for longest_chain_block

### DIFF
--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -635,52 +635,88 @@ class ChainDAO(db.Model):
         """Update the longest_chain_block materialization to reflect
         this chain — if this chain is currently the longest.
 
-        Three sub-cases:
-        - Bootstrap: table is empty → populate via the iterative
-          tip→genesis walk in _rebuild_longest_chain_blocks
-          (one-time cost).
-        - Steady-state extend: table's last entry is our previous tip
-          → INSERT one row at position = max + 1.
-        - Reorg / out-of-order: anything else → full DELETE + rebuild.
+        Smart-reorg algorithm: walks the chain's tip back via
+        BlockDAO.prev, collecting blocks, until it finds one already
+        in the materialization (the common ancestor) OR walks to
+        genesis.
 
-        No-op when this chain is not the longest. Called from
-        Chain.to_db() so the materialization update participates in
-        the same SQLAlchemy session/transaction as the chain row save.
+        - Bootstrap (empty table): short-circuit to
+          _rebuild_longest_chain_blocks; avoids N redundant per-step
+          'is in table?' lookups against an empty table.
+        - Already in sync: first walked block (the tip) matches; the
+          collected diverging list is empty; return without mutation.
+        - Shallow / deep reorg with common ancestor: truncate the
+          materialization above the ancestor's position, insert the
+          diverging suffix in genesis-first order. O(reorg depth) walk.
+        - Catastrophic 'different chain' (no common ancestor before
+          genesis): delete all and insert the entire collected
+          diverging list as the new chain (reusing the list avoids
+          a redundant second walk via _rebuild_*).
+
+        Called from Chain.to_db() inside the same SQLAlchemy
+        session/transaction as the chain row save.
         """
         if not self._is_longest():
             return
 
-        current_max = db.session.query(
-            db.func.max(LongestChainBlockDAO.position)
-        ).scalar()
-
-        if current_max is None:
+        # Bootstrap fast-path: empty materialization → use the
+        # rebuild method directly, skipping per-step lookups against
+        # an empty table.
+        if not db.session.query(
+            db.session.query(LongestChainBlockDAO).exists()
+        ).scalar():
             self._rebuild_longest_chain_blocks()
             return
 
-        table_tip_block_id = (
-            db.session.query(LongestChainBlockDAO.block_id)
-            .filter(LongestChainBlockDAO.position == current_max)
-            .scalar()
-        )
+        # Smart-reorg walk: collect blocks from new tip back until we
+        # hit one already in the materialization OR reach genesis.
+        diverging: list[BlockDAO] = []
+        current: BlockDAO | None = self.block
+        common_ancestor_position: int | None = None
+        while current is not None:
+            pos = (
+                db.session.query(LongestChainBlockDAO.position)
+                .filter(LongestChainBlockDAO.block_id == current.id)
+                .scalar()
+            )
+            if pos is not None:
+                common_ancestor_position = pos
+                break
+            diverging.append(current)
+            current = current.prev
 
-        if table_tip_block_id == self.block_id:
-            # Already in sync (defensive — e.g., to_db called twice).
+        if not diverging:
+            # Tip itself was the first match — already in sync.
             return
 
-        if table_tip_block_id == self.block.prev_id:
-            # Normal extend: append one row.
-            db.session.add(
-                LongestChainBlockDAO(
-                    block_id=self.block_id,
-                    position=current_max + 1,
+        if common_ancestor_position is None:
+            # Walked to genesis without overlap: different chain
+            # entirely. Use the collected list directly instead of
+            # re-walking via _rebuild_*.
+            db.session.query(LongestChainBlockDAO).delete()
+            for position, block in enumerate(reversed(diverging)):
+                db.session.add(
+                    LongestChainBlockDAO(
+                        block_id=block.id,
+                        position=position,
+                    )
                 )
-            )
             ChainDAO._bump_generation()
             return
 
-        # Reorg or gap: rebuild.
-        self._rebuild_longest_chain_blocks()
+        # Common ancestor at position K. Truncate above K, append
+        # the diverging suffix in genesis-first order.
+        db.session.query(LongestChainBlockDAO).filter(
+            LongestChainBlockDAO.position > common_ancestor_position
+        ).delete()
+        for offset, block in enumerate(reversed(diverging), start=1):
+            db.session.add(
+                LongestChainBlockDAO(
+                    block_id=block.id,
+                    position=common_ancestor_position + offset,
+                )
+            )
+        ChainDAO._bump_generation()
 
     def _rebuild_longest_chain_blocks(self) -> None:
         """Wipe and repopulate longest_chain_block by walking the

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -500,8 +500,7 @@ def test_smart_reorg_walks_only_to_common_ancestor(app, mill_block, wallet):
             .order_by(LongestChainBlockDAO.position)
             .all()
         )
-        ids_before = {r.block_id for r in rows_before}
-        positions_before = [r.position for r in rows_before]
+        snapshot_before = [(r.block_id, r.position) for r in rows_before]
 
         _m, _new_tip = mill_block(wallet)
 
@@ -510,12 +509,11 @@ def test_smart_reorg_walks_only_to_common_ancestor(app, mill_block, wallet):
             .order_by(LongestChainBlockDAO.position)
             .all()
         )
-        # First 5 rows' block_ids are unchanged: smart-reorg did NOT
-        # delete-and-rebuild from scratch (which would have made new
-        # row instances with new identities or different orderings).
-        # The same block_id set is present in the same positions.
-        assert {r.block_id for r in rows_after[:5]} == ids_before
-        assert [r.position for r in rows_after[:5]] == positions_before
+        # First 5 rows' (block_id, position) pairs unchanged: smart-
+        # reorg did NOT delete-and-rebuild. Using ordered pairs (not a
+        # set) catches bugs that would shift block_ids between positions.
+        snapshot_after = [(r.block_id, r.position) for r in rows_after[:5]]
+        assert snapshot_after == snapshot_before
         # And exactly one new row at the tail.
         assert len(rows_after) == len(rows_before) + 1
         assert rows_after[-1].position == 5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -486,10 +486,11 @@ def test_smart_reorg_shallow(app, mill_block, wallet):
 
 
 def test_smart_reorg_walks_only_to_common_ancestor(app, mill_block, wallet):
-    """The walk stops at the first block found in the materialization.
-    For a steady-state extend, this means walking back one step to
-    find the common ancestor, and inserting exactly one new row —
-    not a full DELETE + bulk INSERT.
+    """The walk stops at the first block found in the materialization
+    instead of falling through to the rebuild path. Verified by
+    patching ChainDAO._rebuild_longest_chain_blocks and asserting it
+    is NOT invoked during a steady-state extend (the smart-reorg
+    common-ancestor branch must handle the case).
     """
     with app.app_context():
         for _ in range(5):
@@ -502,16 +503,24 @@ def test_smart_reorg_walks_only_to_common_ancestor(app, mill_block, wallet):
         )
         snapshot_before = [(r.block_id, r.position) for r in rows_before]
 
-        _m, _new_tip = mill_block(wallet)
+        with patch.object(
+            ChainDAO,
+            '_rebuild_longest_chain_blocks',
+            autospec=True,
+        ) as rebuild_spy:
+            _m, _new_tip = mill_block(wallet)
+
+        # The smart-reorg path must NOT have invoked the rebuild
+        # method for a steady-state extend. If the implementation
+        # regresses to a full rebuild, this fails loudly.
+        rebuild_spy.assert_not_called()
 
         rows_after = (
             db.session.query(LongestChainBlockDAO)
             .order_by(LongestChainBlockDAO.position)
             .all()
         )
-        # First 5 rows' (block_id, position) pairs unchanged: smart-
-        # reorg did NOT delete-and-rebuild. Using ordered pairs (not a
-        # set) catches bugs that would shift block_ids between positions.
+        # First 5 rows' (block_id, position) pairs unchanged.
         snapshot_after = [(r.block_id, r.position) for r in rows_after[:5]]
         assert snapshot_after == snapshot_before
         # And exactly one new row at the tail.
@@ -556,31 +565,85 @@ def test_smart_reorg_already_in_sync_short_circuits(app, mill_block, wallet):
 
 
 def test_smart_reorg_deep_reorg_with_no_common_ancestor_falls_back(
-    app, mill_block, wallet
+    app, mill_block, time_stepper, wallet
 ):
     """If the materialization holds block_ids that aren't reachable
     from the current chain's tip via prev pointers, the walk reaches
     genesis without finding a common ancestor. The fallback uses the
     collected list to fully replace the materialization.
+
+    Uses block_ids from a divergent fork chain so the rows satisfy
+    the LongestChainBlockDAO.block_id → block.id FK constraint
+    (which would fire on Postgres or SQLite with foreign_keys=ON).
+    time_stepper ensures the fork's blocks have different timestamps
+    (and thus different block_hashes) than chain_a's, even under the
+    test's easy-target milling.
     """
     with app.app_context():
-        # Build a chain of length 3.
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+
+        # Build chain_a of length 3 (the canonical chain).
         for _ in range(3):
             mill_block(wallet)
-        longest = ChainDAO.longest()
-        assert longest is not None
+            _ = next(time_step)
+        chain_a_longest = ChainDAO.longest()
+        assert chain_a_longest is not None
+        chain_a_block_ids = {
+            r.block_id for r in db.session.query(LongestChainBlockDAO).all()
+        }
 
-        # Corrupt the materialization with fake block_ids that don't
-        # exist in the chain (use very large ints unlikely to collide).
+        # Build a divergent fork chain_b at genesis. Different timestamps
+        # (via time_stepper) make chain_b's blocks have different hashes
+        # than chain_a's blocks under the easy-target deterministic-
+        # nonce milling regime, so they get distinct BlockDAO rows.
+        chain_b = Chain()
+        block_b1 = Block()
+        chain_b.link_block(block_b1)
+        chain_b.seal_block(block_b1, wallet)
+        block_b1.mill()
+        chain_b.add_block(block_b1)
+        _ = next(time_step)
+        block_b2 = Block()
+        chain_b.link_block(block_b2)
+        chain_b.seal_block(block_b2, wallet)
+        block_b2.mill()
+        chain_b.add_block(block_b2)
+        # NOTE: deliberately do NOT call chain_b.to_db() — that would
+        # involve the sync code under test. We want to corrupt the
+        # table by hand to exercise the fallback.
+        fork_block_ids = [
+            BlockDAO.get(block_b1.block_hash).id,
+            BlockDAO.get(block_b2.block_hash).id,
+        ]
+        # Sanity: fork blocks are real BlockDAO rows distinct from
+        # chain_a's.
+        assert all(bid is not None for bid in fork_block_ids)
+        assert not set(fork_block_ids) & chain_a_block_ids
+
+        # Corrupt the materialization with fork block_ids — real FKs
+        # to BlockDAO rows, but not reachable from chain_a's tip via
+        # prev pointers.
         db.session.query(LongestChainBlockDAO).delete()
-        db.session.add(LongestChainBlockDAO(block_id=999_001, position=0))
-        db.session.add(LongestChainBlockDAO(block_id=999_002, position=1))
+        db.session.add(
+            LongestChainBlockDAO(
+                block_id=fork_block_ids[0],
+                position=0,
+            )
+        )
+        db.session.add(
+            LongestChainBlockDAO(
+                block_id=fork_block_ids[1],
+                position=1,
+            )
+        )
         db.session.commit()
 
-        # Sync the longest chain. The walk will not find any block_id
-        # match (chain's blocks aren't 999_001 / 999_002), so it
-        # walks to genesis and falls back to full DELETE + bulk insert.
-        longest.sync_longest_chain_blocks()
+        # Sync chain_a. The walk from chain_a's tip won't find any
+        # fork block in the materialization (chain_a's prev chain
+        # doesn't reach into chain_b's blocks), so it walks to genesis
+        # and falls back to full DELETE + bulk insert.
+        chain_a_longest.sync_longest_chain_blocks()
         db.session.commit()
 
         rows = (
@@ -588,8 +651,9 @@ def test_smart_reorg_deep_reorg_with_no_common_ancestor_falls_back(
             .order_by(LongestChainBlockDAO.position)
             .all()
         )
-        # 3 real blocks now in the materialization; no 999_* rows.
+        # 3 real chain_a blocks now in the materialization; no fork
+        # block_ids.
         assert len(rows) == 3
-        assert all(r.block_id not in (999_001, 999_002) for r in rows)
+        assert all(r.block_id not in fork_block_ids for r in rows)
         # Positions 0, 1, 2 (genesis-first).
         assert [r.position for r in rows] == [0, 1, 2]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -449,3 +449,149 @@ def test_is_longest_cache_survives_across_method_calls(app, mill_block, wallet):
                 f'wallet_balance method (cached after the first '
                 f'property access), got {spy.call_count}'
             )
+
+
+def test_smart_reorg_shallow(app, mill_block, wallet):
+    """A steady-state +1 block via smart-reorg preserves earlier
+    positions (common ancestor at position max-1, only the new tip
+    is inserted)."""
+    with app.app_context():
+        _m, _a1 = mill_block(wallet)
+        _m, _a2 = mill_block(wallet)
+
+        before = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        assert [r.position for r in before] == [0, 1]
+        before_snapshot = [(r.block_id, r.position) for r in before]
+
+        # Mining one more block goes through smart-reorg's "walk back
+        # one step to find common ancestor at position 1, insert one
+        # row at position 2" path — equivalent to the old extend path
+        # in observable behavior.
+        _m, _a3 = mill_block(wallet)
+
+        after = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        # Positions 0 and 1 unchanged.
+        assert [(r.block_id, r.position) for r in after[:2]] == before_snapshot
+        # Position 2 is new.
+        assert after[2].position == 2
+        assert len(after) == 3
+
+
+def test_smart_reorg_walks_only_to_common_ancestor(app, mill_block, wallet):
+    """The walk stops at the first block found in the materialization.
+    For a steady-state extend, this means walking back one step to
+    find the common ancestor, and inserting exactly one new row —
+    not a full DELETE + bulk INSERT.
+    """
+    with app.app_context():
+        for _ in range(5):
+            mill_block(wallet)
+
+        rows_before = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        ids_before = {r.block_id for r in rows_before}
+        positions_before = [r.position for r in rows_before]
+
+        _m, _new_tip = mill_block(wallet)
+
+        rows_after = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        # First 5 rows' block_ids are unchanged: smart-reorg did NOT
+        # delete-and-rebuild from scratch (which would have made new
+        # row instances with new identities or different orderings).
+        # The same block_id set is present in the same positions.
+        assert {r.block_id for r in rows_after[:5]} == ids_before
+        assert [r.position for r in rows_after[:5]] == positions_before
+        # And exactly one new row at the tail.
+        assert len(rows_after) == len(rows_before) + 1
+        assert rows_after[-1].position == 5
+
+
+def test_smart_reorg_already_in_sync_short_circuits(app, mill_block, wallet):
+    """Calling sync_longest_chain_blocks twice on the same chain
+    instance: the second call finds the tip already in the table on
+    its first walk iteration and returns without mutation or
+    generation bump.
+    """
+    with app.app_context():
+        mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+
+        gen_before = ChainDAO._chain_generation
+        rows_before = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        snapshot_before = [(r.block_id, r.position) for r in rows_before]
+
+        # Re-invoke sync; nothing should change.
+        longest.sync_longest_chain_blocks()
+
+        rows_after = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        snapshot_after = [(r.block_id, r.position) for r in rows_after]
+
+        assert snapshot_before == snapshot_after
+        assert ChainDAO._chain_generation == gen_before, (
+            f'expected generation to be unchanged after no-op sync, '
+            f'got {ChainDAO._chain_generation} (was {gen_before})'
+        )
+
+
+def test_smart_reorg_deep_reorg_with_no_common_ancestor_falls_back(
+    app, mill_block, wallet
+):
+    """If the materialization holds block_ids that aren't reachable
+    from the current chain's tip via prev pointers, the walk reaches
+    genesis without finding a common ancestor. The fallback uses the
+    collected list to fully replace the materialization.
+    """
+    with app.app_context():
+        # Build a chain of length 3.
+        for _ in range(3):
+            mill_block(wallet)
+        longest = ChainDAO.longest()
+        assert longest is not None
+
+        # Corrupt the materialization with fake block_ids that don't
+        # exist in the chain (use very large ints unlikely to collide).
+        db.session.query(LongestChainBlockDAO).delete()
+        db.session.add(LongestChainBlockDAO(block_id=999_001, position=0))
+        db.session.add(LongestChainBlockDAO(block_id=999_002, position=1))
+        db.session.commit()
+
+        # Sync the longest chain. The walk will not find any block_id
+        # match (chain's blocks aren't 999_001 / 999_002), so it
+        # walks to genesis and falls back to full DELETE + bulk insert.
+        longest.sync_longest_chain_blocks()
+        db.session.commit()
+
+        rows = (
+            db.session.query(LongestChainBlockDAO)
+            .order_by(LongestChainBlockDAO.position)
+            .all()
+        )
+        # 3 real blocks now in the materialization; no 999_* rows.
+        assert len(rows) == 3
+        assert all(r.block_id not in (999_001, 999_002) for r in rows)
+        # Positions 0, 1, 2 (genesis-first).
+        assert [r.position for r in rows] == [0, 1, 2]


### PR DESCRIPTION
## Summary
- Rewrites `ChainDAO.sync_longest_chain_blocks` to use a smart-reorg algorithm: walk new tip back via `BlockDAO.prev` until hitting a block already in the materialization (the common ancestor), then truncate above that position and insert the diverging suffix.
- Bootstrap fast-path preserved (empty table → `_rebuild_longest_chain_blocks` directly).
- Deep-reorg fallback (no common ancestor reached before genesis) reuses the collected list directly instead of re-walking via `_rebuild_*`.
- `_rebuild_longest_chain_blocks` unchanged — still the bootstrap path and the explicit caller-invoked reset.
- 4 new tests covering shallow reorg, walk-only-to-common-ancestor, already-in-sync short-circuit, and deep-reorg-fallback.

## Why
Closes the algorithmic perf cliff that survived Phase 6.5. On a 5-year chain (~263 k blocks), the prior full-rebuild-on-any-reorg design took 4-22 minutes per reorg depending on DB config — exceeding the 10-min block-time budget. Smart-reorg makes shallow reorgs O(reorg depth) instead of O(chain length).

## Out of scope (per spec)
- Phase 6.7 batched-fetch optimization for the walk lookup.
- Phase 7 SA 2.0 syntax modernization (`Model.query` → `db.session.execute(db.select(...))`).
- mypy override block removal in `models.py` (Phase 7).
- Cross-worker cache invalidation (Phase 7+).
- Generalizing materialization to all chains (Phase 7+).

## Test plan
- [x] `uv run mypy` exits 0.
- [x] `uv run pytest` passes (232 → 236, +4).
- [x] `uv run ruff check` + `format --check` pass.
- [ ] CI green on 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)