### PR TITLE
fix(wc2): reject non-standard public exponents on key import (audit WC2, Low)

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -48,7 +48,9 @@ Originating spec:
 The [wallet/crypto threat-model audit](audits/2026-06-02-wallet-crypto-audit.md) (the fourth audit; design+plan PR #120) found **0 Critical / 0 High / 0 Medium / 2 Low** — no exploitable findings, 12 confirmed strengths. The two Low items are non-exploitable defense-in-depth / hygiene residuals with strict-xfail demonstrations in `tests/test_wallet_audit.py`:
 
 - ✅ **WC1 (Low) — remove dead bespoke `encrypt`/`decrypt`** — closed. Removed `Wallet.encrypt`/`Wallet.decrypt` (and the now-unused `AESGCM` import + `GCM_NONCE_SIZE`/`AES_SESSION_KEY_SIZE` constants) and their tests; `test_wc1_bespoke_encrypt_decrypt_removed` is now a passing regression.
-- **WC2 (Low) — enforce a public-exponent check on key import.** `Wallet.__init__` validates `key_size` but not the exponent; a 3072-bit `e=3` key is accepted. Reject `e != 65537` alongside the size check. Not exploitable (pyca's strict verifier forecloses cube-root forgery) — defense-in-depth + key-profile consistency. Test: `test_wc2_import_rejects_degenerate_exponent`.
+- ✅ **WC2 (Low) — enforce a public-exponent check on key import** — closed. `Wallet.__init__` now rejects any imported key whose public exponent ≠ `PUBLIC_EXPONENT` (65537, the node's own generation exponent, extracted as a shared constant), alongside the existing `key_size` check; `test_wc2_import_rejects_degenerate_exponent` is now a passing regression.
+
+**Both findings remediated — the wallet/crypto audit is fully closed (0/0/0/0 open).**
 
 **Observations (no finding, address opportunistically):** `schema.validate_signature` performs no key→address binding (safe only because every caller runs `validate_pk_address` first — a load-bearing upstream invariant); the KDF behind `BestAvailableEncryption` on encrypted exports is unpinned (operator-local).
 

--- a/docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md
+++ b/docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md
@@ -7,7 +7,7 @@
 
 ## Executive summary
 
-**0 Critical / 0 High / 0 Medium / 2 Low** (at audit time). **Remediation progress: WC1 closed; 1 Low (WC2) open.**
+**0 Critical / 0 High / 0 Medium / 2 Low** (at audit time). **Both Low items (WC1, WC2) are now remediated — audit fully closed; every demonstration in `tests/test_wallet_audit.py` is a passing regression.**
 
 The fan-out produced **no exploitable cryptographic findings**. The crypto root of trust is well-constructed: identity is bound to the public key by a sound double-hash, that binding is re-certified before every signature check on both the transaction and the request-signing paths, signature verification delegates to pyca's strict full-width PKCS#1 v1.5 verifier (foreclosing small-exponent forgery), and key import is fail-closed (malformed material becomes `InvalidKeyError`, never a silent fresh key). Twelve such controls are recorded as **confirmed strengths** below.
 
@@ -21,7 +21,7 @@ Adversarial verification refuted all eight de-duplicated candidates as exploitab
 | id | adversary | severity | description | status | demonstration test |
 |---|---|---|---|---|---|
 | WC1 | confused-primitive / dead-code | Low | `Wallet.encrypt`/`Wallet.decrypt` (bespoke RSA-OAEP + AES-GCM hybrid) have **zero `src/` callers** after PR #111 removed the challenge/response handshake — only tests exercise them. Unreachable bespoke crypto is a re-introduction hazard and standing maintenance/attack surface. Not exploitable (unreachable). | ✅ Remediated — methods + `AESGCM`/nonce-size constants removed; `test_wc1_bespoke_encrypt_decrypt_removed` is now a passing regression. | `test_wc1_bespoke_encrypt_decrypt_removed` (regression) |
-| WC2 | malicious key supplier | Low | `Wallet.__init__` validates `isinstance(RSA*)` + `key_size == 3072` but **does not validate the public exponent**. A 3072-bit `e=3` key loads and is accepted (pyca does not enforce a minimum exponent). Not exploitable today — pyca's strict PKCS#1 v1.5 verifier forecloses cube-root forgery, and a self-chosen weak key derives its own distinct address (no cross-address/cross-node impact) — but accepting non-standard exponents is unnecessary and inconsistent with the node's own `e=65537` generation. | Open (Low) | `test_wc2_import_rejects_degenerate_exponent` (xfail) |
+| WC2 | malicious key supplier | Low | `Wallet.__init__` validated `isinstance(RSA*)` + `key_size == 3072` but **not the public exponent**. A 3072-bit `e=3` key loaded and was accepted (pyca does not enforce a minimum exponent). Not exploitable — pyca's strict PKCS#1 v1.5 verifier forecloses cube-root forgery, and a self-chosen weak key derives its own distinct address (no cross-address/cross-node impact) — but accepting non-standard exponents was unnecessary and inconsistent with the node's own `e=65537` generation. | ✅ Remediated — `Wallet.__init__` now rejects any imported key whose exponent ≠ `PUBLIC_EXPONENT` (65537); `test_wc2_import_rejects_degenerate_exponent` is now a passing regression. | `test_wc2_import_rejects_degenerate_exponent` (regression) |
 
 ## Adversary traces
 

--- a/src/cancelchain/wallet.py
+++ b/src/cancelchain/wallet.py
@@ -22,6 +22,7 @@ RSAKey = RSAPrivateKey | RSAPublicKey
 
 ADDRESS_TAG = 'CC'
 KEY_SIZE = 3072
+PUBLIC_EXPONENT = 65537
 
 
 def b58decode(s: str) -> bytes:
@@ -122,11 +123,17 @@ class Wallet:
             key = import_key(ks, passphrase=passphrase)
         else:
             key = rsa.generate_private_key(
-                public_exponent=65537, key_size=KEY_SIZE
+                public_exponent=PUBLIC_EXPONENT, key_size=KEY_SIZE
             )
         if not isinstance(key, (RSAPrivateKey, RSAPublicKey)):
             raise InvalidKeyError()
         if key.key_size != KEY_SIZE:
+            raise InvalidKeyError()
+        # Reject non-standard public exponents on import (audit WC2). pyca's
+        # loader accepts degenerate exponents (e.g. e=3); pin e to the same
+        # value this node generates so every accepted key shares one profile.
+        pub = key.public_key() if isinstance(key, RSAPrivateKey) else key
+        if pub.public_numbers().e != PUBLIC_EXPONENT:
             raise InvalidKeyError()
         self.key: RSAKey = key
 

--- a/tests/test_wallet_audit.py
+++ b/tests/test_wallet_audit.py
@@ -33,20 +33,14 @@ def test_wc1_bespoke_encrypt_decrypt_removed():
     assert not hasattr(Wallet, 'decrypt')
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='WC2: Wallet.__init__ validates key_size but not the public '
-    'exponent, so a degenerate e=3 key is accepted; flips to passing once an '
-    'exponent check (e == 65537) rejects it.',
-)
 def test_wc2_import_rejects_degenerate_exponent():
-    """WC2 (Low) — `Wallet.__init__` checks `isinstance(RSA*)` + `key_size ==
-    3072` but not the public exponent (pyca does not enforce a minimum). A
-    3072-bit `e=3` key loads and is accepted. Not exploitable today (pyca's
-    strict PKCS#1 v1.5 verifier forecloses cube-root forgery, and a weak
-    self-chosen key derives its own distinct address), but accepting
-    non-standard exponents is unnecessary and inconsistent with the node's own
-    e=65537 generation. The desired behavior is rejection on import.
+    """WC2 (Low) — REMEDIATED. `Wallet.__init__` previously checked
+    `isinstance(RSA*)` + `key_size == 3072` but not the public exponent (pyca
+    does not enforce a minimum), so a 3072-bit `e=3` key loaded and was
+    accepted. It now rejects any imported key whose exponent is not 65537
+    (matching the node's own generation). Not a live vulnerability (pyca's
+    strict PKCS#1 v1.5 verifier forecloses cube-root forgery) — defense-in-
+    depth + key-profile consistency. This regression asserts the rejection.
     """
     weak_key = rsa.generate_private_key(public_exponent=3, key_size=KEY_SIZE)
     pub_b64 = b64encode(


### PR DESCRIPTION
## What

Remediates **WC2 (Low)** from the [wallet/crypto audit](docs/superpowers/audits/2026-06-02-wallet-crypto-audit.md): `Wallet.__init__` now rejects any imported RSA key whose public exponent is not `65537`.

> ⚠️ **Stacked on #122** (fix/wc1). The base is the WC1 branch so this PR shows only the WC2 diff; merge **after** #122 (GitHub auto-retargets this to `main` when #122 merges).

## Why

`Wallet.__init__` validated `isinstance(RSA*)` + `key_size == 3072` but **not the public exponent**. pyca's loader does not enforce a minimum exponent, so a 3072-bit `e=3` key loaded and was accepted. **Not exploitable** — pyca's strict PKCS#1 v1.5 verifier forecloses cube-root forgery, and a weak self-chosen key derives its own distinct hash address (no cross-address/cross-node impact) — but it's unnecessary surface and inconsistent with the node's own `e=65537` generation.

## Changes

- Extract `PUBLIC_EXPONENT = 65537` as a shared constant; use it for both key generation and a new import-time check.
- `Wallet.__init__` now raises `InvalidKeyError` for any key (private or public) whose `public_numbers().e != PUBLIC_EXPONENT`, alongside the existing `key_size` check.
- Flip the WC2 demonstration from strict-xfail to a **passing regression**.
- Mark WC2 closed in the audit report and roadmap — **the wallet/crypto audit is now fully closed (0/0/0/0 open)**.

All existing wallets/fixtures use `e=65537`, so nothing breaks.

## Verification

Suite: **295 passed, 1 skipped, 0 xfailed** (both WC demonstrations are now passing regressions). ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)