### PR TITLE
test: make test_create_wallet width-independent (drop the COLUMNS=200 papercut)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-test-create-wallet-width.md
+++ b/docs/superpowers/plans/2026-05-31-test-create-wallet-width.md
@@ -133,4 +133,4 @@ Expected: empty — this is a test-only change; no source files modified.
 
 - Do NOT change `src/cancelchain/command.py` or the Rich console — the CLI's wrapping of long paths is correct for human use; the test was the bug.
 - Keep the change scoped to `test_create_wallet`. The other `test_command.py` tests use short-substring `in result.output` checks that don't wrap.
-- The `COLUMNS=200` references in `CLAUDE.md` and plan/gate templates can be cleaned up in a separate follow-up once this lands — out of scope here.
+- The `COLUMNS=200` gate-command examples in this session's superpowers specs/plans become unnecessary once this lands, but they are harmless historical records (not worth retro-editing). `CLAUDE.md` does not reference `COLUMNS=200`. Out of scope here either way.

--- a/docs/superpowers/plans/2026-05-31-test-create-wallet-width.md
+++ b/docs/superpowers/plans/2026-05-31-test-create-wallet-width.md
@@ -1,0 +1,136 @@
+# Fix `test_create_wallet` Terminal-Width Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `test_create_wallet` width-independent so the full suite passes at any terminal width (no `COLUMNS=200`).
+
+**Architecture:** The test currently reconstructs a wallet path from Rich-wrapped CLI output; a narrow terminal inserts newlines mid-path and `Wallet.from_file` fails. Replace the output-parsing with a directory glob that asserts the command's real contract: exactly one loadable `*.pem` was written to the requested walletdir. Test-only change; no source change.
+
+**Tech Stack:** pytest, Click `CliRunner`, Rich console, uv.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-test-create-wallet-width-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `tests/test_command.py` | CLI command tests | Add `from pathlib import Path`; rewrite `test_create_wallet` (lines 251-257) to glob the walletdir |
+
+No source files change.
+
+---
+
+### Task 1: Make `test_create_wallet` width-independent
+
+**Files:**
+- Modify: `tests/test_command.py` (imports at top; `test_create_wallet` at lines 251-257)
+
+- [ ] **Step 1: Confirm the bug reproduces on a narrow terminal**
+
+Run: `COLUMNS=40 uv run pytest tests/test_command.py::test_create_wallet -q`
+Expected: FAIL with `FileNotFoundError` on a path containing literal `\n` (Rich wrapped the long temp-dir path at width 40, and `result.output.strip()` left the internal newline in the reconstructed filename).
+
+- [ ] **Step 2: Add the `pathlib.Path` import**
+
+In `tests/test_command.py`, the imports currently are:
+```python
+import os
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+from cancelchain.chain import CURMUDGEON_PER_GRUMBLE, REWARD
+from cancelchain.database import db
+from cancelchain.wallet import Wallet
+```
+Add `from pathlib import Path` to the stdlib import group (after the `tempfile` import):
+```python
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+```
+> Let ruff settle the exact ordering if it differs; `ruff check --fix` will normalize the import block.
+
+- [ ] **Step 3: Rewrite the test body**
+
+The current test (lines 251-257) is:
+```python
+def test_create_wallet(app, runner):
+    with app.app_context(), TemporaryDirectory() as walletdir:
+        result = runner.invoke(
+            args=['wallet', 'create', '--walletdir', walletdir]
+        )
+        wallet_filename = result.output.strip()[len('Created ') :]
+        assert Wallet.from_file(wallet_filename) is not None
+```
+Replace it with:
+```python
+def test_create_wallet(app, runner):
+    with app.app_context(), TemporaryDirectory() as walletdir:
+        result = runner.invoke(
+            args=['wallet', 'create', '--walletdir', walletdir]
+        )
+        assert result.exit_code == 0
+        assert 'Created' in result.output
+        pem_files = list(Path(walletdir).glob('*.pem'))
+        assert len(pem_files) == 1
+        assert Wallet.from_file(str(pem_files[0])) is not None
+```
+The glob finds the created wallet without parsing the formatted output, so terminal-width wrapping can never break it. `exit_code == 0` and the short-literal `'Created' in result.output` retain cheap success signals (the substring is wrap-safe).
+
+- [ ] **Step 4: Verify the fix on a narrow terminal**
+
+Run: `COLUMNS=40 uv run pytest tests/test_command.py::test_create_wallet -v`
+Expected: PASS (this is the case that failed in Step 1).
+
+- [ ] **Step 5: Verify the full command-test module + width-independence**
+
+Run: `COLUMNS=40 uv run pytest tests/test_command.py -q`
+Expected: PASS (the whole module is fine at narrow width).
+
+- [ ] **Step 6: Lint, then commit**
+
+Run:
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+```
+Expected: clean (run `ruff check --fix tests/test_command.py` if the import order is flagged, then re-check). `mypy` is unaffected (tests aren't in its target set, and no source changed).
+Then:
+```bash
+git add tests/test_command.py
+git commit -m "test: make test_create_wallet width-independent"
+```
+
+---
+
+### Task 2: Final gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite with NO `COLUMNS` override**
+
+Run: `uv run pytest -q`
+Expected: all pass (256 passed / 1 skipped, give or take — the key point is it passes **without** `COLUMNS=200`, which is the whole purpose of this fix).
+
+- [ ] **Step 2: Lint + format**
+
+Run:
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+```
+Expected: clean.
+
+- [ ] **Step 3: No migration / schema drift (sanity)**
+
+Run: `git status --porcelain src/cancelchain/`
+Expected: empty — this is a test-only change; no source files modified.
+
+---
+
+## Notes for the implementer
+
+- Do NOT change `src/cancelchain/command.py` or the Rich console — the CLI's wrapping of long paths is correct for human use; the test was the bug.
+- Keep the change scoped to `test_create_wallet`. The other `test_command.py` tests use short-substring `in result.output` checks that don't wrap.
+- The `COLUMNS=200` references in `CLAUDE.md` and plan/gate templates can be cleaned up in a separate follow-up once this lands — out of scope here.

