### PR TITLE
refactor(rename): currency units grumble/curmudgeon → grit/grain (Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 GumptionChain is a custom proof-of-work blockchain (Flask + SQLAlchemy) where tokens are assigned to *subjects* (UTF-8 strings, 1–79 chars) as **opposition** (`subject`, rescindable via `forgive`) or **support** (`support`, permanent). It runs as both a Flask web app (browser views + JSON API) and a `gumptionchain` CLI. The chain is permissioned: API access is gated by role (`READER` < `TRANSACTOR` < `MILLER` < `ADMIN`) keyed off wallet addresses listed in config.
 
-Units: 1 **CCG / grumble** = 100 **curmudgeons** (`CURMUDGEON_PER_GRUMBLE` in `gumptionchain.chain`). Float CLI amounts are converted via `grumble_to_curmudgeons`.
+Units: 1 **GRIT / grit** = 100 **grains** (`GRAIN_PER_GRIT` in `gumptionchain.chain`). Float CLI amounts are converted via `grit_to_grains`.
 
 ## Common commands
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -38,10 +38,10 @@ from gumptionchain.transaction import Transaction
 from gumptionchain.util import dt_2_iso, now
 from gumptionchain.wallet import Wallet
 
-CURMUDGEON_PER_GRUMBLE = 100
+GRAIN_PER_GRIT = 100
 GENESIS_HASH = mill_hash_str('GENESIS')
 MAX_TARGET = '0' * 6 + 'F' * 58
-REWARD = 100 * CURMUDGEON_PER_GRUMBLE
+REWARD = 100 * GRAIN_PER_GRIT
 TARGET_GOAL_SECONDS = 600
 TARGET_INTERVAL = 2016
 TARGET_INTERVAL_SECONDS = TARGET_GOAL_SECONDS * TARGET_INTERVAL

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -32,7 +32,7 @@ from rich.text import Text
 
 from gumptionchain.api_client import ApiClient
 from gumptionchain.block import Block
-from gumptionchain.chain import CURMUDGEON_PER_GRUMBLE
+from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.console import console
 from gumptionchain.database import db
 from gumptionchain.miller import Miller
@@ -54,12 +54,12 @@ CHAIN_MISMATCH_MSG = 'Chain/file mismatch'
 MAX_IMPORT_LINE_BYTES = 4 * 1024 * 1024
 
 
-def grumble_to_curmudgeons(grumble: float) -> int:
-    return int(CURMUDGEON_PER_GRUMBLE * float(grumble))
+def grit_to_grains(grit: float) -> int:
+    return int(GRAIN_PER_GRIT * float(grit))
 
 
-def human_curmudgeons(curmudgeons: int | float) -> str:
-    balance = int(curmudgeons) / CURMUDGEON_PER_GRUMBLE
+def human_grains(grains: int | float) -> str:
+    balance = int(grains) / GRAIN_PER_GRIT
     return f'{balance:.2f}'.rstrip('0').rstrip('.')
 
 
@@ -677,7 +677,7 @@ def create_transfer(
 
     \b
     FROM_ADDRESS is the transaction source address.
-    AMOUNT is the amount (as a float) of CCG to transfer.
+    AMOUNT is the amount (as a float) of GRIT to transfer.
     TO_ADDRESS is the transaction destination address.
     """
     try:
@@ -685,7 +685,7 @@ def create_transfer(
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_transfer_transaction(
             txn_wallet_obj.public_key_b64,
-            grumble_to_curmudgeons(amount),
+            grit_to_grains(amount),
             to_address,
         )
         txn = Transaction.from_json(r.text)
@@ -754,7 +754,7 @@ def create_subject(
 
     \b
     ADDRESS is the transaction source address.
-    AMOUNT is the amount (as a float) of CCG to apply.
+    AMOUNT is the amount (as a float) of GRIT to apply.
     SUBJECT is the raw (unencoded) subject string.
     """
     try:
@@ -762,7 +762,7 @@ def create_subject(
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_subject_transaction(
             txn_wallet_obj.public_key_b64,
-            grumble_to_curmudgeons(amount),
+            grit_to_grains(amount),
             subject,
         )
         txn = Transaction.from_json(r.text)
@@ -829,7 +829,7 @@ def create_forgive(
 
     \b
     ADDRESS is the transaction source address.
-    AMOUNT is the amount (as a float) of CCG to apply.
+    AMOUNT is the amount (as a float) of GRIT to apply.
     SUBJECT is the raw (unencoded) subject string.
     """
     try:
@@ -837,7 +837,7 @@ def create_forgive(
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_forgive_transaction(
             txn_wallet_obj.public_key_b64,
-            grumble_to_curmudgeons(amount),
+            grit_to_grains(amount),
             subject,
         )
         txn = Transaction.from_json(r.text)
@@ -904,7 +904,7 @@ def create_support(
 
     \b
     ADDRESS is the transaction source address.
-    AMOUNT is the amount (as a float) of CCG to apply.
+    AMOUNT is the amount (as a float) of GRIT to apply.
     SUBJECT is the raw (unencoded) subject string.
     """
     try:
@@ -912,7 +912,7 @@ def create_support(
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_support_transaction(
             txn_wallet_obj.public_key_b64,
-            grumble_to_curmudgeons(amount),
+            grit_to_grains(amount),
             subject,
         )
         txn = Transaction.from_json(r.text)
@@ -971,7 +971,7 @@ def create_wallet(walletdir: str | None) -> None:
 )
 @with_appcontext
 def wallet_balance(address: str, host: str | None, wallet: str | None) -> None:
-    """Get the wallet balance in CCG for an address.
+    """Get the wallet balance in GRIT for an address.
 
     \b
     ADDRESS is the wallet address.
@@ -980,7 +980,7 @@ def wallet_balance(address: str, host: str | None, wallet: str | None) -> None:
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_wallet_balance(address)
         balance = r.json().get('balance')
-        console.print(f'{human_curmudgeons(balance)} CCG', style='success')
+        console.print(f'{human_grains(balance)} GRIT', style='success')
     except httpx.HTTPStatusError as e:
         console.print(f'Balance failed: {http_error_message(e)}', style='error')
     except Exception as e:
@@ -1008,7 +1008,7 @@ subject_cli = AppGroup('subject', help='Command group to work with subjects.')
 @with_appcontext
 def subject_balance(subject: str, host: str | None, wallet: str | None) -> None:
     """Get the balance (i.e. subject transactions minus forgiveness
-       transactions) in CCG for a subject.
+       transactions) in GRIT for a subject.
 
     \b
     SUBJECT is the raw (unencoded) subject string.
@@ -1017,7 +1017,7 @@ def subject_balance(subject: str, host: str | None, wallet: str | None) -> None:
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_subject_balance(encode_subject(subject))
         balance = r.json().get('balance')
-        console.print(f'{human_curmudgeons(balance)} CCG', style='success')
+        console.print(f'{human_grains(balance)} GRIT', style='success')
     except httpx.HTTPStatusError as e:
         console.print(
             f'Subject balance failed: {http_error_message(e)}', style='error'
@@ -1043,7 +1043,7 @@ def subject_balance(subject: str, host: str | None, wallet: str | None) -> None:
 )
 @with_appcontext
 def support_balance(subject: str, host: str | None, wallet: str | None) -> None:
-    """Get the support total in CCG for a subject.
+    """Get the support total in GRIT for a subject.
 
     \b
     SUBJECT is the raw (unencoded) subject string.
@@ -1052,7 +1052,7 @@ def support_balance(subject: str, host: str | None, wallet: str | None) -> None:
         client = host_api_client(host=host, wallet_file=wallet)
         r = client.get_subject_support(encode_subject(subject))
         support = r.json().get('support')
-        console.print(f'{human_curmudgeons(support)} CCG', style='success')
+        console.print(f'{human_grains(support)} GRIT', style='success')
     except httpx.HTTPStatusError as e:
         console.print(
             f'Support balance failed: {http_error_message(e)}', style='error'

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -6,8 +6,8 @@ from _sa_helpers import _count_select
 
 from gumptionchain.block import TXN_TIMEOUT, Block
 from gumptionchain.chain import (
-    CURMUDGEON_PER_GRUMBLE,
     GENESIS_HASH,
+    GRAIN_PER_GRIT,
     REWARD,
     Chain,
 )
@@ -254,7 +254,7 @@ def test_db(add_chain_block, app, time_machine, wallet):
         assert block == block_copy
         cb = block.coinbase
         cb_amount = next(iter(block.coinbase.outflows)).amount
-        remit = 2 * CURMUDGEON_PER_GRUMBLE
+        remit = 2 * GRAIN_PER_GRIT
         then_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(then_dt)
         t = Transaction()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,12 +2,12 @@ import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-from gumptionchain.chain import CURMUDGEON_PER_GRUMBLE, REWARD
+from gumptionchain.chain import GRAIN_PER_GRIT, REWARD
 from gumptionchain.database import db
 from gumptionchain.wallet import Wallet
 
-REWARD_CCG = int(REWARD / CURMUDGEON_PER_GRUMBLE)
-SUBJECT_CCG = 2
+REWARD_GRIT = int(REWARD / GRAIN_PER_GRIT)
+SUBJECT_GRIT = 2
 
 
 def get_wallet_file(address, walletdir=None, app=None):
@@ -114,7 +114,7 @@ def run_txn_subject(runner, subject, txn_wallet, txn_wallet_file, confirm=True):
             'txn',
             'subject',
             txn_wallet.address,
-            str(SUBJECT_CCG),
+            str(SUBJECT_GRIT),
             subject,
             '--txn-wallet',
             txn_wallet_file,
@@ -164,7 +164,7 @@ def run_txn_forgive(runner, subject, txn_wallet, txn_wallet_file, confirm=True):
             'txn',
             'forgive',
             txn_wallet.address,
-            str(SUBJECT_CCG),
+            str(SUBJECT_GRIT),
             subject,
             '--txn-wallet',
             txn_wallet_file,
@@ -213,7 +213,7 @@ def run_txn_support(runner, subject, txn_wallet, txn_wallet_file, confirm=True):
             'txn',
             'support',
             txn_wallet.address,
-            str(SUBJECT_CCG),
+            str(SUBJECT_GRIT),
             subject,
             '--txn-wallet',
             txn_wallet_file,
@@ -267,22 +267,23 @@ def test_wallet_balance(
     with app.app_context():
         mill_block(wallet)
         result = runner.invoke(args=['wallet', 'balance', wallet.address])
-        assert f'{REWARD_CCG} CCG' in result.output
+        assert f'{REWARD_GRIT} GRIT' in result.output
         wf = get_wallet_file(wallet.address, app=app)
         run_txn_subject(runner, subject_raw, wallet, wf)
         w = Wallet()
         mill_block(w)
         result = runner.invoke(args=['wallet', 'balance', wallet.address])
-        assert f'{REWARD_CCG - SUBJECT_CCG} CCG' in result.output
+        assert f'{REWARD_GRIT - SUBJECT_GRIT} GRIT' in result.output
         to_wallet = Wallet()
         run_txn_transfer(runner, wallet, to_wallet, wf)
         mill_block(w)
         result = runner.invoke(args=['wallet', 'balance', wallet.address])
-        assert f'{REWARD_CCG - 2 * SUBJECT_CCG} CCG' in result.output
+        assert f'{REWARD_GRIT - 2 * SUBJECT_GRIT} GRIT' in result.output
         result = runner.invoke(args=['wallet', 'balance', to_wallet.address])
-        assert f'{SUBJECT_CCG} CCG' in result.output
+        assert f'{SUBJECT_GRIT} GRIT' in result.output
         result = runner.invoke(args=['wallet', 'balance', w.address])
-        assert f'{int(2 * REWARD_CCG + 0.5 * SUBJECT_CCG)} CCG' in result.output
+        expected = int(2 * REWARD_GRIT + 0.5 * SUBJECT_GRIT)
+        assert f'{expected} GRIT' in result.output
         result = runner.invoke(args=['wallet', 'balance', 'foo'])
         assert 'Not Found' in result.output
 
@@ -293,16 +294,16 @@ def test_subject_balance(
     with app.app_context():
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'balance', subject_raw])
-        assert '0 CCG' in result.output
+        assert '0 GRIT' in result.output
         wf = get_wallet_file(wallet.address, app=app)
         run_txn_subject(runner, subject_raw, wallet, wf)
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'balance', subject_raw])
-        assert f'{SUBJECT_CCG} CCG' in result.output
+        assert f'{SUBJECT_GRIT} GRIT' in result.output
         run_txn_subject(runner, subject_raw, wallet, wf)
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'balance', subject_raw])
-        assert f'{2 * SUBJECT_CCG} CCG' in result.output
+        assert f'{2 * SUBJECT_GRIT} GRIT' in result.output
 
 
 def test_subject_support(
@@ -311,16 +312,16 @@ def test_subject_support(
     with app.app_context():
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'support', subject_raw])
-        assert '0 CCG' in result.output
+        assert '0 GRIT' in result.output
         wf = get_wallet_file(wallet.address, app=app)
         run_txn_support(runner, subject_raw, wallet, wf)
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'support', subject_raw])
-        assert f'{SUBJECT_CCG} CCG' in result.output
+        assert f'{SUBJECT_GRIT} GRIT' in result.output
         run_txn_support(runner, subject_raw, wallet, wf)
         mill_block(wallet)
         result = runner.invoke(args=['subject', 'support', subject_raw])
-        assert f'{2 * SUBJECT_CCG} CCG' in result.output
+        assert f'{2 * SUBJECT_GRIT} GRIT' in result.output
 
 
 def test_mill(app, runner, wallet):

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -5,7 +5,7 @@ import pytest
 from _sa_helpers import _count
 
 from gumptionchain.block import TXN_TIMEOUT
-from gumptionchain.chain import CURMUDGEON_PER_GRUMBLE as CPG
+from gumptionchain.chain import GRAIN_PER_GRIT as GPG
 from gumptionchain.chain import REWARD
 from gumptionchain.exceptions import (
     DuplicateMinedTransactionError,
@@ -38,7 +38,7 @@ def test_miller_create_block(app, time_machine, time_stepper, wallet):
         cb0 = b0.coinbase
         cb0_amount = next(iter(cb0.outflows)).amount
         w2 = Wallet()
-        remit = 2 * CPG
+        remit = 2 * GPG
         t0 = Transaction()
         t0.add_inflow(Inflow(outflow_txid=cb0.txid, outflow_idx=0))
         t0.add_outflow(Outflow(amount=remit, address=w2.address))
@@ -54,9 +54,9 @@ def test_miller_create_block(app, time_machine, time_stepper, wallet):
         _ = next(time_step)
         assert m.longest_chain.length == 3
         assert m.longest_chain.balance(wallet.address) == (3 * REWARD) - (
-            2 * CPG
+            2 * GPG
         )
-        assert m.longest_chain.balance(w2.address) == 2 * CPG
+        assert m.longest_chain.balance(w2.address) == 2 * GPG
         time_machine.move_to(now_dt)
         assert m.longest_chain.get_block(b2.block_hash)
 


### PR DESCRIPTION
## Phase 4 — currency units grumble/curmudgeon → grit/grain

Fourth of the phased **CancelChain → GumptionChain** rename (plan in #134; Phases 1–3 merged). Pure rename — **no behavior change** (the on-disk base unit is an integer; these are display/identifier names).

### What changed
- `chain.py`: `CURMUDGEON_PER_GRUMBLE` → `GRAIN_PER_GRIT` (value still `100`; `REWARD` math unchanged)
- `command.py`: helpers `grumble_to_curmudgeons` → `grit_to_grains`, `human_curmudgeons` → `human_grains` (param/locals → `grit`/`grains`); ticker `CCG` → **`GRIT`** across CLI help, docstrings, and `console.print` output
- tests (`test_chain.py`, `test_command.py`, `test_miller.py`) + `CLAUDE.md` units paragraph
  - `test_miller.py`: the stale `as CPG` import alias renamed to `GPG` so it doesn't misname the new constant
  - `test_command.py`: one assertion extracted to a local to satisfy line-length (behavior-preserving)

### Deliberately untouched
`ADDRESS_TAG='CC'` + `CC…CC` addresses (Phase 5), `gc-sig-v1`/`GC-*` (Phase 3), `GC_` prefix (Phase 2), `cc_check.db`/`cc_version` (Phase 6), `miller`/`Miller`.

### Verification
- `uv run pytest` → **299 passed, 1 skipped** (`test_command.py` asserts the CLI balance/transfer output against the `GRIT` ticker)
- `ruff` clean; `mypy` 0 errors
- Case-insensitive whole-repo residual grep (`CURMUDGEON`/`grumble`/`curmudgeon`/`CCG`): empty outside historical docs
- Adversarial review confirmed both conversion helpers are arithmetically identical (rename-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
