### PR TITLE
fix(cli4): bound import line length to prevent OOM (audit CLI4, Low)

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -48,7 +48,9 @@ Originating spec:
 The [CLI / operator-surface threat-model audit](audits/2026-06-02-cli-audit.md) (the fifth audit; design+plan PR #126) found **0 Critical / 0 High / 1 Medium / 1 Low** — 9 of 11 candidates refuted (cross-references to the closed verification/auth audits, operator self-harm, or UX nits), 10 confirmed strengths. The two findings have strict-xfail demonstrations in `tests/test_cli_audit.py`:
 
 - ✅ **CLI1 (Medium) — `wallet create` writes the private key world-readable & unencrypted** — closed. `Wallet.to_file` now creates the PEM via `os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)` — owner-only (never momentarily group/world-readable, umask-independent) and exclusive (refuses to follow a pre-planted symlink or clobber an existing key); `test_cli1_wallet_create_writes_private_key_0600` is now a passing regression. (Optional `--passphrase` for at-rest encryption was not added — the load-bearing exposure was the file mode.)
-- **CLI4 (Low) — `import` buffers an unbounded single line.** `import_blocks_command` reads each line with no length bound before `Block.from_json`; a crafted `.jsonl` with one multi-GB line OOM-kills the one-shot import (bounded, recoverable, idempotent-resumable). Fix: bound per-line input before parsing. Test: `test_cli4_import_bounds_line_length`.
+- ✅ **CLI4 (Low) — `import` buffers an unbounded single line** — closed. New `bounded_lines` helper caps each line at `MAX_IMPORT_LINE_BYTES` (4 MiB, ≫ any legitimate block) via `readline(cap + 1)` so a single line is never buffered whole, aborting on overflow with a clear error; applied to BOTH the count pass and the parse pass. `test_cli4_import_bounds_line_length` is now a passing regression.
+
+**Both findings remediated — the CLI / operator-surface audit is fully closed (0/0/0/0 open).**
 
 Originating report:
 - [CLI / operator-surface audit](audits/2026-06-02-cli-audit.md) — findings table, strengths, recommendations.

--- a/docs/superpowers/audits/2026-06-02-cli-audit.md
+++ b/docs/superpowers/audits/2026-06-02-cli-audit.md
@@ -7,7 +7,7 @@
 
 ## Executive summary
 
-**0 Critical / 0 High / 1 Medium / 1 Low** (at audit time). **Remediation progress: CLI1 closed; 1 Low (CLI4) open.**
+**0 Critical / 0 High / 1 Medium / 1 Low** (at audit time). **Both findings (CLI1, CLI4) are now remediated — audit fully closed; every demonstration in `tests/test_cli_audit.py` is a passing regression.**
 
 The CLI is a thin layer over already-audited subsystems, and the audit confirmed that framing: of 11 de-duplicated candidates, **9 were refuted** — most as operator self-harm (the operator targeting their own node/files), cross-references to the closed verification/auth audits, or UX-only nits — leaving **two genuine findings** where an *external* party (a co-located local user, or the supplier of an imported file) drives the impact:
 
@@ -21,7 +21,7 @@ Ten controls are recorded as **confirmed strengths**, chief among them that ever
 | id | adversary | severity | description | status | demonstration test |
 |---|---|---|---|---|---|
 | CLI1 | co-located local user/process reading `WALLET_DIR` | Medium | `wallet create` → `Wallet.to_file` → `open(filename, 'wb')` writes the PEM at the process umask (commonly `0o644`/`0o664` → group/other-readable), `NoEncryption` (no passphrase path), and no `O_EXCL`. `read_wallets` auto-loads every `*.pem` as a live signing identity. A second local principal reads the unencrypted key and gains full signing capability for the operator's address. Not self-harm (a *different* principal is the adversary); not a crypto cross-reference (key *parsing* is the crypto audit's; file-write permission wiring is the CLI's). | ✅ Remediated — `Wallet.to_file` now writes the PEM via `os.open(..., O_WRONLY\|O_CREAT\|O_EXCL, 0o600)` (owner-only, no symlink-follow/clobber); `test_cli1_wallet_create_writes_private_key_0600` is now a passing regression. | `test_cli1_wallet_create_writes_private_key_0600` (regression) |
-| CLI4 | supplier of an externally-sourced `.jsonl` the operator imports | Low | `import_blocks_command` reads the file twice (`sum(1 for line in f)` then `for line in f: Block.from_json(line)`) with no line-length/read-size bound; `click.Path(exists=True)` bounds existence only. A single multi-GB line with no interior newline is buffered whole, OOM-killing the one-shot import *before* validation. Bounded, recoverable, idempotent-resumable (the dedup skip resumes a re-run); no state corruption or disclosure. | Open (Low) | `test_cli4_import_bounds_line_length` (xfail) |
+| CLI4 | supplier of an externally-sourced `.jsonl` the operator imports | Low | `import_blocks_command` reads the file twice (`sum(1 for line in f)` then `for line in f: Block.from_json(line)`) with no line-length/read-size bound; `click.Path(exists=True)` bounds existence only. A single multi-GB line with no interior newline is buffered whole, OOM-killing the one-shot import *before* validation. Bounded, recoverable, idempotent-resumable (the dedup skip resumes a re-run); no state corruption or disclosure. | ✅ Remediated — `bounded_lines` caps each line at `MAX_IMPORT_LINE_BYTES` (4 MiB) in both the count and parse passes via `readline(cap+1)`, aborting on overflow before the line is buffered whole; `test_cli4_import_bounds_line_length` is now a passing regression. | `test_cli4_import_bounds_line_length` (regression) |
 
 ## Adversary traces
 

--- a/src/cancelchain/command.py
+++ b/src/cancelchain/command.py
@@ -136,7 +136,7 @@ def bounded_lines(
     """
     for line in iter(lambda: f.readline(max_bytes + 1), ''):
         if len(line) > max_bytes:
-            msg = f'Import line exceeds the {max_bytes}-byte limit'
+            msg = f'Import line exceeds the {max_bytes}-character limit'
             raise ValueError(msg)
         yield line
 

--- a/src/cancelchain/command.py
+++ b/src/cancelchain/command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Generator
 from datetime import timedelta
 from http.client import responses
 from typing import Any
@@ -43,6 +44,10 @@ from cancelchain.wallet import Wallet
 
 REFRESH_PER_SECOND = 8
 CHAIN_MISMATCH_MSG = 'Chain/file mismatch'
+# Cap a single JSONL line during `import` so a crafted file with one enormous
+# line can't OOM the import (audit CLI4). 4 MiB is far larger than any
+# legitimate block (~100 transactions), so real data is never rejected.
+MAX_IMPORT_LINE_BYTES = 4 * 1024 * 1024
 
 
 def grumble_to_curmudgeons(grumble: float) -> int:
@@ -114,6 +119,22 @@ def address_wallet(address: str, wallet_file: str | None = None) -> Wallet:
         msg = f'No wallet for {address}'
         raise Exception(msg)
     return wallet
+
+
+def bounded_lines(
+    f: Any, max_bytes: int = MAX_IMPORT_LINE_BYTES
+) -> Generator[str, None, None]:
+    """Yield lines from `f`, refusing any line longer than `max_bytes`.
+
+    `f.readline(max_bytes + 1)` reads at most `max_bytes + 1` characters, so a
+    single unbounded line is never buffered whole; a line over the cap aborts
+    with a clear error instead of exhausting memory (audit CLI4).
+    """
+    for line in iter(lambda: f.readline(max_bytes + 1), ''):
+        if len(line) > max_bytes:
+            msg = f'Import line exceeds the {max_bytes}-byte limit'
+            raise ValueError(msg)
+        yield line
 
 
 def read_last_line(file: str) -> str:
@@ -475,10 +496,12 @@ def import_blocks_command(file: str) -> None:
         node = Node(logger=current_app.logger)
         with open(file, encoding='utf-8') as f:
             progress_bar = ProgressBar(
-                'Importing Blocks', console=console, total=sum(1 for line in f)
+                'Importing Blocks',
+                console=console,
+                total=sum(1 for _ in bounded_lines(f)),
             )
         with open(file, encoding='utf-8') as f, progress_bar as progress:
-            for line in f:
+            for line in bounded_lines(f):
                 block = Block.from_json(line)
                 if Block.from_db(block.block_hash) is None:  # type: ignore[arg-type]
                     node.add_block(block)

--- a/src/cancelchain/command.py
+++ b/src/cancelchain/command.py
@@ -46,7 +46,11 @@ REFRESH_PER_SECOND = 8
 CHAIN_MISMATCH_MSG = 'Chain/file mismatch'
 # Cap a single JSONL line during `import` so a crafted file with one enormous
 # line can't OOM the import (audit CLI4). 4 MiB is far larger than any
-# legitimate block (~100 transactions), so real data is never rejected.
+# legitimate block (~100 transactions), so real data is never rejected. The
+# import opens the file in text mode, so this is enforced as a character count
+# (== bytes for the ASCII-dominant block JSON; at most ~4x bytes for
+# pathological all-multibyte-UTF-8 input — still bounded, well short of the
+# GB-scale exhaustion this guards against).
 MAX_IMPORT_LINE_BYTES = 4 * 1024 * 1024
 
 

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -14,7 +14,7 @@ mirrors tests/test_command.py.
 import os
 import stat
 
-import pytest
+from cancelchain.command import MAX_IMPORT_LINE_BYTES
 
 
 def test_cli1_wallet_create_writes_private_key_0600(app, runner, tmp_path):
@@ -43,30 +43,23 @@ def test_cli1_wallet_create_writes_private_key_0600(app, runner, tmp_path):
         os.umask(old_umask)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='CLI4: `import` buffers an unbounded single line — in BOTH the '
-    'count pass (sum(1 for line in f)) and the parse pass (Block.from_json). '
-    'A full fix must bound the line in both; this test observes the parse '
-    'pass and flips once the oversized line no longer reaches Block.from_json.',
-)
 def test_cli4_import_bounds_line_length(app, runner, tmp_path, monkeypatch):
-    """CLI4 (Low) — `cancelchain import` reads the file line-by-line with no
-    length bound and hands the whole line to `Block.from_json`, so a crafted
-    `.jsonl` with one enormous line is buffered whole (OOM risk). Desired: the
-    import bounds per-line input, so `Block.from_json` never receives the full
-    oversized line. Bounded-observation: an 8 MiB line — far larger than any
-    legitimate block (~hundreds of KB at MAX_TRANSACTIONS) so any sane cap
-    rejects it — with no real exhaustion.
+    """CLI4 (Low) — REMEDIATED. `cancelchain import` used to read each line
+    with no length bound and hand the whole line to `Block.from_json`, so a
+    crafted `.jsonl` with one enormous line was buffered whole (OOM risk).
+    `bounded_lines` now caps each line at `MAX_IMPORT_LINE_BYTES` in BOTH the
+    count and parse passes, aborting on overflow before the full line is
+    buffered or parsed. Bounded-observation: one line just over the cap (no
+    real exhaustion); assert the import rejects it and the full line never
+    reaches `Block.from_json`.
     """
-    oversize = 8 * 1024 * 1024  # 8 MiB, >> any legitimate block line
     seen_lengths: list[int] = []
 
     # Block.from_json is a @classmethod; monkeypatch.setattr replaces it with
-    # this plain function, stripping the classmethod descriptor. The import's
-    # `Block.from_json(line)` call therefore passes `line` as `data` (no `cls`
-    # is injected), so len(data) is the line length. The *args tail is purely
-    # defensive.
+    # this plain function, stripping the classmethod descriptor, so the
+    # import's `Block.from_json(line)` passes `line` as `data` (no `cls`). The
+    # *args tail is purely defensive. (Post-fix the oversized line is rejected
+    # in the count pass before from_json is reached, so this records nothing.)
     def recording_from_json(data, *args, **kwargs):
         seen_lengths.append(len(data))
         msg = 'stop after recording'
@@ -77,13 +70,13 @@ def test_cli4_import_bounds_line_length(app, runner, tmp_path, monkeypatch):
     )
 
     big = tmp_path / 'big.jsonl'
-    big.write_text('x' * oversize + '\n')
+    big.write_text('x' * (MAX_IMPORT_LINE_BYTES + 1024) + '\n')
     with app.app_context():
-        runner.invoke(args=['import', str(big)])
+        result = runner.invoke(args=['import', str(big)])
 
-    # Desired post-fix: the full oversized line never reaches Block.from_json
-    # (either bounded below `oversize`, or rejected before the call).
-    assert not seen_lengths or max(seen_lengths) < oversize, (
-        f'import delivered an unbounded {max(seen_lengths)}-byte line to '
-        'Block.from_json'
+    # The over-cap line is rejected (import aborts) and is never delivered to
+    # Block.from_json beyond the cap.
+    assert 'Import failed' in result.output
+    assert not seen_lengths or max(seen_lengths) <= MAX_IMPORT_LINE_BYTES, (
+        f'import delivered a {max(seen_lengths)}-byte line to Block.from_json'
     )


### PR DESCRIPTION
## What

Remediates **CLI4 (Low)** from the [CLI audit](docs/superpowers/audits/2026-06-02-cli-audit.md) — the last open finding. `cancelchain import` no longer buffers an unbounded line into memory. **This closes the CLI audit at 0/0/0/0.**

## Why

`import_blocks_command` read each JSONL line with no length bound — in **both** the count pass (`sum(1 for line in f)`) and the parse pass — and handed the whole line to `Block.from_json`. A crafted `.jsonl` with one multi-GB line (no interior newline) was buffered whole and could OOM-kill the one-shot import before any validation.

## Fix

- `MAX_IMPORT_LINE_BYTES = 4 * 1024 * 1024` — far larger than any legitimate ~100-txn block (worst case <300 KB, >13× headroom), so real data is never rejected.
- `bounded_lines(f)` — reads via `f.readline(cap + 1)`, which stops at the cap, so **a single line is never buffered whole**; a line over the cap raises a clear `ValueError`.
- Applied to **both** passes (the count pass runs first and aborts on an oversized line, so `Block.from_json` is never reached).

## Verification

Suite: **297 passed, 1 skipped, 0 xfailed** — both CLI demonstrations are now passing regressions. The CLI4 test writes a line just over the cap and asserts the import rejects it (`Import failed`) and never delivers the full line to `Block.from_json`. ruff + format + mypy clean. Audit report → 0/0/0/0; roadmap updated.

Internal cross-model review confirmed the fix correct and complete (text-mode `readline(N)` semantics, 4 MiB headroom vs a max block, the count-pass-aborts-first ordering, and the test is a genuine regression guard). Its one note — the cap is a *character* count in text mode (== bytes for ASCII; ≤~4× for pathological UTF-8, still bounded) — is documented in the constant's comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)