--- a/docs/superpowers/specs/2026-05-31-test-create-wallet-width-design.md
+++ b/docs/superpowers/specs/2026-05-31-test-create-wallet-width-design.md
@@ -1,0 +1,103 @@
+# Fix `test_create_wallet` Terminal-Width Dependency Design
+
+**Type:** test bug fix (latent on main).
+
+---
+
+## Problem
+
+`tests/test_command.py::test_create_wallet` reconstructs a wallet file path
+from the CLI's printed output and loads it:
+
+```python
+result = runner.invoke(args=['wallet', 'create', '--walletdir', walletdir])
+wallet_filename = result.output.strip()[len('Created ') :]
+assert Wallet.from_file(wallet_filename) is not None
+```
+
+The `wallet create` command prints via a **Rich `Console`**
+(`src/cancelchain/command.py:927` → `console.print(f'Created {filename}', …)`;
+`console` is defined in `src/cancelchain/console.py`). Rich soft-wraps output
+to the terminal width (80 columns by default under the test harness, narrower
+in CI / narrow terminals). When the temp-dir path + address + `.pem` exceeds
+that width, Rich inserts newlines **inside** the path. `result.output.strip()`
+only trims the ends, so the reconstructed `wallet_filename` keeps the internal
+newlines and `Wallet.from_file` raises `FileNotFoundError`.
+
+Reproduced at `COLUMNS=40`:
+
+```
+FileNotFoundError: [Errno 2] No such file or directory:
+'\n/tmp/.../CCm874wmWvf\njaHsm8iazEAD4peqG6dzvbqTDajmVjso7xCC.pem'
+```
+
+This is why the full suite currently requires `COLUMNS=200` — a papercut on
+every run. The CLI behaviour is fine (wrapping long paths is reasonable for
+humans); the **test** is at fault for treating human-formatted output as a
+machine-readable path.
+
+## Goal
+
+Make `test_create_wallet` width-independent so the full suite passes at any
+terminal width, without `COLUMNS=200`.
+
+## Approach
+
+Stop parsing the formatted output for a path. Verify the command's actual
+contract instead: after `wallet create --walletdir X`, exactly one loadable
+`*.pem` file exists in `X`. This is independent of width, styling, wrapping,
+and the exact print wording.
+
+## Change
+
+One file: `tests/test_command.py`. Add `from pathlib import Path` to the
+imports, and rewrite the test body:
+
+```python
+def test_create_wallet(app, runner):
+    with app.app_context(), TemporaryDirectory() as walletdir:
+        result = runner.invoke(
+            args=['wallet', 'create', '--walletdir', walletdir]
+        )
+        assert result.exit_code == 0
+        assert 'Created' in result.output
+        pem_files = list(Path(walletdir).glob('*.pem'))
+        assert len(pem_files) == 1
+        assert Wallet.from_file(str(pem_files[0])) is not None
+```
+
+- `Path(walletdir).glob('*.pem')` finds the created wallet without any output
+  parsing.
+- `len(pem_files) == 1` asserts exactly one wallet was written to the
+  requested directory.
+- `Wallet.from_file(str(pem_files[0]))` confirms it is loadable (the original
+  assertion, now fed a clean path).
+- `exit_code == 0` and `'Created' in result.output` retain two cheap signals
+  that the command ran and reported success. `'Created'` is a short literal
+  substring check, which is wrap-safe.
+
+No source change. The CLI's Rich-wrapped output is unchanged.
+
+## Testing
+
+- Run on a **narrow** terminal to prove width-independence:
+  `COLUMNS=40 uv run pytest tests/test_command.py::test_create_wallet -v`
+  → PASS (fails on `main`).
+- Full suite with **no** `COLUMNS` override:
+  `uv run pytest` → all pass (no longer width-dependent).
+
+## Out of scope (non-goals)
+
+- Changing the `wallet create` CLI output / Rich console wrapping (it is
+  correct for human use).
+- Other `test_command.py` tests — they use short-substring `in result.output`
+  checks that don't wrap; only `test_create_wallet` reconstructs a path.
+- Removing the now-unnecessary `COLUMNS=200` references in `CLAUDE.md` and the
+  plan/gate command templates — a separate follow-up cleanup once this lands.
+
+## Acceptance criteria
+
+1. `COLUMNS=40 uv run pytest tests/test_command.py::test_create_wallet` passes.
+2. `uv run pytest` (no `COLUMNS` override) passes the full suite.
+3. `ruff check`/`format` clean, `mypy` clean (no src change). No migration /
+   schema change.

