### PR TITLE
docs(a7b): canonical-genesis uniqueness design + plan

### DIFF
--- a/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
+++ b/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
@@ -200,6 +200,7 @@ from cancelchain.exceptions import (
     InvalidCoinbaseError,
     InvalidTransactionError,
     MismatchedCoinbaseError,
+    MissingBlockError,
 )
 ```
 
@@ -218,8 +219,10 @@ def test_a7_j_disjoint_genesis_reorg_rejected(
     catastrophic-rebuild branch is correct PoW longest-chain behavior. The
     gap is the alternate-genesis admission (A7.b). This test proves closing
     A7.b closes A7.j: even a LONGER fork (g2 + child b2, length 2 vs the
-    canonical length 1) cannot win, because its root genesis g2 is rejected,
-    making b2 unrootable. The reorg never completes.
+    canonical length 1) cannot win. Its root genesis g2 is rejected
+    (DuplicateGenesisError), and its child b2 is then unrootable — submitting
+    b2 raises MissingBlockError because its parent g2 was never admitted. The
+    reorg never completes.
     """
     with app.app_context():
 
@@ -261,10 +264,14 @@ def test_a7_j_disjoint_genesis_reorg_rejected(
         assert b2.idx == 1
         assert b2.prev_hash == g2.block_hash
 
-        # The fork's root g2 is rejected at admission, so the whole longer
-        # fork is unrootable and the reorg can never trigger.
+        # The fork's root g2 is rejected at admission.
         with pytest.raises(DuplicateGenesisError):
             m1.receive_block(g2.to_json())
+        # b2 is therefore unrootable: its parent g2 was never persisted, so
+        # receive_block rejects it locally with MissingBlockError (no peer
+        # fill is attempted). The longer fork can never be assembled.
+        with pytest.raises(MissingBlockError):
+            m1.receive_block(b2.to_json())
 
         # Canonical chain unchanged; registry still single.
         post_chain = ChainDAO.longest()
@@ -386,5 +393,5 @@ Expected: empty — this change adds no migration.
 
 - **Do not** import `GENESIS_HASH` into `block.py` (circular import). The helper keys on `idx == 0`, which is equivalent to genesis by the `idx == prev_index + 1` invariant.
 - **Idempotency is load-bearing.** The `existing_genesis.block_hash != block.block_hash` guard is what keeps `Chain.validate()` full-chain revalidation green (revalidating the canonical genesis compares it against itself). Do not simplify it to a bare "a genesis already exists → raise".
-- Keep the A7.j test self-contained (submit `g2` directly); do not wire a peer `fill_chain` walk — the point is that g2's rejection makes the longer fork unrootable.
+- Keep the A7.j test self-contained: submit `g2` then `b2` directly via `receive_block`. Both raise locally (`DuplicateGenesisError`, then `MissingBlockError`) — `receive_block` raises `MissingBlockError` on a missing parent without attempting a peer `fill_chain` walk (`node.py:160-165`). Do not wire a peer proxy. The point is that g2's rejection makes the longer fork unrootable, which b2's `MissingBlockError` concretely demonstrates.
 - This is a fix PR: no adjacent refactors. The pre-existing `test_create_wallet` terminal-width bug is out of scope (separate PR).

--- a/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
+++ b/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
@@ -1,0 +1,390 @@
+# A7.b — Canonical-Genesis Uniqueness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject alternate-genesis blocks at validation time so they can't fragment the chain registry (and so a disjoint-genesis reorg, A7.j, becomes unreachable).
+
+**Architecture:** Add a `Block.genesis_from_db()` domain helper (symmetric with `Block.from_db`, keyed on `idx == 0` to avoid a `chain.py → block.py` circular import). In `Chain.validate_block`, when the candidate is a genesis block, reject it with a new `DuplicateGenesisError(InvalidBlockError)` if a *different* genesis is already persisted. The `block_hash`-equality guard keeps the check idempotent (safe in `Chain.validate()` full-chain revalidation). No schema/migration change.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]` DAOs), Pydantic v2 domain dataclasses, pytest + time-machine, uv.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md`
+
+---
+
+## Prerequisites (read before starting)
+
+- **Full-suite pytest needs `COLUMNS=200`**: a latent terminal-width bug in `tests/test_command.py::test_create_wallet` (unrelated to this work) fails on narrow terminals. Always run the full suite as `COLUMNS=200 uv run pytest`.
+- `idx == 0 ⟺ genesis` is guaranteed by `validate_block`'s `idx == prev_index + 1` rule (only a genesis has `prev_index == -1`). That is why the helper keys on `idx`, not `prev_hash == GENESIS_HASH` — and why `block.py` must NOT import `GENESIS_HASH` from `chain.py` (it would create a circular import; `chain.py` already imports `Block` from `block.py`).
+- `BlockDAO.get(idx=0)` already exists (`src/cancelchain/models.py:393-402`): `db.select(cls).filter_by(idx=idx)` → `scalar_one_or_none()`. Reuse it.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/cancelchain/exceptions.py` | Exception hierarchy | Add `DuplicateGenesisError(InvalidBlockError)` |
+| `src/cancelchain/block.py` | `Block` domain dataclass + DB round-trip | Add `Block.genesis_from_db()` classmethod |
+| `src/cancelchain/chain.py` | Chain validation | Import `DuplicateGenesisError`; add genesis-uniqueness check in `validate_block` |
+| `tests/test_block.py` | `Block` unit tests | Add `test_genesis_from_db` |
+| `tests/test_verification_audit.py` | Audit demonstration/regression tests | Un-xfail `test_a7_b…`; add `test_a7_j…`; update module docstring; import `DuplicateGenesisError` |
+| `docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md` | Audit record | Mark A7.b remediated, A7.j closed-via-A7.b; update counts |
+| `docs/superpowers/ROADMAP.md` | Roadmap | Move A7.b to remediated; severity → 0/0/0/3 |
+
+---
+
+### Task 1: `Block.genesis_from_db()` helper
+
+**Files:**
+- Modify: `src/cancelchain/block.py` (after `from_db`, ends at line 389)
+- Test: `tests/test_block.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_block.py` (the file already imports `Block`, `GENESIS_HASH`, and defines `TEST_TARGET = 'F' * 64`; `app`, `reward`, `wallet` are conftest fixtures). Mirror the persistence pattern in `test_db` (line 163):
+
+```python
+def test_genesis_from_db(app, reward, wallet):
+    """Block.genesis_from_db() returns None until a genesis is persisted,
+    then returns the persisted canonical genesis."""
+    with app.app_context():
+        assert Block.genesis_from_db() is None
+        block = Block()
+        block.link(0, GENESIS_HASH, TEST_TARGET)
+        block.seal(wallet, reward)
+        block.mill()
+        block.validate()
+        block.to_db()
+        genesis = Block.genesis_from_db()
+        assert genesis is not None
+        assert genesis == block
+        assert genesis.idx == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_block.py::test_genesis_from_db -v`
+Expected: FAIL with `AttributeError: type object 'Block' has no attribute 'genesis_from_db'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/cancelchain/block.py`, immediately after the `from_db` classmethod (which ends at line 389), add:
+
+```python
+    @classmethod
+    def genesis_from_db(cls) -> Self | None:
+        dao = BlockDAO.get(idx=0)
+        return cls.from_dao(dao) if dao else None
+```
+
+`BlockDAO` is already imported in `block.py` (line 33). No new imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_block.py::test_genesis_from_db -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cancelchain/block.py tests/test_block.py
+git commit -m "feat(a7b): add Block.genesis_from_db() helper"
+```
+
+---
+
+### Task 2: `DuplicateGenesisError` + the `validate_block` check (un-xfail A7.b)
+
+**Files:**
+- Modify: `src/cancelchain/exceptions.py` (InvalidBlockError subclasses, ~line 109)
+- Modify: `src/cancelchain/chain.py` (exception import block lines 14-32; `validate_block` lines 171-198)
+- Test (acceptance): `tests/test_verification_audit.py::test_a7_b_alternate_genesis_fragments_chain_registry` (already exists, currently `@pytest.mark.xfail(strict=True)`)
+
+- [ ] **Step 1: Make the existing demonstrator the failing test (remove its xfail)**
+
+In `tests/test_verification_audit.py`, delete the `@pytest.mark.xfail(...)` decorator block (lines 324-336) that sits directly above `def test_a7_b_alternate_genesis_fragments_chain_registry`. The decorator to remove is exactly:
+
+```python
+@pytest.mark.xfail(
+    reason=(
+        'Audit finding A7.b — severity Low — Chain.validate_block has no '
+        '"is the canonical genesis already taken?" check, so any block '
+        'with prev_hash=GENESIS_HASH, idx=0, target=MAX_TARGET is accepted '
+        'as a fresh genesis. Each accepted alternate genesis creates a new '
+        'ChainDAO row, fragmenting the chain registry into N parallel '
+        'single-block chains and consuming DB rows without any operational '
+        'recovery path. See '
+        'docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md'
+    ),
+    strict=True,
+)
+```
+
+Leave the `def test_a7_b_alternate_genesis_fragments_chain_registry(...)` and its body unchanged (it already asserts `pytest.raises(InvalidBlockError)` and `_chain_count() == initial_chain_count`).
+
+- [ ] **Step 2: Run it to verify it fails (gap still present)**
+
+Run: `uv run pytest tests/test_verification_audit.py::test_a7_b_alternate_genesis_fragments_chain_registry -v`
+Expected: FAIL — today `receive_block(g2)` does NOT raise, so `pytest.raises(InvalidBlockError)` fails (and/or `_chain_count()` becomes 2).
+
+- [ ] **Step 3: Add the exception**
+
+In `src/cancelchain/exceptions.py`, immediately after the `class InvalidBlockError(CCError): pass` block (line 109-110), add:
+
+```python
+class DuplicateGenesisError(InvalidBlockError):
+    pass
+```
+
+- [ ] **Step 4: Wire the check into `validate_block`**
+
+In `src/cancelchain/chain.py`, add `DuplicateGenesisError` to the alphabetically-sorted exception import block (lines 14-32) — insert it as the FIRST entry, before `EmptyChainError`:
+
+```python
+from cancelchain.exceptions import (
+    DuplicateGenesisError,
+    EmptyChainError,
+    FutureBlockError,
+    ...
+```
+
+Then in `validate_block` (line 171), insert the genesis-uniqueness check immediately after the `FutureBlockError` check (line 174) and before `prev_block = ...` (line 175):
+
+```python
+    def validate_block(self, block: Block) -> None:
+        block.validate()
+        if block.timestamp_dt is not None and block.timestamp_dt > now():
+            raise FutureBlockError()
+        if is_genesis_block(block):
+            existing_genesis = Block.genesis_from_db()
+            if (
+                existing_genesis is not None
+                and existing_genesis.block_hash != block.block_hash
+            ):
+                raise DuplicateGenesisError()
+        prev_block = Block.from_db(block.prev_hash) if block.prev_hash else None
+        ...  # rest unchanged
+```
+
+- [ ] **Step 5: Run the acceptance test to verify it passes**
+
+Run: `uv run pytest tests/test_verification_audit.py::test_a7_b_alternate_genesis_fragments_chain_registry -v`
+Expected: PASS — `receive_block(g2)` now raises `DuplicateGenesisError` (a subclass of `InvalidBlockError`) and the `ChainDAO` count stays 1.
+
+- [ ] **Step 6: Verify no other genesis flow regressed**
+
+Run: `COLUMNS=200 uv run pytest tests/test_chain.py tests/test_block.py tests/test_models.py tests/test_node.py -q`
+Expected: PASS (the canonical first-genesis flow, milling, and full-chain `Chain.validate()` revalidation are unaffected — the check is idempotent for the single persisted genesis).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cancelchain/exceptions.py src/cancelchain/chain.py tests/test_verification_audit.py
+git commit -m "fix(a7b): reject alternate-genesis blocks in Chain.validate_block"
+```
+
+---
+
+### Task 3: A7.j disjoint-reorg regression test
+
+**Files:**
+- Modify: `tests/test_verification_audit.py` (add import; add test after `test_a7_b…` ends, ~line 408, before the A7.e xfail block)
+
+- [ ] **Step 1: Import `DuplicateGenesisError`**
+
+In `tests/test_verification_audit.py`, add `DuplicateGenesisError` to the `cancelchain.exceptions` import block (currently imports `InvalidBlockError, InvalidCoinbaseError, InvalidTransactionError, MismatchedCoinbaseError`), keeping it alphabetically sorted:
+
+```python
+from cancelchain.exceptions import (
+    DuplicateGenesisError,
+    InvalidBlockError,
+    InvalidCoinbaseError,
+    InvalidTransactionError,
+    MismatchedCoinbaseError,
+)
+```
+
+- [ ] **Step 2: Write the regression test**
+
+Insert directly after the end of `test_a7_b_alternate_genesis_fragments_chain_registry` (its last line is `assert _chain_count() == initial_chain_count`), before the next `@pytest.mark.xfail(` block for A7.e. This is a plain (non-xfail) regression test. `Block`, `GENESIS_HASH`, `REWARD`, `Miller`, `ChainDAO`, `db`, `now`, `TEST_TARGET`, and `datetime` are already imported/defined in the file.
+
+```python
+def test_a7_j_disjoint_genesis_reorg_rejected(
+    app, time_machine, wallet, miller_2_wallet
+) -> None:
+    """A7.j: a longer fork rooted at an alternate genesis cannot displace
+    the canonical chain — its root genesis is rejected at admission.
+
+    A7.j (disjoint-ancestor reorg) has no standalone finding: the
+    catastrophic-rebuild branch is correct PoW longest-chain behavior. The
+    gap is the alternate-genesis admission (A7.b). This test proves closing
+    A7.b closes A7.j: even a LONGER fork (g2 + child b2, length 2 vs the
+    canonical length 1) cannot win, because its root genesis g2 is rejected,
+    making b2 unrootable. The reorg never completes.
+    """
+    with app.app_context():
+
+        def _chain_count() -> int:
+            return len(db.session.execute(db.select(ChainDAO)).scalars().all())
+
+        now_dt = now()
+        when_dt = now_dt - datetime.timedelta(hours=1)
+        time_machine.move_to(when_dt)
+        # Canonical genesis g1 paying `wallet`.
+        m1 = Miller(milling_wallet=wallet)
+        g1 = m1.create_block()
+        m1.mill_block(g1)
+        assert g1.block_hash is not None
+        assert g1.idx == 0
+        canonical_chain = ChainDAO.longest()
+        assert canonical_chain is not None
+        canonical_tip = canonical_chain.block.block_hash
+        assert canonical_tip == g1.block_hash
+        assert _chain_count() == 1
+
+        # Build a LONGER disjoint fork rooted at an alternate genesis.
+        when_dt += datetime.timedelta(minutes=5)
+        time_machine.move_to(when_dt)
+        g2 = Block()
+        g2.link(0, GENESIS_HASH, TEST_TARGET)
+        g2.seal(miller_2_wallet, REWARD)
+        g2.mill()
+        assert g2.block_hash is not None
+        assert g2.block_hash != g1.block_hash
+        assert g2.idx == 0
+        # Child b2 chains off g2 — fork length 2 > canonical length 1.
+        when_dt += datetime.timedelta(minutes=5)
+        time_machine.move_to(when_dt)
+        b2 = Block()
+        b2.link(1, g2.block_hash, TEST_TARGET)
+        b2.seal(miller_2_wallet, REWARD)
+        b2.mill()
+        assert b2.idx == 1
+        assert b2.prev_hash == g2.block_hash
+
+        # The fork's root g2 is rejected at admission, so the whole longer
+        # fork is unrootable and the reorg can never trigger.
+        with pytest.raises(DuplicateGenesisError):
+            m1.receive_block(g2.to_json())
+
+        # Canonical chain unchanged; registry still single.
+        post_chain = ChainDAO.longest()
+        assert post_chain is not None
+        assert post_chain.block.block_hash == canonical_tip
+        assert _chain_count() == 1
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_verification_audit.py::test_a7_j_disjoint_genesis_reorg_rejected -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run the whole audit module**
+
+Run: `uv run pytest tests/test_verification_audit.py -q`
+Expected: A7.b and A7.j are among the passing tests; the remaining open findings (A1.f, A7.e, A7.h) still xfail. Confirm **0 failures and 0 unexpectedly-passing xfails** (exactly 3 xfailed remain).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_verification_audit.py
+git commit -m "test(a7b): add A7.j disjoint-genesis reorg regression test"
+```
+
+---
+
+### Task 4: Docs — audit, ROADMAP, test module docstring
+
+**Files:**
+- Modify: `tests/test_verification_audit.py` (module docstring)
+- Modify: `docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md`
+- Modify: `docs/superpowers/ROADMAP.md`
+
+- [ ] **Step 1: Update the test module docstring**
+
+In `tests/test_verification_audit.py`, the module docstring lists remediated findings as "(e.g. A2.e, A4.c)". Update that parenthetical to include A7.b:
+
+Find: `pass as plain regression tests guarding the fix (e.g. A2.e, A4.c).`
+Replace: `pass as plain regression tests guarding the fix (e.g. A2.e, A4.c, A7.b).`
+
+- [ ] **Step 2: Update the audit doc**
+
+In `docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md`:
+
+(a) Intro count (line 9):
+Find: `Two have since been remediated (A2.e, A4.c); four remain open.`
+Replace: `Three have since been remediated (A2.e, A4.c, A7.b); three remain open (A7.h, A7.e, A1.f).`
+
+(b) Findings-table count line (line 38):
+Find: `4 open findings: 0 Critical / 0 High / 0 Medium / 4 Low (post-A4.c).`
+Replace: `3 open findings: 0 Critical / 0 High / 0 Medium / 3 Low (post-A7.b).`
+
+(c) A7.b findings-table row (line 43): prefix the description with a remediation marker, mirroring how remediated findings are flagged elsewhere in the table. Change the leading `| A7.b | Low |` cell text to begin with `✅ Remediated (PR #<N_impl>). ` and flip the substance to past tense ("accepted … " → "previously accepted; now rejected via a canonical-genesis check raising `DuplicateGenesisError`"). Keep the row's test reference.
+
+(d) A7.b deep-dive section (the `**Outcome:**` / `**Finding A7.b…**` / `**Remediation sketch:**` block around lines 885-895): add a `✅ **Remediated.**` lead-in to the Finding paragraph and append a sentence describing the shipped fix: `Chain.validate_block` now calls `Block.genesis_from_db()` and raises `DuplicateGenesisError(InvalidBlockError)` when a different genesis is already persisted; `Block.genesis_from_db()` keys on `idx == 0` to avoid a `chain.py → block.py` circular import. Flip the `**Outcome:**` line for sub-attack b.ii from `ACCEPTED` to `REJECTED (post-remediation)`.
+
+(e) A7.j cross-link section (around lines 1072-1089): update the `**No new finding for j.**` paragraph to note A7.j's entry path is now closed: append `Closed via the A7.b remediation (PR #<N_impl>): the alternate-genesis root is rejected at admission, so a disjoint-ancestor reorg can no longer be mounted. Regression: test_a7_j_disjoint_genesis_reorg_rejected.`
+
+(f) Remediation-priority section "### 3. A7.b (Low)" (around line 1163): add a `✅ **Implemented.**` lead-in and replace the "Acceptance signal: … flips from xfail to pass" sentence with `Acceptance signal: test_a7_b_alternate_genesis_fragments_chain_registry is now a passing regression test (xfail removed); test_a7_j_disjoint_genesis_reorg_rejected proves the A7.j reorg path is closed.`
+
+- [ ] **Step 3: Update the ROADMAP**
+
+In `docs/superpowers/ROADMAP.md`:
+
+(a) Remove the A7.b bullet from the open-findings list (line 52, the `1. **A7.b — Low — Alternate-genesis…**` item) and renumber the remaining open items (A7.h, A7.e, A1.f) accordingly.
+
+(b) Update the open-findings severity line wherever it states the current tally (it reads `0 Critical / 0 High / 0 Medium / 4 Low` post-A4.c) to `0 Critical / 0 High / 0 Medium / 3 Low`.
+
+(c) Add a remediated entry for A7.b in the same style as the A4.c entry (the `✅ **Audit finding A4.c …**` line), linking the docs PR (this branch's PR) and the impl PR placeholder:
+
+```markdown
+- ✅ **Audit finding A7.b — alternate-genesis admission fragments the chain registry** — closed by docs PR [#<N_docs>](https://github.com/gumptionthomas/cancelchain/pull/<N_docs>) (design+plan) and impl PR [#<N_impl>](https://github.com/gumptionthomas/cancelchain/pull/<N_impl>). `Chain.validate_block` now rejects a block claiming genesis when a different genesis is already persisted, raising `DuplicateGenesisError` (via a `Block.genesis_from_db()` helper keyed on `idx == 0`). This also closes A7.j (disjoint-ancestor reorg), whose only entry path is alternate-genesis admission. No schema change. Brings audit severity to 0 Critical / 0 High / 0 Medium / 3 Low.
+```
+
+> The `#<N_docs>` / `#<N_impl>` placeholders are filled in once the PRs are opened (docs PR number when committing on this branch; impl PR number after it is opened), mirroring the A4.c closeout.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_verification_audit.py docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md docs/superpowers/ROADMAP.md
+git commit -m "docs(a7b): mark A7.b remediated, A7.j closed-via-A7.b; update counts"
+```
+
+---
+
+### Task 5: Final gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite**
+
+Run: `COLUMNS=200 uv run pytest`
+Expected: **244 passed, 3 xfailed, 1 skipped** (the post-A4.c baseline was 241 passed / 4 xfailed / 1 skipped; this PR adds `test_genesis_from_db` and `test_a7_j…` as passing, and moves `test_a7_b…` from xfailed to passed). No unexpectedly-passing xfails. If the baseline differs, the invariant that must hold is: +2 net new passing tests, and A7.b moved from xfailed to passed (xfailed count drops by exactly 1).
+
+- [ ] **Step 2: xfail audit cross-check**
+
+Run: `uv run pytest --runxfail tests/test_verification_audit.py -q`
+Expected: the three still-open findings surface their real failure modes; A2.e/A4.c/A7.b/A7.j pass.
+
+- [ ] **Step 3: Lint + format + types**
+
+Run:
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy
+```
+Expected: all clean. (No schema change ⇒ no migration / `db check` impact.)
+
+- [ ] **Step 4: Confirm no migration drift (sanity)**
+
+Run: `git status --porcelain src/cancelchain/migrations/`
+Expected: empty — this change adds no migration.
+
+---
+
+## Notes for the implementer
+
+- **Do not** import `GENESIS_HASH` into `block.py` (circular import). The helper keys on `idx == 0`, which is equivalent to genesis by the `idx == prev_index + 1` invariant.
+- **Idempotency is load-bearing.** The `existing_genesis.block_hash != block.block_hash` guard is what keeps `Chain.validate()` full-chain revalidation green (revalidating the canonical genesis compares it against itself). Do not simplify it to a bare "a genesis already exists → raise".
+- Keep the A7.j test self-contained (submit `g2` directly); do not wire a peer `fill_chain` walk — the point is that g2's rejection makes the longer fork unrootable.
+- This is a fix PR: no adjacent refactors. The pre-existing `test_create_wallet` terminal-width bug is out of scope (separate PR).

--- a/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
+++ b/docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md
@@ -325,23 +325,27 @@ Replace: `Three have since been remediated (A2.e, A4.c, A7.b); three remain open
 Find: `4 open findings: 0 Critical / 0 High / 0 Medium / 4 Low (post-A4.c).`
 Replace: `3 open findings: 0 Critical / 0 High / 0 Medium / 3 Low (post-A7.b).`
 
-(c) A7.b findings-table row (line 43): prefix the description with a remediation marker, mirroring how remediated findings are flagged elsewhere in the table. Change the leading `| A7.b | Low |` cell text to begin with `✅ Remediated (PR #<N_impl>). ` and flip the substance to past tense ("accepted … " → "previously accepted; now rejected via a canonical-genesis check raising `DuplicateGenesisError`"). Keep the row's test reference.
+(c) A7.b findings-table row (line 43): **remove the entire `| A7.b | Low | … |` row.** This findings table lists only *open* findings — A2.e and A4.c were removed from it when they were remediated (verify: neither appears in the table today). Do the same for A7.b. After removal the table lists A1.f, A7.e, A7.h.
 
-(d) A7.b deep-dive section (the `**Outcome:**` / `**Finding A7.b…**` / `**Remediation sketch:**` block around lines 885-895): add a `✅ **Remediated.**` lead-in to the Finding paragraph and append a sentence describing the shipped fix: `Chain.validate_block` now calls `Block.genesis_from_db()` and raises `DuplicateGenesisError(InvalidBlockError)` when a different genesis is already persisted; `Block.genesis_from_db()` keys on `idx == 0` to avoid a `chain.py → block.py` circular import. Flip the `**Outcome:**` line for sub-attack b.ii from `ACCEPTED` to `REJECTED (post-remediation)`.
+(d) A7.b deep-dive section (the `**Outcome:**` / `**Finding A7.b…**` / `**Remediation sketch:**` block around lines 885-895): add a `✅ **Remediated.**` lead-in to the Finding paragraph and append a sentence describing the shipped fix: `Chain.validate_block` now calls `Block.genesis_from_db()` and raises `DuplicateGenesisError(InvalidBlockError)` when a different genesis is already persisted; `Block.genesis_from_db()` keys on `idx == 0` to avoid a `chain.py → block.py` circular import. Flip the `**Outcome:**` line for sub-attack b.ii from `ACCEPTED` to `REJECTED (post-remediation)`. (Match the existing A4.c convention: its deep-dive uses a `✅ **Implemented (v2 binding fix).**` lead-in.)
 
 (e) A7.j cross-link section (around lines 1072-1089): update the `**No new finding for j.**` paragraph to note A7.j's entry path is now closed: append `Closed via the A7.b remediation (PR #<N_impl>): the alternate-genesis root is rejected at admission, so a disjoint-ancestor reorg can no longer be mounted. Regression: test_a7_j_disjoint_genesis_reorg_rejected.`
 
-(f) Remediation-priority section "### 3. A7.b (Low)" (around line 1163): add a `✅ **Implemented.**` lead-in and replace the "Acceptance signal: … flips from xfail to pass" sentence with `Acceptance signal: test_a7_b_alternate_genesis_fragments_chain_registry is now a passing regression test (xfail removed); test_a7_j_disjoint_genesis_reorg_rejected proves the A7.j reorg path is closed.`
+(f) Remediation-priority section "### 3. A7.b (Low)" (around line 1163): mirror the A4.c heading convention (A4.c's heading reads `### 2. A4.c (Medium) — ✅ Implemented — coinbase-to-block binding…`). Change the A7.b heading to `### 3. A7.b (Low) — ✅ Implemented — canonical-genesis check in Chain.validate_block`, add a `✅ **Implemented.**` lead-in to the body, and replace the "Acceptance signal: … flips from xfail to pass" sentence with `Acceptance signal: test_a7_b_alternate_genesis_fragments_chain_registry is now a passing regression test (xfail removed); test_a7_j_disjoint_genesis_reorg_rejected proves the A7.j reorg path is closed.`
 
 - [ ] **Step 3: Update the ROADMAP**
 
 In `docs/superpowers/ROADMAP.md`:
 
-(a) Remove the A7.b bullet from the open-findings list (line 52, the `1. **A7.b — Low — Alternate-genesis…**` item) and renumber the remaining open items (A7.h, A7.e, A1.f) accordingly.
+(a) Update the open-findings count prose (line 48):
+Find: `Four open findings from the 2026-05-29 verification pipeline audit (A2.e and A4.c are closed; see Closed items).`
+Replace: `Three open findings from the 2026-05-29 verification pipeline audit (A2.e, A4.c, and A7.b are closed; see Closed items).`
 
-(b) Update the open-findings severity line wherever it states the current tally (it reads `0 Critical / 0 High / 0 Medium / 4 Low` post-A4.c) to `0 Critical / 0 High / 0 Medium / 3 Low`.
+(b) Remove the A7.b numbered item from the open-findings list (item `1. **A7.b — Low — Alternate-genesis admission fragments chain registry.**…`) and renumber the remaining items so A7.h, A7.e, A1.f become 1, 2, 3.
 
-(c) Add a remediated entry for A7.b in the same style as the A4.c entry (the `✅ **Audit finding A4.c …**` line), linking the docs PR (this branch's PR) and the impl PR placeholder:
+> Note: there is **no standalone open-findings severity-tally line** in the ROADMAP. The only `0 Critical / 0 High / 0 Medium / 4 Low` string lives inside the A4.c **Closed-items historical entry**, which records the severity *at A4.c's close* and must **NOT** be modified. Do not touch it. The new severity tally (`… / 3 Low`) appears only in the new A7.b closed entry added in (c) below, and in the audit doc (Step 2a/2b).
+
+(c) Add a remediated entry for A7.b at the end of the "Closed items (historical reference)" section, in the same style as the A4.c entry (the `✅ **Audit finding A4.c …**` line), linking the docs PR (this branch's PR) and the impl PR placeholder:
 
 ```markdown
 - ✅ **Audit finding A7.b — alternate-genesis admission fragments the chain registry** — closed by docs PR [#<N_docs>](https://github.com/gumptionthomas/cancelchain/pull/<N_docs>) (design+plan) and impl PR [#<N_impl>](https://github.com/gumptionthomas/cancelchain/pull/<N_impl>). `Chain.validate_block` now rejects a block claiming genesis when a different genesis is already persisted, raising `DuplicateGenesisError` (via a `Block.genesis_from_db()` helper keyed on `idx == 0`). This also closes A7.j (disjoint-ancestor reorg), whose only entry path is alternate-genesis admission. No schema change. Brings audit severity to 0 Critical / 0 High / 0 Medium / 3 Low.
@@ -393,5 +397,5 @@ Expected: empty — this change adds no migration.
 
 - **Do not** import `GENESIS_HASH` into `block.py` (circular import). The helper keys on `idx == 0`, which is equivalent to genesis by the `idx == prev_index + 1` invariant.
 - **Idempotency is load-bearing.** The `existing_genesis.block_hash != block.block_hash` guard is what keeps `Chain.validate()` full-chain revalidation green (revalidating the canonical genesis compares it against itself). Do not simplify it to a bare "a genesis already exists → raise".
-- Keep the A7.j test self-contained: submit `g2` then `b2` directly via `receive_block`. Both raise locally (`DuplicateGenesisError`, then `MissingBlockError`) — `receive_block` raises `MissingBlockError` on a missing parent without attempting a peer `fill_chain` walk (`node.py:160-165`). Do not wire a peer proxy. The point is that g2's rejection makes the longer fork unrootable, which b2's `MissingBlockError` concretely demonstrates.
+- Keep the A7.j test self-contained: submit `g2` then `b2` directly via `receive_block`. Both raise locally (`DuplicateGenesisError`, then `MissingBlockError`) — `receive_block` raises `MissingBlockError` on a missing parent without attempting a peer `fill_chain` walk (`node.py:159-165`). Do not wire a peer proxy. The point is that g2's rejection makes the longer fork unrootable, which b2's `MissingBlockError` concretely demonstrates.
 - This is a fix PR: no adjacent refactors. The pre-existing `test_create_wallet` terminal-width bug is out of scope (separate PR).

--- a/docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md
@@ -149,17 +149,19 @@ Add a test (e.g. `test_a7_j_disjoint_genesis_reorg_rejected`) that:
    admitted, would be longer than the canonical chain and would trigger the
    catastrophic-rebuild reorg.
 3. Submits the fork's **root** g2 directly via `m1.receive_block(g2.to_json())`
-   and asserts it is rejected with `InvalidBlockError` (`DuplicateGenesisError`).
-   Because g2 is the parent every block in the fork depends on, its rejection
-   makes the entire longer fork unrootable: b2 can never be applied (its
-   `prev_hash` resolves to no persisted block). Asserts the canonical tip is
-   unchanged and the `ChainDAO` count stays 1.
+   and asserts it is rejected with `DuplicateGenesisError`. Then submits b2
+   and asserts it is rejected with `MissingBlockError` — because g2 was never
+   admitted, b2's parent resolves to no persisted block, so the longer fork
+   is unrootable. (`Node.receive_block` raises `MissingBlockError` locally on
+   a missing parent; no peer fill is attempted, keeping the test
+   self-contained.) Asserts the canonical tip is unchanged and the `ChainDAO`
+   count stays 1.
 
 This proves closing A7.b closes A7.j: a longer disjoint fork cannot displace
-the canonical chain because its root genesis is rejected at admission.
-Submitting g2 directly (rather than relying on a peer `fill_chain` walk) keeps
-the test self-contained and independent of peer-proxy wiring, while still
-exercising the exact gate that blocks the reorg.
+the canonical chain because its root genesis is rejected at admission, and its
+descendants are unrootable. Submitting g2 and b2 directly (rather than relying
+on a peer `fill_chain` walk) keeps the test self-contained and independent of
+peer-proxy wiring, while still exercising the exact gates that block the reorg.
 
 **Docstring counts.** Update the `tests/test_verification_audit.py` module
 docstring to reflect A7.b moving from open to remediated.

--- a/docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md
@@ -1,0 +1,201 @@
+# A7.b — Canonical-Genesis Uniqueness Design
+
+**Audit finding:** A7.b (Low) — *Alternate-genesis admission fragments chain registry.*
+**Also closes:** A7.j (Low, related — disjoint-ancestor reorg) — its only entry path is the alternate-genesis admission this fix rejects.
+**Source audit:** `docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md`
+
+---
+
+## Problem
+
+`Chain.validate_block` (`src/cancelchain/chain.py`) accepts any block whose
+`prev_hash == GENESIS_HASH`, `idx == 0`, and `target == MAX_TARGET`,
+**regardless of whether a different genesis is already persisted.**
+`is_genesis_block(block)` is just a `prev_hash == GENESIS_HASH` flag, not an
+"is this *the* canonical genesis" predicate. Each accepted alternate genesis
+spawns a fresh `ChainDAO` row (via `Node.add_block`'s `create_chain`
+fallback), fragmenting the chain registry into N parallel single-block
+chains.
+
+`ChainDAO.longest()` still picks the canonical winner by deterministic
+tiebreaker, so **chain-correctness is preserved** — value conservation and
+`wallet_balance` reads are unaffected (only the canonical chain's
+`LongestChainBlockDAO` rows feed balances). The gap is **DB-bloat /
+inventory-pollution**: a MILLER-role adversary can mint unlimited
+cheap-to-mill alternate genesis blocks, each adding an unrooted
+`ChainDAO`/`BlockDAO`/`TransactionDAO`/`OutflowDAO` row with no operational
+recovery path. Severity Low.
+
+**A7.j link.** A disjoint-ancestor reorg (Attack j) — where a longer chain
+rooted at a *different* genesis displaces the canonical chain — can only be
+mounted if that alternate genesis was first admitted. The
+catastrophic-rebuild branch is itself correct PoW longest-chain behavior;
+the actual gap is the alternate-genesis admission (A7.b). Rejecting
+alternate genesis blocks closes A7.j's only entry path. Two-for-one.
+
+## Goal
+
+Enforce canonical-genesis uniqueness at the validation layer: once a genesis
+block is persisted, reject any *different* block that also claims to be
+genesis. Do this without changing the `is_genesis_block` predicate, the
+bootstrap flow, or the schema.
+
+## Approach
+
+Validate-time uniqueness check (the audit's "more conservative fix"), using
+a domain helper symmetric with the existing `Block.from_db`. A DB-layer
+partial unique index was considered and rejected: a plain `UNIQUE(prev_hash)`
+would wrongly forbid legitimate sibling/fork blocks that share a parent, and
+a partial index needs migration work plus SQLite-specific handling for a Low
+finding.
+
+### Components
+
+Four small touches, no schema/migration change.
+
+**1. `src/cancelchain/exceptions.py` — new exception**
+
+```python
+class DuplicateGenesisError(InvalidBlockError):
+    pass
+```
+
+Placed alongside the other `InvalidBlockError` subclasses. Mirrors the
+`MismatchedCoinbaseError(InvalidCoinbaseError)` pattern introduced by A4.c.
+
+**2. `src/cancelchain/block.py` — new classmethod**
+
+Symmetric with the existing `Block.from_db(block_hash)`:
+
+```python
+@classmethod
+def genesis_from_db(cls) -> Self | None:
+    dao = BlockDAO.get(idx=0)
+    return cls.from_dao(dao) if dao else None
+```
+
+Returns the persisted canonical genesis (or `None` if none exists yet).
+
+- Reuses the existing `BlockDAO.get(idx=0)` classmethod (which executes
+  `db.select(BlockDAO).filter_by(idx=0)` → `scalar_one_or_none()`).
+- **Deliberately keyed on `idx == 0`, not `prev_hash == GENESIS_HASH`.**
+  `idx == 0 ⟺ genesis` is guaranteed by `validate_block`'s
+  `idx == prev_index + 1` rule (only a genesis has `prev_index == -1`).
+  Keying on `idx` lets `block.py` avoid importing `GENESIS_HASH` from
+  `chain.py`, which would create a circular import (`chain.py` already
+  imports `Block` from `block.py`). `BlockDAO.idx` is an indexed column,
+  so the lookup is cheap.
+- `scalar_one_or_none()` is correct because the remediation guarantees at
+  most one `idx == 0` row exists going forward; if that invariant were ever
+  violated it would raise loudly (acceptable — it signals corruption this
+  fix is designed to prevent). No pre-fix fragmented DBs exist to migrate
+  (no deployed installs).
+
+**3. `src/cancelchain/chain.py` — the check**
+
+In `validate_block`, in the genesis branch, immediately after the
+`FutureBlockError` check and before `prev_block` is fetched:
+
+```python
+if is_genesis_block(block):
+    existing = Block.genesis_from_db()
+    if existing is not None and existing.block_hash != block.block_hash:
+        raise DuplicateGenesisError()
+```
+
+Plus importing `DuplicateGenesisError`. Early, cheap rejection for genesis
+candidates; non-genesis blocks skip it entirely.
+
+### Data flow & idempotency
+
+The `existing.block_hash != block.block_hash` guard is the whole correctness
+story:
+
+| Scenario | `genesis_from_db()` | Result |
+|---|---|---|
+| First genesis (empty `BlockDAO`) | `None` | passes → persists |
+| Alternate genesis (different hash) | canonical g1 | `DuplicateGenesisError`; `ChainDAO` count stays 1 |
+| Byte-identical resubmit of canonical | g1 (same hash) | no raise (idempotent); `Node.receive_block` already short-circuits duplicate hashes before validation regardless |
+| `Chain.validate()` full-chain revalidation | the canonical genesis itself | same hash → no raise (safe) |
+
+The revalidation row is the critical one: this repeats the A4.c lesson —
+the check must not break `cancelchain validate`. It is safe here because it
+is a hash-equality guard against the *single* persisted genesis, not a
+lineage walk or a "does any prior block exist" query, so revalidating the
+canonical genesis compares it against itself and passes.
+
+### Error handling
+
+`DuplicateGenesisError` subclasses `InvalidBlockError`, so it propagates
+through the existing `InvalidBlockError` handling in `Node.receive_block`,
+`Node.fill_chain`, and `Chain.validate` (which wraps block errors into
+`InvalidChainError`). No new catch sites.
+
+## Testing
+
+**Acceptance — un-xfail the existing demonstrator.**
+`tests/test_verification_audit.py::test_a7_b_alternate_genesis_fragments_chain_registry`
+already asserts the post-remediation behavior: `m1.receive_block(g2.to_json())`
+raises `InvalidBlockError`, and the `ChainDAO` registry stays at one row.
+Remove its `@pytest.mark.xfail` so it becomes a passing regression test.
+
+**New — A7.j disjoint-reorg regression test.**
+Add a test (e.g. `test_a7_j_disjoint_genesis_reorg_rejected`) that:
+1. Mines the canonical genesis g1 (paying `wallet`); records the canonical
+   tip and `ChainDAO` count (1).
+2. Hand-builds a *longer* fork rooted at an alternate genesis: g2
+   (`prev_hash=GENESIS_HASH`, `idx=0`, paying `miller_2_wallet`) plus at
+   least one honestly-milled child b2 chaining off g2 — a chain that, if
+   admitted, would be longer than the canonical chain and would trigger the
+   catastrophic-rebuild reorg.
+3. Submits the fork's **root** g2 directly via `m1.receive_block(g2.to_json())`
+   and asserts it is rejected with `InvalidBlockError` (`DuplicateGenesisError`).
+   Because g2 is the parent every block in the fork depends on, its rejection
+   makes the entire longer fork unrootable: b2 can never be applied (its
+   `prev_hash` resolves to no persisted block). Asserts the canonical tip is
+   unchanged and the `ChainDAO` count stays 1.
+
+This proves closing A7.b closes A7.j: a longer disjoint fork cannot displace
+the canonical chain because its root genesis is rejected at admission.
+Submitting g2 directly (rather than relying on a peer `fill_chain` walk) keeps
+the test self-contained and independent of peer-proxy wiring, while still
+exercising the exact gate that blocks the reorg.
+
+**Docstring counts.** Update the `tests/test_verification_audit.py` module
+docstring to reflect A7.b moving from open to remediated.
+
+## Documentation updates
+
+- **Audit doc** (`docs/superpowers/audits/2026-05-29-verification-pipeline-audit.md`):
+  mark A7.b remediated (status banner like the A2.e / A4.c entries),
+  flip the A7.b Outcome/Result to REJECTED, and note A7.j is closed via the
+  A7.b remediation. Update the intro summary — currently "Two have since been
+  remediated (A2.e, A4.c); four remain open" → "Three have since been
+  remediated (A2.e, A4.c, A7.b); three remain open (A7.h, A7.e, A1.f)" — and
+  the remediation-priority section's A7.b entry. Also update the findings-
+  table count line ("4 open findings: 0 Critical / 0 High / 0 Medium / 4 Low
+  (post-A4.c)" → "3 open findings: 0 Critical / 0 High / 0 Medium / 3 Low
+  (post-A7.b)").
+- **ROADMAP** (`docs/superpowers/ROADMAP.md`): remove A7.b from the open-
+  findings list, add a remediated entry linking the spec/plan + impl PRs,
+  and update the severity line to **0 Critical / 0 High / 0 Medium / 3 Low**
+  (remaining open: A7.h, A7.e, A1.f). A7.j was never a counted finding;
+  note it as closed-via-A7.b.
+
+## Out of scope
+
+- The other open Low findings (A7.h non-printable subjects, A7.e
+  `TXN_TIMEOUT` operator inconsistency, A1.f mined-txid mempool replay) —
+  each is a separate follow-up PR.
+- Any change to the `is_genesis_block` predicate, the bootstrap/genesis
+  milling flow, or the schema.
+- Hardcoding a canonical genesis block into `db.create_all()` / migrations
+  (the rejected alternative — it changes the bootstrap flow).
+
+## Acceptance criteria
+
+1. `test_a7_b_alternate_genesis_fragments_chain_registry` passes with its
+   `xfail` removed.
+2. The new A7.j disjoint-reorg regression test passes.
+3. Full suite green (`COLUMNS=200 uv run pytest`), `ruff check`/`format`
+   clean, `mypy` clean. No migration / `db check` impact (no schema change).


### PR DESCRIPTION
## What

Design spec + implementation plan for remediating audit finding **A7.b** (Low) — *alternate-genesis admission fragments the chain registry*. Also closes **A7.j** (disjoint-ancestor reorg) as a two-for-one: a longer fork rooted at an alternate genesis can only exist if that genesis was admitted, which this rejects.

Docs-only PR (spec + plan). Implementation lands as a separate PR.

## The fix (designed here)

- New `DuplicateGenesisError(InvalidBlockError)`.
- New `Block.genesis_from_db()` domain helper — symmetric with `Block.from_db`, reuses `BlockDAO.get(idx=0)`. Keyed on `idx == 0` (not `prev_hash == GENESIS_HASH`) specifically to avoid a `chain.py → block.py` circular import; `idx == 0 ⟺ genesis` is guaranteed by `validate_block`'s `idx == prev_index + 1` rule.
- `Chain.validate_block` rejects a block claiming genesis when a *different* genesis is already persisted. The `block_hash`-equality guard keeps the check idempotent — safe in `Chain.validate()` full-chain revalidation (the A4.c lesson applied).
- No schema change.

## Tests (planned)

- Un-xfail the existing `test_a7_b_alternate_genesis_fragments_chain_registry`.
- New self-contained A7.j regression: submit alternate genesis g2 (→ `DuplicateGenesisError`), then its child b2 (→ `MissingBlockError`, parent never admitted), proving the longer fork is unrootable — no peer-proxy wiring needed.

## Files

- `docs/superpowers/specs/2026-05-30-a7b-genesis-uniqueness-design.md`
- `docs/superpowers/plans/2026-05-30-a7b-genesis-uniqueness.md`

## Review process

Ran an internal cross-model adversarial review (two Sonnet reviewers, different model from the Opus authoring) to convergence before opening. Both independently flagged the same defect — the plan's audit/ROADMAP docs-edit instructions targeted strings that don't exist where claimed (the findings table lists only *open* findings; the ROADMAP has no standalone severity line) — now fixed. All design-correctness checks (line numbers, every API, the circular-import claim, idempotency/revalidation safety, the full A7.j exception trace, the count math) were verified correct against the live repo. This PR gets one Copilot backstop pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)