### PR TITLE
refactor(rename): residual cc_/CCError identifiers → gc_/GCError (Phase 6, final)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
       # `Base.metadata` against the schema implied by the migration history.
       # Four slashes = absolute SQLAlchemy URI (sqlite:////absolute/path),
       # avoiding Flask's relative-URI instance-folder resolution that would
-      # otherwise land the file in src/instance/cc_check.db.
+      # otherwise land the file in src/instance/gc_check.db.
       - env:
-          FLASK_SQLALCHEMY_DATABASE_URI: sqlite:////${{ runner.temp }}/cc_check.db
+          FLASK_SQLALCHEMY_DATABASE_URI: sqlite:////${{ runner.temp }}/gc_check.db
         run: |
           uv run gumptionchain db upgrade
           uv run gumptionchain db check

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -31,8 +31,8 @@ from gumptionchain.block import Block, expiry_cutoff
 from gumptionchain.cache import cache
 from gumptionchain.chain import Chain
 from gumptionchain.exceptions import (
-    CCError,
     EmptyChainError,
+    GCError,
     InvalidRoleConfigError,
     MempoolFullError,
     MissingBlockError,
@@ -307,7 +307,7 @@ class BlockView(MethodView):
                         cache.set(key, block_json)
                 if block_json:
                     return make_json_response(block_json)
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -336,7 +336,7 @@ class BlockView(MethodView):
                 queue_block_post_process(block, vhosts)
         except MissingBlockError:
             abort(404)
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -391,7 +391,7 @@ class TxnView(MethodView):
                 queue_txn_post_process(txn, vhosts)
         except MempoolFullError:
             return make_json_response({'error': 'mempool full'}, 503)
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -443,7 +443,7 @@ class TransferTxnView(MethodView):
             return make_json_response(
                 lc.create_transfer(wallet, amount, dest_address).to_json()
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -496,7 +496,7 @@ class SubjectTxnView(MethodView):
             return make_json_response(
                 lc.create_subject(wallet, amount, subject).to_json()
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -531,7 +531,7 @@ class ForgiveTxnView(MethodView):
             return make_json_response(
                 lc.create_forgive(wallet, amount, subject).to_json()
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -566,7 +566,7 @@ class SupportTxnView(MethodView):
             return make_json_response(
                 lc.create_support(wallet, amount, subject).to_json()
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -611,7 +611,7 @@ class PendingTxnView(MethodView):
                 earliest=earliest, expired=expired
             )
             return make_json_response([json.loads(j) for j in pending_json])
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -638,7 +638,7 @@ class WalletBalanceView(MethodView):
             return make_json_response(
                 {'balance': balance, 'as_of_block': block_hash}
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -667,7 +667,7 @@ class SubjectBalanceView(MethodView):
             return make_json_response(
                 {'balance': balance, 'as_of_block': block_hash}
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)
@@ -696,7 +696,7 @@ class SubjectSupportView(MethodView):
             return make_json_response(
                 {'support': support, 'as_of_block': block_hash}
             )
-        except CCError as err:
+        except GCError as err:
             return make_error_response(err)
         except Exception as e:
             exception_response(e)

--- a/src/gumptionchain/application.py
+++ b/src/gumptionchain/application.py
@@ -59,8 +59,8 @@ def init_app(
     app.cli.add_command(command.subject_cli)
 
     @app.context_processor
-    def inject_cc_version() -> dict[str, str]:
-        return {'cc_version': __version__}
+    def inject_gc_version() -> dict[str, str]:
+        return {'gc_version': __version__}
 
     @app.template_filter('utc_datetime')
     def utc_datetime(

--- a/src/gumptionchain/exceptions.py
+++ b/src/gumptionchain/exceptions.py
@@ -11,7 +11,7 @@ from typing import Any
 Message = str | bytes | list[Any] | dict[str, Any]
 
 
-class CCError(Exception):
+class GCError(Exception):
     def __init__(self, message: Message | None = None) -> None:
         # Use `is None` instead of truthy check so empty containers
         # ({}, [], "", b"") aren't silently replaced with the class name —
@@ -26,7 +26,7 @@ class CCError(Exception):
             self.messages = msg
 
 
-class InvalidWalletError(CCError):
+class InvalidWalletError(GCError):
     pass
 
 
@@ -38,7 +38,7 @@ class NoPrivateKeyError(InvalidWalletError):
     pass
 
 
-class InvalidTransactionError(CCError):
+class InvalidTransactionError(GCError):
     pass
 
 
@@ -110,7 +110,7 @@ class MismatchedCoinbaseError(InvalidCoinbaseError):
     pass
 
 
-class InvalidBlockError(CCError):
+class InvalidBlockError(GCError):
     pass
 
 
@@ -166,7 +166,7 @@ class MissingBlockError(InvalidBlockError):
     pass
 
 
-class InvalidChainError(CCError):
+class InvalidChainError(GCError):
     pass
 
 
@@ -178,9 +178,9 @@ class MissingPreviousBlockError(InvalidChainError):
     pass
 
 
-class InvalidRoleConfigError(CCError):
+class InvalidRoleConfigError(GCError):
     pass
 
 
-class MempoolFullError(CCError):
+class MempoolFullError(GCError):
     pass

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -31,7 +31,7 @@
 
   {% block footer -%}
   <div class="footer text-center">
-    Version {{ cc_version }} | <a href="https://gumption.com/chain" class="link-dark">gumption.com/chain</a>
+    Version {{ gc_version }} | <a href="https://gumption.com/chain" class="link-dark">gumption.com/chain</a>
   </div>
   {%- endblock %}
 


### PR DESCRIPTION
## Phase 6 — residual `cc_`/`CCError` identifiers (final phase)

The last of the phased **CancelChain → GumptionChain** rename (plan in #134; Phases 1–5 merged). Closes out the remaining CancelChain-flavored identifiers. Pure rename — **no behavior change**.

### What changed
- `cc_check.db` → `gc_check.db` (CI temp-DB filename in `.github/workflows/tests.yml`)
- `cc_version` / `inject_cc_version` → `gc_version` / `inject_gc_version` (`application.py` context processor + `templates/base.html` footer)
- `CCError` → `GCError` (base exception class in `exceptions.py`, all 6 subclass bases, and 11 `except` sites + import in `api.py` — 19 refs total)

### Verification
- `uv run pytest` → **299 passed, 1 skipped**; `ruff` clean; `mypy` 0
- Exception hierarchy intact (all subclasses re-rooted at `GCError`; zero `CCError` survives → no `NameError` risk); context-processor dict key matches `{{ gc_version }}`
- **Whole-rename completeness gate (the closer):** an independent 14-pattern sweep — `cancelchain`, `cc-sig`/`CC-*`, `CC_`, `CCG`/grumble/curmudgeon, `ADDRESS_TAG='CC'`, `CC…CC`, `cc.sqlite`, `thecancelbutton`, `CCError`, etc. — returns **zero hits** outside the historical `docs/superpowers/` and the one intentional `.git-blame-ignore-revs` comment.

With this merged, **no CancelChain-flavored identifier remains in the codebase.** Remaining work is external-infra only (GitHub repo rename, `gumption.com/chain` site, email) per the plan's checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
