### PR TITLE
chore: ignore .zed/ editor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ _build/
 
 # vscode
 .vscode/
+
+# zed
+.zed/


### PR DESCRIPTION
Adds `.zed/` to `.gitignore` alongside the existing `.vscode/` entry, so Zed's per-project editor settings don't show up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)