### PR TITLE
docs(audit): CLI / operator-surface threat-model audit — 0/0/1/1 + demonstration tests

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -47,7 +47,7 @@ Originating spec:
 
 The [CLI / operator-surface threat-model audit](audits/2026-06-02-cli-audit.md) (the fifth audit; design+plan PR #126) found **0 Critical / 0 High / 1 Medium / 1 Low** — 9 of 11 candidates refuted (cross-references to the closed verification/auth audits, operator self-harm, or UX nits), 10 confirmed strengths. The two findings have strict-xfail demonstrations in `tests/test_cli_audit.py`:
 
-- **CLI1 (Medium) — `wallet create` writes the private key world-readable & unencrypted.** `Wallet.to_file` → `open(filename, 'wb')` lands at the process umask (no `chmod 0o600`, no `O_EXCL`, no passphrase); a co-located local user reads a live signing identity. Fix: create the PEM atomically owner-only (`os.open(..., O_EXCL, 0o600)` or temp-file + `chmod 0o600` + rename); optionally add `--passphrase`. Test: `test_cli1_wallet_create_writes_private_key_0600`.
+- **CLI1 (Medium) — `wallet create` writes the private key world-readable & unencrypted.** `Wallet.to_file` → `open(filename, 'wb')` lands at the process umask (no `chmod 0o600`, no `O_EXCL`, no passphrase); a co-located local user reads a live signing identity. Fix: create the PEM atomically owner-only (`os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)` or temp-file + `chmod 0o600` + rename); optionally add `--passphrase`. Test: `test_cli1_wallet_create_writes_private_key_0600`.
 - **CLI4 (Low) — `import` buffers an unbounded single line.** `import_blocks_command` reads each line with no length bound before `Block.from_json`; a crafted `.jsonl` with one multi-GB line OOM-kills the one-shot import (bounded, recoverable, idempotent-resumable). Fix: bound per-line input before parsing. Test: `test_cli4_import_bounds_line_length`.
 
 Originating report:

--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -43,6 +43,18 @@ Originating spec:
 
 ---
 
+## Audit remediation — CLI findings (2026-06-02)
+
+The [CLI / operator-surface threat-model audit](audits/2026-06-02-cli-audit.md) (the fifth audit; design+plan PR #126) found **0 Critical / 0 High / 1 Medium / 1 Low** — 9 of 11 candidates refuted (cross-references to the closed verification/auth audits, operator self-harm, or UX nits), 10 confirmed strengths. The two findings have strict-xfail demonstrations in `tests/test_cli_audit.py`:
+
+- **CLI1 (Medium) — `wallet create` writes the private key world-readable & unencrypted.** `Wallet.to_file` → `open(filename, 'wb')` lands at the process umask (no `chmod 0o600`, no `O_EXCL`, no passphrase); a co-located local user reads a live signing identity. Fix: create the PEM atomically owner-only (`os.open(..., O_EXCL, 0o600)` or temp-file + `chmod 0o600` + rename); optionally add `--passphrase`. Test: `test_cli1_wallet_create_writes_private_key_0600`.
+- **CLI4 (Low) — `import` buffers an unbounded single line.** `import_blocks_command` reads each line with no length bound before `Block.from_json`; a crafted `.jsonl` with one multi-GB line OOM-kills the one-shot import (bounded, recoverable, idempotent-resumable). Fix: bound per-line input before parsing. Test: `test_cli4_import_bounds_line_length`.
+
+Originating report:
+- [CLI / operator-surface audit](audits/2026-06-02-cli-audit.md) — findings table, strengths, recommendations.
+
+---
+
 ## Audit remediation — wallet/crypto findings (2026-06-02)
 
 The [wallet/crypto threat-model audit](audits/2026-06-02-wallet-crypto-audit.md) (the fourth audit; design+plan PR #120) found **0 Critical / 0 High / 0 Medium / 2 Low** — no exploitable findings, 12 confirmed strengths. The two Low items are non-exploitable defense-in-depth / hygiene residuals, each with a demonstration in `tests/test_wallet_audit.py` (strict-xfail while open, a passing regression once remediated):

--- a/docs/superpowers/audits/2026-06-02-cli-audit.md
+++ b/docs/superpowers/audits/2026-06-02-cli-audit.md
@@ -1,7 +1,7 @@
 # CLI & Operator-Surface Threat-Modeled Audit
 
 **Date:** 2026-06-02
-**Surface:** the operator-facing command layer — `command.py` (1034 LOC) and the `cli`/`FlaskGroup` command-tree wiring in `__init__.py`.
+**Surface:** the operator-facing command layer — `command.py` (~1034 LOC) and the `cli`/`FlaskGroup` command-tree wiring in `__init__.py`.
 **Design:** [`specs/2026-06-02-cli-audit-design.md`](../specs/2026-06-02-cli-audit-design.md) — scope razor (operator-trust model + four cross-referenced closed audits), adversary categories, severity rubric.
 **Method:** three-phase multi-agent fan-out — 6 analyst agents (one per adversary category) → de-dup → 3 adversarial refuters per candidate (survives only if a majority fail to refute) → synthesis. **35 raw candidates → 11 canonical → 2 surviving findings.**
 

--- a/docs/superpowers/audits/2026-06-02-cli-audit.md
+++ b/docs/superpowers/audits/2026-06-02-cli-audit.md
@@ -1,0 +1,57 @@
+# CLI & Operator-Surface Threat-Modeled Audit
+
+**Date:** 2026-06-02
+**Surface:** the operator-facing command layer — `command.py` (1034 LOC) and the `cli`/`FlaskGroup` command-tree wiring in `__init__.py`.
+**Design:** [`specs/2026-06-02-cli-audit-design.md`](../specs/2026-06-02-cli-audit-design.md) — scope razor (operator-trust model + four cross-referenced closed audits), adversary categories, severity rubric.
+**Method:** three-phase multi-agent fan-out — 6 analyst agents (one per adversary category) → de-dup → 3 adversarial refuters per candidate (survives only if a majority fail to refute) → synthesis. **35 raw candidates → 11 canonical → 2 surviving findings.**
+
+## Executive summary
+
+**0 Critical / 0 High / 1 Medium / 1 Low.**
+
+The CLI is a thin layer over already-audited subsystems, and the audit confirmed that framing: of 11 de-duplicated candidates, **9 were refuted** — most as operator self-harm (the operator targeting their own node/files), cross-references to the closed verification/auth audits, or UX-only nits — leaving **two genuine findings** where an *external* party (a co-located local user, or the supplier of an imported file) drives the impact:
+
+- **CLI1 (Medium)** — `cancelchain wallet create` writes the new RSA **private key world-readable and unencrypted** (no `chmod 0o600`, no `O_EXCL`, no passphrase). A different local user/process can read a live signing identity.
+- **CLI4 (Low)** — `cancelchain import` buffers an **unbounded single line** into memory (twice) before any size check — a crafted `.jsonl` from an untrusted source can OOM-kill the one-shot import.
+
+Ten controls are recorded as **confirmed strengths**, chief among them that every imported block is rebound to its recomputed header hash and routed through `Chain.validate_block` before persistence (the load-bearing control that neutralized the silent-dedup-skip, export-poisoning, and TOCTOU candidates).
+
+## Findings table
+
+| id | adversary | severity | description | status | demonstration test |
+|---|---|---|---|---|---|
+| CLI1 | co-located local user/process reading `WALLET_DIR` | Medium | `wallet create` → `Wallet.to_file` → `open(filename, 'wb')` writes the PEM at the process umask (commonly `0o644`/`0o664` → group/other-readable), `NoEncryption` (no passphrase path), and no `O_EXCL`. `read_wallets` auto-loads every `*.pem` as a live signing identity. A second local principal reads the unencrypted key and gains full signing capability for the operator's address. Not self-harm (a *different* principal is the adversary); not a crypto cross-reference (key *parsing* is the crypto audit's; file-write permission wiring is the CLI's). | Open (Medium) | `test_cli1_wallet_create_writes_private_key_0600` (xfail) |
+| CLI4 | supplier of an externally-sourced `.jsonl` the operator imports | Low | `import_blocks_command` reads the file twice (`sum(1 for line in f)` then `for line in f: Block.from_json(line)`) with no line-length/read-size bound; `click.Path(exists=True)` bounds existence only. A single multi-GB line with no interior newline is buffered whole, OOM-killing the one-shot import *before* validation. Bounded, recoverable, idempotent-resumable (the dedup skip resumes a re-run); no state corruption or disclosure. | Open (Low) | `test_cli4_import_bounds_line_length` (xfail) |
+
+## Adversary traces
+
+Six lenses traced 35 raw candidates → 11 canonical; 2 survived:
+
+1. **Malicious import-file supplier (C1).** The unbounded-line OOM is **CLI4**. The silent dedup-skip (a crafted self-reported `block_hash` colliding with an existing block drops it with no warning) and any "import accepts attacker state" reduce to the verification audit: `node.add_block` rebinds to the *recomputed* `get_header_hash()` and runs `Chain.validate_block` before commit, so no invalid/forged-identity block is admitted — refuted as a CLI finding (the residue is a cosmetic progress-bar gap).
+2. **Malicious export-target (C2).** Append-vs-overwrite is guarded by a chain-membership check (`command.py:435-438`): a pre-seeded file whose last line isn't a block in the operator's own longest chain raises `CHAIN_MISMATCH_MSG` *before* the output is opened for writing — fails safe. `read_last_line` edge cases are operator-local. Refuted.
+3. **Hostile host/config (C3).** Refuted on both legs: the signing wallet resolves only from the operator's own `WALLET_DIR` (`wallets.get(address)` returns `None` for a phantom address, and `ApiClient` re-rejects a username/address mismatch) — credential-selection is operator-internal (self-harm); and `cc-sig-v1` signatures are node-host-bound (`_canonical` includes `node_host`), so a signature captured by a hostile endpoint can't be replayed against the real node — the SSRF leg is the auth audit's, closed.
+4. **Wallet-file read & write (C4).** The write side is **CLI1**. The read side (malicious `*.pem`) reduces to the crypto audit (key parsing) plus `click.Path(exists=True)` — refuted as a CLI finding.
+5. **Info-disclosure / error-hygiene (C5).** All `console.print_exception()` calls use Rich's default `show_locals=False` → no frame-local key/signature/passphrase rendered, only exception type/message and in-repo paths, to the operator's own stdout. `http_error_message` leaks nothing sensitive. The bare `raise Exception` is a UX nit (out of scope). Refuted.
+6. **Resource / robustness (C6).** The unbounded line is **CLI4**. The double-read pass, silent skip, `read_last_line` edges, and `--multi` worker crashes are operator-local robustness (self-harm/Low) or reduce to the validated/rolled-back DB path. Refuted.
+
+## Cross-cutting observations & confirmed strengths
+
+The audit records what is sound. Ten controls confirmed:
+
+1. **Every imported block is fully validated before commit** — `node.add_block` → `chain.add_block`/`create_chain` → `Chain.validate_block` (`node.py:187-194`, `chain.py:155-207`), rebinding the self-reported `block_hash` to the recomputed `get_header_hash()`. *The* load-bearing control: it makes block-validity candidates verification-audit cross-references, not CLI findings.
+2. **`click.Path(exists=True)`** on the `import` file and all `--wallet`/`--txn-wallet` options (`command.py:466` + the option list) — rules out non-existent-path injection (does not bound content size — see CLI4).
+3. **Host-username → wallet self-binding** — a hostile `--host` can only select a key the operator already holds (`command.py:95-96`), with a second `ApiClient` mismatch guard (`api_client.py:44-56`).
+4. **`cc-sig-v1` node-host binding** defeats SSRF-shaped signature replay (`signing.py:44`, `:120-129`).
+5. **Export append-vs-overwrite is chain-membership-guarded** and fails safe before opening the output (`command.py:435-438`).
+6. **Export/import error paths fail safe** — broad `except` + clean console feedback, output file untouched until after the decision logic (`command.py:460-462`, `:486-488`).
+7. **Rich tracebacks render `show_locals=False`** — no secret material in any `print_exception()` (`command.py:387,461,487,570,601`).
+8. **`read_wallets` isolates per-file load failures** — one corrupt `*.pem` doesn't abort the rest (`application.py`).
+9. **`Wallet.from_file` validates key material on load** (cross-ref crypto audit, closed).
+10. **`Node.add_block` rolls back the session on DB error** — no half-committed partial state (`node.py:187-209`).
+
+## Recommendations
+
+- **CLI1 — write the private key with restrictive permissions, atomically.** Create the PEM via `os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)` (or temp-file + `os.chmod(0o600)` + atomic rename), so the key is never momentarily group/world-readable and a pre-planted symlink / existing key can't be silently followed/clobbered. Optionally add a `--passphrase` to `wallet create` wired through to `to_file(passphrase=...)` for at-rest encryption. The **load-bearing fix is the `0o600` permission**; the demonstration asserts it.
+- **CLI4 — bound per-line input before parsing.** Reject (or stream-cap) any line exceeding a configurable byte ceiling before handing it to `Block.from_json`; optionally drop the separate count pass (it doubles the read for a cosmetic progress bar) for a streaming indicator.
+
+Each finding is remediated in its own cycle (brainstorm → spec → plan → execution, internal cross-model review to convergence, one Copilot backstop), flipping its strict-xfail demonstration to a passing regression and driving the audit toward **0/0/0/0**. Tracked under "Audit remediation — CLI findings" in the roadmap.

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -66,6 +66,11 @@ def test_cli4_import_bounds_line_length(app, runner, tmp_path, monkeypatch):
     oversize = 8 * 1024 * 1024  # 8 MiB, >> any legitimate block line
     seen_lengths: list[int] = []
 
+    # Block.from_json is a @classmethod; monkeypatch.setattr replaces it with
+    # this plain function, stripping the classmethod descriptor. The import's
+    # `Block.from_json(line)` call therefore passes `line` as `data` (no `cls`
+    # is injected), so len(data) is the line length. The *args tail is purely
+    # defensive.
     def recording_from_json(data, *args, **kwargs):
         seen_lengths.append(len(data))
         msg = 'stop after recording'

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -50,9 +50,10 @@ def test_cli1_wallet_create_writes_private_key_0600(app, runner, tmp_path):
 
 @pytest.mark.xfail(
     strict=True,
-    reason='CLI4: `import` buffers an unbounded single line before parsing; '
-    'flips once a per-line size bound stops the full line reaching '
-    'Block.from_json.',
+    reason='CLI4: `import` buffers an unbounded single line — in BOTH the '
+    'count pass (sum(1 for line in f)) and the parse pass (Block.from_json). '
+    'A full fix must bound the line in both; this test observes the parse '
+    'pass and flips once the oversized line no longer reaches Block.from_json.',
 )
 def test_cli4_import_bounds_line_length(app, runner, tmp_path, monkeypatch):
     """CLI4 (Low) — `cancelchain import` reads the file line-by-line with no

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -1,0 +1,88 @@
+"""Demonstration tests for the 2026-06-02 CLI / operator-surface audit.
+
+Each test demonstrates one finding and asserts the DESIRED post-fix
+behavior. While a finding is open it carries
+``@pytest.mark.xfail(strict=True)``; once remediated the marker is dropped
+and it becomes a passing regression (tests below may be a mix). All file I/O
+is confined to ``tmp_path``; no test exhausts real memory/disk or writes
+outside it. See docs/superpowers/audits/2026-06-02-cli-audit.md.
+
+The `app` and `runner` fixtures come from tests/conftest.py; CLI invocation
+mirrors tests/test_command.py.
+"""
+
+import os
+import stat
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='CLI1: `wallet create` writes the private-key PEM at the process '
+    'umask (group/other-readable), not 0o600; flips once to_file creates it '
+    'owner-only.',
+)
+def test_cli1_wallet_create_writes_private_key_0600(app, runner, tmp_path):
+    """CLI1 (Medium) — `cancelchain wallet create` writes the new RSA private
+    key via `Wallet.to_file` → `open(filename, 'wb')` with no `chmod 0o600`,
+    so it lands at the process umask (commonly 0o644/0o664 → readable by a
+    different local user/process, who then holds a live signing identity).
+    Desired: the key file is owner-read/write only (0o600). The umask is
+    pinned permissive so the test is deterministic regardless of the runner's
+    environment.
+    """
+    old_umask = os.umask(0o022)
+    try:
+        with app.app_context():
+            result = runner.invoke(
+                args=['wallet', 'create', '-d', str(tmp_path)]
+            )
+        assert result.exit_code == 0, result.output
+        pems = list(tmp_path.glob('*.pem'))
+        assert len(pems) == 1, f'expected one *.pem, got {pems}'
+        mode = stat.S_IMODE(os.stat(pems[0]).st_mode)
+        # Desired post-fix: owner-only. Today: inherits umask (e.g. 0o644).
+        assert mode == 0o600, f'private key world/group-accessible: {oct(mode)}'
+    finally:
+        os.umask(old_umask)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='CLI4: `import` buffers an unbounded single line before parsing; '
+    'flips once a per-line size bound stops the full line reaching '
+    'Block.from_json.',
+)
+def test_cli4_import_bounds_line_length(app, runner, tmp_path, monkeypatch):
+    """CLI4 (Low) — `cancelchain import` reads the file line-by-line with no
+    length bound and hands the whole line to `Block.from_json`, so a crafted
+    `.jsonl` with one enormous line is buffered whole (OOM risk). Desired: the
+    import bounds per-line input, so `Block.from_json` never receives the full
+    oversized line. Bounded-observation: an 8 MiB line — far larger than any
+    legitimate block (~hundreds of KB at MAX_TRANSACTIONS) so any sane cap
+    rejects it — with no real exhaustion.
+    """
+    oversize = 8 * 1024 * 1024  # 8 MiB, >> any legitimate block line
+    seen_lengths: list[int] = []
+
+    def recording_from_json(data, *args, **kwargs):
+        seen_lengths.append(len(data))
+        msg = 'stop after recording'
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        'cancelchain.block.Block.from_json', recording_from_json
+    )
+
+    big = tmp_path / 'big.jsonl'
+    big.write_text('x' * oversize + '\n')
+    with app.app_context():
+        runner.invoke(args=['import', str(big)])
+
+    # Desired post-fix: the full oversized line never reaches Block.from_json
+    # (either bounded below `oversize`, or rejected before the call).
+    assert not seen_lengths or max(seen_lengths) < oversize, (
+        f'import delivered an unbounded {max(seen_lengths)}-byte line to '
+        'Block.from_json'
+    )


### PR DESCRIPTION
## What

The **fifth** threat-model audit of cancelchain — the **CLI / operator surface** (`command.py` + the `cli` wiring) — executed per the design+plan from #126. Adds the audit report and strict-xfail demonstration tests.

## Method

Three-phase multi-agent fan-out: **6 analyst agents** → **de-dup** → **3 adversarial refuters per candidate** → **synthesis**. 41 agents total. **35 raw candidates → 11 canonical → 2 surviving findings.**

## Result: 0 Critical / 0 High / 1 Medium / 1 Low

The CLI is a thin layer over already-audited subsystems, and the audit confirmed it — **9 of 11 candidates refuted** (cross-references to the closed verification/auth audits, operator self-harm, or UX nits), **10 confirmed strengths**. Two genuine findings where an *external* party drives the impact:

- **CLI1 (Medium)** — `wallet create` writes the RSA private key **world-readable and unencrypted** (`Wallet.to_file` → `open('wb')`, no `chmod 0o600` / `O_EXCL` / passphrase; `read_wallets` auto-loads it as a live signing identity). A co-located local user reads a usable key. Not self-harm (a *different* principal is the adversary); not a crypto cross-reference (key *parsing* is the crypto audit's — file-write wiring is the CLI's). This is the finding the design's internal review pre-identified.
- **CLI4 (Low)** — `import` buffers an **unbounded single line** before parsing; a crafted `.jsonl` OOM-kills the one-shot import (bounded, recoverable, idempotent-resumable).

**Load-bearing strength:** every imported block is rebound to its recomputed header hash and routed through `Chain.validate_block` before commit — which neutralized the silent-dedup-skip, export-poisoning, and TOCTOU candidates (all verification-audit cross-references).

## Tests

`tests/test_cli_audit.py` — two `@pytest.mark.xfail(strict=True)` demonstrations (`CliRunner` + `tmp_path`): the wallet-create test pins umask and asserts `0o600`; the import test bounds an 8 MiB line via a `Block.from_json` recorder. Suite: **295 passed, 1 skipped, 2 xfailed**; ruff + format + mypy clean.

## Review

Internal cross-model (Sonnet) review ran before this PR — verified both findings and severities against the code, spot-checked 5 of 10 strengths (the `add_block`→`validate_block` routing, the host→wallet self-binding + `ApiClient` guard, `cc-sig-v1` node-host binding, `print_exception` `show_locals=False`, the export chain-membership guard), and confirmed the 0/0/1/1 headline is honest. It scrutinized the `Block.from_json` classmethod monkeypatch and confirmed it flips correctly; I added a clarifying comment on that subtlety.

Docs + tests only — no source behavior changed (the two fixes are separate remediation cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)