### PR TITLE
docs(audit): web / browser-UI threat-model audit — 0/0/0/2 + demonstration tests

### DIFF
--- a/docs/superpowers/ROADMAP.md
+++ b/docs/superpowers/ROADMAP.md
@@ -43,6 +43,18 @@ Originating spec:
 
 ---
 
+## Audit remediation — web findings (2026-06-02)
+
+The [web / browser-UI threat-model audit](audits/2026-06-02-web-audit.md) (the sixth and final audit; design+plan PR #130) found **0 Critical / 0 High / 0 Medium / 2 Low** — 2 of 4 candidates refuted (a cosmetic SRI nit that HTML5 error recovery still enforces, and an N+1 cross-referenced to the perf roadmap), 10 confirmed strengths. The two Low findings have strict-xfail demonstrations in `tests/test_web_audit.py`:
+
+- **WEB1 (Low) — no HTTP security-hardening headers.** HTML responses ship no CSP/X-Frame-Options/X-Content-Type-Options/Referrer-Policy/HSTS (`application.py` wires no `after_request`/Talisman). Defense-in-depth gap (read-only/cookieless caps it at Low). Fix: an `@app.after_request` hook (or Flask-Talisman) setting them on HTML responses. Test: `test_web1_security_headers_present`.
+- **WEB2 (Low) — browser views `return e`.** All four views' generic handler returns a raw `Exception` (not a valid Flask response → `make_response` TypeError → generic 500) and logs a full traceback. Fix: `abort(500)` / a real error response (keep `except HTTPException: return e`). Test: `test_web2_view_error_yields_clean_500`.
+
+Originating report:
+- [Web / browser-UI audit](audits/2026-06-02-web-audit.md) — findings table, strengths, recommendations.
+
+---
+
 ## Audit remediation — CLI findings (2026-06-02)
 
 The [CLI / operator-surface threat-model audit](audits/2026-06-02-cli-audit.md) (the fifth audit; design+plan PR #126) found **0 Critical / 0 High / 1 Medium / 1 Low** — 9 of 11 candidates refuted (cross-references to the closed verification/auth audits, operator self-harm, or UX nits), 10 confirmed strengths. The two findings have strict-xfail demonstrations in `tests/test_cli_audit.py`:

--- a/docs/superpowers/audits/2026-06-02-web-audit.md
+++ b/docs/superpowers/audits/2026-06-02-web-audit.md
@@ -1,0 +1,57 @@
+# Web / Browser-UI Threat-Modeled Audit
+
+**Date:** 2026-06-02
+**Surface:** the browser-facing web UI — `browser.py`, the Jinja templates in `templates/`, and the HTML-response wiring in `application.py`.
+**Design:** [`specs/2026-06-02-web-audit-design.md`](../specs/2026-06-02-web-audit-design.md) — scope razor (public-explorer-by-design; read-only/cookieless caps header findings at Low/Medium; data-validity/auth/perf cross-referenced), adversary categories, severity rubric.
+**Method:** three-phase multi-agent fan-out — 6 analyst agents (one per adversary category) → de-dup → 3 adversarial refuters per candidate (survives only if a majority fail to refute) → synthesis. **18 raw candidates → 4 canonical → 2 surviving findings.**
+
+## Executive summary
+
+**0 Critical / 0 High / 0 Medium / 2 Low.**
+
+A read-only, cookieless, autoescaped explorer audited exactly as predicted: the web vulnerability class is largely *structurally absent*. Of 4 de-duplicated candidates, **2 were refuted** (one factually, one as a perf cross-reference), leaving **two Low defense-in-depth findings** and **10 confirmed strengths**:
+
+- **WEB1 (Low)** — no HTTP security-hardening headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS) on any HTML response.
+- **WEB2 (Low)** — the browser views `return e` (a raw `Exception`) in their generic handler — a latent response-correctness bug, with full-traceback-to-log disclosure (client disclosure bounded by the shipped `DEBUG=False`).
+
+No XSS, CSRF, SQLi, SSTI, open-redirect, or session weakness survived: Jinja autoescape is on with **no `| safe`/`Markup`/`render_template_string` anywhere**, the URL converters constrain path params to alphabets that exclude `<>"'` (keeping even the `onclick` JS-attribute context safe), all routes are GET-only with no cookie/session, and queries are ORM-parameterized.
+
+## Findings table
+
+| id | adversary | severity | description | status | demonstration test |
+|---|---|---|---|---|---|
+| WEB1 | remote visitor / clickjacker / MIME-sniffer | Low | No `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, or HSTS on HTML responses — `init_app` (`application.py:30-79`) wires no `after_request`/Talisman; the only header mutation is `Content-Type: application/json` on the JSON API. Defense-in-depth gap; held at Low because the explorer is read-only/cookieless/login-less (no session to steal, no action to forge) and there is no confirmed XSS for a missing CSP to backstop. | Open (Low) | `test_web1_security_headers_present` (xfail) |
+| WEB2 | remote visitor triggering a view exception | Low | All four views end `except Exception as e: current_app.logger.exception(e); return e` (`browser.py:29-31,41-43,65-67,98-100`). An `Exception` is not a valid Flask return — `make_response` raises `TypeError`, resolved to a generic 500. Residue: a latent response-correctness bug + a full traceback written to the app log on every view error; a direct traceback-to-client would additionally require `DEBUG=True` (not shipped). | Open (Low) | `test_web2_view_error_yields_clean_500` (xfail) |
+
+## Adversary traces
+
+Six lenses traced 18 raw candidates → 4 canonical; 2 survived:
+
+1. **XSS / content-injection (W1).** Traced every `{{ }}` across all five templates and all attacker-authored fields (`subject`/`forgive`/`support` + `human_subject`; `address`/`public_key`/`signature`), the `<title>` f-strings, and the `onclick="window.location='{{ url_for(...) }}'"` JS-attribute context (`block.html:65`, `transaction.html:56`). **All refuted → strengths:** autoescape on for `.html`, no `| safe`/`Markup`, `human_subject`→plain `str`, `url_for` Markup-escaped, and the `MillHashConverter` alphabet excludes `'`/`"` so the JS-string context can't break out.
+2. **Response-header hardening (W2).** The missing-headers gap is **WEB1**. The malformed `integrity="…"crossorigin` (`base.html:39`) was **refuted**: the WHATWG "missing-whitespace-between-attributes" error recovery parses both attributes, so SRI is in fact enforced — a cosmetic one-line cleanup, not a finding (SRI recorded as a strength).
+3. **Info-disclosure / error-handling (W3).** The `return e` pattern is **WEB2**, graded Low — `DEBUG=False` ships, path params are converter-constrained (no reflected request data), so client disclosure is bounded to a generic 500; the residue is the latent bug + log-only traceback.
+4. **Injection (W4).** Refuted: ORM `filter_by` parameterization, converter-bounded path params, hardcoded template names (no SSTI), no raw SQL/string-format.
+5. **Resource / DoS (W5).** Pagination is bounded by Flask-SQLAlchemy's `max_per_page` (default 100) → refuted. The `transaction_view` N+1 inflow loop (`browser.py:87-91`) was **cross-referenced out** to the perf roadmap (and its amplification is a validated on-chain transaction's inflow count — the verification audit's domain); `TransactionDAO.get` is a single indexed point lookup, not a recursive-CTE walk, so the severity-inflating claim was factually wrong.
+6. **Session / CSRF / cookie (W6).** Refuted → strengths: all routes GET-only, no cookie/session/flash/`set_cookie`, the only writes are authenticated `/api/*` (`cc-sig-v1`, not cookies) — CSRF is genuinely N/A.
+
+## Cross-cutting observations & confirmed strengths
+
+Ten controls confirmed:
+
+1. **Jinja2 autoescape on for every `.html`** — attacker-authored fields render as inert HTML-escaped text. The primary anti-XSS control.
+2. **No `| safe`, `Markup()`, or `render_template_string`** anywhere (grep-confirmed) — autoescape is never bypassed; template names are hardcoded literals (no SSTI).
+3. **`human_subject`→`decode_subject` returns a plain `str`** (`application.py:76-78`, `payload.py:31-36`) — the decoded subject is still autoescaped.
+4. **`MillHashConverter` strict 64-char base64** on `block_hash`/`txid` (`application.py:120-124`) — the alphabet excludes `<>"'`, keeping the `onclick` JS-string context (`block.html:65`, `transaction.html:56`) un-breakoutable.
+5. **`AddressConverter`/`SubjectConverter`** reject malformed path inputs at routing time (`application.py:113-117,127-131`).
+6. **`url_for()` emits URL-safe, autoescaped href/onclick output** — no URL-parameter injection in links.
+7. **ORM-parameterized queries throughout** (`models.py` `TransactionDAO.get`/`BlockDAO.get`/`ChainDAO.chains`) — SQLi unreachable from path/query params.
+8. **Read-only, cookieless, login-less design** — no session to steal, no state-changing route to forge; this is *why* WEB1 lands at Low.
+9. **SRI + `crossorigin` on all CDN assets** (`base.html:10,39,41`) — a tampered CDN asset is rejected by the browser (the `:39` missing-space is cosmetic; HTML5 error recovery still enforces SRI).
+10. **`DEBUG`/`PROPAGATE_EXCEPTIONS` not enabled in shipped config** — the raw-Exception path resolves to a generic 500, never the Werkzeug debugger; bounds WEB2's disclosure to logs. **Pagination bounded** by `max_per_page` (default 100).
+
+## Recommendations
+
+- **WEB1 — add response-hardening headers.** Register an `@app.after_request` hook (or Flask-Talisman) setting `Content-Security-Policy` (`default-src 'self'` plus the CDN origins in `base.html`), `X-Frame-Options: DENY` (or `frame-ancestors 'none'`), `X-Content-Type-Options: nosniff`, `Referrer-Policy` (`no-referrer`/`strict-origin-when-cross-origin`), and `Strict-Transport-Security` on HTTPS. Apply to HTML responses; leave the JSON API unchanged.
+- **WEB2 — return a real response on error.** Replace the generic-handler `return e` with `abort(500)` (or a rendered error template), keeping `except HTTPException as e: return e` (an `HTTPException` is a valid WSGI response). Optionally register a 500 `errorhandler` so unexpected exceptions resolve to a controlled response.
+
+Each finding is remediated in its own cycle (brainstorm → spec → plan → execution, internal cross-model review to convergence, one Copilot backstop), flipping its strict-xfail demonstration to a passing regression and driving the audit toward **0/0/0/0**. Tracked under "Audit remediation — web findings" in the roadmap.

--- a/docs/superpowers/audits/2026-06-02-web-audit.md
+++ b/docs/superpowers/audits/2026-06-02-web-audit.md
@@ -41,13 +41,15 @@ Ten controls confirmed:
 1. **Jinja2 autoescape on for every `.html`** — attacker-authored fields render as inert HTML-escaped text. The primary anti-XSS control.
 2. **No `| safe`, `Markup()`, or `render_template_string`** anywhere (grep-confirmed) — autoescape is never bypassed; template names are hardcoded literals (no SSTI).
 3. **`human_subject`→`decode_subject` returns a plain `str`** (`application.py:76-78`, `payload.py:31-36`) — the decoded subject is still autoescaped.
-4. **`MillHashConverter` strict 64-char base64** on `block_hash`/`txid` (`application.py:120-124`) — the alphabet excludes `<>"'`, keeping the `onclick` JS-string context (`block.html:65`, `transaction.html:56`) un-breakoutable.
+4. **`MillHashConverter` requires `len == 64` + `validate_base64`** on `block_hash`/`txid` (`application.py:120-124`) — constraining them to the base64 alphabet `[A-Za-z0-9+/=]` (the hash values are hex, a subset), which excludes `<>"'`, keeping the `onclick` JS-string context (`block.html:65`, `transaction.html:56`) un-breakoutable.
 5. **`AddressConverter`/`SubjectConverter`** reject malformed path inputs at routing time (`application.py:113-117,127-131`).
 6. **`url_for()` emits URL-safe, autoescaped href/onclick output** — no URL-parameter injection in links.
 7. **ORM-parameterized queries throughout** (`models.py` `TransactionDAO.get`/`BlockDAO.get`/`ChainDAO.chains`) — SQLi unreachable from path/query params.
 8. **Read-only, cookieless, login-less design** — no session to steal, no state-changing route to forge; this is *why* WEB1 lands at Low.
-9. **SRI + `crossorigin` on all CDN assets** (`base.html:10,39,41`) — a tampered CDN asset is rejected by the browser (the `:39` missing-space is cosmetic; HTML5 error recovery still enforces SRI).
+9. **SRI + `crossorigin` on the Bootstrap CSS/JS and jQuery CDN assets** (`base.html:10,39,41`) — a tampered version of those is rejected by the browser (the `:39` missing-space is cosmetic; HTML5 error recovery still enforces SRI). *(Partial — see the observation below: the Bootstrap-Icons and Google-Fonts stylesheets carry no `integrity`.)*
 10. **`DEBUG`/`PROPAGATE_EXCEPTIONS` not enabled in shipped config** — the raw-Exception path resolves to a generic 500, never the Werkzeug debugger; bounds WEB2's disclosure to logs. **Pagination bounded** by `max_per_page` (default 100).
+
+**Observation (no finding) — two CDN stylesheets lack SRI.** `base.html:11-12` load the Bootstrap-Icons font CSS (`cdn.jsdelivr.net`) and the Google-Fonts Material-Icons CSS (`fonts.googleapis.com`) with **no `integrity` attribute** (unlike the Bootstrap CSS/JS and jQuery, which have SRI). A compromised CDN could serve altered CSS. Impact is bounded on this read-only, cookieless, input-less explorer (CSS-exfiltration techniques need sensitive form inputs, of which there are none), so this is below the finding bar — but it folds naturally into the WEB1 hardening: add `integrity` to those `<link>`s and/or constrain `style-src`/`font-src` in the CSP.
 
 ## Recommendations
 

--- a/tests/test_web_audit.py
+++ b/tests/test_web_audit.py
@@ -1,0 +1,61 @@
+"""Demonstration tests for the 2026-06-02 web / browser-UI audit.
+
+Each test demonstrates one finding and asserts the DESIRED post-fix
+behavior. While a finding is open it carries
+``@pytest.mark.xfail(strict=True)``; once remediated the marker is dropped
+and it becomes a passing regression (tests below may be a mix). Tests drive
+routes via the Flask test client and assert on response headers/body; no
+test makes a real external network request. See
+docs/superpowers/audits/2026-06-02-web-audit.md.
+
+The `app`, `test_client` fixtures come from tests/conftest.py; route
+invocation mirrors tests/test_browser.py.
+"""
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='WEB1: no response-hardening headers (CSP/X-Frame-Options/'
+    'X-Content-Type-Options/Referrer-Policy) are wired yet.',
+)
+def test_web1_security_headers_present(app, test_client):
+    """WEB1 (Low) — HTML responses ship no security-hardening headers
+    (`application.py` wires no `after_request`/Talisman). Desired: every HTML
+    response carries CSP, X-Frame-Options, X-Content-Type-Options, and
+    Referrer-Policy. Served entirely in-process — no external network.
+    """
+    with app.app_context():
+        resp = test_client.get('/')
+    assert resp.status_code == 200
+    assert 'Content-Security-Policy' in resp.headers
+    assert resp.headers.get('X-Content-Type-Options') == 'nosniff'
+    assert resp.headers.get('X-Frame-Options') in ('DENY', 'SAMEORIGIN')
+    assert 'Referrer-Policy' in resp.headers
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='WEB2: browser views `return e` (a raw Exception), which is not a '
+    'valid Flask response; flips once they return abort(500) / a real '
+    'response.',
+)
+def test_web2_view_error_yields_clean_500(app, test_client, monkeypatch):
+    """WEB2 (Low) — when a view's business logic raises an unexpected
+    exception, the generic handler does `return e` (`browser.py`), returning a
+    raw `Exception` that is not a valid Flask response. Desired: the view
+    yields a clean 500 response (via `abort(500)`) with no internal detail in
+    the body. A sentinel-bearing exception is injected via the `longest_chain`
+    helper used by `index_view`.
+    """
+
+    def boom():
+        msg = 'web2-sentinel-internal-detail'
+        raise ValueError(msg)
+
+    monkeypatch.setattr('cancelchain.browser.longest_chain', boom)
+    with app.app_context():
+        resp = test_client.get('/')
+    assert resp.status_code == 500
+    assert b'web2-sentinel' not in resp.data

