### PR TITLE
refactor(models): typed DeclarativeBase + drop module-level mypy disables

### DIFF
--- a/src/cancelchain/database.py
+++ b/src/cancelchain/database.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase
 
-db = SQLAlchemy()
+
+class Base(DeclarativeBase):
+    pass
+
+
+db = SQLAlchemy(model_class=Base)

--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -22,6 +22,13 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from cancelchain.database import Base, db
 from cancelchain.wallet import Wallet
 
+# Chain-factory returns below carry `# type: ignore[no-any-return]` because
+# Flask-SQLAlchemy's `db.select` / `db.aliased` / `db.desc` facade methods
+# return `Any`, even though the underlying `sqlalchemy` primitives are typed.
+# Remove the ignores when FSA's stubs improve, or when these sites migrate
+# to direct `from sqlalchemy import select, desc` / `from sqlalchemy.orm
+# import aliased` imports.
+
 _PASSWORD_HASHER = PasswordHasher()
 
 

--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -1,12 +1,5 @@
 from __future__ import annotations
 
-# Flask-SQLAlchemy's `db.Model` is dynamically attached and shows up as
-# `Any` to mypy strict, which triggers `name-defined` (Name "db.Model"
-# is not defined) and `misc` (Class cannot subclass "Model" of type
-# "Any") errors on every DAO class declaration here. Phase 7b will
-# switch to a typed `DeclarativeBase` subclass and remove this
-# suppression.
-# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"
 import datetime
 import uuid
 from collections.abc import Generator
@@ -26,7 +19,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from cancelchain.database import db
+from cancelchain.database import Base, db
 from cancelchain.wallet import Wallet
 
 _PASSWORD_HASHER = PasswordHasher()
@@ -50,7 +43,7 @@ block_transactions = db.Table(
 )
 
 
-class TransactionDAO(db.Model):
+class TransactionDAO(Base):
     __tablename__ = 'transaction'
 
     id: Mapped[int] = mapped_column(
@@ -109,14 +102,14 @@ class TransactionDAO(db.Model):
         cls, block_chain: Select[tuple[BlockDAO]]
     ) -> Select[tuple[TransactionDAO]]:
         block_alias = db.aliased(BlockDAO, block_chain.subquery())
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(TransactionDAO)
             .join(block_alias, TransactionDAO.blocks)
             .order_by(TransactionDAO.timestamp.desc(), TransactionDAO.id)
         )
 
 
-class OutflowDAO(db.Model):
+class OutflowDAO(Base):
     __tablename__ = 'outflow'
 
     id: Mapped[int] = mapped_column(
@@ -176,7 +169,7 @@ class OutflowDAO(db.Model):
         cls, transactions_chain: Select[tuple[TransactionDAO]]
     ) -> Select[tuple[OutflowDAO]]:
         txn_alias = db.aliased(TransactionDAO, transactions_chain.subquery())
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(OutflowDAO)
             .join(txn_alias, OutflowDAO.transaction)
             .order_by(
@@ -187,7 +180,7 @@ class OutflowDAO(db.Model):
         )
 
 
-class InflowDAO(db.Model):
+class InflowDAO(Base):
     __tablename__ = 'inflow'
 
     id: Mapped[int] = mapped_column(
@@ -237,7 +230,7 @@ class InflowDAO(db.Model):
         cls, transactions_chain: Select[tuple[TransactionDAO]]
     ) -> Select[tuple[InflowDAO]]:
         txn_alias = db.aliased(TransactionDAO, transactions_chain.subquery())
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(InflowDAO)
             .join(txn_alias, InflowDAO.transaction)
             .order_by(
@@ -248,7 +241,7 @@ class InflowDAO(db.Model):
         )
 
 
-class BlockDAO(db.Model):
+class BlockDAO(Base):
     __tablename__ = 'block'
 
     id: Mapped[int] = mapped_column(
@@ -311,14 +304,14 @@ class BlockDAO(db.Model):
             .where(BlockDAO.id == self.id)
             .cte(recursive=True)
         )
