### PR TITLE
perf(mempool): SQL-filter expiry instead of re-parsing the whole pool

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -93,15 +93,11 @@ RFC 9421 HTTP Message Signatures is deferred until there is third-party-client d
 
 ---
 
-## (perf follow-up) Indexed/SQL-filtered mempool expiry + reads
-
-`discard_expired_pending_txns` / `PendingTxnView` / `create_block` iterate the full pool re-parsing every row via `PendingTxnSet.__iter__`. Now bounded to O(cap) by the N2 admission cap (`CC_MAX_PENDING_TXNS`); convert to an indexed timestamp query to drop the Python re-parse on the mill critical path. Surfaced by the 2026-06-01 P2P/networking audit (N2 finding).
-
----
-
 ## Closed items (historical reference)
 
 Each removed from this file when the closing PR landed. Keep here for now so future Claude sessions can see what was on the list.
+
+- ✅ **(perf follow-up) Indexed/SQL-filtered mempool expiry** — closed by PR [#118](https://github.com/gumptionthomas/cancelchain/pull/118). Added an index on `pending_txn.timestamp` (folded into the pre-1.0 base migration); `discard_expired_pending_txns` now uses `PendingTxnDAO.delete_expired(cutoff)` — an indexed SQL filter (`timestamp < cutoff`) + single-commit ORM `session.delete()` per row (so the `ioflows` cascade removes children — the FK has no `ON DELETE CASCADE`); `Miller.pending_chain_txns` iterates `query_json(expired=cutoff)` so the mill path only parses live rows; new `block.expiry_cutoff(reference_dt)` is the single-source cutoff helper. Open-boundary semantics preserved. Surfaced by the 2026-06-01 P2P/networking audit (N2 finding).
 
 - ✅ **P2P/networking threat-modeled audit — fully closed (0 Critical / 0 High / 0 Medium / 0 Low)** — closed by docs PR [#112](https://github.com/gumptionthomas/cancelchain/pull/112) (design + plan) and impl PRs below. All four findings (N1–N4) are remediated; every `@pytest.mark.xfail(strict=True)` demonstration in `tests/test_network_audit.py` is now a passing regression test. The P2P/networking audit is **fully closed at 0/0/0/0**. Originating report: [P2P/networking audit](audits/2026-06-01-network-p2p-audit.md).
   - ✅ **N1 (High) — `fill_chain` unbounded ancestor walk** — configurable depth cap (`CC_MAX_CHAIN_FILL_DEPTH`) + returned-hash check in `request_block`. Closed by PR #114.

--- a/src/cancelchain/api.py
+++ b/src/cancelchain/api.py
@@ -27,7 +27,7 @@ from pydantic import (
 
 from cancelchain import signing
 from cancelchain.api_client import PEER_HOST_HEADER
-from cancelchain.block import TXN_TIMEOUT, Block
+from cancelchain.block import Block, expiry_cutoff
 from cancelchain.cache import cache
 from cancelchain.chain import Chain
 from cancelchain.exceptions import (
@@ -606,7 +606,7 @@ class PendingTxnView(MethodView):
             node, _, _ = node_lc_dao()
             node.discard_expired_pending_txns()
             earliest = args.get('earliest')
-            expired = now() - TXN_TIMEOUT
+            expired = expiry_cutoff(now())
             pending_json = node.pending_txns.query_json(
                 earliest=earliest, expired=expired
             )

--- a/src/cancelchain/block.py
+++ b/src/cancelchain/block.py
@@ -51,15 +51,27 @@ TXN_TIMEOUT = timedelta(hours=4)
 MISSED_TARGET_MSG = 'Missed target'
 
 
+def expiry_cutoff(reference_dt: datetime) -> datetime:
+    """The expiry boundary datetime relative to reference_dt: a pending
+    txn is expired iff its timestamp is strictly older than this cutoff
+    (timestamp < cutoff). This is the SQL-filterable form of the
+    `txn_is_expired` rule — callers pass `expiry_cutoff(now())` as the
+    `expired` cutoff to PendingTxnDAO.json_datas / delete_expired, which
+    keep `timestamp >= cutoff` so the boundary txn stays alive.
+    """
+    return reference_dt - TXN_TIMEOUT
+
+
 def txn_is_expired(txn_timestamp_dt: datetime, reference_dt: datetime) -> bool:
     """A txn is expired iff its timestamp is strictly older than
     TXN_TIMEOUT relative to reference_dt. Open boundary: a txn exactly
     TXN_TIMEOUT old (txn_timestamp_dt == reference_dt - TXN_TIMEOUT) is
     NOT expired. Single source of truth for the expiry boundary — every
     other site (Node.discard_expired_pending_txns, Miller.pending_chain_txns,
-    and the PendingTxnDAO.json_datas SQL query) applies this same rule.
+    and the PendingTxnDAO.json_datas SQL query) applies this same rule
+    via `expiry_cutoff`.
     """
-    return txn_timestamp_dt < reference_dt - TXN_TIMEOUT
+    return txn_timestamp_dt < expiry_cutoff(reference_dt)
 
 
 def validate_hash_diff(block_hash: str, target: str) -> bool:

--- a/src/cancelchain/migrations/versions/63d32cd7621a_initial_schema.py
+++ b/src/cancelchain/migrations/versions/63d32cd7621a_initial_schema.py
@@ -50,6 +50,7 @@ def upgrade():
     sa.PrimaryKeyConstraint('id', name=op.f('pk_pending_txn'))
     )
     with op.batch_alter_table('pending_txn', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_pending_txn_timestamp'), ['timestamp'], unique=False)
         batch_op.create_index(batch_op.f('ix_pending_txn_txid'), ['txid'], unique=True)
 
     op.create_table('transaction',
@@ -172,6 +173,7 @@ def downgrade():
     op.drop_table('transaction')
     with op.batch_alter_table('pending_txn', schema=None) as batch_op:
         batch_op.drop_index(batch_op.f('ix_pending_txn_txid'))
+        batch_op.drop_index(batch_op.f('ix_pending_txn_timestamp'))
 
     op.drop_table('pending_txn')
     op.drop_table('chain_fill')

--- a/src/cancelchain/miller.py
+++ b/src/cancelchain/miller.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from cancelchain.block import MAX_TRANSACTIONS, Block, txn_is_expired
+from cancelchain.block import MAX_TRANSACTIONS, Block, expiry_cutoff
 from cancelchain.chain import Chain
 from cancelchain.milling import milling_generator
 from cancelchain.node import Node
@@ -68,15 +68,13 @@ class Miller(Node):
     def pending_chain_txns(
         self, chain: Chain
     ) -> Generator[Transaction, None, None]:
-        reference_dt = now()
-        for txn in self.pending_txns:
-            if (
-                txn.timestamp_dt is not None
-                and not txn_is_expired(txn.timestamp_dt, reference_dt)
-                and not chain.get_transaction(
-                    txn.txid  # type: ignore[arg-type]
-                )
-            ):
+        # Filter expired txns in SQL (indexed timestamp >= cutoff) so the
+        # mill critical path only parses live rows; the already-mined
+        # check stays in Python (needs a chain lookup per txn).
+        cutoff = expiry_cutoff(now())
+        for json_data in self.pending_txns.query_json(expired=cutoff):
+            txn = Transaction.from_json(json_data)
+            if not chain.get_transaction(txn.txid):  # type: ignore[arg-type]
                 yield txn
 
     def create_block(self) -> Block:

--- a/src/cancelchain/models.py
+++ b/src/cancelchain/models.py
@@ -839,7 +839,7 @@ class PendingTxnDAO(Base):
         Integer, autoincrement=True, primary_key=True
     )
     txid: Mapped[str] = mapped_column(String(100), unique=True, index=True)
-    timestamp: Mapped[datetime.datetime] = mapped_column(DateTime)
+    timestamp: Mapped[datetime.datetime] = mapped_column(DateTime, index=True)
     json_data: Mapped[str] = mapped_column(Text)
     received: Mapped[datetime.datetime | None] = mapped_column(
         DateTime, default=datetime.datetime.utcnow
@@ -882,6 +882,32 @@ class PendingTxnDAO(Base):
         stmt = stmt.order_by(cls.timestamp, cls.txid)
         for (json_data,) in db.session.execute(stmt):
             yield json_data
+
+    @classmethod
+    def delete_expired(cls, cutoff: datetime.datetime) -> int:
+        """Delete every pending txn strictly older than `cutoff`
+        (timestamp < cutoff) in a single commit, returning the count
+        removed. Uses an indexed SQL filter to fetch only the expired
+        rows (no whole-pool re-parse) and ORM `session.delete()` per row
+        so the `ioflows` relationship cascade removes companion
+        PendingIOflowDAO rows — a Core bulk DELETE would orphan them, as
+        the FK carries no ON DELETE CASCADE. Open boundary: a txn exactly
+        at the cutoff is kept (mirrors block.txn_is_expired / json_datas).
+        """
+        rows = (
+            db.session.execute(db.select(cls).where(cls.timestamp < cutoff))
+            .scalars()
+            .all()
+        )
+        if not rows:
+            # Nothing expired: skip the commit so an empty pass stays a
+            # true no-op and never flushes unrelated in-flight session
+            # state (matches the pre-refactor per-eviction behavior).
+            return 0
+        for row in rows:
+            db.session.delete(row)
+        db.session.commit()
+        return len(rows)
 
     @classmethod
     def get(cls, txid: str) -> PendingTxnDAO | None:

--- a/src/cancelchain/node.py
+++ b/src/cancelchain/node.py
@@ -10,7 +10,7 @@ import httpx
 from flask import current_app
 from sqlalchemy.exc import SQLAlchemyError
 
-from cancelchain.block import Block, txn_is_expired
+from cancelchain.block import Block, expiry_cutoff
 from cancelchain.chain import Chain, is_genesis_block
 from cancelchain.database import db
 from cancelchain.exceptions import (
@@ -109,12 +109,7 @@ class Node:
         return txn if added else None
 
     def discard_expired_pending_txns(self) -> None:
-        reference_dt = now()
-        for txn in self.pending_txns:
-            if txn.timestamp_dt is not None and txn_is_expired(
-                txn.timestamp_dt, reference_dt
-            ):
-                self.pending_txns.discard(txn)
+        self.pending_txns.discard_expired(expiry_cutoff(now()))
 
     def send_block(
         self,

--- a/src/cancelchain/transaction.py
+++ b/src/cancelchain/transaction.py
@@ -446,6 +446,14 @@ class PendingTxnSet(MutableSet[Transaction]):
         if dao is not None:
             dao.delete()
 
+    def discard_expired(self, cutoff: datetime) -> int:
+        # Bulk-evict every pending txn strictly older than `cutoff` in a
+        # single SQL-filtered, single-commit pass (and cascade their
+        # ioflow rows). Returns the count removed. Far cheaper than
+        # iterating self and calling discard() per txn, which re-parses
+        # the whole pool and commits once per eviction.
+        return PendingTxnDAO.delete_expired(cutoff)
+
     def query_json(
         self,
         earliest: datetime | None = None,

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import patch
 
 import pytest
+from _sa_helpers import _count
 
 from cancelchain.block import TXN_TIMEOUT
 from cancelchain.chain import CURMUDGEON_PER_GRUMBLE as CPG
@@ -11,6 +12,7 @@ from cancelchain.exceptions import (
     InsufficientFundsError,
 )
 from cancelchain.miller import Miller
+from cancelchain.models import PendingIOflowDAO, PendingTxnDAO
 from cancelchain.payload import Inflow, Outflow
 from cancelchain.transaction import Transaction
 from cancelchain.util import now
@@ -78,6 +80,35 @@ def test_expired_transaction(app, time_machine, wallet):
         assert len(m.pending_txns) == 0
         m.mill_block(b1)
         assert len(b1.txns) == 1
+
+
+def test_discard_expired_removes_ioflow_children(app, time_machine, wallet):
+    """discard_expired_pending_txns evicts expired pending txns AND their
+    companion PendingIOflowDAO rows. The bulk SQL-filtered delete uses
+    ORM session.delete() per row precisely so the `ioflows` cascade fires
+    — a Core bulk DELETE would orphan the children (the FK has no ON
+    DELETE CASCADE)."""
+    with app.app_context():
+        m = Miller(milling_wallet=wallet)
+        b0 = m.create_block()
+        m.mill_block(b0)
+        now_dt = now()
+        # Build a transfer spending the mined coinbase; the inflow
+        # references an existing (mined) outflow, so add() creates a
+        # PendingIOflowDAO companion row.
+        when_dt = now_dt - TXN_TIMEOUT - datetime.timedelta(seconds=1)
+        time_machine.move_to(when_dt)
+        t0 = m.longest_chain.create_transfer(
+            wallet, m.longest_chain.balance(wallet.address), wallet.address
+        )
+        t0.sign()
+        time_machine.move_to(now_dt)
+        m.receive_transaction(t0.txid, t0.to_json())
+        assert PendingTxnDAO.count() == 1
+        assert _count(PendingIOflowDAO) == 1
+        m.discard_expired_pending_txns()
+        assert PendingTxnDAO.count() == 0
+        assert _count(PendingIOflowDAO) == 0
 
 
 def test_duplicate_transaction(app, time_machine, wallet):


### PR DESCRIPTION
## What & why

The mempool expiry path re-parsed **every** pending-txn row in Python and deleted expired txns **one-per-commit**. The N2 networking-audit follow-up flagged this — now bounded to O(cap) by the admission cap, but still doing a full-pool Python re-parse on the mill critical path and N commits per expiry sweep. This converts it to indexed SQL filters.

Closes the **"Indexed/SQL-filtered mempool expiry + reads"** roadmap item (`docs/superpowers/ROADMAP.md`), surfaced by the 2026-06-01 P2P/networking audit (N2).

## Changes

- **Index** on `pending_txn.timestamp` — folded into the single pre-1.0 base migration (`63d32cd7621a`); `cancelchain db check` parity confirmed.
- **`PendingTxnDAO.delete_expired(cutoff)`** — selects only expired rows (`timestamp < cutoff`) and deletes them in a **single commit**, via ORM `session.delete()` per row so the `ioflows` cascade removes companion `PendingIOflowDAO` children. A Core bulk `DELETE` would orphan them — the FK has **no** `ON DELETE CASCADE`. A no-rows pass skips the commit (true no-op, matches old behavior).
- **`Node.discard_expired_pending_txns`** delegates to it (was: iterate full pool + per-row commit).
- **`Miller.pending_chain_txns`** iterates `query_json(expired=cutoff)` so the mill critical path only parses **live** rows; the already-mined check stays in Python (needs a chain lookup per txn).
- **`block.expiry_cutoff(reference_dt)`** — new single-source cutoff helper; `txn_is_expired` and the API `PendingTxnView` route through it.

## Semantics preserved

Open-boundary rule (a txn **exactly** `TXN_TIMEOUT` old is **kept**) holds at every site: `delete_expired` uses `timestamp < cutoff`, `json_datas` keeps `timestamp >= cutoff`. Guarded by the existing `test_a7_e_*` boundary test.

## Tests

Full suite **295 passed / 1 skipped**, ruff + ruff format + mypy clean, `cancelchain db check` parity green. Adds `test_discard_expired_removes_ioflow_children` asserting expired eviction also removes the ioflow children (the cascade-correctness guard).

## Review

Internal cross-model (Sonnet) adversarial pass run before this PR: verified boundary semantics, cascade/orphan correctness, ordering preservation, the dropped non-null guard, migration naming/parity, and dead-import cleanup. One finding (unconditional commit on empty eviction) — addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)