--- a/tests/test_web_audit.py
+++ b/tests/test_web_audit.py
@@ -24,15 +24,19 @@ def test_web1_security_headers_present(app, test_client):
     """WEB1 (Low) — HTML responses ship no security-hardening headers
     (`application.py` wires no `after_request`/Talisman). Desired: every HTML
     response carries CSP, X-Frame-Options, X-Content-Type-Options, and
-    Referrer-Policy. Served entirely in-process — no external network.
+    Referrer-Policy, and (on HTTPS) HSTS. Issued over an https base_url so
+    HSTS — which should only be set on secure requests — is exercised
+    alongside the always-on headers. Served entirely in-process — no external
+    network.
     """
     with app.app_context():
-        resp = test_client.get('/')
+        resp = test_client.get('/', base_url='https://localhost')
     assert resp.status_code == 200
     assert 'Content-Security-Policy' in resp.headers
     assert resp.headers.get('X-Content-Type-Options') == 'nosniff'
     assert resp.headers.get('X-Frame-Options') in ('DENY', 'SAMEORIGIN')
     assert 'Referrer-Policy' in resp.headers
+    assert 'Strict-Transport-Security' in resp.headers
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## What

The **sixth and final** threat-model audit of cancelchain — the **browser/web UI** (`browser.py` + templates + the HTML-response wiring) — executed per the design+plan from #130. Adds the report and strict-xfail demonstration tests. **This is the last uncovered surface.**

