### PR TITLE
fix(wc1): remove dead bespoke encrypt/decrypt hybrid (audit WC1, Low)

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -45,7 +45,7 @@ Originating spec:
 
 ## Audit remediation — wallet/crypto findings (2026-06-02)
 
-The [wallet/crypto threat-model audit](audits/2026-06-02-wallet-crypto-audit.md) (the fourth audit; design+plan PR #120) found **0 Critical / 0 High / 0 Medium / 2 Low** — no exploitable findings, 12 confirmed strengths. The two Low items are non-exploitable defense-in-depth / hygiene residuals with strict-xfail demonstrations in `tests/test_wallet_audit.py`:
+The [wallet/crypto threat-model audit](audits/2026-06-02-wallet-crypto-audit.md) (the fourth audit; design+plan PR #120) found **0 Critical / 0 High / 0 Medium / 2 Low** — no exploitable findings, 12 confirmed strengths. The two Low items are non-exploitable defense-in-depth / hygiene residuals, each with a demonstration in `tests/test_wallet_audit.py` (strict-xfail while open, a passing regression once remediated):
 
 - ✅ **WC1 (Low) — remove dead bespoke `encrypt`/`decrypt`** — closed. Removed `Wallet.encrypt`/`Wallet.decrypt` (and the now-unused `AESGCM` import + `GCM_NONCE_SIZE`/`AES_SESSION_KEY_SIZE` constants) and their tests; `test_wc1_bespoke_encrypt_decrypt_removed` is now a passing regression.
 - **WC2 (Low) — enforce a public-exponent check on key import.** `Wallet.__init__` validates `key_size` but not the exponent; a 3072-bit `e=3` key is accepted. Reject `e != 65537` alongside the size check. Not exploitable (pyca's strict verifier forecloses cube-root forgery) — defense-in-depth + key-profile consistency. Test: `test_wc2_import_rejects_degenerate_exponent`.

--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -47,7 +47,7 @@ Originating spec:
 
 The [wallet/crypto threat-model audit](audits/2026-06-02-wallet-crypto-audit.md) (the fourth audit; design+plan PR #120) found **0 Critical / 0 High / 0 Medium / 2 Low** — no exploitable findings, 12 confirmed strengths. The two Low items are non-exploitable defense-in-depth / hygiene residuals with strict-xfail demonstrations in `tests/test_wallet_audit.py`:
 
-- **WC1 (Low) — remove dead bespoke `encrypt`/`decrypt`.** The RSA-OAEP + AES-GCM hybrid has zero `src/` callers after PR #111; recommend removal (and its tests). Test: `test_wc1_bespoke_encrypt_decrypt_removed`.
+- ✅ **WC1 (Low) — remove dead bespoke `encrypt`/`decrypt`** — closed. Removed `Wallet.encrypt`/`Wallet.decrypt` (and the now-unused `AESGCM` import + `GCM_NONCE_SIZE`/`AES_SESSION_KEY_SIZE` constants) and their tests; `test_wc1_bespoke_encrypt_decrypt_removed` is now a passing regression.
 - **WC2 (Low) — enforce a public-exponent check on key import.** `Wallet.__init__` validates `key_size` but not the exponent; a 3072-bit `e=3` key is accepted. Reject `e != 65537` alongside the size check. Not exploitable (pyca's strict verifier forecloses cube-root forgery) — defense-in-depth + key-profile consistency. Test: `test_wc2_import_rejects_degenerate_exponent`.
 
 **Observations (no finding, address opportunistically):** `schema.validate_signature` performs no key→address binding (safe only because every caller runs `validate_pk_address` first — a load-bearing upstream invariant); the KDF behind `BestAvailableEncryption` on encrypted exports is unpinned (operator-local).

--- a/docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md
+++ b/docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md
@@ -7,7 +7,7 @@
 
 ## Executive summary
 
-**0 Critical / 0 High / 0 Medium / 2 Low.**
+**0 Critical / 0 High / 0 Medium / 2 Low** (at audit time). **Remediation progress: WC1 closed; 1 Low (WC2) open.**
 
 The fan-out produced **no exploitable cryptographic findings**. The crypto root of trust is well-constructed: identity is bound to the public key by a sound double-hash, that binding is re-certified before every signature check on both the transaction and the request-signing paths, signature verification delegates to pyca's strict full-width PKCS#1 v1.5 verifier (foreclosing small-exponent forgery), and key import is fail-closed (malformed material becomes `InvalidKeyError`, never a silent fresh key). Twelve such controls are recorded as **confirmed strengths** below.
 
@@ -20,7 +20,7 @@ Adversarial verification refuted all eight de-duplicated candidates as exploitab
 
 | id | adversary | severity | description | status | demonstration test |
 |---|---|---|---|---|---|
-| WC1 | confused-primitive / dead-code | Low | `Wallet.encrypt`/`Wallet.decrypt` (bespoke RSA-OAEP + AES-GCM hybrid) have **zero `src/` callers** after PR #111 removed the challenge/response handshake — only tests exercise them. Unreachable bespoke crypto is a re-introduction hazard and standing maintenance/attack surface. Not exploitable (unreachable). | Open (Low) | `test_wc1_bespoke_encrypt_decrypt_removed` (xfail) |
+| WC1 | confused-primitive / dead-code | Low | `Wallet.encrypt`/`Wallet.decrypt` (bespoke RSA-OAEP + AES-GCM hybrid) have **zero `src/` callers** after PR #111 removed the challenge/response handshake — only tests exercise them. Unreachable bespoke crypto is a re-introduction hazard and standing maintenance/attack surface. Not exploitable (unreachable). | ✅ Remediated — methods + `AESGCM`/nonce-size constants removed; `test_wc1_bespoke_encrypt_decrypt_removed` is now a passing regression. | `test_wc1_bespoke_encrypt_decrypt_removed` (regression) |
 | WC2 | malicious key supplier | Low | `Wallet.__init__` validates `isinstance(RSA*)` + `key_size == 3072` but **does not validate the public exponent**. A 3072-bit `e=3` key loads and is accepted (pyca does not enforce a minimum exponent). Not exploitable today — pyca's strict PKCS#1 v1.5 verifier forecloses cube-root forgery, and a self-chosen weak key derives its own distinct address (no cross-address/cross-node impact) — but accepting non-standard exponents is unnecessary and inconsistent with the node's own `e=65537` generation. | Open (Low) | `test_wc2_import_rejects_degenerate_exponent` (xfail) |
 
 ## Adversary traces

--- a/src/cancelchain/wallet.py
+++ b/src/cancelchain/wallet.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric.rsa import (
     RSAPrivateKey,
     RSAPublicKey,
 )
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from cancelchain.exceptions import InvalidKeyError, NoPrivateKeyError
 from cancelchain.milling import mill_hash_bin
@@ -23,8 +22,6 @@ RSAKey = RSAPrivateKey | RSAPublicKey
 
 ADDRESS_TAG = 'CC'
 KEY_SIZE = 3072
-GCM_NONCE_SIZE = 12
-AES_SESSION_KEY_SIZE = 16
 
 
 def b58decode(s: str) -> bytes:
@@ -205,38 +202,6 @@ class Wallet:
             # TypeError: wrong types from caller.
             return False
         return True
-
-    def encrypt(self, data: bytes) -> str:
-        session_key = os.urandom(AES_SESSION_KEY_SIZE)
-        enc_session_key = self.public_key.encrypt(
-            session_key,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA256(),
-                label=None,
-            ),
-        )
-        nonce = os.urandom(GCM_NONCE_SIZE)
-        ciphertext_with_tag = AESGCM(session_key).encrypt(nonce, data, None)
-        return b64encode(enc_session_key + nonce + ciphertext_with_tag)
-
-    def decrypt(self, msg: str) -> bytes:
-        if self.private_key is None:
-            raise NoPrivateKeyError()
-        raw = b64decode(msg)
-        key_size_bytes = self.private_key.key_size // 8
-        enc_session_key = raw[:key_size_bytes]
-        nonce = raw[key_size_bytes : key_size_bytes + GCM_NONCE_SIZE]
-        ciphertext = raw[key_size_bytes + GCM_NONCE_SIZE :]
-        session_key = self.private_key.decrypt(
-            enc_session_key,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA256(),
-                label=None,
-            ),
-        )
-        return AESGCM(session_key).decrypt(nonce, ciphertext, None)
 
     def to_dict(self) -> dict[str, str]:
         return {'private_key': self.private_key_b58}

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -32,16 +32,6 @@ def test_create_invalid_key():
         Wallet(ks='foo')
 
 
-def test_crypto(wallet):
-    s = 'This is a secret'
-    msg = wallet.encrypt(s.encode())
-    assert msg != s
-    wallet2 = Wallet()
-    with pytest.raises(ValueError):
-        wallet2.decrypt(msg)
-    assert wallet.decrypt(msg).decode() == s
-
-
 def test_create_from_key(
     wallet_private_key_b58,
     wallet_public_key_b64,
@@ -133,13 +123,6 @@ def test_wallet_verify_rejects_mutated_payload():
 def test_wallet_verify_rejects_garbage_signature():
     w = Wallet()
     assert w.validate_signature(b'data', 'garbagebase64==') is False
-
-
-def test_wallet_encrypt_decrypt_round_trip():
-    w = Wallet()
-    plaintext = b'session-challenge-payload'
-    ciphertext = w.encrypt(plaintext)
-    assert w.decrypt(ciphertext) == plaintext
 
 
 def test_wallet_encrypted_pem_round_trip(tmp_path):

--- a/tests/test_wallet_audit.py
+++ b/tests/test_wallet_audit.py
@@ -22,17 +22,12 @@ from cancelchain.exceptions import InvalidKeyError
 from cancelchain.wallet import KEY_SIZE, Wallet, b64encode
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='WC1: the bespoke encrypt/decrypt hybrid is dead (zero src callers '
-    'post-#111) and should be removed; flips to passing once it is gone.',
-)
 def test_wc1_bespoke_encrypt_decrypt_removed():
-    """WC1 (Low) — the RSA-OAEP + AES-GCM hybrid `Wallet.encrypt` /
-    `Wallet.decrypt` has no production caller after PR #111 replaced the
-    challenge/response handshake (only tests reference it). Unreachable
-    bespoke crypto is a re-introduction hazard and standing surface; the
-    recommended remediation is removal. This asserts the end state.
+    """WC1 (Low) — REMEDIATED. The RSA-OAEP + AES-GCM hybrid `Wallet.encrypt`
+    / `Wallet.decrypt` had no production caller after PR #111 replaced the
+    challenge/response handshake (only tests referenced it). Unreachable
+    bespoke crypto is a re-introduction hazard and standing surface; it was
+    removed. This regression asserts it stays gone.
     """
     assert not hasattr(Wallet, 'encrypt')
     assert not hasattr(Wallet, 'decrypt')

--- a/tests/test_wallet_audit.py
+++ b/tests/test_wallet_audit.py
@@ -1,11 +1,13 @@
 """Demonstration tests for the 2026-06-02 wallet/crypto threat-model audit.
 
-Each test below demonstrates one audit finding and is marked
+Each test below demonstrates one audit finding and asserts the DESIRED
+post-fix behavior. While a finding is still open it carries
 ``@pytest.mark.xfail(strict=True)`` — strict mode means the test MUST fail
-today (the gap is real) and forces the marker's removal when the finding is
-remediated (the xfail would otherwise "unexpectedly pass" and error the
-suite). Each test asserts the DESIRED post-fix behavior, so it flips to a
-passing regression when the fix lands. See
+today (the gap is real) and forces the marker's removal at remediation (the
+xfail would otherwise "unexpectedly pass" and error the suite). Once a finding
+is remediated the marker is dropped and the test becomes a passing
+regression; tests below may therefore be a mix of strict-xfail (open) and
+plain regression (closed). See
 docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md.
 
 The audit found 0 exploitable findings (0 Critical / 0 High / 0 Medium); the


### PR DESCRIPTION
## What

Remediates **WC1 (Low)** from the [wallet/crypto audit](docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md): removes the dead bespoke RSA-OAEP + AES-GCM hybrid `Wallet.encrypt` / `Wallet.decrypt`.

## Why

Both methods had **zero production callers** after PR #111 replaced the challenge/response auth handshake with `cc-sig-v1` — only tests referenced them. Unreachable bespoke crypto is a standing re-introduction hazard (one refactor away from a reachable path) and pure attack/maintenance surface. The audit recommended removal (smallest surface).

## Changes

- Remove `Wallet.encrypt` / `Wallet.decrypt`, plus the now-unused `AESGCM` import and `GCM_NONCE_SIZE` / `AES_SESSION_KEY_SIZE` constants. (`os`, `padding`, `hashes`, `b64decode`, `NoPrivateKeyError` all remain in use elsewhere — confirmed by ruff + a repo-wide sweep.)
- Remove the two tests that exercised them (`test_crypto`, `test_wallet_encrypt_decrypt_round_trip`).
- Flip the WC1 demonstration from strict-xfail to a **passing regression** (`test_wc1_bespoke_encrypt_decrypt_removed` now asserts the methods stay gone).
- Mark WC1 closed in the audit report (headline → 0/0/0/1) and the roadmap.

No production behavior changes (the removed code was unreachable). Remaining references live only in frozen historical `docs/superpowers/` migration artifacts (not rewritten — dated records of past state).

## Verification

Suite: **294 passed, 1 skipped, 1 xfailed** (only WC2 remains open). ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)