### PR TITLE
docs(design): opposition/support/rescind transaction redesign — spec + PR-1 plan

### DIFF
--- a/docs/superpowers/plans/2026-06-03-pr1-opposition-rescind-rename.md
+++ b/docs/superpowers/plans/2026-06-03-pr1-opposition-rescind-rename.md
@@ -1,0 +1,615 @@
+# PR 1 — Opposition / Rescind pure rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the `subject` (cancel-flavored) outflow kind to `opposition` and the `forgive` outflow kind to `rescind` across the entire codebase, with zero behavior change.
+
+**Architecture:** Pure identifier rename. The on-chain serialization (`Outflow.data_csv`) keeps field *positions*, so the rename produces byte-identical block hashes — this PR is **not** a hard fork and does not touch consensus. The coinbase sentiment weights (`schadenfreude`/`grace`/`mudita`) are unchanged; only the fields they read are renamed. The follow-on PR 2 (support rescindability, `rescind_kind`, `regret`, `mudita`→½) carries all consensus changes.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]`), Pydantic v2, Alembic/Flask-Migrate, pytest, uv, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-opposition-support-rescind-design.md`
+
+---
+
+## CRITICAL GUARDRAIL — "subject" is two different things
+
+The word `subject` is overloaded. **Only the opposition outflow kind is renamed.** The
+target-string noun is preserved. Get this wrong and you will break unrelated code.
+
+### RENAME — the opposition outflow *kind* (`subject` → `opposition`)
+- `Outflow.subject` field, `OutflowModel.subject` field, `OutflowDAO.subject` column
+- `Outflow.schadenfreude` reads `self.subject`
+- `Outflow(subject=...)` / `OutflowDAO(subject=...)` keyword arguments
+- `.subject` attribute access on an outflow object (e.g. `o.subject`, `outflow.subject`, `ioflow` has none)
+- `Chain.create_subject` → `create_opposition`
+- `ChainDAO.subject_balance` → `opposition_balance`
+- API `SubjectTxnView`, `SubjectBalanceView`, routes `/transaction/subject`, `/subject/<…>/balance`
+- `ApiClient.get_subject_transaction`, `get_subject_balance`
+- CLI `txn subject`, `subject balance`
+
+### RENAME — the forgive outflow *kind* (`forgive` → `rescind`)
+- `Outflow.forgive`, `OutflowModel.forgive`, `OutflowDAO.forgive` column
+- `Outflow.grace` reads `self.forgive`
+- `Outflow(forgive=...)` keyword args, `.forgive` attribute access
+- `Chain.create_forgive` → `create_rescind`
+- `ChainDAO.unforgiven_outflows` → `unrescinded_outflows`, `unforgiven_address_outflows` → `unrescinded_address_outflows`
+- API `ForgiveTxnView`, route `/transaction/forgive`
+- `ApiClient.get_forgive_transaction`
+- CLI `txn forgive`
+
+### RENAME — support balance accessor (name only; logic unchanged in PR 1)
+- `ChainDAO.subject_support` → `support_balance`, `Chain.subject_support` → `support_balance`
+- `ApiClient.get_subject_support` → `get_support_balance`
+- (route `/subject/<…>/support`, CLI `subject support`, and `Outflow.support`/`mudita` are **unchanged**)
+
+### PRESERVE — "subject" the target string (DO NOT TOUCH)
+- `encode_subject`, `decode_subject`, `validate_subject`, `validate_raw_subject`, `_check_raw_subject`, `_RawSubjectField`, the `Subject` type, `MIN/MAX_SUBJECT_LENGTH`
+- `SubjectConverter`, the URL converter key `'subject'`, the path converter `<subject:subject>`, `human_subject` template filter
+- the `'subject'` **JSON query-param name** in API requests/clients
+- `SubjectTxnQueryModel` (shared model carrying the subject string — keep the name)
+- the `subject_cli` command group (`gc subject …`) and `SubjectSupportView` class name
+- every function parameter / local variable named `subject` that holds the target string
+- test fixtures `subject`, `subject_raw`; constants `SUBJECT_1`, `SUBJECT_2`
+
+When in doubt: if the value is a UTF-8 target string, it's the noun → **preserve**. If it's an
+outflow destination field / kind / the txn that creates one → **rename**.
+
+---
+
+## File map (PR 1)
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/payload.py` | rename `Outflow`/`OutflowModel` fields, `data_csv`, `schadenfreude`/`grace` reads, `validate_destinations` |
+| `src/gumptionchain/models.py` | rename `OutflowDAO` columns + ctor; rename DAO methods `subject_balance`/`subject_support`/`unforgiven_*` |
+| `src/gumptionchain/transaction.py` | rename `Outflow(subject=…, forgive=…)` kwargs in `from_dao`/`from_db` |
+| `src/gumptionchain/chain.py` | rename `create_subject`/`create_forgive`; `subject_support` wrapper; `validate_block_txn`/`validate_txn_inflow` attr reads + Outflow kwargs + local dict |
+| `src/gumptionchain/api.py` | rename views, routes, endpoint names, `lc.*` call sites |
+| `src/gumptionchain/api_client.py` | rename client methods + request paths |
+| `src/gumptionchain/command.py` | rename CLI verbs + command fns + client call sites |
+| `src/gumptionchain/templates/transaction.html` | `o.subject`→`o.opposition`, `o.forgive`→`o.rescind` |
+| `src/gumptionchain/migrations/versions/<new>.py` | new migration: rename `outflow` columns |
+| `tests/conftest.py` + `tests/test_*.py` | update kwargs/attr/method/route/verb references |
+
+Each task renames one identifier (or one tightly-coupled set) **across its definition, every
+call site, and its tests in the same commit**, so the full suite stays green after every task.
+
+---
+
+## Task 1: Rename the two outflow-kind fields (`subject`→`opposition`, `forgive`→`rescind`)
+
+This is the atomic core: the field rename touches every layer at once, because a half-renamed
+field leaves dangling attribute access. Do it all in one commit.
+
+**Files:**
+- Modify: `src/gumptionchain/payload.py`
+- Modify: `src/gumptionchain/models.py` (columns + ctor only; method renames are Tasks 2–3)
+- Modify: `src/gumptionchain/transaction.py`
+- Modify: `src/gumptionchain/chain.py` (Outflow kwargs + attr reads in `validate_block_txn`/`validate_txn_inflow` and `create_*` bodies; method *names* stay until Tasks 2–3)
+- Modify: `src/gumptionchain/templates/transaction.html`
+- Create: `src/gumptionchain/migrations/versions/<generated>.py`
+- Modify: `tests/conftest.py`, `tests/test_payload.py`, `tests/test_transaction.py`, `tests/test_models.py`, and any other test building `Outflow(subject=…/forgive=…)` or reading `.subject`/`.forgive`
+
+- [ ] **Step 1: Update the payload unit tests to the new field names (red first)**
+
+In `tests/test_payload.py`, change every `Outflow(subject=…)` → `Outflow(opposition=…)`,
+`Outflow(forgive=…)` → `Outflow(rescind=…)`, and every `.subject`/`.forgive` attribute
+assertion on an outflow → `.opposition`/`.rescind`. The `schadenfreude`/`grace`/`mudita`
+assertions and their expected values stay the same (weights unchanged in PR 1). Example:
+
+```python
+def test_outflow_schadenfreude(subject):
+    outflow = Outflow(amount=9, opposition=subject)   # was subject=subject
+    assert outflow.schadenfreude == 4
+
+def test_outflow_grace(subject):
+    outflow = Outflow(amount=9, rescind=subject)       # was forgive=subject
+    assert outflow.grace == 4
+```
+
+- [ ] **Step 2: Run payload tests to confirm they fail**
+
+Run: `uv run pytest tests/test_payload.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'opposition'`.
+
+- [ ] **Step 3: Rename the fields in `payload.py`**
+
+Edit the `Outflow` dataclass fields and `data_csv` (keep positions — byte-identical output):
+
+```python
+@dataclass
+class Outflow:
+    amount: int | None = None
+    address: str | None = None
+    opposition: str | None = None
+    rescind: str | None = None
+    support: str | None = None
+
+    @property
+    def data_csv(self) -> str:
+        return ','.join(
+            [
+                str(self.amount),
+                self.address if self.address is not None else '',
+                self.opposition if self.opposition is not None else '',
+                self.rescind if self.rescind is not None else '',
+                self.support if self.support is not None else '',
+            ]
+        )
+
+    @property
+    def schadenfreude(self) -> int:
+        if self.opposition is not None and self.amount is not None:
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def grace(self) -> int:
+        if self.rescind is not None and self.amount is not None:
+            return int(self.amount / 2)
+        return 0
+```
+
+(`mudita` is unchanged.) Then edit `OutflowModel`:
+
+```python
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: AddressType | None = None
+    opposition: Subject | None = None
+    rescind: Subject | None = None
+    support: Subject | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
+        options = [
+            v
+            for v in (self.opposition, self.rescind, self.support)
+            if v is not None
+        ]
+        if not (
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
+        ):
+            raise ValueError(INVALID_DESTINATION_MSG)
+        return self
+```
+
+- [ ] **Step 4: Run payload tests to confirm they pass**
+
+Run: `uv run pytest tests/test_payload.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Rename the `OutflowDAO` columns + constructor in `models.py`**
+
+Rename the two mapped columns and their constructor params/assignments (keep `support`):
+
+```python
+    opposition: Mapped[str | None] = mapped_column(String(500))
+    rescind: Mapped[str | None] = mapped_column(String(500))
+    support: Mapped[str | None] = mapped_column(String(500))
+```
+
+In `OutflowDAO.__init__`, rename params `subject`→`opposition`, `forgive`→`rescind` and the
+corresponding `self.opposition = opposition` / `self.rescind = rescind` assignments. Do **not**
+touch the `subject_balance`/`subject_support`/`unforgiven_*` *methods* yet (Tasks 2–3).
+
+- [ ] **Step 6: Rename the `Outflow(...)` kwargs in `transaction.py`**
+
+In `from_dao` and `from_db` (the two `Outflow(...)` constructions), rename:
+
+```python
+                    opposition=outflow.opposition,   # was subject=outflow.subject
+                    rescind=outflow.rescind,          # was forgive=outflow.forgive
+```
+and in the `from_dao` DAO variant: `opposition=outflow_dao.opposition`, `rescind=outflow_dao.rescind`.
+
+- [ ] **Step 7: Rename Outflow kwargs + attribute reads in `chain.py` (method names unchanged here)**
+
+In `create_subject`'s body: `Outflow(amount=amount, subject=subject)` → `Outflow(amount=amount, opposition=subject)`.
+In `create_forgive`'s body: `Outflow(amount=amount, forgive=subject)` → `Outflow(amount=amount, rescind=subject)`, and the excess `Outflow(amount=balance - amount, subject=subject)` → `opposition=subject`.
+(`subject` here is the target-string variable — keep it; only the kwarg name changes.)
+
+In `validate_block_txn`, rename the attribute reads and the local accumulator for clarity:
+
+```python
+        # add inflow amounts
+        opposition_amounts: dict[str, int] = {}
+        other_amounts = 0
+        for i in txn.inflows:
+            amount, subject = self.validate_txn_inflow(
+                block, txn, i, txn_in_block=txn_in_block
+            )
+            if subject:
+                opposition_amount: int | None = opposition_amounts.get(subject, 0)
+                opposition_amounts[subject] = (opposition_amount or 0) + amount
+            else:
+                other_amounts += amount
+        # subtract outflow amounts
+        for o in txn.outflows:
+            if o.rescind:
+                rescind_amount = opposition_amounts.get(o.rescind, 0)
+                opposition_amounts[o.rescind] = rescind_amount - (o.amount or 0)
+            elif o.opposition:
+                opposition_amount = opposition_amounts.get(o.opposition)
+                if opposition_amount and opposition_amount > 0:
+                    if (o.amount or 0) > opposition_amount:
+                        opposition_amounts[o.opposition] = 0
+                        other_amounts -= (o.amount or 0) - opposition_amount
+                    else:
+                        opposition_amounts[o.opposition] = opposition_amount - (
+                            o.amount or 0
+                        )
+                else:
+                    other_amounts -= o.amount or 0
+            else:
+                other_amounts -= o.amount or 0
+        if other_amounts != 0:
+            raise ImbalancedTransactionError()
+        for _, amount in opposition_amounts.items():
+            if amount != 0:
+                raise ImbalancedTransactionError()
+```
+
+In `validate_txn_inflow`, rename the guard attribute read (forgive→rescind; support stays):
+
+```python
+        # inflow's outflow can't be for rescind or support
+        if ioflow.rescind is not None or ioflow.support is not None:
+            raise InvalidInflowOutflowError()
+```
+
+(The `subject` return value of `validate_txn_inflow` is the opposition target string and stays
+named `subject` for now; it is internal.)
+
+- [ ] **Step 8: Update the template**
+
+`src/gumptionchain/templates/transaction.html` lines ~101–102:
+
+```html
+                <td class="col-2">{{ o.opposition }}{% if o.opposition %} <em>({{ o.opposition | human_subject }})</em>{% endif %}</td>
+                <td class="col-2">{{ o.rescind }}{% if o.rescind %} <em>({{ o.rescind | human_subject }})</em>{% endif %}</td>
+```
+(Line ~103 `o.support` is unchanged. `human_subject` filter is unchanged.)
+
+- [ ] **Step 9: Update remaining test/conftest field references**
+
+In `tests/conftest.py` (the outflow-building fixtures around lines 231–232 and 250–251):
+`subject=request.param[2]` → `opposition=request.param[2]`, `forgive=request.param[3]` →
+`rescind=request.param[3]`. Then sweep the rest of the suite:
+
+Run: `grep -rn "Outflow(.*subject=\|Outflow(.*forgive=\|\.subject\b\|\.forgive\b" tests`
+Update each hit that builds/reads an **outflow** kind (rename) — leave subject-string fixtures
+and `encode_subject(...)` etc. untouched. Update `test_transaction.py` and `test_models.py`
+outflow constructions/reads the same way.
+
+- [ ] **Step 10: Create the column-rename migration**
+
+Scaffold a migration (auto-sets revision id + `down_revision = '63d32cd7621a'`):
+
+Run: `uv run gumptionchain db migrate -m "rename outflow kinds subject->opposition forgive->rescind"`
+
+Then **replace** the generated `upgrade()`/`downgrade()` bodies (autogenerate emits drop+add for
+renames — wrong) with explicit SQLite-safe batch renames:
+
+```python
+def upgrade() -> None:
+    with op.batch_alter_table('outflow', schema=None) as batch_op:
+        batch_op.alter_column('subject', new_column_name='opposition')
+        batch_op.alter_column('forgive', new_column_name='rescind')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('outflow', schema=None) as batch_op:
+        batch_op.alter_column('opposition', new_column_name='subject')
+        batch_op.alter_column('rescind', new_column_name='forgive')
+```
+
+- [ ] **Step 11: Verify schema parity and run the full suite**
+
+Run: `uv run gumptionchain db check`
+Expected: no error (model metadata from `create_all` matches the migration head).
+
+Run: `uv run pytest -q`
+Expected: PASS (full suite). The renamed Outflow `data_csv` is byte-identical, so any
+hash/merkle assertions still pass unchanged.
+
+- [ ] **Step 12: Lint, format, type-check**
+
+Run: `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all clean.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(rename): outflow kinds subject->opposition, forgive->rescind (fields)"
+```
+
+---
+
+## Task 2: Rename `create_subject`→`create_opposition` and `create_forgive`→`create_rescind`
+
+**Files:**
+- Modify: `src/gumptionchain/chain.py` (method defs)
+- Modify: `src/gumptionchain/api.py` (`lc.create_subject` / `lc.create_forgive` call sites)
+- Modify: `src/gumptionchain/command.py` if it calls `lc.create_*` directly (it calls the client, not chain — verify)
+- Modify: `tests/test_chain.py`, `tests/test_miller.py`, `tests/test_verification_audit.py`, and any test calling `create_subject`/`create_forgive`
+
+- [ ] **Step 1: Update tests to call the new method names (red first)**
+
+Run: `grep -rn "create_subject\|create_forgive" tests`
+Rename each call: `create_subject(` → `create_opposition(`, `create_forgive(` → `create_rescind(`.
+(Signatures are unchanged in PR 1: `create_rescind(wallet, amount, subject)`.)
+
+- [ ] **Step 2: Run affected tests to confirm failure**
+
+Run: `uv run pytest tests/test_chain.py -q`
+Expected: FAIL — `AttributeError: 'Chain' object has no attribute 'create_opposition'`.
+
+- [ ] **Step 3: Rename the method definitions in `chain.py`**
+
+`def create_subject(` → `def create_opposition(`; `def create_forgive(` → `def create_rescind(`.
+Bodies already updated in Task 1; only the `def` line changes.
+
+- [ ] **Step 4: Update call sites in `api.py`**
+
+In `SubjectTxnView`: `lc.create_subject(wallet, amount, subject)` → `lc.create_opposition(...)`.
+In `ForgiveTxnView`: `lc.create_forgive(wallet, amount, subject)` → `lc.create_rescind(...)`.
+
+- [ ] **Step 5: Confirm no stragglers**
+
+Run: `grep -rn "create_subject\|create_forgive" src tests`
+Expected: no matches.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(rename): Chain.create_subject->create_opposition, create_forgive->create_rescind"
+```
+
+---
+
+## Task 3: Rename DAO/Chain query methods
+
+`subject_balance`→`opposition_balance`, `subject_support`→`support_balance`,
+`unforgiven_outflows`→`unrescinded_outflows`, `unforgiven_address_outflows`→`unrescinded_address_outflows`.
+(Logic is unchanged in PR 1 — `support_balance` still sums all support; the unspent-only change is PR 2.)
+
+**Files:**
+- Modify: `src/gumptionchain/models.py` (`ChainDAO` method defs)
+- Modify: `src/gumptionchain/chain.py` (`Chain` wrapper methods + `create_rescind`'s `unrescinded_address_outflows` call)
+- Modify: `src/gumptionchain/api.py` (`lc.subject_balance` / `lc.subject_support` call sites)
+- Modify: `tests/test_models.py`, `tests/test_chain.py`, and any test calling these
+
+- [ ] **Step 1: Update tests to the new method names (red first)**
+
+Run: `grep -rn "subject_balance\|subject_support\|unforgiven_outflows\|unforgiven_address_outflows" tests`
+Rename: `subject_balance`→`opposition_balance`, `subject_support`→`support_balance`,
+`unforgiven_outflows`→`unrescinded_outflows`, `unforgiven_address_outflows`→`unrescinded_address_outflows`.
+
+- [ ] **Step 2: Run affected tests to confirm failure**
+
+Run: `uv run pytest tests/test_models.py tests/test_chain.py -q`
+Expected: FAIL — `AttributeError` on the renamed methods.
+
+- [ ] **Step 3: Rename the definitions and internal call sites**
+
+In `models.py` rename the four `ChainDAO` method defs. In `chain.py` rename the `Chain`
+wrapper methods (`subject_balance`/`subject_support`) and update `create_rescind`'s body call
+`self.unforgiven_address_outflows(...)` → `self.unrescinded_address_outflows(...)`.
+
+- [ ] **Step 4: Update call sites in `api.py`**
+
+`SubjectBalanceView`: `lc.subject_balance(subject)` → `lc.opposition_balance(subject)`.
+`SubjectSupportView`: `lc.subject_support(subject)` → `lc.support_balance(subject)`.
+
+- [ ] **Step 5: Confirm no stragglers**
+
+Run: `grep -rn "subject_balance\|subject_support\|unforgiven_" src tests`
+Expected: no matches.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(rename): ChainDAO subject_balance->opposition_balance, subject_support->support_balance, unforgiven_*->unrescinded_*"
+```
+
+---
+
+## Task 4: Rename the API surface (views, routes, endpoint names, client methods)
+
+**Files:**
+- Modify: `src/gumptionchain/api.py`
+- Modify: `src/gumptionchain/api_client.py`
+- Modify: `tests/test_api.py`, `tests/test_network_audit.py`, `tests/test_browser.py`, and any test/template using `url_for(...)` on the renamed endpoints
+
+- [ ] **Step 1: Update API tests to the new routes/client methods (red first)**
+
+In `tests/test_api.py` (and others hitting these), rename request paths and client calls:
+- `/transaction/subject` → `/transaction/opposition`; `/transaction/forgive` → `/transaction/rescind`
+- `/subject/<…>/balance` → `/subject/<…>/opposition` (`/support` unchanged)
+- `get_subject_transaction` → `get_opposition_transaction`; `get_forgive_transaction` → `get_rescind_transaction`
+- `get_subject_balance` → `get_opposition_balance`; `get_subject_support` → `get_support_balance`
+
+The `'subject'` JSON query-param key sent in request bodies is **unchanged** (it carries the
+target string).
+
+- [ ] **Step 2: Run API tests to confirm failure**
+
+Run: `uv run pytest tests/test_api.py -q`
+Expected: FAIL (404s on new routes / missing client methods).
+
+- [ ] **Step 3: Rename views, routes, and endpoint names in `api.py`**
+
+- `class SubjectTxnView` → `class OppositionTxnView`; its `route('/transaction/subject', …)`
+  → `route('/transaction/opposition', …)`; `as_view('txn_subject_transactor')` →
+  `as_view('txn_opposition_transactor')`.
+- `class ForgiveTxnView` → `class RescindTxnView`; `route('/transaction/forgive', …)` →
+  `route('/transaction/rescind', …)`; `as_view('txn_forgive_transactor')` →
+  `as_view('txn_rescind_transactor')`.
+- `class SubjectBalanceView` → `class OppositionBalanceView`;
+  `route('/subject/<subject:subject>/balance', …)` →
+  `route('/subject/<subject:subject>/opposition', …)`;
+  `as_view('subject_balance_transactor')` → `as_view('opposition_balance_transactor')`.
+- `SubjectSupportView` **keep** (route `/subject/<…>/support` unchanged; it already calls
+  `lc.support_balance` from Task 3). Keep `SubjectTxnQueryModel` (shared subject-string query).
+
+Keep the `<subject:subject>` converter usage verbatim (preserved noun).
+
+- [ ] **Step 4: Rename client methods + paths in `api_client.py`**
+
+- `get_subject_transaction` → `get_opposition_transaction`, path `/api/transaction/subject` → `/api/transaction/opposition`
+- `get_forgive_transaction` → `get_rescind_transaction`, path `/api/transaction/forgive` → `/api/transaction/rescind`
+- `get_subject_balance` → `get_opposition_balance`, path `/api/subject/{subject}/balance` → `/api/subject/{subject}/opposition`
+- `get_subject_support` → `get_support_balance`, path `/api/subject/{subject}/support` (path unchanged)
+
+Keep the `'subject': subject` entry in the request `data` dicts (target-string param).
+
+- [ ] **Step 5: Update any `url_for` references to renamed endpoints**
+
+Run: `grep -rn "txn_subject_transactor\|txn_forgive_transactor\|subject_balance_transactor" src tests`
+Update each (templates and tests) to the new endpoint names. Expected after: no matches for the
+old names.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(rename): API routes/views/client for opposition & rescind"
+```
+
+---
+
+## Task 5: Rename the CLI verbs and command functions
+
+**Files:**
+- Modify: `src/gumptionchain/command.py`
+- Modify: `tests/test_command.py`
+
+- [ ] **Step 1: Update CLI tests to the new verbs (red first)**
+
+In `tests/test_command.py`, rename invocations: `txn subject` → `txn opposition`,
+`txn forgive` → `txn rescind`, `subject balance` → `subject opposition`. (`txn support` and
+`subject support` are unchanged.) Update any references to the renamed client methods from
+Task 4 if the tests assert on them.
+
+- [ ] **Step 2: Run CLI tests to confirm failure**
+
+Run: `uv run pytest tests/test_command.py -q`
+Expected: FAIL (no such command `opposition`).
+
+- [ ] **Step 3: Rename the commands + functions in `command.py`**
+
+- `@txn_cli.command('subject')` → `@txn_cli.command('opposition')`; `def create_subject(` →
+  `def create_opposition(`; inside it `client.get_subject_transaction(...)` →
+  `client.get_opposition_transaction(...)`.
+- `@txn_cli.command('forgive')` → `@txn_cli.command('rescind')`; `def create_forgive(` →
+  `def create_rescind(`; inside it `client.get_forgive_transaction(...)` →
+  `client.get_rescind_transaction(...)`.
+- `@subject_cli.command('balance')` → `@subject_cli.command('opposition')`; `def subject_balance(` →
+  `def opposition_balance(`; inside it `client.get_subject_balance(...)` →
+  `client.get_opposition_balance(...)`.
+- `@subject_cli.command('support')` (keep); inside `support_balance(...)`:
+  `client.get_subject_support(...)` → `client.get_support_balance(...)`.
+
+Keep the `subject_cli` group name and all `subject` argument names (target strings).
+
+- [ ] **Step 4: Confirm no stragglers**
+
+Run: `grep -rn "get_subject_transaction\|get_forgive_transaction\|get_subject_balance\|get_subject_support" src tests`
+Expected: no matches.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(rename): CLI txn opposition/rescind and subject opposition"
+```
+
+---
+
+## Task 6: Final verification sweep
+
+**Files:** none expected (verification only; fix stragglers if any).
+
+- [ ] **Step 1a: Grep for identifiers that must be fully gone (expect zero)**
+
+These have no preserved-noun meaning — every hit is a straggler. `forgive` never refers to the
+noun, so all `forgive` forms must vanish:
+
+```bash
+grep -rn "\.forgive\b\|forgive=\|create_subject\|create_forgive\|/transaction/subject\|/transaction/forgive\|/subject/<subject:subject>/balance\|subject_balance\|subject_support\|unforgiven\|get_subject_transaction\|get_forgive_transaction\|get_subject_balance\|get_subject_support\|ForgiveTxnView\|SubjectTxnView\|SubjectBalanceView\|txn_subject_transactor\|txn_forgive_transactor\|subject_balance_transactor" src tests
+```
+Expected: **no matches.** Rename any hit.
+
+- [ ] **Step 1b: Advisory grep for `.subject` / `subject=` (manual review — both meanings exist)**
+
+```bash
+grep -rn "\.subject\b\|subject=" src tests
+```
+Expected hits are **only** the preserved target-string noun: `SubjectTxnQueryModel.subject`,
+`model.subject`, client/CLI calls passing `subject=<string>`, and similar. There must be **no**
+hit that is an `Outflow`/`OutflowDAO` kind field or kwarg (those are now `opposition=`). Review
+each; rename only true outflow-kind hits.
+
+- [ ] **Step 2: Confirm preserved nouns are intact (sanity)**
+
+Run: `grep -rn "encode_subject\|decode_subject\|SubjectConverter\|human_subject\|<subject:subject>\|SUBJECT_1" src tests | head`
+Expected: these still exist (they must NOT have been renamed).
+
+- [ ] **Step 3: Full gate — tests, schema, lint, types**
+
+Run:
+```bash
+uv run pytest -q
+uv run gumptionchain db check
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy
+```
+Expected: all clean.
+
+- [ ] **Step 4: Commit any straggler fixes (if Steps 1–3 required edits)**
+
+```bash
+git add -A
+git commit -m "refactor(rename): clean up residual subject/forgive references"
+```
+
+---
+
+## Definition of done (PR 1)
+
+- `subject` outflow kind is `opposition`, `forgive` outflow kind is `rescind`, end-to-end (domain,
+  DAO, migration, chain, API routes/views, client, CLI, template).
+- `subject_support` accessor is now `support_balance` (logic unchanged).
+- The target-string noun ("subject") is untouched everywhere it appears.
+- Full suite + `db check` + ruff + ruff format + mypy all green.
+- Block/merkle hashes unchanged (no consensus impact) — PR 1 is not a hard fork.
+- PR 2 (support rescindability, `rescind_kind`, `--kind`, `regret`, `mudita`→½) builds on this.

--- a/docs/superpowers/specs/2026-06-03-opposition-support-rescind-design.md
+++ b/docs/superpowers/specs/2026-06-03-opposition-support-rescind-design.md
@@ -1,0 +1,298 @@
+# Opposition / Support / Rescind — transaction model redesign
+
+**Date:** 2026-06-03
+**Status:** Approved design, pre-implementation
+**Type:** Hard fork (greenfield chain — no on-chain data to preserve)
+
+## Summary
+
+Two related changes, both shedding residual "CancelChain" framing now that the
+project is GumptionChain:
+
+1. **Rename the opposition transaction.** The `subject` outflow kind (the
+   `cancel`-flavored stake) becomes **`opposition`**, sitting naturally beside
+   the existing `support`. The word "subject" survives only where it means *the
+   target string being acted on*.
+2. **Make support rescindable, symmetrically.** The old `forgive` transaction
+   (undo opposition only) becomes a single **`rescind`** transaction that undoes
+   *either* opposition or support. This removes the asymmetry where opposition
+   could be walked back but support could not.
+
+The chain is greenfield, so we take the clean break: renamed wire fields, a new
+metadata column, and a rebalanced coinbase rule, with no migration/replay story.
+
+## Motivation
+
+"Subject" was only ever a euphemism for "cancel" — a subject was the thing you
+were cancelling. In a chain not marketed around cancellation, that name carries
+no meaning and actively confuses, because "subject" is *also* the generic word
+for the target string that both opposition and support point at. The rename
+disambiguates: `subject` (the noun) stays as the target string; `opposition`
+(the verb/kind) names the stake.
+
+`forgive` existed mainly to soften "cancel" — and its one-sidedness (you could
+rescind opposition but never support) was an artifact of that branding, on the
+assumption that to "undo" support you'd post a compensating opposition. With the
+softening no longer needed, a single neutral `rescind` that works in both
+directions is both simpler to explain (one new term) and more honest.
+
+## Terminology decisions
+
+| Old (outflow kind) | New | Holds | Notes |
+|---|---|---|---|
+| `address` | `address` | a wallet address | unchanged |
+| `subject` | **`opposition`** | the subject string being opposed | renamed |
+| `support` | `support` | the subject string being supported | unchanged |
+| `forgive` | **`rescind`** | the subject string being un-staked | renamed + generalized |
+| — | **`rescind_kind`** | `'opposition'` \| `'support'` | new metadata field |
+
+**"Subject" the noun survives** everywhere it denotes the 1–79 char target
+string: the `Subject` Pydantic type, `encode_subject` / `decode_subject`,
+`SubjectConverter` (URL routing), `MIN/MAX_SUBJECT_LENGTH`, the `human_subject`
+template filter, and the per-subject query API (`/subject/<s>/…`). Only the two
+outflow *kinds* (`subject` → `opposition`, `forgive` → `rescind`) are renamed.
+
+The single new term users must learn is **`rescind`**. `rescind_kind` is
+internal metadata, surfaced at the CLI/API as a required `--kind` / `kind`
+parameter.
+
+## Data model
+
+### Outflow fields (`payload.py`, `models.py`)
+
+The "at most one destination" invariant changes from
+`{address, subject, forgive, support}` to:
+
+> exactly one of `{address}` **xor** `{opposition, support, rescind}`,
+> **and** `rescind_kind` is present if-and-only-if `rescind` is set.
+
+`rescind_kind` is *not* a destination — the destination is the subject string in
+the `rescind` field. `rescind_kind` is parallel metadata recording which kind of
+stake is being undone. `OutflowModel.validate_destinations()` enforces both
+clauses; `rescind_kind ∈ {'opposition', 'support'}` when present, else `None`.
+
+### Canonical serialization (`Outflow.data_csv`)
+
+Current order is `amount, address, subject, forgive, support`. The new canonical
+order is:
+
+```
+amount, address, opposition, support, rescind, rescind_kind
+```
+
+with empty string for any `None` field. This changes the byte content of every
+outflow, hence every transaction and block header hash — see **Hard fork**.
+
+### DAO (`models.py` `OutflowDAO`)
+
+Rename columns `subject → opposition`, `forgive → rescind`; keep `support`; add
+`rescind_kind` (`String`, nullable). All `String(500)`-style sizing as today;
+`rescind_kind` is a short enum-valued string.
+
+## Economic model: burn stays burned (Model A)
+
+Rescinding **never refunds**. The enforced invariant:
+
+> Grains tagged to a subject (an `opposition` or `support` outflow) may only flow
+> into a `rescind` outflow, or back into the same-subject / same-kind stake as
+> change. They may **never** flow into a spendable `address` outflow.
+
+So staking is always a one-way removal of those grains from circulation;
+rescinding relocates them from an `opposition`/`support` outflow into a permanent
+`rescind` outflow but never returns them to a wallet. (This mirrors how `forgive`
+behaves today — `forgive` outflows are terminal — generalized to support.)
+
+To make support symmetric with opposition, the consume rules change:
+
+- **Support outflows become spendable — but only into a `rescind`.** Today the
+  inflow guard (`chain.py` `validate_txn_inflow`) rejects *both* `forgive` and
+  `support` outflows as inflows. The new guard rejects only `rescind` outflows
+  (which stay terminal). `opposition` and `support` outflows are both
+  consumable, exclusively by a `rescind`.
+- **`support_balance` becomes unspent-only** (mirrors `opposition_balance`), so
+  rescinding support drops the tally automatically as the support outflow is
+  consumed.
+
+## Coinbase reward & sentiment metrics
+
+This is the crux, and the reason the change is consensus-affecting.
+
+### What the metrics are
+
+`schadenfreude` / `grace` / `mudita` are **not cosmetic**. Each block's totals
+are minted as brand-new grains paid to the miller in the coinbase, on top of the
+base block `reward` (`block.create_coinbase` → `Transaction.coinbase`).
+`Block.validate_coinbase` enforces that the coinbase outflows *exactly* equal
+`[reward, schadenfreude, grace, mudita]` (nonzero components, in order) — so
+every node re-derives these and rejects a block whose miller minted the wrong
+amount. The weights are monetary policy baked into consensus.
+
+### The rule the weights encode
+
+A staked grain pays the miller its **full face value over its lifetime**, split
+half at mint and half at rescind, and staking removes the grain from circulation
+permanently. Opposition splits ½ (oppose) + ½ (forgive/rescind); support
+currently pays the full value at mint because it had no rescind half. Each fully
+cycled stake is a **zero-sum transfer from staker to millers** — supply
+conserved.
+
+### Change: symmetric halves
+
+Adding a rescind half to support means support's mint half must drop to ½, with
+the other ½ paid as the new `regret` metric on rescind. Final scheme — all four
+at half weight:
+
+| Metric | Trigger | Weight |
+|---|---|---|
+| `schadenfreude` | `opposition` set | `amount // 2` |
+| `grace` | `rescind` set & `rescind_kind == 'opposition'` | `amount // 2` |
+| `mudita` | `support` set | `amount // 2` ← **changed from full** |
+| `regret` (new) | `rescind` set & `rescind_kind == 'support'` | `amount // 2` |
+
+Every stake now pays the miller ½ at mint and ½ at rescind, fully symmetric
+across opposition and support, supply-neutral over a full lifecycle. Picking full
+weight instead would make the chain inflationary (millers minting up to 2× each
+stake) and was explicitly rejected.
+
+### Plumbing
+
+- `Outflow` gains a `regret` property; `grace`/`schadenfreude` gain the
+  `rescind_kind` / field-rename conditions; `mudita` divisor changes to `// 2`.
+- `Transaction` and `Block` gain `regret` aggregations alongside the existing
+  three.
+- `Transaction.coinbase` gains a `regret` parameter; `Block.create_coinbase`
+  passes `self.regret`.
+- `Block.validate_coinbase` extends the expected component list to
+  `[reward, schadenfreude, grace, mudita, regret]` (nonzero, in that order).
+
+## Validation & accounting (`chain.py`)
+
+`validate_block_txn` currently tracks a single `subject_amounts[subject]` pool
+(fed by opposition inflows, drained by `forgive`/`subject` outflows) plus an
+`other_amounts` pool, and requires both to net to zero. Two changes:
+
+1. **Per-kind pools.** Track opposition and support amounts separately per
+   subject (e.g. keyed by `(subject, kind)`), because the two are opposite
+   sentiments and a rescind is single-kind. `validate_txn_inflow` must report
+   *which* kind a consumed outflow was (`opposition` vs `support`) so the inflow
+   routes to the correct pool — today it returns only the opposition subject.
+2. **Rescind cross-check.** A `rescind` outflow drains the pool named by its
+   `rescind_kind`. Validation rejects the transaction if `rescind_kind` does not
+   match the kind of the outflows actually consumed (can't claim
+   `--kind opposition` while eating support outflows). The
+   "grains can't reach an `address` outflow" invariant falls out of the pool
+   bookkeeping, as it does today for opposition.
+
+Single-kind rescind is enforced: a rescind transaction consumes outflows of one
+kind only.
+
+## Balances & queries (`models.py`, `chain.py`)
+
+- `subject_balance` → **`opposition_balance`** (unchanged logic: sum of unspent
+  `opposition` outflows for a subject).
+- `subject_support` → **`support_balance`**, logic changed to **unspent-only**
+  (join inflows, filter spent), mirroring `opposition_balance`.
+- `unforgiven_outflows` / `unforgiven_address_outflows` → rename to
+  `unrescinded_*`; add a support-kind variant (or parameterize by kind) so
+  `create_rescind` can gather unspent outflows of the requested kind.
+
+## Domain construction (`chain.py`)
+
+- `create_subject` → **`create_opposition`** (rename).
+- `create_forgive` → **`create_rescind(wallet, amount, subject, kind)`**.
+  Gathers the caller's unspent outflows *of `kind`* for `subject`, emits an
+  `Outflow(amount, rescind=subject, rescind_kind=kind)`, with any change going
+  back to the same-kind stake of the same subject.
+- `create_support` — construction unchanged (consume general unspent outflows,
+  emit a `support` outflow, change back to `address`); its output simply becomes
+  rescind-eligible downstream.
+
+## CLI / API / client surface
+
+| Layer | Old | New |
+|---|---|---|
+| CLI txn | `txn subject` / `txn forgive` / `txn support` | `txn opposition` / `txn rescind … --kind opposition\|support` / `txn support` |
+| CLI query | `subject balance` / `subject support` | `subject opposition` / `subject support` |
+| API route | `/transaction/{subject,forgive,support}` | `/transaction/{opposition,rescind,support}` (rescind takes a `kind` param) |
+| API route | `/subject/<s>/balance` | `/subject/<s>/opposition` (`/support` unchanged) |
+| Client | `get_subject_transaction` / `get_forgive_transaction` / `get_subject_balance` / `get_subject_support` | `get_opposition_transaction` / `get_rescind_transaction(…, kind)` / `get_opposition_balance` / `get_support_balance` |
+
+The query command group `subject` stays (it operates on subjects-the-noun); its
+`balance` subcommand becomes `opposition` to name what it tallies. View classes,
+Pydantic query models, and templates referencing the renamed kinds/metrics
+update accordingly, and templates gain `regret`.
+
+## Schema migration
+
+Two hand-reviewed Alembic migrations, one per PR: PR 1 renames columns
+`subject → opposition` and `forgive → rescind`; PR 2 adds `rescind_kind`. The
+`support_balance` change is code-only (query shape). After each, `gumptionchain
+db check` must still pass — the `db.create_all()` metadata and the migration head
+must agree.
+
+## Hard fork
+
+This is a clean break, acceptable only because the chain is greenfield:
+
+1. `data_csv` changes → all block header hashes change.
+2. `mudita` full → ½ changes the coinbase consensus rule → blocks valid under
+   the old rule fail under the new one.
+
+No genesis/data is carried forward. Any local `gumptionchain.db` is discarded and
+re-`init`'d (consistent with the existing Phase-8 "rm the db" guidance).
+
+## Decomposition
+
+Two PRs, matching the project's phased style:
+
+- **PR 1 — pure rename, no behavior change.** `subject → opposition`,
+  `forgive → rescind` (rescind still opposition-only, no `--kind` yet,
+  `rescind_kind` absent), metrics keep current weights (`mudita` full). Purely
+  mechanical: field/column/method/route/client/template renames + migration.
+  Ships green on its own.
+- **PR 2 — new capability.** Support becomes rescind-eligible; `rescind` gains
+  `--kind` and the `rescind_kind` column; `support_balance` → unspent-only;
+  per-kind validation pools + cross-check; `mudita` → ½ and the new `regret`
+  metric + coinbase plumbing. This PR carries the consensus change.
+
+Splitting this way keeps PR 1 a low-risk rename reviewable in isolation, and
+isolates every consensus-affecting change in PR 2.
+
+## Testing
+
+- **Rename coverage (PR 1):** existing `test_payload`, `test_transaction`,
+  `test_chain` suites updated to the new names; assert renamed routes/CLI verbs
+  respond and old ones 404 / error.
+- **Rescind symmetry (PR 2):** stake support then rescind it; assert
+  `support_balance` drops to zero and grains land in a terminal `rescind`
+  outflow, never an `address` outflow.
+- **Cross-check:** a rescind whose `rescind_kind` disagrees with the consumed
+  outflows is rejected (`ImbalancedTransactionError` / a dedicated error).
+- **Single-kind:** a rescind attempting to consume mixed opposition+support
+  outflows is rejected.
+- **Coinbase economics:** for opposition and support lifecycles, assert the
+  coinbase mints `amount // 2` at mint and `amount // 2` at rescind, and that
+  `validate_coinbase` rejects a miscomputed `regret`/`mudita`.
+- **Burn invariant:** attempting to spend an `opposition`/`support` outflow into
+  an `address` outflow is rejected.
+
+## Decisions log (resolved during brainstorming)
+
+- Undo verb: **`rescind`** (over revoke/withdraw/retract), single term for both
+  directions.
+- Economics: **Model A** (burn stays burned) — rescinding never refunds.
+- Disambiguation: **single-kind** rescind, **one** command/route with an
+  explicit **`--kind`** parameter (not two subcommands).
+- `rescind` is **self-describing** — `rescind_kind` stored on the outflow,
+  cross-checked against consumed inflows.
+- Sentiment weights: **symmetric halves** — `schadenfreude / grace / mudita /
+  regret` all `amount // 2`; `mudita` drops from full weight. New metric for
+  rescinded support is **`regret`**.
+- Chain is **greenfield** — hard fork accepted, no migration/replay.
+
+## Out of scope
+
+- Any refund/withdrawable-stake economics (explicitly rejected: Model A only).
+- Reworking the base block `reward` schedule or difficulty retargeting.
+- Renaming `schadenfreude` / `mudita` (kept as-is; only `grace` is joined by the
+  new `regret`).


### PR DESCRIPTION
## Summary
- Design spec + PR-1 implementation plan for shedding the residual "CancelChain" terminology in the transaction model.
- **Rename:** the `subject` (cancel-flavored) outflow kind → `opposition`; the `forgive` undo → a single `rescind` that works for **both** opposition and support.
- **New behavior (PR 2):** support becomes rescindable; `rescind` is single-kind and self-describing (`--kind` / stored `rescind_kind`); coinbase sentiment metrics rebalanced to **symmetric halves** (`schadenfreude`/`grace`/`mudita`/`regret` all `amount//2`, with `mudita` dropping from full weight) so every stake pays the miller ½ at mint and ½ at rescind, supply-neutral.
- **Economics:** Model A — burn stays burned (rescinding never refunds).
- Greenfield hard fork (no chain data to preserve); decomposed into **PR 1 (pure rename)** → **PR 2 (new capability)**.

Docs only — no code changes.

Files:
- `docs/superpowers/specs/2026-06-03-opposition-support-rescind-design.md`
- `docs/superpowers/plans/2026-06-03-pr1-opposition-rescind-rename.md`

## Test Plan
- [ ] N/A (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)