### PR TITLE
test(signing): fix int(time.time()) truncation flake in freshness tests

### DIFF
--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -64,19 +64,29 @@ def test_verify_rejects_wrong_node():
 
 
 def test_verify_rejects_stale_timestamp():
+    # Pin a single `now` for both the signed timestamp and verify(): using
+    # int(time.time()) independently on each side lets a 1-second tick land
+    # between them, collapsing the boundary check (the just-past-boundary
+    # offset + truncation can net to exactly FRESHNESS_SECONDS, which the
+    # strict `>` does not reject) — a real flake. verify() exposes `now`
+    # precisely for this.
     w = Wallet()
-    old = int(time.time()) - (signing.FRESHNESS_SECONDS + 1)
+    now = int(time.time())
+    old = now - (signing.FRESHNESS_SECONDS + 1)
     headers = signing.sign_headers(w, timestamp=old, **REQ)
     with pytest.raises(signing.SignatureError):
-        signing.verify(headers, **REQ)
+        signing.verify(headers, now=now, **REQ)
 
 
 def test_verify_rejects_future_timestamp():
+    # See test_verify_rejects_stale_timestamp: pin one `now` for both sides
+    # so the int(time.time()) truncation race cannot collapse the boundary.
     w = Wallet()
-    future = int(time.time()) + (signing.FRESHNESS_SECONDS + 1)
+    now = int(time.time())
+    future = now + (signing.FRESHNESS_SECONDS + 1)
     headers = signing.sign_headers(w, timestamp=future, **REQ)
     with pytest.raises(signing.SignatureError):
-        signing.verify(headers, **REQ)
+        signing.verify(headers, now=now, **REQ)
 
 
 def test_verify_rejects_pubkey_address_mismatch():


### PR DESCRIPTION
## What

Fixes the time-boundary flake in `tests/test_signing.py::test_verify_rejects_future_timestamp` (and the latent same-shape risk in `test_verify_rejects_stale_timestamp`).

## Root cause

The test computed `future = int(time.time()) + (FRESHNESS_SECONDS + 1)` at one instant (T0), then `verify()` read `int(time.time())` again at T1. `int()` truncates, so a 1-second tick landing between T0 and T1 collapsed the gap to exactly `FRESHNESS_SECONDS` — and `verify`'s strict `abs(current - ts) > FRESHNESS_SECONDS` does **not** reject the boundary → `DID NOT RAISE`. Observed on PR #120 (a docs-only PR — one 3.13 job failed while its parallel job passed on identical code).

## Fix

Pin a single `now` and pass it to `verify(now=...)` — the injection seam `verify()` already exposes for exactly this. Both sides now use the identical integer, so the offset is deterministically `FRESHNESS_SECONDS + 1` and the boundary race is gone. No magic margin widening, no new dependency.

## Verification

10/10 loop runs green on both tests; full suite **295 passed, 1 skipped**; ruff + format + mypy clean. Test-only change.

Closes the known-flake item tracked from the wallet/crypto audit session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)