### PR TITLE
docs(phase-7b): Phase 7b typed DeclarativeBase design + plan

### DIFF
--- a/docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
+++ b/docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
@@ -1,0 +1,520 @@
+# Phase 7b — typed `DeclarativeBase` + mypy override removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` directive and the 7-line stale header comment block from `src/cancelchain/models.py`. Fix any mypy errors that surface; if FSA's stubs don't propagate `model_class=Base` through to `db.Model`, fall back to direct `class XDAO(Base):` subclassing across the ~10 DAOs.
+
+**Architecture:** Pure typing change. Two production files touched (`database.py` adds `Base(DeclarativeBase)` + the `model_class=Base` kwarg; `models.py` loses the per-file mypy disable header). No schema, no behavior, no test count changes. The fallback (direct `Base` subclassing) is mechanical and decided after the first mypy run — no upfront commitment needed.
+
+**Tech Stack:** SQLAlchemy 2.0.50 + Flask-SQLAlchemy 3.1.1 (existing — both already support typed `DeclarativeBase` via `SQLAlchemy(model_class=...)`). No dependency changes. The companion design spec is `docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md`.
+
+---
+
+## Prerequisites
+
+- Working directory: the cancelchain repo root. Run all commands from there.
+- `uv --version` 0.4.x or newer; `gh --version` works and `gh auth status` shows authenticated.
+- Phase 7a merged. Verify with `git log --oneline -3 main` showing `4070978 feat(models): SA 2.0 query syntax migration (#76)` near the top.
+- The branch `docs/phase-7b-design` exists locally with one commit:
+  - `6742711 docs(phase-7b): add typed DeclarativeBase migration design spec`
+  This plan adds a second commit on that branch (the plan file itself) and ships both as the docs PR.
+- CI hard-gates `ruff check`, `ruff format --check`, and `mypy` (strict).
+- Test baseline: **236 passed, 1 skipped**. Phase 7b adds zero new tests; the count stays 236.
+- Each PR ends with `wor` (Copilot review wait + reply) and `mwg` (merge when green); the controller handles those, not the implementer subagent.
+- Never push directly to `main`.
+
+---
+
+## File Map
+
+| Task | PR | Files |
+|---|---|---|
+| 1 | docs PR | `docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md` (this file) + spec already on branch |
+| 2 | impl PR | `src/cancelchain/database.py`, `src/cancelchain/models.py`. Possibly `src/cancelchain/models.py` DAO declarations only if the FSA-stubs fallback triggers (Step 6 below). |
+| 3 | acceptance | none (verification only) |
+
+---
+
+## Task 1: Ship the docs PR (spec + plan)
+
+**Files:** The design spec is committed on `docs/phase-7b-design` (`6742711`). This task adds the implementation plan as a second commit and ships both as one docs PR.
+
+- [ ] **Step 1: Confirm branch state**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git ls-files docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md
+git rev-list --count main..HEAD
+```
+
+Expected: branch is `docs/phase-7b-design`; spec file is tracked; commit count above main is `1`.
+
+- [ ] **Step 2: Verify the plan file is present and untracked**
+
+```bash
+ls -la docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
+git status docs/superpowers/plans/
+```
+
+Expected: file exists; shows as untracked.
+
+- [ ] **Step 3: Stage and commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
+git commit -m "$(cat <<'EOF'
+docs(phase-7b): add typed DeclarativeBase migration implementation plan
+
+Spells out the single-PR impl: branch off main, edit database.py
+to add Base(DeclarativeBase) + the model_class=Base kwarg, edit
+models.py to remove the 7-line stale header comment block and the
+# mypy: disable-error-code directive, run mypy to see what
+surfaces, fix surfaced errors inline (per-line # type: ignore[code]
+is the explicit escape hatch), fall back to direct
+class XDAO(Base): subclassing across the ~10 DAOs if FSA stubs
+don't propagate model_class through to db.Model. Pure typing
+pass — no schema, no behavior, no test count changes (236 stays
+236).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin docs/phase-7b-design
+```
+
+- [ ] **Step 5: Open the docs PR**
+
+```bash
+gh pr create --base main --head docs/phase-7b-design --title "docs(phase-7b): Phase 7b typed DeclarativeBase design + plan" --body "$(cat <<'EOF'
+## Summary
+- Adds the Phase 7b design spec (\`docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md\`).
+- Adds the Phase 7b implementation plan (\`docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md\`).
+- No code changes.
+
+Phase 7b closes Phase 3's explicit sunset commitment for the per-file \`mypy: disable-error-code\` block on \`src/cancelchain/models.py\` — the last remaining blocker after Phase 7a (commit 4070978) removed every legacy \`Model.query\` / \`db.session.query(...)\` call site and migrated every \`Query[X]\` annotation to \`Select[tuple[X]]\`. Switches Flask-SQLAlchemy's \`db = SQLAlchemy()\` to use a typed \`DeclarativeBase\` subclass via \`db = SQLAlchemy(model_class=Base)\`, then removes the per-file override directive. Pure typing pass — no schema, no behavior, no test count change.
+
+## Test plan
+- [x] Spec self-review passed.
+- [x] Plan self-review passed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Stop — controller handles wor + mwg + sync**
+
+---
+
+## Task 2: Phase 7b impl — typed `DeclarativeBase` + override removal
+
+**Files:**
+- Modify: `src/cancelchain/database.py` (3 changes: add `DeclarativeBase` import, define `Base` class, add `model_class=Base` kwarg)
+- Modify: `src/cancelchain/models.py` (remove the 7-line header comment block + the `# mypy: disable-error-code` directive; possibly add narrow per-line ignores or rewrite DAO declarations to `class XDAO(Base):` depending on the Step 6 mypy run)
+
+The migration is short. Steps 2 and 4 are the actual edits; Step 3 is a measurement (run mypy with the override gone and inventory what surfaces); Step 6 is the remediation based on Step 3's findings. After each edit, run `uv run pytest -x 2>&1 | tail -5` to catch runtime regressions early.
+
+### Step 1: Branch off main + sanity check baseline
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/phase-7b-declarative-base
+git log --oneline -1
+```
+
+Expected: the top commit is `4070978 feat(models): SA 2.0 query syntax migration (#76)`.
+
+Then confirm the baseline gates are green BEFORE any edit:
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run pytest 2>&1 | tail -3
+```
+
+Expected: mypy `Success: no issues found in 24 source files`; ruff `All checks passed!`; pytest `236 passed, 1 skipped`.
+
+If any gate fails on a clean main, stop and surface — something has drifted since 7a merged.
+
+### Step 2: Edit `src/cancelchain/database.py`
+
+The current file is 6 lines:
+
+```python
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+```
+
+After:
+
+```python
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+db = SQLAlchemy(model_class=Base)
+```
+
+Three changes:
+1. New import: `from sqlalchemy.orm import DeclarativeBase`.
+2. New `Base` class definition (empty body — no mixins, no overrides).
+3. `SQLAlchemy()` → `SQLAlchemy(model_class=Base)`.
+
+Verify:
+
+```bash
+grep -n 'DeclarativeBase\|model_class=Base' src/cancelchain/database.py
+```
+
+Expected: two matches — the import and the `SQLAlchemy(...)` call.
+
+### Step 3: Run pytest + mypy to measure the surface
+
+```bash
+uv run pytest 2>&1 | tail -3
+uv run mypy 2>&1 | tail -20
+```
+
+`pytest` is the runtime safety net — if Flask-SQLAlchemy's `model_class=Base` interaction breaks anything (relationship back-population, table args, lazy session), it surfaces here. **All 236 tests must still pass at this step.** If anything fails, stop and investigate — the failure is the `Base` swap interacting with runtime behavior, not a mypy issue.
+
+`mypy` tells us what the `Base` swap did to the type surface. There are three possible outcomes:
+
+- **Outcome A — mypy now passes** (zero errors with `models.py` still carrying its disable block): the base swap alone resolves the typing concerns. Proceed to Step 4 (remove the disable block). The expected case for FSA 3.1+ with the stubs we have.
+- **Outcome B — mypy reports new errors that were previously masked** but the disable block is still in place: this means the disable block was actively suppressing real errors that the base swap newly created (rare; would indicate the dynamic `db.Model` was masking something the typed `Base` exposes). Capture the error list and surface as a concern — this is unexpected enough to escalate.
+- **Outcome C — no change** (mypy still says zero errors because the disable block is still in place): the expected case where Step 3 doesn't tell us much; the real measurement is Step 5 after the disable block comes out.
+
+In practice the most likely outcome is C — the disable block is still hiding everything, so we proceed to Step 4 to remove it and run mypy again in Step 5.
+
+### Step 4: Remove the `models.py` header comment + mypy disable directive
+
+Open `src/cancelchain/models.py`. The current top of file (post-7a) is:
+
+```python
+from __future__ import annotations
+
+# Flask-SQLAlchemy's `db.Model` is dynamically attached and shows up as
+# `Any` to mypy strict, which triggers `name-defined` (Name "db.Model"
+# is not defined) and `misc` (Class cannot subclass "Model" of type
+# "Any") errors on every DAO class declaration here. Phase 7b will
+# switch to a typed `DeclarativeBase` subclass and remove this
+# suppression.
+# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"
+import datetime
+```
+
+Delete lines 3-11 (the 7-line `#` comment block plus the `# mypy: disable-error-code` directive plus the blank-line-equivalent that connects them). The result:
+
+```python
+from __future__ import annotations
+
+import datetime
+```
+
+That's the only change in Step 4. The DAO declarations (`class XDAO(db.Model):` at multiple sites in this file) stay unchanged for now — those become typed automatically IF Flask-SQLAlchemy's stubs propagate `model_class=Base` through to `db.Model` (the canonical FSA 3.x pattern that this PR is exercising).
+
+Verify:
+
+```bash
+grep -n 'mypy: disable-error-code\|Phase 7b will' src/cancelchain/models.py
+```
+
+Expected: returns nothing.
+
+### Step 5: Run mypy to measure what surfaces
+
+```bash
+uv run mypy 2>&1
+```
+
+Inventory the output. This is the moment of truth.
+
+**Expected case (clean):** `Success: no issues found in 24 source files`. The base swap + override removal is enough; no further edits to `models.py` needed. Proceed to Step 7.
+
+**Likely case (a handful of leftover errors):** 1-5 errors surface, typically `no-any-return` on a `Result.scalar_one_or_none()` call where mypy can't see through the typed Select, or `no-untyped-call` on a specific `db.session.execute(...)` chain. Proceed to Step 6 to remediate.
+
+**Concerning case (many errors, or `class XDAO(db.Model):` declarations still trigger `name-defined` / `misc`):** Flask-SQLAlchemy's stubs aren't propagating `model_class=Base` through `db.Model`. Proceed to Step 6 with the fallback path (direct `Base` subclassing).
+
+Capture the full mypy output for the next step:
+
+```bash
+uv run mypy 2>&1 | tee /tmp/phase7b-mypy.log
+```
+
+### Step 6: Remediate surfaced errors
+
+Three remediation patterns, applied based on the Step 5 inventory:
+
+**Pattern A — narrow per-line ignore.** For an isolated error that resists a clean annotation fix:
+
+```python
+# Before (line N triggers no-any-return)
+return db.session.execute(stmt).scalar_one_or_none()
+
+# After
+return db.session.execute(stmt).scalar_one_or_none()  # type: ignore[no-any-return]
+```
+
+Add a short comment on the ignore line OR the line above explaining why, so a future reader doesn't have to re-derive the reasoning. The format follows the pre-existing per-line ignores in models.py (lines 166, 232, 233, 519, 771 from the post-7a state).
+
+**Pattern B — explicit annotation or `cast()`.** For a return-type mismatch that has a clean fix:
+
+```python
+from typing import cast
+
+# Before
+def get(...) -> XDAO | None:
+    return db.session.execute(stmt).scalar_one_or_none()
+
+# After (if cast is cleaner than a per-line ignore)
+def get(...) -> XDAO | None:
+    return cast('XDAO | None', db.session.execute(stmt).scalar_one_or_none())
+```
+
+Prefer this over Pattern A when the cast clearly improves readability or types-check verification at the call site. Add `cast` to the `typing` imports if needed.
+
+**Pattern C — switch DAO declarations to `class XDAO(Base):` directly.** ONLY if Step 5 surfaced `name-defined` or `misc` errors on the DAO class declarations themselves (meaning FSA's stubs don't propagate `model_class` through `db.Model`). Locate the ~10 DAO class declarations:
+
+```bash
+grep -n '^class .*DAO(db\.Model):\|^class ApiToken(db\.Model):' src/cancelchain/models.py
+```
+
+For each declaration, change `(db.Model)` → `(Base)` and add `from cancelchain.database import Base` to the imports (alongside the existing `from cancelchain.database import db`). The runtime behavior is identical because `db.Model IS Base` after Step 2 — this change is purely for mypy's resolution.
+
+**After remediation, re-run mypy AND pytest:**
+
+```bash
+uv run mypy
+uv run pytest 2>&1 | tail -3
+```
+
+Both must exit clean. Iterate Step 6 until both gates are clean. If you're applying more than ~5 per-line ignores OR more than 2 of the three patterns simultaneously, stop and surface — the spec's "single-PR shape" decision has a fallback to splitting, but that's a controller-level call, not an implementer one.
+
+### Step 7: Verify all gates
+
+```bash
+uv run mypy
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pytest
+```
+
+All four must exit 0. Test count: 236 passed, 1 skipped (unchanged).
+
+### Step 8: Run the benchmark harness for sanity
+
+```bash
+uv run python bench/rebuild_walk_bench.py --sizes 1000 10000 100000 2>&1 | tail -10
+```
+
+Expected: per-step times ~0.25 ms/step (matching the Phase 7a baseline). Typing changes shouldn't affect runtime performance, so this is mostly a smoke check. If significantly slower, investigate before committing — that would indicate something at runtime changed unexpectedly.
+
+### Step 9: Commit
+
+```bash
+git add src/cancelchain/database.py src/cancelchain/models.py
+git commit -m "$(cat <<'EOF'
+feat(models): typed DeclarativeBase + remove mypy override block
+
+Phase 7b. Switches Flask-SQLAlchemy's db = SQLAlchemy() to use a
+typed DeclarativeBase subclass via db = SQLAlchemy(model_class=
+Base), then removes the # mypy: disable-error-code=
+"no-untyped-call,no-any-return,name-defined,misc" directive and
+the 7-line stale header comment block from src/cancelchain/
+models.py. Closes Phase 3's explicit sunset commitment for the
+per-file mypy override on models.py — the last remaining blocker
+after Phase 7a (commit 4070978) modernized every legacy call site
+and annotation.
+
+Pure typing pass: no schema changes, no behavior changes, no new
+tests, test count stays 236. Bench harness confirms per-step
+rebuild perf is unchanged from the Phase 7a baseline.
+
+src/cancelchain/database.py:
+- New import: `from sqlalchemy.orm import DeclarativeBase`.
+- New `class Base(DeclarativeBase): pass` declaration.
+- `db = SQLAlchemy()` → `db = SQLAlchemy(model_class=Base)`.
+
+src/cancelchain/models.py:
+- Remove the 7-line `#` comment block at the top of the file
+  explaining why the disable block existed.
+- Remove the `# mypy: disable-error-code="no-untyped-call,
+  no-any-return,name-defined,misc"` directive.
+- [Add any per-line `# type: ignore[code]` additions or DAO
+  declaration rewrites from Step 6 here if they were needed.]
+
+Phase 7 closed. The 5 pre-existing per-line # type:
+ignore[assignment] lines (Mapped[X] vs X | None invariants in DAO
+__init__ methods) stay; those are a separate typing concern not
+covered by the typed-base swap.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Note for the implementer:** The commit message bullet list under `models.py:` includes a bracketed placeholder for any Step 6 additions. Replace that bracket with a concrete list of what was added (or delete the bracketed line if Step 6 added nothing). The rest of the commit message stays as written.
+
+### Step 10: Push and open PR
+
+```bash
+git push -u origin feat/phase-7b-declarative-base
+gh pr create --base main --title "feat(models): typed DeclarativeBase + remove mypy override block" --body "$(cat <<'EOF'
+## Summary
+- Switches Flask-SQLAlchemy's \`db = SQLAlchemy()\` to use a typed \`DeclarativeBase\` subclass via \`db = SQLAlchemy(model_class=Base)\` (new \`Base(DeclarativeBase)\` class in \`src/cancelchain/database.py\`).
+- Removes the \`# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"\` directive and the 7-line stale header comment block from \`src/cancelchain/models.py\`.
+- Pure typing pass — no schema changes, no behavior changes, no new tests, no test-count change (236 stays 236).
+
+## Why
+Phase 7b closes Phase 3's explicit sunset commitment for the per-file mypy override on \`models.py\` — the last remaining blocker after Phase 7a (commit 4070978) modernized every legacy \`Model.query\` / \`db.session.query(...)\` call site and migrated every \`Query[X]\` annotation to \`Select[tuple[X]]\`. With this PR, Phase 7 closes.
+
+## Out of scope (per spec)
+- No DAO behavior changes. The DAO class declarations either stay as \`class XDAO(db.Model):\` (typed automatically through FSA's \`model_class=Base\` propagation) or move to direct \`class XDAO(Base):\` subclassing — whichever mypy needs, decided during impl.
+- No removal of the 5 pre-existing per-line \`# type: ignore[assignment]\` lines (Mapped[X] vs X | None invariants in DAO __init__ methods — a separate typing concern).
+- No \`MappedAsDataclass\` migration (out of scope — would rewrite every DAO \`__init__\` signature).
+
+## Test plan
+- [x] \`uv run mypy\` exits 0 with NO per-file override on \`models.py\`.
+- [x] \`uv run pytest\` passes 236 (unchanged).
+- [x] \`uv run ruff check\` + \`format --check\` pass.
+- [x] \`bench/rebuild_walk_bench.py --sizes 1000 10000 100000\` matches the Phase 7a baseline (~0.25 ms/step).
+- [ ] CI green on 3.12 and 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 11: Stop — controller handles wor + mwg + sync
+
+---
+
+## Task 3: Phase 7b acceptance verification
+
+**Files:** none modified. Final verification after the impl PR lands on main.
+
+- [ ] **Step 1: Confirm clean main**
+
+```bash
+git checkout main && git pull --ff-only
+git log --oneline -3
+```
+
+Expected: top two commits are the docs PR squash and the impl PR squash.
+
+- [ ] **Step 2: Override directive eradicated**
+
+```bash
+grep -n 'mypy: disable-error-code' src/cancelchain/models.py
+```
+
+Expected: returns nothing. The override directive is gone from `models.py`.
+
+```bash
+grep -n 'DeclarativeBase\|model_class=Base' src/cancelchain/database.py
+```
+
+Expected: two matches (the import line and the `SQLAlchemy(...)` call).
+
+- [ ] **Step 3: Hard CI gates pass**
+
+```bash
+uv run ruff check src tests; echo "ruff check exit: $?"
+uv run ruff format --check src tests; echo "ruff format exit: $?"
+uv run mypy; echo "mypy exit: $?"
+```
+
+All three exit 0. **The headline acceptance gate is `mypy exit: 0`** — that confirms the typed `Base` is doing its job without any per-file overrides on `models.py`.
+
+- [ ] **Step 4: Tests pass on 3.12 and 3.13**
+
+```bash
+uv run --python 3.12 pytest 2>&1 | tail -3
+uv run --python 3.13 pytest 2>&1 | tail -3
+```
+
+Expected: both print `236 passed, 1 skipped`.
+
+- [ ] **Step 5: Benchmark perf unchanged**
+
+```bash
+uv run python bench/rebuild_walk_bench.py --sizes 1000 10000 100000 2>&1 | tail -10
+```
+
+Expected: per-step times ~0.25 ms/step on local SQLite (matching Phase 7a baseline within noise).
+
+- [ ] **Step 6: CLI smoke**
+
+```bash
+uv run cancelchain --help
+```
+
+Expected: prints the full command tree (an `ERROR: 'SQLALCHEMY_DATABASE_URI' must be set` message is expected if there's no `.env` in cwd, but the `--help` output still renders).
+
+- [ ] **Step 7: Docker build smoke**
+
+```bash
+docker build --target builder -t cc-phase7b-final .
+```
+
+Expected: succeeds.
+
+- [ ] **Step 8: Acceptance complete**
+
+If Steps 1-7 all pass, Phase 7b is done. Phase 7 closes. No commit.
+
+---
+
+## Notes on the wor / mwg workflow
+
+Each PR (Tasks 1 and 2) ends with the controller running `wor` and `mwg`:
+
+1. **`wor`:** poll PR until Copilot review completes. Read inline comments. Reply one at a time with verified `in_reply_to_id` (per the user's memory).
+2. **`mwg`:** `gh pr checks <N> --watch`; once green, `gh pr merge <N> --squash --delete-branch`.
+
+If Copilot review requests substantive changes, push a new commit (do not amend) and post a `/copilot review` comment on the PR — Copilot's auto-review only fires on the initial push; subsequent rounds need the manual trigger (per the user's memory).
+
+---
+
+## Risks and watchpoints
+
+### Risk: FSA stubs don't propagate `model_class=Base` through to `db.Model`
+
+Per the spec's Risks section, this is the most likely source of unexpected mypy surface. If Step 5's mypy output shows `name-defined` errors on the `class XDAO(db.Model):` declarations themselves (e.g., `error: Name "db.Model" is not defined  [name-defined]`) or `misc` errors on follow-on `Class cannot subclass "Model" of type "Any"`, FSA's stubs aren't carrying the type. The fix is Step 6's Pattern C — direct `Base` subclassing across the ~10 DAOs. This is mechanical (find/replace `(db.Model)` → `(Base)` in DAO class headers, plus add `Base` to the import block in `models.py`) and shouldn't take more than a few minutes.
+
+### Risk: `no-any-return` on `scalar_one_or_none()` / `scalars().first()` chains
+
+SA 2.x's `Select[tuple[X]]` typing carries through `db.session.execute(...).scalar_one_or_none()` to return `X | None`, but `Result.scalars().first()` returns `X | None` too — the typing chain should be clean. If mypy reports `no-any-return` on a specific site, prefer Pattern A (per-line ignore with a short comment) over Pattern B (explicit cast), because a cast at every "fetch one" call site bloats the codebase without buying real type safety. Per-line ignores are the documented escape hatch.
+
+### Risk: `no-untyped-call` on `db.aliased(...)` or specific FSA helpers
+
+`db.aliased` from Flask-SQLAlchemy's facade delegates to `sqlalchemy.orm.aliased`, which is typed. If mypy reports `no-untyped-call` on `db.aliased(...)`, the FSA stubs aren't quite right. Two paths: (a) per-line ignore (Pattern A), or (b) import `aliased` directly from `sqlalchemy.orm` and use it instead of going through `db`. (b) is a slightly larger change but a real improvement; consider it if mypy flags this pattern at more than 2-3 sites.
+
+### Risk: pytest fails after Step 2's `database.py` edit
+
+Possible runtime breakage from the `model_class=Base` swap. Most likely culprit: a Flask-SQLAlchemy feature that interacts with the dynamic `Model` (e.g., automatic `__tablename__` derivation if any DAO doesn't explicitly set it — verify with `grep -L '__tablename__' src/cancelchain/models.py` to confirm all DAOs do set it explicitly; the current codebase does). If a test fails at Step 3, stop and inspect — surface the failure to the user before continuing.
+
+### Risk: the 5 pre-existing per-line `# type: ignore[assignment]` lines start failing
+
+The `Mapped[X]` vs `X | None` assignment issue these cover is independent of the base class. Typed `DeclarativeBase` shouldn't change which errors they suppress. If any of them stops being needed (mypy says `unused-ignore`), that's a small win — delete the ignore. If any of them needs a different code (e.g., `assignment` became `no-any-return`), update the code in the ignore.
+
+### Risk: `# type: ignore[misc]` proliferation if Pattern C is needed
+
+Pattern C (direct `Base` subclassing) is preferred over adding `# type: ignore[misc]` on every DAO declaration, precisely because per-line `misc` ignores would create N noisy lines for an N-DAO file. The direct-subclassing fix is one find/replace operation. If you're considering Pattern C with `# type: ignore[misc]` on >2 lines, prefer the direct-subclassing path.
+
+### Risk: Bench harness regression
+
+Typing changes shouldn't affect runtime. If Step 8's bench numbers differ noticeably from Phase 7a's baseline (~0.25 ms/step), something at runtime changed unexpectedly — surface it. The base class swap COULD theoretically change SA's table registration order or relationship resolution order, but in practice this is fully deterministic and shouldn't show up in bench numbers.

--- a/docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
+++ b/docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` directive and the 7-line stale header comment block from `src/cancelchain/models.py`. Fix any mypy errors that surface; if FSA's stubs don't propagate `model_class=Base` through to `db.Model`, fall back to direct `class XDAO(Base):` subclassing across the ~10 DAOs.
+**Goal:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` directive and the 6-line stale header comment block from `src/cancelchain/models.py`. Fix any mypy errors that surface; if FSA's stubs don't propagate `model_class=Base` through to `db.Model`, fall back to direct `(Base):` subclassing across all 11 `db.Model` subclasses (8 `DAO`-suffixed + `ChainFill`, `ChainFillBlock`, `ApiToken`).
 
 **Architecture:** Pure typing change. Two production files touched (`database.py` adds `Base(DeclarativeBase)` + the `model_class=Base` kwarg; `models.py` loses the per-file mypy disable header). No schema, no behavior, no test count changes. The fallback (direct `Base` subclassing) is mechanical and decided after the first mypy run — no upfront commitment needed.
 
@@ -67,12 +67,13 @@ docs(phase-7b): add typed DeclarativeBase migration implementation plan
 
 Spells out the single-PR impl: branch off main, edit database.py
 to add Base(DeclarativeBase) + the model_class=Base kwarg, edit
-models.py to remove the 7-line stale header comment block and the
+models.py to remove the 6-line stale header comment block and the
 # mypy: disable-error-code directive, run mypy to see what
 surfaces, fix surfaced errors inline (per-line # type: ignore[code]
 is the explicit escape hatch), fall back to direct
-class XDAO(Base): subclassing across the ~10 DAOs if FSA stubs
-don't propagate model_class through to db.Model. Pure typing
+(Base): subclassing across all 11 db.Model subclasses if FSA
+stubs don't propagate model_class through to db.Model (8
+DAO-suffixed classes + ChainFill, ChainFillBlock, ApiToken). Pure typing
 pass — no schema, no behavior, no test count changes (236 stays
 236).
 