--- a/docs/superpowers/specs/2026-05-31-test-create-wallet-width-design.md
+++ b/docs/superpowers/specs/2026-05-31-test-create-wallet-width-design.md
@@ -92,8 +92,11 @@ No source change. The CLI's Rich-wrapped output is unchanged.
   correct for human use).
 - Other `test_command.py` tests — they use short-substring `in result.output`
   checks that don't wrap; only `test_create_wallet` reconstructs a path.
-- Removing the now-unnecessary `COLUMNS=200` references in `CLAUDE.md` and the
-  plan/gate command templates — a separate follow-up cleanup once this lands.
+- The `COLUMNS=200` gate-command examples in this session's superpowers
+  specs/plans (`docs/superpowers/{specs,plans}/…`) become unnecessary once
+  this lands. They are harmless historical records (the prefix still works);
+  not worth retro-editing merged docs. (`CLAUDE.md` does not reference
+  `COLUMNS=200`.)
 
 ## Acceptance criteria
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from cancelchain.chain import CURMUDGEON_PER_GRUMBLE, REWARD
@@ -253,8 +254,11 @@ def test_create_wallet(app, runner):
         result = runner.invoke(
             args=['wallet', 'create', '--walletdir', walletdir]
         )
-        wallet_filename = result.output.strip()[len('Created ') :]
-        assert Wallet.from_file(wallet_filename) is not None
+        assert result.exit_code == 0
+        assert 'Created' in result.output
+        pem_files = list(Path(walletdir).glob('*.pem'))
+        assert len(pem_files) == 1
+        assert Wallet.from_file(str(pem_files[0])) is not None
 
 
 def test_wallet_balance(


### PR DESCRIPTION
## What

`tests/test_command.py::test_create_wallet` was terminal-width-dependent — the reason the full suite needed `COLUMNS=200`. This makes it width-independent. Single combined PR (spec + plan + fix); test-only change, no source change.

## Root cause

The test reconstructed the wallet path from the `wallet create` command's `console.print(f'Created {filename}')` output. That `console` is a **Rich `Console`**, which soft-wraps to the terminal width (80 in the harness, narrower in CI). When the temp-dir path + address + `.pem` exceeds the width, Rich inserts newlines **inside** the path; `result.output.strip()` only trims the ends, so the reconstructed filename kept the internal `\n` and `Wallet.from_file` raised `FileNotFoundError`.

Reproduced at `COLUMNS=40`: `FileNotFoundError: '\n/tmp/.../CCm874...\n...pem'`.

## Fix

Stop parsing human-formatted output. Verify the command's contract directly — exactly one loadable `*.pem` is written to the requested walletdir:

```python
assert result.exit_code == 0
assert 'Created' in result.output            # short literal, wrap-safe
pem_files = list(Path(walletdir).glob('*.pem'))
assert len(pem_files) == 1
assert Wallet.from_file(str(pem_files[0])) is not None
```

Width/format/styling-independent. The CLI's human-facing wrapping is unchanged.

> Note: a reviewer suggested re-adding `assert str(pem_files[0]) in result.output` to verify the printed path. Deliberately **not** done — that's exactly the width-sensitive check being removed (a wrapped path has embedded newlines, so the clean path string isn't a substring). Decoupling printed-path-correctness from the load is what makes the test width-independent.

## Gates

- `COLUMNS=40 uv run pytest tests/test_command.py::test_create_wallet` → **passes** (fails on `main`)
- `uv run pytest` (no `COLUMNS` override) → **256 passed, 1 skipped** — the papercut is gone
- `ruff check`/`format` clean · no source change

## Follow-up (separate, not this PR)

The `COLUMNS=200` references in `CLAUDE.md` and the plan/gate templates can now be removed.

## Review

Internal cross-model review (Sonnet) on the diff: APPROVED. This PR gets one Copilot backstop pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)