-        return base.union_all(
+        return base.union_all(  # type: ignore[no-any-return]
             db.select(BlockDAO).where(BlockDAO.id == base.c.prev_id)
         )
 
     @property
     def block_chain(self) -> Select[tuple[BlockDAO]]:
         block_alias = db.aliased(BlockDAO, self._block_chain)
-        return db.select(block_alias)
+        return db.select(block_alias)  # type: ignore[no-any-return]
 
     @property
     def transactions_chain(self) -> Select[tuple[TransactionDAO]]:
@@ -403,7 +396,7 @@ class BlockDAO(db.Model):
         that compose on the result (subquery / filter / first) see the
         same row order.
         """
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(BlockDAO)
             .join(
                 LongestChainBlockDAO,
@@ -421,7 +414,7 @@ class BlockDAO(db.Model):
         """
         blocks_subq = cls.longest_chain_blocks_q().subquery()
         block_alias = db.aliased(BlockDAO, blocks_subq)
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(TransactionDAO)
             .join(block_alias, TransactionDAO.blocks)
             .order_by(TransactionDAO.timestamp.desc(), TransactionDAO.id)
@@ -435,7 +428,7 @@ class BlockDAO(db.Model):
         """
         txn_subq = cls.longest_chain_transactions_q().subquery()
         txn_alias = db.aliased(TransactionDAO, txn_subq)
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(OutflowDAO)
             .join(txn_alias, OutflowDAO.transaction)
             .order_by(
@@ -452,7 +445,7 @@ class BlockDAO(db.Model):
         """
         txn_subq = cls.longest_chain_transactions_q().subquery()
         txn_alias = db.aliased(TransactionDAO, txn_subq)
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(InflowDAO)
             .join(txn_alias, InflowDAO.transaction)
             .order_by(
@@ -463,7 +456,7 @@ class BlockDAO(db.Model):
         )
 
 
-class LongestChainBlockDAO(db.Model):
+class LongestChainBlockDAO(Base):
     """Flat materialization of the canonical chain's block membership.
 
     One row per block in the currently-longest chain, keyed by block.id
@@ -488,7 +481,7 @@ class LongestChainBlockDAO(db.Model):
         self.position = position
 
 
-class ChainDAO(db.Model):
+class ChainDAO(Base):
     __tablename__ = 'chain'
 
     id: Mapped[int] = mapped_column(
@@ -627,8 +620,8 @@ class ChainDAO(db.Model):
         stmt = stmt.order_by(db.desc('ct'), OutflowDAO.address)
         if limit is not None:
             stmt = stmt.limit(limit)
-            return db.select(db.aliased(stmt.subquery()))
-        return stmt
+            return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
+        return stmt  # type: ignore[no-any-return]
 
     def _is_longest(self) -> bool:
         """True iff this ChainDAO row is currently the longest chain.
@@ -819,7 +812,7 @@ class ChainDAO(db.Model):
 
     @classmethod
     def chains(cls) -> Select[tuple[ChainDAO]]:
-        return (
+        return (  # type: ignore[no-any-return]
             db.select(cls)
             .join(cls.block)
             .order_by(
@@ -832,7 +825,7 @@ class ChainDAO(db.Model):
         return db.session.execute(cls.chains()).scalars().first()
 
 
-class PendingTxnDAO(db.Model):
+class PendingTxnDAO(Base):
     __tablename__ = 'pending_txn'
 
     id: Mapped[int] = mapped_column(
@@ -887,7 +880,7 @@ class PendingTxnDAO(db.Model):
         ).scalar_one_or_none()
 
 
-class PendingIOflowDAO(db.Model):
+class PendingIOflowDAO(Base):
     __tablename__ = 'pending_ioflow'
 
     id: Mapped[int] = mapped_column(
@@ -911,7 +904,7 @@ class PendingIOflowDAO(db.Model):
         db.session.commit()
 
 
-class ChainFill(db.Model):
+class ChainFill(Base):
     __tablename__ = 'chain_fill'
 
     id: Mapped[int] = mapped_column(
@@ -935,7 +928,7 @@ class ChainFill(db.Model):
         db.session.commit()
 
 
-class ChainFillBlock(db.Model):
+class ChainFillBlock(Base):
     __tablename__ = 'chain_fill_block'
 
     id: Mapped[int] = mapped_column(
@@ -957,7 +950,7 @@ class ChainFillBlock(db.Model):
         db.session.commit()
 
 
-class ApiToken(db.Model):
+class ApiToken(Base):
     __tablename__ = 'api_token'
 
     id: Mapped[int] = mapped_column(


### PR DESCRIPTION
## Summary

Phase 7b: switch DAO classes from Flask-SQLAlchemy's untyped `db.Model` to a direct `sqlalchemy.orm.DeclarativeBase` subclass, and remove the module-level `# mypy: disable-error-code="no-untyped-call,no-any-return,name-defined,misc"` override from `src/cancelchain/models.py`.

The override was a Phase 7a placeholder. With this PR, DAO declarations are typed at the source and three of the four suppressed codes (`no-untyped-call`, `name-defined`, `misc`) are eliminated outright.

## What changed

**`src/cancelchain/database.py`** — define `class Base(DeclarativeBase): pass` and pass `model_class=Base` to `SQLAlchemy(...)` so `db.Model` and `Base` reference the same registry. `db.session` and table-creation paths are unchanged.

**`src/cancelchain/models.py`**
- Remove the module-level `# mypy: disable-error-code=...` directive and its preamble comment.
- Pattern C: switch all 11 DAO classes from `(db.Model)` to direct `(Base)` subclassing (`TransactionDAO`, `OutflowDAO`, `InflowDAO`, `BlockDAO`, `LongestChainBlockDAO`, `ChainDAO`, `PendingTxnDAO`, `PendingIOflowDAO`, `ChainFill`, `ChainFillBlock`, `ApiToken`). Import line updated to `from cancelchain.database import Base, db`.
- Pattern A: add 12 per-line `# type: ignore[no-any-return]` ignores on chain-factory return statements. Root cause: FSA's `db.select` / `db.aliased` / `db.desc` facade methods return `Any` even though the underlying `sqlalchemy.select` / `aliased` / `desc` are typed. The 12 sites cluster around this single systematic root cause and can be removed wholesale in a follow-up PR when FSA stubs improve, or via a direct-sqlalchemy-import migration.
- The 5 pre-existing `# type: ignore[assignment]` ignores are unrelated (Mapped-vs-instance relationship assignments) and remain in place.

## Test plan

- [x] `uv run mypy` → `Success: no issues found in 24 source files`
- [x] `uv run ruff check src tests` → All checks passed
- [x] `uv run ruff format --check src tests` → 41 files already formatted
- [x] `uv run pytest` → 236 passed, 1 skipped
- [x] `uv run python bench/rebuild_walk_bench.py --sizes 1000 10000 100000` → ~0.25 ms/step (1k: 0.260, 10k: 0.255, 100k: 0.253), matches Phase 6.6 baseline