@@ -115,7 +116,7 @@ EOF
 
 **Files:**
 - Modify: `src/cancelchain/database.py` (3 changes: add `DeclarativeBase` import, define `Base` class, add `model_class=Base` kwarg)
-- Modify: `src/cancelchain/models.py` (remove the 7-line header comment block + the `# mypy: disable-error-code` directive; possibly add narrow per-line ignores or rewrite DAO declarations to `class XDAO(Base):` depending on the Step 6 mypy run)
+- Modify: `src/cancelchain/models.py` (remove the 6-line header comment block + the `# mypy: disable-error-code` directive; possibly add narrow per-line ignores or rewrite DAO declarations to `class XDAO(Base):` depending on the Step 6 mypy run)
 
 The migration is short. Steps 2 and 4 are the actual edits; Step 3 is a measurement (run mypy with the override gone and inventory what surfaces); Step 6 is the remediation based on Step 3's findings. After each edit, run `uv run pytest -x 2>&1 | tail -5` to catch runtime regressions early.
 
@@ -180,7 +181,7 @@ Verify:
 grep -n 'DeclarativeBase\|model_class=Base' src/cancelchain/database.py
 ```
 
-Expected: two matches — the import and the `SQLAlchemy(...)` call.
+Expected: three matches — (1) the `from sqlalchemy.orm import DeclarativeBase` import, (2) the `class Base(DeclarativeBase):` class definition, and (3) the `db = SQLAlchemy(model_class=Base)` call.
 
 ### Step 3: Run pytest + mypy to measure the surface
 
@@ -216,7 +217,7 @@ from __future__ import annotations
 import datetime
 ```
 
