### PR TITLE
docs(audit): P2P/networking threat-model audit — 0/1/2/1 + demonstration tests

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -93,6 +93,22 @@ RFC 9421 HTTP Message Signatures is deferred until there is third-party-client d
 
 ---
 
+## Audit remediation — P2P/networking findings
+
+The 2026-06-01 [P2P/networking audit](audits/2026-06-01-network-p2p-audit.md) (design+plan [#112](https://github.com/gumptionthomas/cancelchain/pull/112)) produced **0 Critical / 1 High / 2 Medium / 1 Low**. Every finding is an availability/resource-bounding gap on an otherwise-validated, otherwise-authorized path (the trusted-input boundary holds). Each has a `@pytest.mark.xfail(strict=True)` demonstration in `tests/test_network_audit.py`; remediation flips it to a passing regression. Open items:
+
+- ⏳ **N1 (High) — `fill_chain` unbounded ancestor walk** — no depth cap on the `while True` walk (`node.py:343-361`) + `request_block` never verifies the returned block's hash equals the requested `prev_hash`, so a hostile sync peer drives unbounded round-trips + `ChainFillBlock` commits and never terminates. Fix: configurable depth cap (`CC_MAX_CHAIN_FILL_DEPTH`) + returned-hash check. Test: `test_n1_fill_chain_has_no_depth_cap`.
+- ⏳ **N2 (Medium) — mempool has no admission cap** — `pending_txns` admits unbounded distinct valid txns (`node.py:95-102`); every expiry/mill/pending scan re-materializes the whole pool (O(mempool)). Fix: `CC_MAX_PENDING_TXNS` cap + indexed/SQL-filtered expiry. Test: `test_n2_mempool_has_no_admission_cap`.
+- ⏳ **N3 (Medium) — duplicate-txn re-gossip amplification** — an already-pending txn is re-gossiped on every receipt (`send_transaction` outside the newly-added guard, `node.py:95-105`), 1→N fan-out; the block path already dedups before gossiping. Fix: gate re-gossip on newly-added (mirror the block path). Test: `test_n3_pending_txn_regossiped_on_every_receipt`.
+- ⏳ **N4 (Low) — synchronous broker publish on the request thread** — `post_process.delay()` runs in-thread via the `http_post` signal (`api.py:120-158`), coupling POST latency to broker liveness (bounded ~16s by Celery defaults). Fix: move the publish off the request thread. Test: `test_n4_async_publish_blocks_request_thread`.
+
+**Cross-cutting:** all four are the same missing-bound class — adopt a "bound every attacker-influenced accumulator (+ a bounded-observation test)" convention. The `ChainFill` orphan-rows-on-crash hygiene note (A5.c) is made worse by N1 and is worth folding into the N1 fix.
+
+Originating report:
+- [P2P/networking audit — Findings table + Recommendations](audits/2026-06-01-network-p2p-audit.md)
+
+---
+
 ## Closed items (historical reference)
 
 Each removed from this file when the closing PR landed. Keep here for now so future Claude sessions can see what was on the list.

--- a/docs/superpowers/audits/2026-06-01-network-p2p-audit.md
+++ b/docs/superpowers/audits/2026-06-01-network-p2p-audit.md
@@ -1,0 +1,82 @@
+# P2P / Networking Threat-Modeled Audit
+
+**Date:** 2026-06-01
+**Scope:** Node/Miller orchestration + peer-facing API views. Trusted boundaries: the `validate_*` verification pipeline and the `cc-sig-v1` / `authorize()` auth layer. See [design](../specs/2026-06-01-network-p2p-audit-design.md).
+**Method:** Three-phase multi-agent fan-out — one analyst per of six adversary categories (discover), an adversarial refuter per candidate (verify), then synthesis. 23 candidate attacks were traced; 7 survived refutation; deduped to 4 findings.
+
+## Executive summary
+
+**0 Critical / 0 High → 1 High / 2 Medium / 1 Low.** The trusted-input boundary holds: every confirmed finding is an **availability / resource-bounding gap on an otherwise-validated, otherwise-authorized path** — "valid, authenticated peer input in hostile volume, depth, or pattern," exactly the in-scope case. None reduces to a verification-validity or authorization break. The recurring root is a **missing-bound pattern**: the node has no depth cap on `fill_chain`'s ancestor walk, no size cap on the `pending_txns` mempool, and no idempotency/rate guard on duplicate transaction gossip (grep confirms no `MAX_DEPTH` / `MAX_FILL` / `MAX_PENDING` / rate-limit constants exist anywhere). A secondary theme: **validation is deferred past the point where resources are already committed** — `request_block` stages an ancestor without checking the returned block's hash matches what was requested, and mempool admission defers chain/UTXO checks to mill time, so an attacker pays ~zero to make the victim commit unbounded staging/pending rows.
+
+| ID | Adversary | Severity | Description | Status | Demonstration test |
+|---|---|---|---|---|---|
+| N1 | Resource-exhaustion / eclipse / framing (merged) | **High** | `fill_chain` stages an attacker-controlled, uncapped chain of ancestor blocks — one HTTP round-trip + one committed staging row per ancestor, no depth bound, never terminates | ⏳ open (xfail) | `test_network_audit.py::test_n1_fill_chain_has_no_depth_cap` |
+| N2 | Resource-exhaustion / framing (merged) | Medium | `pending_txns` mempool has no admission cap; floods of distinct valid txns grow unbounded and every expiry/mill/pending scan re-materializes the whole pool | ⏳ open (xfail) | `test_network_audit.py::test_n2_mempool_has_no_admission_cap` |
+| N3 | Gossip-loop / amplification | Medium | Already-pending txn is re-gossiped on every receipt: 1 duplicate POST forces N outbound peer POSTs (the block path has the dedup guard the txn path lacks) | ⏳ open (xfail) | `test_network_audit.py::test_n3_pending_txn_regossiped_on_every_receipt` |
+| N4 | Async post-process path | Low | Celery broker publish runs synchronously on the web-request thread; an unreachable/slow broker stalls every block/txn POST (bounded by Celery defaults) | ⏳ open (xfail) | `test_network_audit.py::test_n4_async_publish_blocks_request_thread` |
+
+## Adversary traces
+
+### 1. Resource-exhaustion peer
+
+The dominant category. Two surviving findings, both "no cap on an attacker-influenced accumulator."
+
+- **N1 (High) — `fill_chain` unbounded ancestor walk.** A peer the victim *pulls from* (a `CC_PEERS` sync target, or a Miller's `milling_peer` via `poll_latest_blocks`, which `mill_block` invokes automatically every poll cycle) answers `get_block(latest)` with a structurally-valid tip whose `prev_hash` is unknown to the victim. `fill_chain` (`node.py:343-361`) enters `while True` and calls `request_block(prev_hash)` per ancestor. `request_block` (`node.py:221-236`) returns `Block.from_json(r.text)` for any 200 **without** verifying the returned block's hash equals the requested `prev_hash` and **without** calling `block.validate()` — only structural Pydantic validation runs during the walk. The attacker answers every request with a fresh structurally-valid block whose `prev_hash` again never resolves and is never genesis, so none of the three loop-termination conditions is ever met (all three are attacker-controlled). Each iteration issues one outbound round-trip and commits one `ChainFillBlock` Text-blob row (`node.py:356-361`); the walk never terminates and the `finally` cleanup (`node.py:410-412`) never runs. The per-request httpx 10s timeout (`api_client.py:55`) does not help — a cooperative attacker answers quickly, so the timeout never trips. All cost is paid in the pre-validation staging phase; the batch is discarded at apply if it doesn't link, so the work is pure waste.
+
+- **N2 (Medium) — mempool unbounded admission.** See category 4 (the framing analyst surfaced the same finding); merged into N2.
+
+### 2. Eclipse / chain-feeding peer
+
+Converged on **N1**. The eclipse lens independently traced the same uncapped `fill_chain` walk from the chain-feeding angle (serving a valid-but-fake deep chain to pin the node), confirming the reachability via the automated `Miller.poll_latest_blocks` → `mill_block` path rather than only the CLI `sync`. No additional distinct finding — the deep-chain feed and the resource-exhaustion walk are the same code gap.
+
+### 3. Gossip-loop / amplification abuser
+
+- **N3 (Medium) — duplicate-txn re-gossip amplification.** In `Node.receive_transaction` (`node.py:95-105`) the duplicate check only guards the mempool *add* (the `added` flag); `send_transaction` at lines 103-104 is called **unconditionally** whenever `process=True` (the synchronous default, `CC_API_ASYNC_PROCESSING` off, set in `TxnView.post` `api.py:380-388`). So an authenticated TRANSACTOR peer that repeatedly POSTs the *same* already-pending txn with an empty/omitted `Peer-Hosts` header forces the victim to re-fan-out to all N peers on every duplicate receipt, carrying zero new state, while the synchronous handler blocks a worker doing up to N sequential outbound POSTs. This is a genuine asymmetry vs. the block path, which early-returns `None` for a known block *before* gossiping (`node.py:162-163, 181-182`). The `visited_hosts`/`Peer-Hosts` loop-guard is attacker-controllable and only prevents looping back to nodes already in the path; it does not couple mempool-membership to the gossip decision.
+
+The loop-guard itself was probed for spoofing/loop-induction and **holds** — the visited-set growth makes each storm terminate (bounded by peer count N and mesh diameter), so the abuse is N-fold amplification per request, not an infinite or exponential loop.
+
+### 4. Protocol / framing abuser
+
+Converged on **N1** and **N2**.
+
+- **N2 (Medium) — mempool unbounded admission.** An attacker holding a TRANSACTOR-allowlisted address POSTs distinct, individually-valid, freshly-timestamped txns to `/api/transaction/<txid>`. Admission validation (`txn.validate`, `transaction.py:224-233`) is shape + signature + txid only — it does **not** check inflows against chain UTXO/balance/double-spend (that runs only at mill time, `miller.py:89-91`), so one key mints unlimited distinct admitted txids without holding real funds. Each admit commits one `PendingTxnDAO` row plus up to `MAX_FLOWS=50` `PendingIOflowDAO` rows (`transaction.py:393-437`). No admission cap exists; the only eviction is `discard_expired_pending_txns`, gated on `TXN_TIMEOUT=4h`. Worse, `PendingTxnSet.__iter__` (`transaction.py:385-388`) builds a `Transaction.from_json` per row with no SQL filter, and the expiry sweep (`node.py:107-113`), `Miller.create_block` (`miller.py:62-102`), and the READER-reachable `PendingTxnView.get` (`api.py:593-614`) all iterate the full set — so every mill attempt, sweep, and `/transaction/pending` GET is O(mempool) full deserialization on the milling critical path.
+
+- Payload-size: there is **no `MAX_CONTENT_LENGTH` anywhere** (grep-confirmed). This was traced, but every body-size path the framing analyst followed either reached `authorize()`/`validate()` first (cross-references to the auth/verification boundaries, out of scope per the razor) or reduced to N2's accumulator growth, so no separate payload-size finding survived as an in-scope networking issue.
+
+### 5. Race / concurrency
+
+**No surviving findings.** Candidates here (concurrent `fill_chain`/`receive_block` against the same prefix; `ChainFill` orphan rows on interleave) were refuted: the A2.e atomic-apply remediation (deferred per-block commits + single post-loop commit/rollback in `fill_chain`, `node.py:369-393`) bounds partial-state corruption, and the `finally`-block `ChainFill` cleanup handles the normal-exit case. The pre-existing **`ChainFill` orphan-rows-on-process-crash** hygiene observation (A5.c from the verification audit — staging rows leaked if the process is killed mid-fill) remains a documented operational-hygiene note below the per-finding remediation bar, not a new finding here. (Note N1 makes the orphan-row exposure worse in practice — a wedged, never-terminating walk accumulates uncommitted-cleanup staging rows — which is an additional argument for the N1 depth cap.)
+
+### 6. Async post-process path
+
+- **N4 (Low) — synchronous broker publish on the request thread.** With `CC_API_ASYNC_PROCESSING=true` and `CELERY_BROKER_URL` set to a down/slow broker, `BlockView.post`/`TxnView.post` → `queue_*_post_process` → `http_post_signal.send` (fired synchronously in the request thread, `api.py:120-127`) → `handle_http_post` → `post_process.delay()` (`api.py:150-151`) runs **before** the 202 is built. `tasks.py:16` does only `celery.conf.update(app.config)` — no `broker_transport_options`, no publish-retry/timeout overrides — so the kombu publish runs inline on the gunicorn worker and stalls on a dead broker. **Bounded, hence Low:** Celery 5.6.3 defaults (`task_publish_retry` max_retries=3 at 0/0.2/0.4/0.6s, `broker_connection_timeout=4s`) cap a silently-dropping publish at ~16s before `.delay()` raises (caught by `exception_response`) and the thread frees; a connection-refused broker fails near-instantly; the pool self-recovers when the broker returns. Reachability is weak under the hostile-peer model — the peer cannot induce the broker outage (operator config + infra failure); it only adds ordinary POST volume atop a pre-existing operator-side degraded condition.
+
+## Cross-cutting observations
+
+1. **Missing-bound pattern repeats across the P2P/staging/mempool surface.** No depth cap on `fill_chain`'s ancestor walk, no size cap on the `pending_txns` mempool, no idempotency/rate guard on duplicate txn gossip. Every confirmed finding is a "valid authenticated input in hostile volume/pattern" availability issue — the trusted-input boundary holds; the **resource-bounding boundary does not**.
+
+2. **Validation is deferred past the point where resources are already committed.** `request_block` runs only structural Pydantic validation and never checks returned-hash == requested-prev_hash; full `Block.validate()` (PoW/merkle/chain) runs only in the apply phase after the entire chain is staged. Mempool admission checks shape+signature+txid but defers chain/UTXO/balance/double-spend to mill time. In both paths an attacker pays ~zero to make the victim commit unbounded staging/pending rows before any meaningful rejection. Pulling a cheap structural+identity check forward (and capping the work) closes both.
+
+3. **The documented full-pool re-materialization cost is the amplifier for N2.** `PendingTxnSet.__iter__` re-parses every row via `Transaction.from_json` on every expiry sweep, mill attempt, and `/transaction/pending` GET, with no SQL filter — the same class as the project's known recursive-CTE/full-scan performance bottleneck. Unbounded admission and O(mempool) full-scan reads compound multiplicatively; fixing either alone helps, fixing both is needed.
+
+4. **Block-path vs txn-path asymmetry is a recurring tell.** The block path already early-returns on a known block before gossiping (`node.py:162-163`); the txn path re-gossips unconditionally. The inbound missing-parent path uses the bounded `fill_peer` push; the outbound sync path uses the unbounded `fill_chain` walk. The safer pattern already exists in-tree on the sibling path — the fixes are largely "make the txn/`fill_chain` path match the block/`fill_peer` path," which lowers fix risk.
+
+5. **What was checked and holds (not findings):** the `cc-sig-v1` per-request signature auth and the live `Role.address_role` re-authorization gate, the `Peer-Hosts`/`visited_hosts` loop-guard correctness, the A2.e atomic `fill_chain` apply, and the block apply-phase validation. The four confirmed issues are all resource-bounding gaps on otherwise-validated, otherwise-authorized paths.
+
+## Recommendations
+
+Prioritized; each maps to a finding and to the [roadmap](../ROADMAP.md) remediation entry.
+
+1. **FIRST (N1, High): Cap `fill_chain`'s staging walk.** Add a configurable maximum depth/row count to the `while True` loop (`node.py:343-361`), aborting and cleaning up the `ChainFill` when exceeded; **and** in `request_block` (`node.py:221-236`) verify the returned block's hash equals the requested `prev_hash` before staging. Together these turn an unbounded, non-terminating, attacker-steered walk into a bounded one. Lock it in with the `requests_mock` bounded-observation test.
+
+2. **(N2, Medium): Add a mempool admission cap.** A configurable `MAX_PENDING` checked in `receive_transaction` (`node.py:95`) before `pending_txns.add`, rejecting/evicting once full. Pair it with an indexed/SQL-filtered expiry query so `discard_expired_pending_txns` and `PendingTxnView` no longer re-materialize the whole pool in Python on the milling critical path — addressing both the disk-growth and the O(mempool) read-amplification halves.
+
+3. **(N3, Medium): Couple txn gossip to mempool-membership.** Move `send_transaction` inside the `if txn not in self.pending_txns` block in `receive_transaction` (`node.py:95-105`), mirroring the block path's early-return-before-gossip. Optionally add a short-window API-layer idempotency/rate guard. Removes the 1→N per-duplicate-request amplification with a well-tested in-tree precedent.
+
+4. **(N4, Low): Harden the async publish path.** Move the `post_process.delay()` publish off the request thread (fire-and-forget with a short bounded connection timeout / `broker_transport_options`, or enqueue without blocking the 202) so a degraded broker can't stall gossip POSTs even for the ~16s Celery-default window. Lowest priority — bounded and operator-gated today.
+
+5. **Adopt a "bound every attacker-influenced accumulator" convention.** Where authenticated-but-hostile peer input can drive growth (staging tables, mempool, gossip fan-out, retry loops), require an explicit configurable cap **and** a bounded-observation availability test at the same time the accumulator is introduced. These four findings are the same missing-bound class surfacing in four places; a convention prevents the next one.
+
+## Demonstration tests
+
+Each finding has a `@pytest.mark.xfail(strict=True)` test in `tests/test_network_audit.py`. Availability findings use the bounded-observation convention — they drive the uncapped behavior only up to a small, safe bound and never exhaust real resources. `--runxfail tests/test_network_audit.py` makes every demonstration fail (proving the gap); strict mode forces each marker's removal when the finding is remediated.

--- a/tests/test_network_audit.py
+++ b/tests/test_network_audit.py
@@ -11,8 +11,27 @@ uncapped behavior only up to a small, safe bound and assert the missing cap
 is observable. No test exhausts real memory, disk, or wall-clock.
 """
 
+import datetime
+import threading
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from cancelchain.api_client import ApiClient
+from cancelchain.block import Block
+from cancelchain.chain import REWARD
 from cancelchain.database import db
+from cancelchain.miller import Miller
 from cancelchain.models import ChainFillBlock
+from cancelchain.payload import Inflow, Outflow, encode_subject
+from cancelchain.transaction import Transaction
+from cancelchain.util import now
+
+# Matches the `easy_mill_chain` session-scoped fixture's patched
+# MAX_TARGET — every target in tests is the 64-character all-F hex string
+# (the max 256-bit target) so PoW is trivially found.
+TEST_TARGET = 'F' * 64
 
 # Per-finding tests (and any further imports: pytest, Block, Node, ...) are
 # appended below this scaffold. Shared fixtures (app, *_wallet,
@@ -37,3 +56,257 @@ def staged_chain_fill_count(app):
             )
             or 0
         )
+
+
+def _hostile_block(prev_block: Block, wallet, idx_offset: int = 1) -> Block:
+    """Construct a fully-mined Block extending `prev_block` without
+    persisting anything to the DB.
+
+    Mirrors tests/test_verification_audit.py: linked to `prev_block` by
+    hash + idx, sealed with a coinbase paying `wallet`, given a merkle
+    root, timestamped at now() (under the active time_machine), and milled
+    to satisfy the TEST_TARGET (all-F) proof-of-work requirement.
+    """
+    b = Block()
+    assert prev_block.idx is not None
+    assert prev_block.block_hash is not None
+    b.link(prev_block.idx + idx_offset, prev_block.block_hash, TEST_TARGET)
+    b.seal(wallet, REWARD)
+    b.mill()
+    return b
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        'AUDIT N1: fill_chain has no depth cap on its ancestor walk; a '
+        'hostile peer drives an attacker-controlled number of request_block '
+        'round-trips + ChainFillBlock commits. Remove this marker when '
+        'fill_chain honors a configurable depth cap (contract: '
+        "app.config['CC_MAX_CHAIN_FILL_DEPTH']) and aborts the walk at the "
+        'threshold.'
+    ),
+)
+def test_n1_fill_chain_has_no_depth_cap(app, time_machine, wallet) -> None:
+    """N1: fill_chain's `while True` ancestor walk (node.py:343-361) has no
+    depth cap, so a hostile peer drives an attacker-controlled number of
+    request_block calls + ChainFillBlock commits.
+
+    The remediation contract is a configurable depth cap read from
+    app.config['CC_MAX_CHAIN_FILL_DEPTH']; the walk must abort once it has
+    requested that many ancestors. Today there is no such cap, so the walk
+    runs until our patched request_block hits its own SAFETY bound.
+    """
+    with app.app_context():
+        now_dt = now()
+        time_machine.move_to(now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_wallet=wallet)
+        g = m.create_block()
+        m.mill_block(g)
+
+        # Build a hostile tip whose ancestors are NOT in the DB, so the
+        # backward walk must request_block its way down.
+        tip = _hostile_block(g, wallet)
+        tip2 = _hostile_block(tip, wallet)
+        assert tip2.block_hash is not None
+        assert Block.from_db(tip2.block_hash) is None
+
+        # Remediation contract: cap the ancestor walk at this depth.
+        app.config['CC_MAX_CHAIN_FILL_DEPTH'] = 3
+
+        call_count = [0]
+        # SAFETY: cap our fake peer so today's uncapped walk terminates
+        # rather than hanging. Each call ignores the requested hash and
+        # returns a FRESH extending hostile block whose prev_hash is a
+        # never-stored non-genesis hash, so the walk keeps going.
+        safety = 8
+        current = [tip2]
+
+        def counting_fake(block_hash):
+            call_count[0] += 1
+            if call_count[0] > safety:
+                return None
+            nxt = _hostile_block(current[0], wallet)
+            current[0] = nxt
+            return nxt
+
+        with patch.object(m, 'request_block', side_effect=counting_fake):
+            m.fill_chain(tip2)
+
+        # TODAY: no cap -> walk runs to SAFETY=8 -> call_count == 8 ->
+        # 8 <= 3 is FALSE -> xfail. AFTER FIX: walk stops at the cap ->
+        # call_count <= 3 -> passes -> remove the marker.
+        assert call_count[0] <= 3
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        'AUDIT N2: pending_txns mempool has no admission cap; an '
+        'authenticated TRANSACTOR floods unbounded distinct valid txns. '
+        'Remove this marker when receive_transaction enforces a configurable '
+        "cap (contract: app.config['CC_MAX_PENDING_TXNS']) and "
+        'rejects/evicts past it.'
+    ),
+)
+def test_n2_mempool_has_no_admission_cap(app, time_machine, wallet) -> None:
+    """N2: the pending_txns mempool has no admission cap (node.py:95-102);
+    admission validation is shape+sig+txid only (no balance), so one
+    transactor floods unbounded distinct valid txns.
+
+    Remediation contract: a configurable cap app.config['CC_MAX_PENDING_TXNS'].
+    """
+    with app.app_context():
+        now_dt = now()
+        time_machine.move_to(now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_wallet=wallet)
+
+        # Remediation contract: cap the mempool BEFORE submitting.
+        app.config['CC_MAX_PENDING_TXNS'] = 3
+
+        # Submit 6 DISTINCT structurally-valid signed txns. Each varies the
+        # subject so its txid differs; validate() is shape+sig+txid only
+        # (NO balance check), so these unfunded opposition txns admit — that
+        # IS the finding.
+        for i in range(6):
+            t = Transaction()
+            # A dummy inflow reference satisfies the shape check (regular
+            # txns require >= 1 inflow); validate() is shape+sig+txid only
+            # (no chain lookup / balance check), so the unfunded txn admits.
+            t.add_inflow(Inflow(outflow_txid='0' * 64, outflow_idx=0))
+            t.add_outflow(
+                Outflow(amount=1, subject=encode_subject(f'subj-{i}'))
+            )
+            t.set_wallet(wallet)
+            t.seal()
+            t.sign()
+            m.receive_transaction(t.txid, t.to_json())
+
+        # TODAY: no cap -> all 6 admitted -> len == 6 -> 6 <= 3 FALSE ->
+        # xfail. AFTER FIX: cap honored -> len <= 3 -> passes -> remove marker.
+        assert len(m.pending_txns) <= 3
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        'AUDIT N3: an already-pending txn is re-gossiped on every receipt '
+        "(send_transaction called outside the 'newly added' guard), enabling "
+        '1->N fan-out amplification. Remove this marker when '
+        'receive_transaction only re-gossips a txn it actually newly added '
+        "(mirroring the block path's dedup-before-gossip)."
+    ),
+)
+def test_n3_pending_txn_regossiped_on_every_receipt(
+    app, time_machine, wallet
+) -> None:
+    """N3: an ALREADY-PENDING txn is re-gossiped on every receipt because
+    send_transaction is called unconditionally outside the
+    `if txn not in self.pending_txns` guard (node.py:95-105), unlike the
+    block path which dedups before gossiping.
+    """
+    with app.app_context():
+        now_dt = now()
+        time_machine.move_to(now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_wallet=wallet)
+
+        # One valid signed txn (dummy inflow satisfies the shape check).
+        t = Transaction()
+        t.add_inflow(Inflow(outflow_txid='0' * 64, outflow_idx=0))
+        t.add_outflow(Outflow(amount=1, subject=encode_subject('subj-n3')))
+        t.set_wallet(wallet)
+        t.seal()
+        t.sign()
+
+        # First receipt: admits to pending (and gossips — expected).
+        m.receive_transaction(t.txid, t.to_json())
+        assert t in m.pending_txns
+
+        # Wire a spy peer that records every gossip call, installed AFTER the
+        # first receipt so `calls` reflects only the second-receipt fan-out.
+        calls: list[str] = []
+        peer = 'http://peer.host:8000'
+
+        class SpyClient:
+            host = peer
+
+            def post_transaction(self, txn, visited_hosts=None):
+                calls.append(txn.txid)
+
+        m.peers = [peer]
+        m.clients = {peer: SpyClient()}
+
+        # SECOND receipt of the SAME already-pending txn. With m.host=None,
+        # visited_hosts starts empty so send_transaction would contact the
+        # peer.
+        m.receive_transaction(t.txid, t.to_json())
+
+        # TODAY: send_transaction fires unconditionally -> calls == [t.txid]
+        # -> calls == [] FALSE -> xfail. AFTER FIX (gossip gated on
+        # newly-added, mirroring the block path) -> no gossip on the 2nd
+        # receipt -> calls == [] -> passes -> remove marker.
+        assert calls == []
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        'AUDIT N4: the Celery broker publish (post_process.delay) runs '
+        'synchronously on the web-request thread via the http_post signal, '
+        'coupling POST latency to broker liveness. Remove this marker when '
+        'the publish is moved off the request thread.'
+    ),
+)
+def test_n4_async_publish_blocks_request_thread(
+    app, host, host_netloc, requests_proxy, wallet
+) -> None:
+    """N4: the Celery broker publish runs synchronously on the web-request
+    thread — handle_http_post -> post_process.delay() is fired in-thread via
+    the http_post signal during the POST, so it executes on the request
+    handler's thread rather than off it.
+    """
+    with app.app_context():
+        # Enable the async post-processing path. The CC_ prefix is stripped
+        # in app.config, so the gate key is API_ASYNC_PROCESSING. A valid
+        # in-memory broker URL keeps .delay() from erroring on config, and
+        # NODE_HOST must embed the local wallet address (http://<addr>@host)
+        # so queue_post_process doesn't warn-and-skip before the signal.
+        app.config['API_ASYNC_PROCESSING'] = True
+        app.config['CELERY_BROKER_URL'] = 'memory://'
+        app.config['NODE_HOST'] = f'http://{wallet.address}@{host_netloc}'
+
+        main_tid = threading.get_ident()
+        delay_tid: list[int] = []
+
+        def fake_delay(*args, **kwargs):
+            delay_tid.append(threading.get_ident())
+
+        # Mine a block as the (ADMIN-privileged) wallet and POST it through
+        # the real ApiClient/requests_proxy. Use create_block() + b.mill()
+        # (NOT mill_block, which calls receive_block and would persist the
+        # block locally) so the POSTed block is NEW to the server's DB —
+        # otherwise receive_block short-circuits (block already present) and
+        # the async queue path is never reached.
+        m = Miller(milling_wallet=wallet)
+        b = m.create_block()
+        b.mill()
+
+        # Patch where handle_http_post looks it up: post_process is imported
+        # into cancelchain.api and called as post_process.delay(...).
+        with patch(
+            'cancelchain.api.post_process.delay', side_effect=fake_delay
+        ):
+            response = ApiClient(host, wallet).post_block(b)
+
+        # The async path returns 202 ACCEPTED after queueing.
+        assert response.status_code == httpx.codes.ACCEPTED
+        # The signal fired synchronously, so delay recorded the publish
+        # thread id.
+        assert delay_tid, 'post_process.delay was never called'
+
+        # TODAY: the signal fires synchronously in the request handler, which
+        # (under httpx WSGITransport) runs in the test's own thread ->
+        # delay_tid[0] == main_tid -> != FALSE -> xfail. AFTER FIX (publish
+        # moved off the request thread) -> different thread -> passes ->
+        # remove marker.
+        assert delay_tid[0] != main_tid

--- a/tests/test_network_audit.py
+++ b/tests/test_network_audit.py
@@ -1,0 +1,39 @@
+"""Demonstration tests for the 2026-06-01 P2P/networking threat-model audit.
+
+Each test below demonstrates one audit finding and is marked
+``@pytest.mark.xfail(strict=True)`` -- strict mode means the test MUST fail
+today (the gap is real) and forces the marker's removal when the finding is
+remediated (the xfail would otherwise "unexpectedly pass" and error the
+suite). See docs/superpowers/audits/2026-06-01-network-p2p-audit.md.
+
+Availability findings use a *bounded-observation* convention: drive the
+uncapped behavior only up to a small, safe bound and assert the missing cap
+is observable. No test exhausts real memory, disk, or wall-clock.
+"""
+
+from cancelchain.database import db
+from cancelchain.models import ChainFillBlock
+
+# Per-finding tests (and any further imports: pytest, Block, Node, ...) are
+# appended below this scaffold. Shared fixtures (app, *_wallet,
+# requests_proxy, remote_requests_proxy, mill_block, host, time_stepper) come
+# from tests/conftest.py.
+
+
+def staged_chain_fill_count(app):
+    """Count ChainFillBlock rows currently staged -- used by availability
+    tests that assert fill_chain stages an attacker-controlled number of
+    blocks with no depth cap.
+
+    NB: this project uses SQLAlchemy 2.0 with a plain ``DeclarativeBase``
+    (``SQLAlchemy(model_class=Base)``), NOT ``db.Model`` -- so the legacy
+    ``Model.query`` attribute does NOT exist here (it raises AttributeError).
+    Use the 2.0 count idiom (mirrors ``tests/_sa_helpers._count``).
+    """
+    with app.app_context():
+        return (
+            db.session.scalar(
+                db.select(db.func.count()).select_from(ChainFillBlock)
+            )
+            or 0
+        )

--- a/tests/test_network_audit.py
+++ b/tests/test_network_audit.py
@@ -21,9 +21,7 @@ import pytest
 from cancelchain.api_client import ApiClient
 from cancelchain.block import Block
 from cancelchain.chain import REWARD
-from cancelchain.database import db
 from cancelchain.miller import Miller
-from cancelchain.models import ChainFillBlock
 from cancelchain.payload import Inflow, Outflow, encode_subject
 from cancelchain.transaction import Transaction
 from cancelchain.util import now
@@ -37,25 +35,6 @@ TEST_TARGET = 'F' * 64
 # appended below this scaffold. Shared fixtures (app, *_wallet,
 # requests_proxy, remote_requests_proxy, mill_block, host, time_stepper) come
 # from tests/conftest.py.
-
-
-def staged_chain_fill_count(app):
-    """Count ChainFillBlock rows currently staged -- used by availability
-    tests that assert fill_chain stages an attacker-controlled number of
-    blocks with no depth cap.
-
-    NB: this project uses SQLAlchemy 2.0 with a plain ``DeclarativeBase``
-    (``SQLAlchemy(model_class=Base)``), NOT ``db.Model`` -- so the legacy
-    ``Model.query`` attribute does NOT exist here (it raises AttributeError).
-    Use the 2.0 count idiom (mirrors ``tests/_sa_helpers._count``).
-    """
-    with app.app_context():
-        return (
-            db.session.scalar(
-                db.select(db.func.count()).select_from(ChainFillBlock)
-            )
-            or 0
-        )
 
 
 def _hostile_block(prev_block: Block, wallet, idx_offset: int = 1) -> Block:
@@ -83,7 +62,7 @@ def _hostile_block(prev_block: Block, wallet, idx_offset: int = 1) -> Block:
         'hostile peer drives an attacker-controlled number of request_block '
         'round-trips + ChainFillBlock commits. Remove this marker when '
         'fill_chain honors a configurable depth cap (contract: '
-        "app.config['CC_MAX_CHAIN_FILL_DEPTH']) and aborts the walk at the "
+        "app.config['MAX_CHAIN_FILL_DEPTH']) and aborts the walk at the "
         'threshold.'
     ),
 )
@@ -93,7 +72,7 @@ def test_n1_fill_chain_has_no_depth_cap(app, time_machine, wallet) -> None:
     request_block calls + ChainFillBlock commits.
 
     The remediation contract is a configurable depth cap read from
-    app.config['CC_MAX_CHAIN_FILL_DEPTH']; the walk must abort once it has
+    app.config['MAX_CHAIN_FILL_DEPTH']; the walk must abort once it has
     requested that many ancestors. Today there is no such cap, so the walk
     runs until our patched request_block hits its own SAFETY bound.
     """
@@ -112,7 +91,7 @@ def test_n1_fill_chain_has_no_depth_cap(app, time_machine, wallet) -> None:
         assert Block.from_db(tip2.block_hash) is None
 
         # Remediation contract: cap the ancestor walk at this depth.
-        app.config['CC_MAX_CHAIN_FILL_DEPTH'] = 3
+        app.config['MAX_CHAIN_FILL_DEPTH'] = 3
 
         call_count = [0]
         # SAFETY: cap our fake peer so today's uncapped walk terminates
@@ -133,8 +112,9 @@ def test_n1_fill_chain_has_no_depth_cap(app, time_machine, wallet) -> None:
         with patch.object(m, 'request_block', side_effect=counting_fake):
             m.fill_chain(tip2)
 
-        # TODAY: no cap -> walk runs to SAFETY=8 -> call_count == 8 ->
-        # 8 <= 3 is FALSE -> xfail. AFTER FIX: walk stops at the cap ->
+        # TODAY: no cap -> walk runs to the SAFETY bound -> call_count == 9
+        # (8 served + 1 terminating None) -> 9 <= 3 is FALSE -> xfail.
+        # AFTER FIX: walk stops at the cap ->
         # call_count <= 3 -> passes -> remove the marker.
         assert call_count[0] <= 3
 
@@ -145,7 +125,7 @@ def test_n1_fill_chain_has_no_depth_cap(app, time_machine, wallet) -> None:
         'AUDIT N2: pending_txns mempool has no admission cap; an '
         'authenticated TRANSACTOR floods unbounded distinct valid txns. '
         'Remove this marker when receive_transaction enforces a configurable '
-        "cap (contract: app.config['CC_MAX_PENDING_TXNS']) and "
+        "cap (contract: app.config['MAX_PENDING_TXNS']) and "
         'rejects/evicts past it.'
     ),
 )
@@ -154,7 +134,7 @@ def test_n2_mempool_has_no_admission_cap(app, time_machine, wallet) -> None:
     admission validation is shape+sig+txid only (no balance), so one
     transactor floods unbounded distinct valid txns.
 
-    Remediation contract: a configurable cap app.config['CC_MAX_PENDING_TXNS'].
+    Remediation contract: a configurable cap app.config['MAX_PENDING_TXNS'].
     """
     with app.app_context():
         now_dt = now()
@@ -162,7 +142,7 @@ def test_n2_mempool_has_no_admission_cap(app, time_machine, wallet) -> None:
         m = Miller(milling_wallet=wallet)
 
         # Remediation contract: cap the mempool BEFORE submitting.
-        app.config['CC_MAX_PENDING_TXNS'] = 3
+        app.config['MAX_PENDING_TXNS'] = 3
 
         # Submit 6 DISTINCT structurally-valid signed txns. Each varies the
         # subject so its txid differs; validate() is shape+sig+txid only


### PR DESCRIPTION
## What

The **third threat-modeled audit** of cancelchain, executing the [design+plan from #112](https://github.com/gumptionthomas/cancelchain/pull/112). Targets the **P2P/networking layer** — Node/Miller orchestration (gossip, `fill_chain`/`fill_peer`, `request_*`, the `pending_txns` mempool, the loop-guard, the `ChainFill` staging lifecycle) + the peer-facing API views. Ships the audit report + one `@pytest.mark.xfail(strict=True)` demonstration per finding. Remediation is separate downstream work.

## Result: 0 Critical / 1 High / 2 Medium / 1 Low

Produced by a three-phase multi-agent fan-out — **23 candidate attacks → 7 survived adversarial refutation → 4 deduped findings**. The trusted-input boundary holds: **every finding is an availability/resource-bounding gap on an otherwise-validated, otherwise-authorized path** ("valid, authenticated peer input in hostile volume/depth/pattern"). None reduces to a verification-validity or auth break.

| ID | Sev | Finding |
|---|---|---|
| N1 | **High** | `fill_chain` walks an attacker-controlled ancestor chain with no depth cap (one HTTP round-trip + one `ChainFillBlock` commit each) and `request_block` never verifies the returned block's hash == requested `prev_hash`, so the walk never terminates |
| N2 | Medium | `pending_txns` mempool has no admission cap; floods grow unbounded and every expiry/mill/pending scan re-materializes the whole pool (O(mempool)) |
| N3 | Medium | An already-pending txn is re-gossiped on every receipt (1→N fan-out); the block path already has the dedup-before-gossip guard the txn path lacks |
| N4 | Low | The Celery broker publish runs synchronously on the web-request thread (bounded ~16s by Celery defaults) |

**Recurring root:** a missing-bound pattern (no `MAX_DEPTH`/`MAX_PENDING`/rate-guard anywhere) + validation deferred past the point resources are committed. Full cross-cutting analysis and a "bound every attacker-influenced accumulator" recommendation are in the report.

## Demonstration tests

`tests/test_network_audit.py` — 4 strict-xfail demonstrations. Availability findings use a **bounded-observation** convention (small safe bounds; no test exhausts real resources). Each fails today on its intended gap and flips to a passing regression when remediated:
- `--runxfail`: `assert 9 <= 3` (N1), `assert 6 <= 3` (N2), `calls == [txid]` (N3), `tid != tid` (N4).
- Normal: **4 xfailed, 0 xpassed**; full suite **286 passed + 4 xfailed**.

## Review

Converged through an internal cross-model review before this PR. It caught a flip-blocking config-key bug (N1/N2 set `app.config['CC_MAX_*']`, but `EnvAppSettings` strips the `CC_` prefix — the strict-xfail would never have flipped on a convention-following remediation) and confirmed each demonstration fails for the right reason and each finding is real and in-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)