## Method

Three-phase multi-agent fan-out: **6 analyst agents** → **de-dup** → **3 adversarial refuters per candidate** → **synthesis**. 20 agents. **18 raw candidates → 4 canonical → 2 surviving findings.**

## Result: 0 Critical / 0 High / 0 Medium / 2 Low

A read-only, cookieless, autoescaped explorer audited as predicted — the web vuln class is largely *structurally absent*. **2 of 4 candidates refuted**, **10 confirmed strengths**. Two Low defense-in-depth findings:

- **WEB1 (Low)** — no HTTP security headers (CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / HSTS) on HTML responses. Held at Low: nothing to clickjack-into-action or session to steal on a read-only/cookieless page.
- **WEB2 (Low)** — the browser views `return e` (a raw `Exception`, not a valid Flask response → `make_response` TypeError → generic 500) + a full traceback to the app log. Client disclosure bounded by the shipped `DEBUG=False`.

**Refuted:** the malformed `integrity/crossorigin` SRI nit (HTML5 error recovery still enforces SRI), and the `transaction_view` N+1 (perf-roadmap cross-ref; `TransactionDAO.get` is an indexed point lookup, not a CTE walk). The `onclick` JS-attribute context was confirmed **safe** (the `MillHashConverter` alphabet excludes quotes) — recorded as a strength.

## Tests

`tests/test_web_audit.py` — two `@pytest.mark.xfail(strict=True)` demonstrations (Flask test client, **no external network**): WEB1 asserts the hardening headers present; WEB2 injects a sentinel exception and asserts a clean 500 with no leak. Suite: **297 passed, 1 skipped, 2 xfailed**; ruff + format + mypy clean.

## Review

Internal cross-model review confirmed both findings + the test mechanisms (the WEB2 strict-xfail is deterministic, not flaky — verified the TESTING-mode propagation today and the `abort(500)` flip post-fix), spot-checked 5 of 10 strengths, and validated both refutations. Two strength-accuracy fixes applied: the hashes are hex (validator is base64), and SRI covers Bootstrap/jQuery but not the icon-font/Google-Fonts stylesheets — the latter added as a below-bar observation folding into WEB1.

Docs + tests only — no source behavior changed (the two fixes are separate remediation cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)