-Delete lines 3-11 (the 7-line `#` comment block plus the `# mypy: disable-error-code` directive plus the blank-line-equivalent that connects them). The result:
+Delete lines 3-9 (the 6-line `#` explanatory comment block at lines 3-8 plus the `# mypy: disable-error-code` directive at line 9). **Do NOT delete lines 10-11** — those are `import datetime` and `import uuid`, which stay. The result:
 
 ```python
 from __future__ import annotations
@@ -286,13 +287,13 @@ def get(...) -> XDAO | None:
 
 Prefer this over Pattern A when the cast clearly improves readability or types-check verification at the call site. Add `cast` to the `typing` imports if needed.
 
-**Pattern C — switch DAO declarations to `class XDAO(Base):` directly.** ONLY if Step 5 surfaced `name-defined` or `misc` errors on the DAO class declarations themselves (meaning FSA's stubs don't propagate `model_class` through `db.Model`). Locate the ~10 DAO class declarations:
+**Pattern C — switch DAO declarations to `class XDAO(Base):` directly.** ONLY if Step 5 surfaced `name-defined` or `misc` errors on the class declarations themselves (meaning FSA's stubs don't propagate `model_class` through `db.Model`). Locate ALL `db.Model` subclasses (note: not all of them have a `DAO` suffix — `ChainFill`, `ChainFillBlock`, and `ApiToken` don't):
 
 ```bash
-grep -n '^class .*DAO(db\.Model):\|^class ApiToken(db\.Model):' src/cancelchain/models.py
+grep -n '^class [A-Za-z]*(db\.Model):' src/cancelchain/models.py
 ```
 
-For each declaration, change `(db.Model)` → `(Base)` and add `from cancelchain.database import Base` to the imports (alongside the existing `from cancelchain.database import db`). The runtime behavior is identical because `db.Model IS Base` after Step 2 — this change is purely for mypy's resolution.
+Expected: 11 matches in the current code — `TransactionDAO`, `OutflowDAO`, `InflowDAO`, `BlockDAO`, `LongestChainBlockDAO`, `ChainDAO`, `PendingTxnDAO`, `PendingIOflowDAO`, `ChainFill`, `ChainFillBlock`, `ApiToken`. For each, change `(db.Model)` → `(Base)` and add `from cancelchain.database import Base` to the imports (alongside the existing `from cancelchain.database import db`). The runtime behavior is identical because `db.Model IS Base` after Step 2 — this change is purely for mypy's resolution. Missing any class would leave `name-defined` / `misc` errors on that line and fail the override-removal acceptance gate.
 
 **After remediation, re-run mypy AND pytest:**
 
@@ -333,7 +334,7 @@ Phase 7b. Switches Flask-SQLAlchemy's db = SQLAlchemy() to use a
 typed DeclarativeBase subclass via db = SQLAlchemy(model_class=
 Base), then removes the # mypy: disable-error-code=
 "no-untyped-call,no-any-return,name-defined,misc" directive and
-the 7-line stale header comment block from src/cancelchain/
+the 6-line stale header comment block from src/cancelchain/
 models.py. Closes Phase 3's explicit sunset commitment for the
 per-file mypy override on models.py — the last remaining blocker
 after Phase 7a (commit 4070978) modernized every legacy call site
@@ -349,8 +350,8 @@ src/cancelchain/database.py:
 - `db = SQLAlchemy()` → `db = SQLAlchemy(model_class=Base)`.
 
 src/cancelchain/models.py:
-- Remove the 7-line `#` comment block at the top of the file
-  explaining why the disable block existed.
+- Remove the 6-line `#` comment block (lines 3-8) at the top of
+  the file explaining why the disable block existed.
 - Remove the `# mypy: disable-error-code="no-untyped-call,
   no-any-return,name-defined,misc"` directive.
 - [Add any per-line `# type: ignore[code]` additions or DAO
@@ -375,7 +376,7 @@ git push -u origin feat/phase-7b-declarative-base
 gh pr create --base main --title "feat(models): typed DeclarativeBase + remove mypy override block" --body "$(cat <<'EOF'
 ## Summary
 - Switches Flask-SQLAlchemy's \`db = SQLAlchemy()\` to use a typed \`DeclarativeBase\` subclass via \`db = SQLAlchemy(model_class=Base)\` (new \`Base(DeclarativeBase)\` class in \`src/cancelchain/database.py\`).
-- Removes the \`# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"\` directive and the 7-line stale header comment block from \`src/cancelchain/models.py\`.
+- Removes the \`# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"\` directive and the 6-line stale header comment block from \`src/cancelchain/models.py\`.
 - Pure typing pass — no schema changes, no behavior changes, no new tests, no test-count change (236 stays 236).
 
 ## Why
@@ -427,7 +428,7 @@ Expected: returns nothing. The override directive is gone from `models.py`.
 grep -n 'DeclarativeBase\|model_class=Base' src/cancelchain/database.py
 ```
 
-Expected: two matches (the import line and the `SQLAlchemy(...)` call).
+Expected: three matches — the `from sqlalchemy.orm import DeclarativeBase` import, the `class Base(DeclarativeBase):` class definition, and the `db = SQLAlchemy(model_class=Base)` call.
 
 - [ ] **Step 3: Hard CI gates pass**
 
@@ -493,7 +494,7 @@ If Copilot review requests substantive changes, push a new commit (do not amend)
 
 ### Risk: FSA stubs don't propagate `model_class=Base` through to `db.Model`
 
-Per the spec's Risks section, this is the most likely source of unexpected mypy surface. If Step 5's mypy output shows `name-defined` errors on the `class XDAO(db.Model):` declarations themselves (e.g., `error: Name "db.Model" is not defined  [name-defined]`) or `misc` errors on follow-on `Class cannot subclass "Model" of type "Any"`, FSA's stubs aren't carrying the type. The fix is Step 6's Pattern C — direct `Base` subclassing across the ~10 DAOs. This is mechanical (find/replace `(db.Model)` → `(Base)` in DAO class headers, plus add `Base` to the import block in `models.py`) and shouldn't take more than a few minutes.
+Per the spec's Risks section, this is the most likely source of unexpected mypy surface. If Step 5's mypy output shows `name-defined` errors on the `class XDAO(db.Model):` declarations themselves (e.g., `error: Name "db.Model" is not defined  [name-defined]`) or `misc` errors on follow-on `Class cannot subclass "Model" of type "Any"`, FSA's stubs aren't carrying the type. The fix is Step 6's Pattern C — direct `Base` subclassing across all 11 `db.Model` subclasses (not just the DAO-suffixed ones — `ChainFill`, `ChainFillBlock`, and `ApiToken` also inherit from `db.Model`). This is mechanical (find/replace `(db.Model)` → `(Base)` in class headers, plus add `Base` to the import block in `models.py`) and shouldn't take more than a few minutes. Missing any of the 11 would leave `name-defined` / `misc` errors on that line and fail the override-removal gate.
 
 ### Risk: `no-any-return` on `scalar_one_or_none()` / `scalars().first()` chains
 

--- a/docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md
+++ b/docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft for review
 **Date:** 2026-05-28
-**Scope:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to use a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` block at the top of `src/cancelchain/models.py` and the stale 7-line header comment that explained it. Fix any mypy errors that surface from removing the override. Phase 7b closes Phase 3's explicit sunset commitment for the per-file mypy override and is the second half of the two-PR Phase 7 split that began with Phase 7a's SA 2.0 call-site syntax migration (merged as commit `4070978`).
+**Scope:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to use a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` block at the top of `src/cancelchain/models.py` and the stale 6-line header comment that explained it. Fix any mypy errors that surface from removing the override. Phase 7b closes Phase 3's explicit sunset commitment for the per-file mypy override and is the second half of the two-PR Phase 7 split that began with Phase 7a's SA 2.0 call-site syntax migration (merged as commit `4070978`).
 
 ## Goal
 
@@ -59,7 +59,7 @@ db = SQLAlchemy(model_class=Base)
 
 ### `models.py` header
 
-Current top of `src/cancelchain/models.py` (lines 3-11 in the post-7a diff):
+Current top of `src/cancelchain/models.py` (lines 3-9 in the post-7a diff — lines 3-8 are the 6-line `#` explanatory comment, line 9 is the `# mypy: disable-error-code` directive; lines 10-11 immediately below are `import datetime` and `import uuid` and are NOT touched by this PR):
 
 ```python
 # Flask-SQLAlchemy's `db.Model` is dynamically attached and shows up as
@@ -71,7 +71,7 @@ Current top of `src/cancelchain/models.py` (lines 3-11 in the post-7a diff):
 # mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"
 ```
 
-Post-7b: both the 7-line comment block AND the `# mypy: disable-error-code` directive are removed. No replacement header — `models.py` should look like any other file in the module after this.
+Post-7b: both the 6-line comment block AND the `# mypy: disable-error-code` directive are removed. No replacement header — `models.py` should look like any other file in the module after this.
 
 ### Expected mypy error coverage by code
 
@@ -103,7 +103,7 @@ Phase 7a added both to the `typing` and `sqlalchemy` import groups at the top of
 ### Files
 
 - Modify: `src/cancelchain/database.py` — add `Base(DeclarativeBase)` class definition + the `model_class=Base` keyword on the `SQLAlchemy(...)` call + one new import (`from sqlalchemy.orm import DeclarativeBase`).
-- Modify: `src/cancelchain/models.py` — remove the 7-line stale header comment block (lines 3-9) and the `# mypy: disable-error-code` directive line (line 11). Nothing else changes unless mypy surfaces an error that needs an inline annotation or per-line ignore.
+- Modify: `src/cancelchain/models.py` — remove the 6-line stale header comment block (lines 3-8) and the `# mypy: disable-error-code` directive line (line 9). Lines 10-11 (`import datetime`, `import uuid`) are NOT touched. Nothing else changes unless mypy surfaces an error that needs an inline annotation or per-line ignore.
 - Potentially modify: `src/cancelchain/models.py` — narrowly-scoped per-line `# type: ignore[code]` additions for any surfaced mypy errors that resist clean annotation fixes. Anticipated count: 0-5 lines. If significantly more, surface as a concern during impl and consider a Phase 7c follow-up rather than ballooning this PR.
 
 ### Imports
@@ -124,7 +124,7 @@ Test count: 236 (unchanged). No new tests; no test removed.
 ## Acceptance
 
 - `grep -n 'mypy: disable-error-code' src/cancelchain/models.py` returns nothing.
-- `grep -n 'DeclarativeBase' src/cancelchain/database.py` returns the class definition.
+- `grep -n 'DeclarativeBase' src/cancelchain/database.py` returns two matches: the `from sqlalchemy.orm import DeclarativeBase` import line and the `class Base(DeclarativeBase):` class definition.
 - `grep -n 'model_class=Base' src/cancelchain/database.py` returns the `SQLAlchemy(...)` call.
 - `uv run mypy` exits 0 — the **headline acceptance gate**. No per-file overrides on `models.py`, no per-call `# type: ignore` lines beyond the documented pre-existing 5 plus any narrowly-scoped additions documented in the PR body.
 - `uv run ruff check src tests` + `uv run ruff format --check src tests` exit 0.
@@ -140,13 +140,13 @@ Test count: 236 (unchanged). No new tests; no test removed.
 
 - **Flask-SQLAlchemy `model_class=Base` interaction edge cases.** The `SQLAlchemy(model_class=...)` kwarg is documented and stable in Flask-SQLAlchemy 3.1+, but there's always a small chance that a Flask-SQLAlchemy-specific feature we use (the dynamic table_args, the lazy session, the relationship back-population) interacts with the typed base in a surprising way. Mitigation: the full test suite is the safety net; if anything breaks at runtime, we surface immediately.
 
-- **`db.Model` mypy resolution through FSA stubs.** At runtime, `db.Model` IS the `Base` class we passed via `model_class=Base` — that's how Flask-SQLAlchemy 3.x wires it. Whether mypy sees that resolution depends on FSA's type stubs. If FSA's stubs propagate `model_class` through to `Model` (FSA 3.1+ does in most cases), then `class XDAO(db.Model):` becomes typed automatically and we get the override-removal for free. If they don't, mypy still sees `db.Model` as `Any`-typed and we have two options: (a) switch DAO declarations to `class XDAO(Base):` directly (one-line-per-class change across ~10 DAOs in models.py — mechanical, but expands the diff), or (b) add a per-line `# type: ignore[misc]` on each DAO declaration. We default to (a) if FSA's stubs don't carry the type — direct subclassing is cleaner long-term and doesn't add a sea of per-line ignores. The impl PR makes this call after running mypy once with the override removed.
+- **`db.Model` mypy resolution through FSA stubs.** At runtime, `db.Model` IS the `Base` class we passed via `model_class=Base` — that's how Flask-SQLAlchemy 3.x wires it. Whether mypy sees that resolution depends on FSA's type stubs. If FSA's stubs propagate `model_class` through to `Model` (FSA 3.1+ does in most cases), then `class XDAO(db.Model):` becomes typed automatically and we get the override-removal for free. If they don't, mypy still sees `db.Model` as `Any`-typed and we have two options: (a) switch every `db.Model` subclass declaration to `(Base):` directly (one-line-per-class change across 11 classes in models.py — `TransactionDAO`, `OutflowDAO`, `InflowDAO`, `BlockDAO`, `LongestChainBlockDAO`, `ChainDAO`, `PendingTxnDAO`, `PendingIOflowDAO`, `ChainFill`, `ChainFillBlock`, `ApiToken` — mechanical, but expands the diff), or (b) add a per-line `# type: ignore[misc]` on each declaration. We default to (a) if FSA's stubs don't carry the type — direct subclassing is cleaner long-term and doesn't add a sea of per-line ignores. The impl PR makes this call after running mypy once with the override removed.
 
 - **Test fixtures that subclass DAOs or rely on `db.Model` dynamically.** A repo-wide check should confirm none exist. Mitigation: a `grep -rn 'db\.Model\|db.Model\b' tests/` before the impl PR opens; if any matches, evaluate whether the typed base breaks the pattern.
 
 - **Mypy strict in CI vs. local resolution.** Mypy versions can disagree about a few edge cases (mostly around `Any` propagation and `cast` validity). Mitigation: pin behavior to `uv run mypy` consistently and verify both locally AND in CI before merging.
 
-- **Phase 6 reference in the stale comment is being removed.** The 7-line header comment block we're removing in this PR mentions "Phase 6 modernizes those call sites" — that text was rewritten in 7a to point at Phase 7b instead, but the entire block goes away now. Anyone searching `git log -S` for these phrases lands on the 7a/7b commits, which is fine. Documented here only because future code archaeologists might wonder where the comment went.
+- **Phase 6 reference in the stale comment is being removed.** The 6-line header comment block we're removing in this PR mentions "Phase 6 modernizes those call sites" — that text was rewritten in 7a to point at Phase 7b instead, but the entire block goes away now. Anyone searching `git log -S` for these phrases lands on the 7a/7b commits, which is fine. Documented here only because future code archaeologists might wonder where the comment went.
 
 ## Open decisions
 

--- a/docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md
+++ b/docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md
@@ -1,0 +1,163 @@
+# Phase 7b — typed `DeclarativeBase` + mypy override removal
+
+**Status:** Draft for review
+**Date:** 2026-05-28
+**Scope:** Switch Flask-SQLAlchemy's `db = SQLAlchemy()` to use a typed `DeclarativeBase` subclass via `db = SQLAlchemy(model_class=Base)`, then remove the `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` block at the top of `src/cancelchain/models.py` and the stale 7-line header comment that explained it. Fix any mypy errors that surface from removing the override. Phase 7b closes Phase 3's explicit sunset commitment for the per-file mypy override and is the second half of the two-PR Phase 7 split that began with Phase 7a's SA 2.0 call-site syntax migration (merged as commit `4070978`).
+
+## Goal
+
+Make `src/cancelchain/models.py` mypy-strict-clean without any per-file disable block. After Phase 7a, every legacy `Model.query` / `db.session.query(...)` call site is gone and every `Query[X]` annotation is now `Select[tuple[X]]`, so the only remaining blocker for the override removal is the dynamic `db.Model` base class — Flask-SQLAlchemy attaches `db.Model` at runtime via `SQLAlchemy()`, which mypy strict cannot resolve (it sees `Any`), triggering `name-defined` on every `class XDAO(db.Model):` declaration and `misc` on every "Class cannot subclass 'Model' of type 'Any'" follow-on. Switching to `SQLAlchemy(model_class=Base)` with `Base(DeclarativeBase)` gives mypy a concrete typed base to resolve against, at which point the four disabled error codes should go quiet without further intervention on most DAO sites.
+
+## Non-goals
+
+- **No new behavior.** Every test that passes before this PR passes after. Test count stays exactly 236 (matching the 7a baseline).
+- **No call-site rewrites.** Phase 7a handled all of those. If a new mypy error surfaces from removing the override, the fix is either an explicit annotation, an explicit `cast(...)`, or a narrowly-scoped per-line `# type: ignore[code]` — never a broader refactor.
+- **No SQL changes.** The `__tablename__`, `mapped_column`, `relationship`, and `__table_args__` declarations are all already SA 2.0 idiomatic and stay unchanged.
+- **No removal of pre-existing per-line `# type: ignore[assignment]` lines.** The five existing per-line ignores in `models.py` (lines 166, 232, 233, 519, 771 in the current diff) are about assigning `X | None` to a `Mapped[X]` non-optional slot inside a DAO `__init__`. That mismatch is a runtime invariant (the value is non-None at the assignment site) that `DeclarativeBase` does not improve. They stay unless we find a cleaner pattern, which is out of scope here.
+- **No dataclass-style DAOs.** `MappedAsDataclass` was rejected as invasive (it would change every DAO's `__init__` signature, with real behavior risk on the existing constructors that do non-trivial validation and side effects inside `with db.session.no_autoflush:` blocks).
+- **No dependency bumps.** SQLAlchemy 2.0.50, Flask-SQLAlchemy 3.1.1 (existing) — both already support typed `DeclarativeBase` with the `model_class=Base` pattern.
+
+## Decisions taken during brainstorming
+
+- **Plain typed `DeclarativeBase`.** The codebase already uses `Mapped[]` and `mapped_column` throughout, so the canonical SA 2.0 typed base is the obvious fit. `MappedAsDataclass` was considered and rejected (see Non-goals).
+- **Single-PR shape.** The 7a plan called Phase 7b a "small mechanical PR; landmark milestone." We commit to that framing: one PR switches the base class, removes the override block, and fixes whatever mypy surfaces — all in one shot. If the surfaced error count balloons unexpectedly during impl, we fall back to per-line ignores within this PR (with TODOs pointing at a Phase 7c follow-up) rather than splitting into multiple PRs.
+- **DAO inheritance keeps using `db.Model`.** After the base swap, `db.Model` IS `Base`. Rewriting every `class XDAO(db.Model):` to `class XDAO(Base):` is gratuitous churn — the dynamic accessor pattern stays since it's how Flask-SQLAlchemy exposes the configured base.
+- **Verify on the full tree, not just `src/cancelchain`.** `uv run mypy` (the project's mypy invocation per `pyproject.toml`'s `[tool.mypy] files = ["src/cancelchain"]`) runs on the right files. We don't expand to tests in this PR — tests don't import `db.Model` and don't subclass DAOs, so they should not need changes.
+- **Per-line ignores are the explicit escape hatch.** For any error code that surfaces but resists a clean type-annotation fix, the impl PR adds a narrow per-line `# type: ignore[code]` with a short comment explaining why, rather than re-adding a file-level disable. This mirrors the pre-existing pattern in models.py (5 per-line `# type: ignore[assignment]` lines from before and during 7a).
+
+## Architecture
+
+### Base class definition (in `database.py`)
+
+Current `src/cancelchain/database.py` is six lines:
+
+```python
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+```
+
+Post-7b:
+
+```python
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+db = SQLAlchemy(model_class=Base)
+```
+
+`Base` is exported only to the extent that other modules need to reference it directly (today they don't — they use `db.Model`). Keeping it module-local is fine; Phase 7+ may export it if needed.
+
+### `models.py` header
+
+Current top of `src/cancelchain/models.py` (lines 3-11 in the post-7a diff):
+
+```python
+# Flask-SQLAlchemy's `db.Model` is dynamically attached and shows up as
+# `Any` to mypy strict, which triggers `name-defined` (Name "db.Model"
+# is not defined) and `misc` (Class cannot subclass "Model" of type
+# "Any") errors on every DAO class declaration here. Phase 7b will
+# switch to a typed `DeclarativeBase` subclass and remove this
+# suppression.
+# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"
+```
+
+Post-7b: both the 7-line comment block AND the `# mypy: disable-error-code` directive are removed. No replacement header — `models.py` should look like any other file in the module after this.
+
+### Expected mypy error coverage by code
+
+| Disabled code | After base swap | Mitigation if surfaces |
+|---|---|---|
+| `name-defined` (Name "db.Model" is not defined) | Disappears — `db.Model` resolves through the typed `Base` | n/a |
+| `misc` (Class cannot subclass "Model" of type "Any") | Disappears — same root cause | n/a |
+| `no-untyped-call` | Mostly disappears — SA 2.x's `db.select`, `db.session.execute`, `Result.scalar_one_or_none`, `db.session.scalar`, `db.aliased`, etc. are typed | Per-call `# type: ignore[no-untyped-call]` with a one-line comment, OR an explicit annotation on the surrounding helper |
+| `no-any-return` | Mostly disappears — `db.session.execute(db.select(Entity)).scalar_one_or_none()` returns `Entity \| None`; DAO methods that return chain-factory `Select`s have explicit `Select[tuple[X]]` annotations from 7a | Per-line `# type: ignore[no-any-return]` for any leftover Result/Row-shape edge cases, OR explicit `cast(...)` at the return site |
+
+### Sites with elevated risk
+
+- **`BlockDAO._block_chain`** (returns `CTE`) — SA 2.x types CTEs as a structural type; the explicit `CTE` annotation is already present from 7a and should satisfy mypy. Watch for `no-any-return` on the `union_all(...)` chain.
+- **`BlockDAO.block_chain` and friends** that return `Select[tuple[X]]` — already annotated by 7a. Any residual error would be a real typing inconsistency worth fixing inline.
+- **`ChainDAO._is_longest()` and the materialization sync code** — sites that mix `LongestChainBlockDAO` reads with column-level `.position` / `.block_id` access. These are post-7a still SA 2.0-idiomatic, but the typed base may surface `no-any-return` on a `db.session.scalar(...)` call returning `int | None` where the caller treats it as `int`. Fix by explicit `or 0` (already in place at most sites) or `cast()`.
+- **`PendingTxnDAO.json_datas` and `BlockDAO.block_hashes`** — generators that yield from `db.session.execute(stmt)` tuple iteration. Should already be typed correctly post-7a; verify.
+- **Relationship attribute access in DAO `__init__` methods** — the existing 5 per-line `# type: ignore[assignment]` ignores cover this. They stay (Non-goal).
+
+### What `db.Model` resolves to after the swap
+
+Today: `db.Model` is set dynamically by `SQLAlchemy()` to a default base; mypy sees `Any`. After: `db.Model` is `Base` (the `DeclarativeBase` subclass we wired via `model_class=Base`). Mypy can resolve `Base` statically and the `class XDAO(db.Model):` declarations become typed `class XDAO(Base):` from mypy's perspective without rewriting the source. This is what makes the override removal mechanical rather than invasive.
+
+### `Any` and `Select` imports
+
+Phase 7a added both to the `typing` and `sqlalchemy` import groups at the top of `models.py`. Both stay; `Any` is still used by `wallet_leaderboard`'s `Select[Any]` annotation, and `Select` is used by every chain-factory return type. The 7a plan's Step 1 removed the dead `if TYPE_CHECKING:` block and the unused `TYPE_CHECKING` import; nothing further to clean up here.
+
+## Changes
+
+### Files
+
+- Modify: `src/cancelchain/database.py` — add `Base(DeclarativeBase)` class definition + the `model_class=Base` keyword on the `SQLAlchemy(...)` call + one new import (`from sqlalchemy.orm import DeclarativeBase`).
+- Modify: `src/cancelchain/models.py` — remove the 7-line stale header comment block (lines 3-9) and the `# mypy: disable-error-code` directive line (line 11). Nothing else changes unless mypy surfaces an error that needs an inline annotation or per-line ignore.
+- Potentially modify: `src/cancelchain/models.py` — narrowly-scoped per-line `# type: ignore[code]` additions for any surfaced mypy errors that resist clean annotation fixes. Anticipated count: 0-5 lines. If significantly more, surface as a concern during impl and consider a Phase 7c follow-up rather than ballooning this PR.
+
+### Imports
+
+`src/cancelchain/database.py`: add `from sqlalchemy.orm import DeclarativeBase`.
+
+`src/cancelchain/models.py`: no import changes anticipated. The `db = SQLAlchemy(...)` instance is still imported from `cancelchain.database`; `db.Model` still works at runtime; `from sqlalchemy import Select` and `from typing import Any, ClassVar` stay as-is from 7a.
+
+## Test plan
+
+- **Regression: all 236 existing tests stay green** on both Python 3.12 and 3.13. This is the primary verification — if any test depends on the dynamic `db.Model` attribute resolution surfacing as a specific type, it will fail here and we'll need a targeted fix.
+- **Mypy strict on the full tree.** `uv run mypy` (which targets `src/cancelchain` per `pyproject.toml`) exits 0 with NO per-file disable block. This is the headline acceptance gate.
+- **Bench harness unchanged.** `bench/rebuild_walk_bench.py --sizes 1000 10000 100000` matches the Phase 7a baseline (~0.25 ms/step on local SQLite).
+- **All 4 CI gates clean.** `uv run ruff check src tests` + `uv run ruff format --check src tests` + `uv run mypy` + `uv run pytest`.
+
+Test count: 236 (unchanged). No new tests; no test removed.
+
+## Acceptance
+
+- `grep -n 'mypy: disable-error-code' src/cancelchain/models.py` returns nothing.
+- `grep -n 'DeclarativeBase' src/cancelchain/database.py` returns the class definition.
+- `grep -n 'model_class=Base' src/cancelchain/database.py` returns the `SQLAlchemy(...)` call.
+- `uv run mypy` exits 0 — the **headline acceptance gate**. No per-file overrides on `models.py`, no per-call `# type: ignore` lines beyond the documented pre-existing 5 plus any narrowly-scoped additions documented in the PR body.
+- `uv run ruff check src tests` + `uv run ruff format --check src tests` exit 0.
+- `uv run pytest` exits 0; test count is 236.
+- `uv run pytest --runmulti` exits 0.
+- `uv run --python 3.13 pytest` also exits 0 with 236 passed.
+- `bench/rebuild_walk_bench.py --sizes 1000 10000 100000` per-step times match the Phase 7a baseline (~0.25 ms/step on local SQLite).
+- `docker build --target builder -t cc-phase7b .` succeeds.
+
+## Risks
+
+- **Unknown mypy error count.** We don't know until we run mypy after removing the override block how many leftover errors will surface. The prediction is "few or zero" based on the per-code analysis above, but predictions about typing surface are notoriously wrong. Mitigation: per-line ignores are an explicit escape hatch; if the count balloons past ~5 leftover lines, that's a signal to add a TODO/Phase 7c note in the PR body and either fix them in this PR (preferred) or split per the "single-PR shape" decision's fallback (if truly necessary).
+
+- **Flask-SQLAlchemy `model_class=Base` interaction edge cases.** The `SQLAlchemy(model_class=...)` kwarg is documented and stable in Flask-SQLAlchemy 3.1+, but there's always a small chance that a Flask-SQLAlchemy-specific feature we use (the dynamic table_args, the lazy session, the relationship back-population) interacts with the typed base in a surprising way. Mitigation: the full test suite is the safety net; if anything breaks at runtime, we surface immediately.
+
+- **`db.Model` mypy resolution through FSA stubs.** At runtime, `db.Model` IS the `Base` class we passed via `model_class=Base` — that's how Flask-SQLAlchemy 3.x wires it. Whether mypy sees that resolution depends on FSA's type stubs. If FSA's stubs propagate `model_class` through to `Model` (FSA 3.1+ does in most cases), then `class XDAO(db.Model):` becomes typed automatically and we get the override-removal for free. If they don't, mypy still sees `db.Model` as `Any`-typed and we have two options: (a) switch DAO declarations to `class XDAO(Base):` directly (one-line-per-class change across ~10 DAOs in models.py — mechanical, but expands the diff), or (b) add a per-line `# type: ignore[misc]` on each DAO declaration. We default to (a) if FSA's stubs don't carry the type — direct subclassing is cleaner long-term and doesn't add a sea of per-line ignores. The impl PR makes this call after running mypy once with the override removed.
+
+- **Test fixtures that subclass DAOs or rely on `db.Model` dynamically.** A repo-wide check should confirm none exist. Mitigation: a `grep -rn 'db\.Model\|db.Model\b' tests/` before the impl PR opens; if any matches, evaluate whether the typed base breaks the pattern.
+
+- **Mypy strict in CI vs. local resolution.** Mypy versions can disagree about a few edge cases (mostly around `Any` propagation and `cast` validity). Mitigation: pin behavior to `uv run mypy` consistently and verify both locally AND in CI before merging.
+
+- **Phase 6 reference in the stale comment is being removed.** The 7-line header comment block we're removing in this PR mentions "Phase 6 modernizes those call sites" — that text was rewritten in 7a to point at Phase 7b instead, but the entire block goes away now. Anyone searching `git log -S` for these phrases lands on the 7a/7b commits, which is fine. Documented here only because future code archaeologists might wonder where the comment went.
+
+## Open decisions
+
+None at design time. Brainstorming resolved:
+- Plain typed `DeclarativeBase` (not `MappedAsDataclass`).
+- Single-PR shape (not split into base swap + ignore cleanup).
+- Per-line ignores are the explicit escape hatch for any leftover surface.
+- The 5 pre-existing `# type: ignore[assignment]` lines stay (different issue, not in 7b scope).
+
+## What comes next
+
+- **Phase 7 closed.** With 7b landed, the SA 2.0 modernization initiative wraps. The per-file `mypy: disable-error-code` block — flagged for removal back in Phase 3 — is gone.
+- **Phase 8+ — Other ROADMAP items.** Per `docs/superpowers/ROADMAP.md`: generalize materialization to all chains, cross-worker `_is_longest()` cache invalidation, Alembic migration framework. None of these depend on 7b's typing work; they're independent.
+- **Phase 7c (conditional).** Only if 7b's mypy surface balloons past the per-line-ignore threshold during impl. The fallback path is explicit in the brainstorming decision — we don't pre-create 7c; it materializes only if needed.


### PR DESCRIPTION
## Summary
- Adds the Phase 7b design spec (`docs/superpowers/specs/2026-05-28-phase-7b-declarative-base-design.md`).
- Adds the Phase 7b implementation plan (`docs/superpowers/plans/2026-05-28-phase-7b-declarative-base.md`).
- No code changes.

Phase 7b closes Phase 3's explicit sunset commitment for the per-file \`mypy: disable-error-code\` block on \`src/cancelchain/models.py\` — the last remaining blocker after Phase 7a (commit 4070978) removed every legacy \`Model.query\` / \`db.session.query(...)\` call site and migrated every \`Query[X]\` annotation to \`Select[tuple[X]]\`. Switches Flask-SQLAlchemy's \`db = SQLAlchemy()\` to use a typed \`DeclarativeBase\` subclass via \`db = SQLAlchemy(model_class=Base)\`, then removes the per-file override directive. Pure typing pass — no schema, no behavior, no test count change.

## Test plan
- [x] Spec self-review passed.
- [x] Plan self-review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)