### PR TITLE
feat: support rescindable + rescind_kind + symmetric-halves coinbase (PR 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this project is
 
-GumptionChain is a custom proof-of-work blockchain (Flask + SQLAlchemy) where tokens are assigned to *subjects* (UTF-8 strings, 1–79 chars) as **opposition** (`opposition`, rescindable via `rescind`) or **support** (`support`, permanent). It runs as both a Flask web app (browser views + JSON API) and a `gumptionchain` CLI. The chain is permissioned: API access is gated by role (`READER` < `TRANSACTOR` < `MILLER` < `ADMIN`) keyed off wallet addresses listed in config.
+GumptionChain is a custom proof-of-work blockchain (Flask + SQLAlchemy) where tokens are assigned to *subjects* (UTF-8 strings, 1–79 chars) as **opposition** (`opposition`, rescindable via `rescind --kind opposition`) or **support** (`support`, rescindable via `rescind --kind support`). It runs as both a Flask web app (browser views + JSON API) and a `gumptionchain` CLI. The chain is permissioned: API access is gated by role (`READER` < `TRANSACTOR` < `MILLER` < `ADMIN`) keyed off wallet addresses listed in config.
 
 Units: 1 **GRIT / grit** = 100 **grains** (`GRAIN_PER_GRIT` in `gumptionchain.chain`). Float CLI amounts are converted via `grit_to_grains`.
 

--- a/docs/superpowers/plans/2026-06-04-pr2-support-rescind-regret.md
+++ b/docs/superpowers/plans/2026-06-04-pr2-support-rescind-regret.md
@@ -1,0 +1,774 @@
+# PR 2 — Support rescindability, `rescind_kind`, symmetric-halves coinbase — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `rescind` transaction work for **both** opposition and support — single-kind and self-describing via a stored `rescind_kind` — and rebalance the coinbase sentiment metrics to symmetric halves so every stake pays the miller ½ at mint and ½ at rescind.
+
+**Architecture:** Build on the PR-1 rename. Add a `rescind_kind` metadata field to `Outflow`; make support outflows consumable (only into a rescind); switch `support_balance` to unspent-only; and replace the single opposition accounting pool in `validate_block_txn` with **per-kind pools** (opposition + support) whose "all pools net to zero" check simultaneously enforces the burn invariant, the rescind-kind/inflow cross-check, and single-kind rescinds. Rebalance metrics: `mudita` full→½, add `regret` (rescind+support, ½), gate `grace` to rescind+opposition.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]`), Pydantic v2, Alembic/Flask-Migrate, pytest, uv, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-opposition-support-rescind-design.md` (on `main`).
+
+**Greenfield migration policy:** Per the decision in PR #143, while pre-launch we **fold schema changes into the single baseline migration** (`src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py`) instead of adding incremental migrations. PR 2 adds the `rescind_kind` column directly to that baseline.
+
+---
+
+## Consensus / hard-fork notes
+
+This PR **is** a hard fork (greenfield, so acceptable):
+- `Outflow.data_csv` gains a `rescind_kind` field → every block/txn hash changes. Tests compute hashes dynamically (wallets sign during the test), so only **hard-coded** expected hashes/txids would break — grep for any and update them (Task 1 includes this check).
+- `mudita` weight full→½ changes the coinbase consensus rule.
+
+The two facts the accounting relies on:
+- A `rescind` outflow drains the per-kind pool named by its `rescind_kind`. An opposition/support outflow consumed as an inflow *fills* the matching pool. Every pool must net to zero. Therefore: you cannot send staked grains to an `address` (pool stays positive), cannot claim the wrong `rescind_kind` (one pool positive, the other negative), and cannot mix kinds in one rescind (the untouched pool stays positive). All three are enforced by the existing `ImbalancedTransactionError` check — no new guard code.
+
+## `rescind_kind` values
+
+Two literal strings, matching the existing outflow-kind names: `'opposition'` and `'support'`. Used on `Outflow.rescind_kind`, `OutflowDAO.rescind_kind`, the `OutflowModel` `Literal`, the CLI `--kind` choice, and the API `kind` param.
+
+---
+
+## File map (PR 2)
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/payload.py` | `Outflow.rescind_kind` field; `data_csv`; `OutflowModel` `rescind_kind` + validation; `grace`/`mudita` weights; new `regret` |
+| `src/gumptionchain/models.py` | `OutflowDAO.rescind_kind` column + ctor; `unrescinded_outflows(kind=...)`; `support_balance`→unspent-only |
+| `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py` | add `rescind_kind` column to baseline `outflow` table |
+| `src/gumptionchain/transaction.py` | `to_dao`/`from_dao` carry `rescind_kind`; `regret` aggregation; `coinbase()` gains `regret` |
+| `src/gumptionchain/block.py` | `regret` aggregation; `create_coinbase` passes `regret`; `validate_coinbase` includes `regret` |
+| `src/gumptionchain/chain.py` | `validate_txn_inflow` allow support + report kind; `validate_block_txn` per-kind pools; `create_rescind(kind)`; `unrescinded_*` pass kind; `support_balance` wrapper unchanged |
+| `src/gumptionchain/api.py` | `RescindTxnQueryModel` (+`kind`); `RescindTxnView` passes kind |
+| `src/gumptionchain/api_client.py` | `get_rescind_transaction(..., kind)` |
+| `src/gumptionchain/command.py` | `txn rescind --kind` option |
+| `src/gumptionchain/templates/transaction.html` | (optional) show `rescind_kind` |
+| `CLAUDE.md` | document support rescindable + four metrics + `rescind --kind` |
+| `tests/*` | new behavior tests + updated metric-weight expectations |
+
+Each task ends green (full suite + ruff + ruff-format + mypy + `db check`). Verify `db check` via:
+```bash
+set -a; source tests/.test.env; set +a
+export FLASK_SQLALCHEMY_DATABASE_URI="sqlite:///$(pwd)/.dbcheck_tmp.db"; rm -f .dbcheck_tmp.db
+uv run gumptionchain db upgrade && uv run gumptionchain db check; rm -f .dbcheck_tmp.db
+```
+Expected: `No new upgrade operations detected.`
+
+---
+
+## Task 1: Add the `rescind_kind` field (rescind stays opposition-only, now self-describing)
+
+Introduce the field end-to-end and make the existing opposition-rescind carry `rescind_kind='opposition'`. No support-rescind, no metric-weight change yet.
+
+**Files:** `payload.py`, `models.py`, baseline migration, `transaction.py`, `chain.py` (`create_rescind` body only), tests.
+
+- [ ] **Step 1: Failing unit tests for the field + validation**
+
+In `tests/test_payload.py` add:
+
+```python
+def test_outflow_rescind_carries_kind():
+    o = Outflow(amount=10, rescind='Zm9v', rescind_kind='opposition')
+    assert o.rescind == 'Zm9v'
+    assert o.rescind_kind == 'opposition'
+
+
+def test_outflow_model_rescind_requires_kind():
+    import pytest
+    from pydantic import ValidationError
+    from gumptionchain.payload import OutflowModel
+    with pytest.raises(ValidationError):
+        OutflowModel(amount=10, rescind='Zm9v')  # missing rescind_kind
+
+
+def test_outflow_model_rescind_kind_requires_rescind():
+    import pytest
+    from pydantic import ValidationError
+    from gumptionchain.payload import OutflowModel
+    with pytest.raises(ValidationError):
+        OutflowModel(amount=10, opposition='Zm9v', rescind_kind='opposition')
+
+
+def test_outflow_model_accepts_rescind_with_kind():
+    from gumptionchain.payload import OutflowModel
+    m = OutflowModel(amount=10, rescind='Zm9v', rescind_kind='support')
+    assert m.rescind_kind == 'support'
+```
+
+(`'Zm9v'` is a valid base64url `Subject`; reuse an existing helper/fixture if the file has one — check the top of `test_payload.py` for how other tests build a subject, e.g. the `subject` fixture, and prefer that.)
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_payload.py -k rescind -q`
+Expected: FAIL (`Outflow` has no `rescind_kind`; `OutflowModel` accepts rescind without kind).
+
+- [ ] **Step 3: Add the field + validation in `payload.py`**
+
+Add a message constant near `INVALID_DESTINATION_MSG` (line 23):
+```python
+INVALID_RESCIND_KIND_MSG = 'rescind_kind must be set if and only if rescind is set'
+```
+
+`OutflowModel` (lines 75–96) — add the field and extend the validator:
+```python
+class OutflowModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    amount: int = Field(ge=1)
+    address: AddressType | None = None
+    opposition: Subject | None = None
+    rescind: Subject | None = None
+    support: Subject | None = None
+    rescind_kind: Literal['opposition', 'support'] | None = None
+
+    @model_validator(mode='after')
+    def validate_destinations(self) -> Self:
+        options = [
+            v
+            for v in (self.opposition, self.rescind, self.support)
+            if v is not None
+        ]
+        if not (
+            (self.address and not options)
+            or (options and len(options) == 1 and not self.address)
+        ):
+            raise ValueError(INVALID_DESTINATION_MSG)
+        if (self.rescind is not None) != (self.rescind_kind is not None):
+            raise ValueError(INVALID_RESCIND_KIND_MSG)
+        return self
+```
+Add `Literal` to the `typing` import at the top of the file if not already imported.
+
+`Outflow` dataclass (lines 106–142) — add the field, extend `data_csv`:
+```python
+@dataclass
+class Outflow:
+    amount: int | None = None
+    address: str | None = None
+    opposition: str | None = None
+    rescind: str | None = None
+    support: str | None = None
+    rescind_kind: str | None = None
+
+    @property
+    def data_csv(self) -> str:
+        return ','.join(
+            [
+                str(self.amount),
+                self.address if self.address is not None else '',
+                self.opposition if self.opposition is not None else '',
+                self.rescind if self.rescind is not None else '',
+                self.support if self.support is not None else '',
+                self.rescind_kind if self.rescind_kind is not None else '',
+            ]
+        )
+```
+(Leave `schadenfreude`/`grace`/`mudita` unchanged in this task.)
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `uv run pytest tests/test_payload.py -k rescind -q`
+Expected: PASS.
+
+- [ ] **Step 5: Add the DAO column + baseline migration**
+
+`models.py` `OutflowDAO` — add the column (after `rescind`, line 127) and ctor param/assignment (lines 150–161):
+```python
+    rescind_kind: Mapped[str | None] = mapped_column(String(16))
+```
+In `__init__`, add a keyword param `rescind_kind: str | None = None` (next to `rescind`) and `self.rescind_kind = rescind_kind` in the same conditional block where `self.rescind` is assigned.
+
+Baseline migration `63d32cd7621a_initial_schema.py` — in the `op.create_table('outflow', ...)` block, add after the `rescind` column (the line `sa.Column('rescind', sa.String(length=500), nullable=True),`):
+```python
+    sa.Column('rescind_kind', sa.String(length=16), nullable=True),
+```
+
+- [ ] **Step 6: Carry `rescind_kind` across the domain↔DAO boundary in `transaction.py`**
+
+`from_dao` (lines 333–342) — add to the `Outflow(...)` construction:
+```python
+                    rescind_kind=outflow_dao.rescind_kind,
+```
+`to_dao` (lines 279–288) — add to the `OutflowDAO(...)` construction:
+```python
+                    rescind_kind=outflow.rescind_kind,
+```
+
+- [ ] **Step 7: Make `create_rescind` self-describing (still opposition-only)**
+
+`chain.py` `create_rescind` (lines 487–506) — set `rescind_kind` on the emitted rescind outflow (only the `add_outflow` line changes):
+```python
+        t.add_outflow(
+            Outflow(amount=amount, rescind=subject, rescind_kind='opposition')
+        )
+```
+(Signature and the rest of the body are unchanged in this task. The change-back outflow stays `Outflow(amount=balance - amount, opposition=subject)`.)
+
+- [ ] **Step 8: Check for hard-coded hashes broken by the `data_csv` change**
+
+Run: `grep -rn "block_hash\s*==\|txid\s*==\|'[0-9a-f]\{64\}'" tests | grep -iv "def \|get_header_hash\|!= " | head`
+Inspect any hit that asserts a *literal* hex hash/txid against computed output and update it (recompute), or confirm the suite is fully dynamic. Then run the full suite (Step 9) — a broken hardcoded hash will surface there.
+
+- [ ] **Step 9: Full suite + lint + types + db check**
+
+Run:
+```bash
+uv run pytest -q
+uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy
+```
+Expected: 303 passed (4 new on top of the 299 baseline), 1 skipped; lint/format/mypy clean.
+Then run the `db check` block from the top of this plan → `No new upgrade operations detected.`
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "feat(payload): add self-describing rescind_kind to outflows"
+```
+
+---
+
+## Task 2: Rebalance the coinbase metrics — `mudita` full→½, add `regret`
+
+The coinbase mints sentiment metrics to the miller and `Block.validate_coinbase` enforces the exact amounts. Make all four metrics half-weight: `schadenfreude`/`grace` (opposition side, already ½) and `mudita`/`regret` (support side). Gate `grace` to rescind-opposition; `regret` is rescind-support.
+
+**Files:** `payload.py`, `transaction.py`, `block.py`, tests.
+
+- [ ] **Step 1: Failing unit tests for the new weights + `regret`**
+
+In `tests/test_payload.py` (alongside the existing `test_outflow_mudita`, which currently asserts full weight):
+
+```python
+def test_outflow_mudita_is_half_weight(subject):
+    outflow = Outflow(amount=10, support=subject)
+    assert outflow.mudita == 5
+
+
+def test_outflow_grace_only_for_opposition_rescind(subject):
+    o = Outflow(amount=10, rescind=subject, rescind_kind='opposition')
+    assert o.grace == 5
+    assert o.regret == 0
+
+
+def test_outflow_regret_for_support_rescind(subject):
+    o = Outflow(amount=10, rescind=subject, rescind_kind='support')
+    assert o.regret == 5
+    assert o.grace == 0
+```
+Also UPDATE the existing `test_outflow_mudita` (it asserts `mudita == 9` for `amount=9`): change the expectation to the half weight `int(9 / 2) == 4`. (Search `test_outflow_mudita` and any `test_txn_mudita` / block mudita assertions and update them to ½ — see Step 5.)
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_payload.py -k "mudita or grace or regret" -q`
+Expected: FAIL (`mudita` still full; `grace` not kind-gated; no `regret`).
+
+- [ ] **Step 3: Update metric properties in `payload.py`**
+
+Replace `grace`/`mudita` and add `regret` (lines 132–142):
+```python
+    @property
+    def grace(self) -> int:
+        if (
+            self.rescind is not None
+            and self.rescind_kind == 'opposition'
+            and self.amount is not None
+        ):
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def mudita(self) -> int:
+        if self.support is not None and self.amount is not None:
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def regret(self) -> int:
+        if (
+            self.rescind is not None
+            and self.rescind_kind == 'support'
+            and self.amount is not None
+        ):
+            return int(self.amount / 2)
+        return 0
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `uv run pytest tests/test_payload.py -k "mudita or grace or regret" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Aggregate `regret` and thread it through the coinbase**
+
+`transaction.py` — add after `mudita` (lines 174–176):
+```python
+    @property
+    def regret(self) -> int:
+        return sum([o.regret for o in self.outflows])
+```
+`transaction.py` `coinbase` classmethod (lines 351–376) — add a `regret` parameter (after `mudita`) and append its outflow after the `mudita` one:
+```python
+    @classmethod
+    def coinbase(
+        cls,
+        wallet: Wallet,
+        reward: int,
+        schadenfreude: int,
+        grace: int,
+        mudita: int,
+        regret: int,
+        prev_hash: str,
+    ) -> Self:
+        outflows: list[Outflow] = []
+        if reward:
+            outflows.append(Outflow(amount=reward, address=wallet.address))
+        if schadenfreude:
+            outflows.append(
+                Outflow(amount=schadenfreude, address=wallet.address)
+            )
+        if grace:
+            outflows.append(Outflow(amount=grace, address=wallet.address))
+        if mudita:
+            outflows.append(Outflow(amount=mudita, address=wallet.address))
+        if regret:
+            outflows.append(Outflow(amount=regret, address=wallet.address))
+        cb = cls(outflows=outflows, prev_hash=prev_hash)
+        cb.set_wallet(wallet)
+        cb.seal()
+        cb.sign()
+        return cb
+```
+
+`block.py` — add after `mudita` (lines 154–156):
+```python
+    @property
+    def regret(self) -> int:
+        return sum([t.regret for t in self.txns])
+```
+`block.py` `create_coinbase` (lines 231–241) — pass `self.regret`:
+```python
+        return Transaction.coinbase(
+            wallet,
+            reward,
+            self.schadenfreude,
+            self.grace,
+            self.mudita,
+            self.regret,
+            prev_hash=self.prev_hash,
+        )
+```
+`block.py` `validate_coinbase` (lines 304–317) — append `regret` to `comps`:
+```python
+        comps = []
+        if self.schadenfreude:
+            comps.append(self.schadenfreude)
+        if self.grace:
+            comps.append(self.grace)
+        if self.mudita:
+            comps.append(self.mudita)
+        if self.regret:
+            comps.append(self.regret)
+        if comps != [o.amount for o in cb.outflows[1:]]:
+            raise InvalidCoinbaseError()
+```
+
+- [ ] **Step 6: Update integration tests that assert specific `mudita`/coinbase amounts**
+
+Run: `grep -rn "mudita\|\.schadenfreude\|\.grace\b" tests`
+Any test asserting a concrete `mudita` value (e.g. `test_txn_mudita` asserting `19`, block/miller coinbase-amount assertions) must change to the half weight (`int(amount/2)`). Tests that mine a block and let the coinbase flow through dynamically need no change. Update each concrete-number assertion.
+
+- [ ] **Step 7: Full suite + lint + types + db check**
+
+Run:
+```bash
+uv run pytest -q
+uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy
+```
+Expected: all green (new tests pass; updated mudita expectations pass). db check unchanged → clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(coinbase): symmetric-halves metrics (mudita->1/2, add regret)"
+```
+
+---
+
+## Task 3: Make support rescindable — per-kind validation, unspent support balance, `rescind --kind`
+
+The behavioral heart of PR 2. Support outflows become consumable (only into a rescind); `validate_block_txn` uses per-kind pools; `support_balance` becomes unspent-only; `create_rescind` takes a `kind`; and the CLI/API/client expose `--kind`.
+
+**Files:** `chain.py`, `models.py`, `api.py`, `api_client.py`, `command.py`, tests.
+
+- [ ] **Step 1: Failing end-to-end test for rescinding support**
+
+In `tests/test_chain.py` (follow the existing pattern there for building a chain and mining — find a test like `test_validate_opposition_ioflows` or a support-staking test and mirror its setup, fixtures, and helpers). Add a test that: stakes support on a subject, asserts `support_balance == amount`, then rescinds support and asserts `support_balance == 0` and that the rescinding txn validates in a mined block. Sketch (adapt names to the file's actual fixtures/helpers):
+
+```python
+def test_rescind_support_drops_support_balance(...):
+    # ... build chain, fund a wallet, stake support of `amt` on `subject`
+    assert lc.support_balance(subject) == amt
+    rescind_txn = lc.create_rescind(wallet, amt, subject, 'support')
+    # ... mine a block containing rescind_txn (mirror existing mining helper)
+    assert lc.support_balance(subject) == 0
+```
+
+Also add a cross-check/burn test:
+```python
+def test_rescind_kind_must_match_consumed_outflows(...):
+    # stake opposition of `amt`, then attempt create_rescind(..., 'support')
+    import pytest
+    from gumptionchain.errors import InsufficientFundsError  # match chain.py's import path
+    with pytest.raises(InsufficientFundsError):
+        lc.create_rescind(wallet, amt, subject, 'support')  # no support to rescind
+```
+(`create_rescind` gathers unspent outflows *of the requested kind*; with none, balance < amount → `InsufficientFundsError`. The deeper consensus cross-check — a hand-forged txn claiming the wrong kind — is covered by the pool-balance check; add a `validate_block_txn`-level test if the file has a helper to inject a raw txn, otherwise the `create_rescind` path test above plus the existing imbalance tests suffice.)
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_chain.py -k "rescind_support or rescind_kind_must" -q`
+Expected: FAIL (`create_rescind()` takes no `kind` arg / support not consumable).
+
+- [ ] **Step 3: Allow support as an inflow and report kind in `validate_txn_inflow`**
+
+`chain.py` `validate_txn_inflow` (lines 254–287). Change the guard (line 270–272) to reject only rescind, and change the return type/value to report both opposition and support of the consumed outflow:
+```python
+    ) -> tuple[int, str | None, str | None]:
+```
+Guard:
+```python
+        # a rescind outflow is terminal and can never be consumed
+        if ioflow.rescind is not None:
+            raise InvalidInflowOutflowError()
+```
+Return (line 287):
+```python
+        return ioflow.amount or 0, ioflow.opposition, ioflow.support
+```
+
+- [ ] **Step 4: Per-kind pools in `validate_block_txn`**
+
+`chain.py` `validate_block_txn` (lines 209–252) — replace the body with per-kind accounting:
+```python
+    def validate_block_txn(
+        self,
+        block: Block,
+        txn: Transaction,
+        txn_in_block: bool = True,  # noqa: FBT001
+    ) -> None:
+        # add inflow amounts, routed by the kind of the consumed outflow
+        opposition_amounts: dict[str, int] = {}
+        support_amounts: dict[str, int] = {}
+        other_amounts = 0
+        for i in txn.inflows:
+            amount, opposition, support = self.validate_txn_inflow(
+                block, txn, i, txn_in_block=txn_in_block
+            )
+            if opposition:
+                opposition_amounts[opposition] = (
+                    opposition_amounts.get(opposition, 0) + amount
+                )
+            elif support:
+                support_amounts[support] = (
+                    support_amounts.get(support, 0) + amount
+                )
+            else:
+                other_amounts += amount
+        # subtract outflow amounts
+        for o in txn.outflows:
+            if o.rescind:
+                if o.rescind_kind == 'support':
+                    support_amounts[o.rescind] = (
+                        support_amounts.get(o.rescind, 0) - (o.amount or 0)
+                    )
+                else:
+                    opposition_amounts[o.rescind] = (
+                        opposition_amounts.get(o.rescind, 0) - (o.amount or 0)
+                    )
+            elif o.opposition:
+                opposition_amount = opposition_amounts.get(o.opposition)
+                if opposition_amount and opposition_amount > 0:
+                    if (o.amount or 0) > opposition_amount:
+                        opposition_amounts[o.opposition] = 0
+                        other_amounts -= (o.amount or 0) - opposition_amount
+                    else:
+                        opposition_amounts[o.opposition] = (
+                            opposition_amount - (o.amount or 0)
+                        )
+                else:
+                    other_amounts -= o.amount or 0
+            elif o.support:
+                support_amount = support_amounts.get(o.support)
+                if support_amount and support_amount > 0:
+                    if (o.amount or 0) > support_amount:
+                        support_amounts[o.support] = 0
+                        other_amounts -= (o.amount or 0) - support_amount
+                    else:
+                        support_amounts[o.support] = (
+                            support_amount - (o.amount or 0)
+                        )
+                else:
+                    other_amounts -= o.amount or 0
+            else:
+                other_amounts -= o.amount or 0
+        if other_amounts != 0:
+            raise ImbalancedTransactionError()
+        for _, amount in opposition_amounts.items():
+            if amount != 0:
+                raise ImbalancedTransactionError()
+        for _, amount in support_amounts.items():
+            if amount != 0:
+                raise ImbalancedTransactionError()
+```
+
+- [ ] **Step 5: `unrescinded_outflows` by kind (`models.py` + `chain.py`)**
+
+`models.py` `unrescinded_outflows` (lines 569–585) — add a required `kind` param selecting the column:
+```python
+    def unrescinded_outflows(
+        self,
+        subject: str,
+        kind: str,
+        address: str | None = None,
+        filter_pending: bool = False,  # noqa: FBT001
+    ) -> Select[tuple[OutflowDAO]]:
+        column = (
+            OutflowDAO.support if kind == 'support' else OutflowDAO.opposition
+        )
+        inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
+        stmt = self.outflows.where(column == subject)
+        stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
+        stmt = stmt.where(inflows_alias.id.is_(None))
+        if address is not None:
+            txn_alias = db.aliased(TransactionDAO, self.transactions.subquery())
+            stmt = stmt.join(txn_alias, OutflowDAO.transaction)
+            stmt = stmt.where(txn_alias.address == address)
+        if filter_pending:
+            stmt = stmt.where(~OutflowDAO.pending.any())
+        return stmt
+```
+`chain.py` `unrescinded_outflows` (lines 377–393) and `unrescinded_address_outflows` (lines 395–417) — thread a `kind` param through to the DAO call:
+```python
+    def unrescinded_outflows(
+        self,
+        subject: str,
+        kind: str,
+        filter_pending: bool = False,  # noqa: FBT001
+    ) -> Iterator[tuple[str, int, Outflow]]:
+        outflow_daos = db.session.execute(
+            self.to_dao().unrescinded_outflows(
+                subject, kind, filter_pending=filter_pending
+            )
+        ).scalars()
+        ...  # body unchanged
+```
+```python
+    def unrescinded_address_outflows(
+        self,
+        address: str,
+        subject: str,
+        kind: str,
+        limit: int | None = None,
+        filter_pending: bool = False,  # noqa: FBT001
+    ) -> Iterator[tuple[str, int, Outflow]]:
+        amount = 0
+        outflow_daos = db.session.execute(
+            self.to_dao().unrescinded_outflows(
+                subject, kind, address=address, filter_pending=filter_pending
+            )
+        ).scalars()
+        ...  # body unchanged
+```
+
+- [ ] **Step 6: `support_balance` → unspent-only (`models.py`)**
+
+`models.py` `support_balance` (lines 598–604) — mirror `opposition_balance` (add the unspent join):
+```python
+    def support_balance(self, subject: str) -> int:
+        inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
+        stmt = self.outflows.where(OutflowDAO.support == subject)
+        stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
+        stmt = stmt.where(inflows_alias.id.is_(None))
+        outflows_alias = db.aliased(OutflowDAO, stmt.subquery())
+        sum_stmt = db.select(db.func.sum(OutflowDAO.amount)).join(
+            outflows_alias, OutflowDAO.id == outflows_alias.id
+        )
+        return db.session.scalar(sum_stmt) or 0
+```
+
+- [ ] **Step 7: `create_rescind(wallet, amount, subject, kind)` (`chain.py`)**
+
+`chain.py` `create_rescind` (lines 487–506) — add `kind`, gather unspent outflows of that kind, emit the self-describing rescind, change back to the same-kind stake:
+```python
+    def create_rescind(
+        self, wallet: Wallet, amount: int, subject: str, kind: str
+    ) -> Transaction:
+        address = wallet.address
+        balance = 0
+        t = Transaction()
+        unrescinded = self.unrescinded_address_outflows(
+            address, subject, kind, limit=amount, filter_pending=True
+        )
+        for txid, index, outflow in unrescinded:
+            balance += outflow.amount or 0
+            t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
+        if balance < amount:
+            raise InsufficientFundsError()
+        t.add_outflow(
+            Outflow(amount=amount, rescind=subject, rescind_kind=kind)
+        )
+        if balance - amount:
+            change = balance - amount
+            if kind == 'support':
+                t.add_outflow(Outflow(amount=change, support=subject))
+            else:
+                t.add_outflow(Outflow(amount=change, opposition=subject))
+        t.set_wallet(wallet)
+        t.seal()
+        return t
+```
+
+- [ ] **Step 8: Wire the `kind` through the surface (API, client, CLI)**
+
+`api.py` — add a rescind-specific query model after `SubjectTxnQueryModel` (line 477) and use it in `RescindTxnView`:
+```python
+class RescindTxnQueryModel(SubjectTxnQueryModel):
+    kind: Literal['opposition', 'support']
+```
+(Add `Literal` to the typing import if needed.) In `RescindTxnView.get` (lines 514–537), validate with `RescindTxnQueryModel`, pull `kind`, and pass it:
+```python
+            model = RescindTxnQueryModel.model_validate(
+                request.args.to_dict(flat=True)
+            )
+            ...
+            args = model.model_dump(exclude_none=True)
+            ...
+            kind = args['kind']
+            ...
+            return make_json_response(
+                lc.create_rescind(wallet, amount, subject, kind).to_json()
+            )
+```
+
+`api_client.py` `get_rescind_transaction` (lines 181–198) — add a required `kind` param and include it in `params`:
+```python
+    def get_rescind_transaction(
+        self,
+        public_key: str,
+        amount: int,
+        subject: str,
+        kind: str,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> httpx.Response:
+        return self.get(
+            '/api/transaction/rescind',
+            params={
+                'public_key': public_key,
+                'amount': str(amount),
+                'subject': subject,
+                'kind': kind,
+            },
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )
+```
+
+`command.py` `create_rescind` (lines 789–844) — add a required `--kind` option and pass it to the client. Add after the `@click.argument('subject')` line (792):
+```python
+@click.option(
+    '--kind',
+    type=click.Choice(['opposition', 'support']),
+    required=True,
+    help='Which stake to rescind: opposition or support.',
+)
+```
+Add `kind: str,` to the function signature (after `subject: str,`) and update the client call:
+```python
+        r = client.get_rescind_transaction(
+            txn_wallet_obj.public_key_b64,
+            grit_to_grains(amount),
+            subject,
+            kind,
+        )
+```
+
+- [ ] **Step 9: Update existing callers/tests of `create_rescind` / `get_rescind_transaction`**
+
+Run: `grep -rn "create_rescind\|get_rescind_transaction\|unrescinded_address_outflows\|unrescinded_outflows" src tests`
+Update every call to pass the new `kind` argument. Existing opposition-rescind call sites pass `'opposition'`. The CLI test for `txn rescind` must add `--kind opposition` (and add a `--kind support` case). The API test for `/transaction/rescind` must add `kind=...`.
+
+- [ ] **Step 10: Run the new + full suite**
+
+Run: `uv run pytest tests/test_chain.py -k "rescind" -q` → expect PASS.
+Run: `uv run pytest -q` → expect all green.
+Run: `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy` → clean.
+Run the `db check` block → `No new upgrade operations detected.`
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add -A
+git commit -m "feat(rescind): support rescindable via rescind --kind; per-kind validation pools"
+```
+
+---
+
+## Task 4: Docs + final verification
+
+**Files:** `CLAUDE.md`, optionally `templates/transaction.html`, verification only otherwise.
+
+- [ ] **Step 1: Update `CLAUDE.md` project description**
+
+In the "What this project is" paragraph (line 7), it currently says support is `(\`support\`, permanent)`. Update to reflect support is now rescindable, e.g.:
+> `... as **opposition** (\`opposition\`, rescindable via \`rescind --kind opposition\`) or **support** (\`support\`, rescindable via \`rescind --kind support\`).`
+If there's a sentence on the sentiment metrics or units nearby, add a one-line note that the coinbase mints `schadenfreude`/`grace`/`mudita`/`regret`, each ½ of the staked amount (½ at mint, ½ at rescind). Keep edits tight; don't rewrite unrelated prose.
+
+- [ ] **Step 2: (Optional) Surface `rescind_kind` in the transaction template**
+
+If `templates/transaction.html` shows a `Rescind` column (it does — added in PR 1), optionally annotate it with the kind, e.g. `{{ o.rescind }}{% if o.rescind_kind %} ({{ o.rescind_kind }}){% endif %}`. Skip if it complicates the layout; not required for correctness.
+
+- [ ] **Step 3: Final grep sweep**
+
+Run: `grep -rn "create_rescind\|get_rescind_transaction\|unrescinded_outflows\|unrescinded_address_outflows" src tests`
+Confirm every call passes a `kind`. No call should use the old 3-arg `create_rescind`.
+
+Run: `grep -rn "\.mudita\b" src` and confirm `mudita` is half-weight at its definition.
+
+- [ ] **Step 4: Full gate**
+
+Run:
+```bash
+uv run pytest -q
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy
+```
+Then the `db check` block → `No new upgrade operations detected.`
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "docs: document support rescindability and symmetric-halves metrics"
+```
+
+---
+
+## Definition of done (PR 2)
+
+- `Outflow` carries `rescind_kind` (`opposition`|`support`), validated present-iff-`rescind`; stored on the DAO and folded into the baseline migration (no incremental migration).
+- Support outflows are consumable only into a rescind; `support_balance` is unspent-only.
+- `validate_block_txn` uses per-kind pools; burn invariant, rescind-kind cross-check, and single-kind rescinds all enforced by the pool-balance check.
+- `create_rescind(wallet, amount, subject, kind)`; CLI `txn rescind … --kind opposition|support`; API `/transaction/rescind` takes `kind`; client `get_rescind_transaction(..., kind)`.
+- Coinbase metrics are symmetric halves: `schadenfreude`/`grace`/`mudita`/`regret` each `amount//2`; `validate_coinbase` enforces `[reward, schadenfreude, grace, mudita, regret]`.
+- Full suite + ruff + ruff-format + mypy + `db check` all green.
+- `CLAUDE.md` reflects support rescindability and the four metrics.
+
+## Self-review notes (resolved)
+
+- **data_csv order:** appended `rescind_kind` after `support` (rather than the spec's illustrative `…, support, rescind, rescind_kind`) to minimize churn — the order is arbitrary for a hard fork; only internal consistency matters.
+- **Cross-check:** enforced implicitly by per-kind pool balance, not a separate guard (documented above).
+- **Migration:** folded into baseline per the greenfield policy (PR #143), not a new migration.

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from enum import Enum
 from functools import wraps
-from typing import Annotated, Any, NoReturn, cast
+from typing import Annotated, Any, Literal, NoReturn, cast
 
 from flask import (
     Blueprint,
@@ -476,6 +476,10 @@ class SubjectTxnQueryModel(BaseModel):
     subject: _RawSubjectField
 
 
+class RescindTxnQueryModel(SubjectTxnQueryModel):
+    kind: Literal['opposition', 'support']
+
+
 class OppositionTxnView(MethodView):
     def get(self, **kwargs: Any) -> Response:
         try:
@@ -514,7 +518,7 @@ blueprint.add_url_rule(
 class RescindTxnView(MethodView):
     def get(self, **kwargs: Any) -> Response:
         try:
-            model = SubjectTxnQueryModel.model_validate(
+            model = RescindTxnQueryModel.model_validate(
                 request.args.to_dict(flat=True)
             )
         except ValidationError as e:
@@ -524,12 +528,13 @@ class RescindTxnView(MethodView):
             public_key_b64 = args['public_key']
             amount = args['amount']
             subject = encode_subject(args['subject'])
+            kind = args['kind']
             wallet = Wallet(b64ks=public_key_b64)
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()
             return make_json_response(
-                lc.create_rescind(wallet, amount, subject).to_json()
+                lc.create_rescind(wallet, amount, subject, kind).to_json()
             )
         except GCError as err:
             return make_error_response(err)

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -183,6 +183,7 @@ class ApiClient:
         public_key: str,
         amount: int,
         subject: str,
+        kind: str,
         timeout: int | float | None = None,
         raise_for_status: bool = True,  # noqa: FBT001
     ) -> httpx.Response:
@@ -192,6 +193,7 @@ class ApiClient:
                 'public_key': public_key,
                 'amount': str(amount),
                 'subject': subject,
+                'kind': kind,
             },
             timeout=timeout,
             raise_for_status=raise_for_status,

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from types import TracebackType
-from typing import Self
+from typing import Literal, Self
 
 import httpx
 
@@ -183,7 +183,7 @@ class ApiClient:
         public_key: str,
         amount: int,
         subject: str,
-        kind: str,
+        kind: Literal['opposition', 'support'],
         timeout: int | float | None = None,
         raise_for_status: bool = True,  # noqa: FBT001
     ) -> httpx.Response:

--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -156,6 +156,10 @@ class Block:
         return sum([t.mudita for t in self.txns])
 
     @property
+    def regret(self) -> int:
+        return sum([t.regret for t in self.txns])
+
+    @property
     def is_sealed(self) -> bool:
         return self.timestamp is not None
 
@@ -237,6 +241,7 @@ class Block:
             self.schadenfreude,
             self.grace,
             self.mudita,
+            self.regret,
             prev_hash=self.prev_hash,
         )
 
@@ -313,6 +318,8 @@ class Block:
             comps.append(self.grace)
         if self.mudita:
             comps.append(self.mudita)
+        if self.regret:
+            comps.append(self.regret)
         if comps != [o.amount for o in cb.outflows[1:]]:
             raise InvalidCoinbaseError()
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -498,7 +498,9 @@ class Chain:
             t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
         if balance < amount:
             raise InsufficientFundsError()
-        t.add_outflow(Outflow(amount=amount, rescind=subject))
+        t.add_outflow(
+            Outflow(amount=amount, rescind=subject, rescind_kind='opposition')
+        )
         if balance - amount:
             t.add_outflow(Outflow(amount=balance - amount, opposition=subject))
         t.set_wallet(wallet)

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -212,25 +212,35 @@ class Chain:
         txn: Transaction,
         txn_in_block: bool = True,  # noqa: FBT001
     ) -> None:
-        # add inflow amounts
+        # add inflow amounts, routed by the kind of the consumed outflow
         opposition_amounts: dict[str, int] = {}
+        support_amounts: dict[str, int] = {}
         other_amounts = 0
         for i in txn.inflows:
-            amount, subject = self.validate_txn_inflow(
+            amount, opposition, support = self.validate_txn_inflow(
                 block, txn, i, txn_in_block=txn_in_block
             )
-            if subject:
-                opposition_amount: int | None = opposition_amounts.get(
-                    subject, 0
+            if opposition:
+                opposition_amounts[opposition] = (
+                    opposition_amounts.get(opposition, 0) + amount
                 )
-                opposition_amounts[subject] = (opposition_amount or 0) + amount
+            elif support:
+                support_amounts[support] = (
+                    support_amounts.get(support, 0) + amount
+                )
             else:
                 other_amounts += amount
         # subtract outflow amounts
         for o in txn.outflows:
             if o.rescind:
-                rescind_amount = opposition_amounts.get(o.rescind, 0)
-                opposition_amounts[o.rescind] = rescind_amount - (o.amount or 0)
+                if o.rescind_kind == 'support':
+                    support_amounts[o.rescind] = support_amounts.get(
+                        o.rescind, 0
+                    ) - (o.amount or 0)
+                else:
+                    opposition_amounts[o.rescind] = opposition_amounts.get(
+                        o.rescind, 0
+                    ) - (o.amount or 0)
             elif o.opposition:
                 opposition_amount = opposition_amounts.get(o.opposition)
                 if opposition_amount and opposition_amount > 0:
@@ -243,11 +253,26 @@ class Chain:
                         )
                 else:
                     other_amounts -= o.amount or 0
+            elif o.support:
+                support_amount = support_amounts.get(o.support)
+                if support_amount and support_amount > 0:
+                    if (o.amount or 0) > support_amount:
+                        support_amounts[o.support] = 0
+                        other_amounts -= (o.amount or 0) - support_amount
+                    else:
+                        support_amounts[o.support] = support_amount - (
+                            o.amount or 0
+                        )
+                else:
+                    other_amounts -= o.amount or 0
             else:
                 other_amounts -= o.amount or 0
         if other_amounts != 0:
             raise ImbalancedTransactionError()
         for _, amount in opposition_amounts.items():
+            if amount != 0:
+                raise ImbalancedTransactionError()
+        for _, amount in support_amounts.items():
             if amount != 0:
                 raise ImbalancedTransactionError()
 
@@ -257,7 +282,7 @@ class Chain:
         txn: Transaction,
         i: Inflow,
         txn_in_block: bool = True,  # noqa: FBT001
-    ) -> tuple[int, str | None]:
+    ) -> tuple[int, str | None, str | None]:
         # txn inflow's outflow exists
         ioflow: Outflow | None = None
         ioflow_txn: Transaction | None = None
@@ -267,8 +292,8 @@ class Chain:
                 ioflow = ioflow_txn.get_outflow(i.outflow_idx or 0)
         if not ioflow:
             raise MissingInflowOutflowError()
-        # inflow's outflow can't be for rescind or support
-        if ioflow.rescind is not None or ioflow.support is not None:
+        # a rescind outflow is terminal and can never be consumed
+        if ioflow.rescind is not None:
             raise InvalidInflowOutflowError()
         # inflow's outflow address equals the txn address
         address = (
@@ -284,7 +309,7 @@ class Chain:
         )
         if num_inflows > 1 or (num_inflows > 0 and not txn_in_block):
             raise SpentTransactionError()
-        return ioflow.amount or 0, ioflow.opposition
+        return ioflow.amount or 0, ioflow.opposition, ioflow.support
 
     def validate_block_coinbase(self, block: Block) -> None:
         block.validate_coinbase()
@@ -377,11 +402,12 @@ class Chain:
     def unrescinded_outflows(
         self,
         subject: str,
+        kind: str,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
         outflow_daos = db.session.execute(
             self.to_dao().unrescinded_outflows(
-                subject, filter_pending=filter_pending
+                subject, kind, filter_pending=filter_pending
             )
         ).scalars()
         for outflow_dao in outflow_daos:
@@ -396,13 +422,14 @@ class Chain:
         self,
         address: str,
         subject: str,
+        kind: str,
         limit: int | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
         amount = 0
         outflow_daos = db.session.execute(
             self.to_dao().unrescinded_outflows(
-                subject, address=address, filter_pending=filter_pending
+                subject, kind, address=address, filter_pending=filter_pending
             )
         ).scalars()
         for outflow_dao in outflow_daos:
@@ -485,13 +512,13 @@ class Chain:
         return t
 
     def create_rescind(
-        self, wallet: Wallet, amount: int, subject: str
+        self, wallet: Wallet, amount: int, subject: str, kind: str
     ) -> Transaction:
         address = wallet.address
         balance = 0
         t = Transaction()
         unrescinded = self.unrescinded_address_outflows(
-            address, subject, limit=amount, filter_pending=True
+            address, subject, kind, limit=amount, filter_pending=True
         )
         for txid, index, outflow in unrescinded:
             balance += outflow.amount or 0
@@ -499,10 +526,14 @@ class Chain:
         if balance < amount:
             raise InsufficientFundsError()
         t.add_outflow(
-            Outflow(amount=amount, rescind=subject, rescind_kind='opposition')
+            Outflow(amount=amount, rescind=subject, rescind_kind=kind)
         )
         if balance - amount:
-            t.add_outflow(Outflow(amount=balance - amount, opposition=subject))
+            change = balance - amount
+            if kind == 'support':
+                t.add_outflow(Outflow(amount=change, support=subject))
+            else:
+                t.add_outflow(Outflow(amount=change, opposition=subject))
         t.set_wallet(wallet)
         t.seal()
         return t

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -234,15 +234,17 @@ class Chain:
         for o in txn.outflows:
             if o.rescind:
                 # rescind_kind is validated to 'opposition'|'support' by
-                # OutflowModel; the else handles 'opposition'.
+                # OutflowModel; reject anything else defensively.
                 if o.rescind_kind == 'support':
                     support_amounts[o.rescind] = support_amounts.get(
                         o.rescind, 0
                     ) - (o.amount or 0)
-                else:
+                elif o.rescind_kind == 'opposition':
                     opposition_amounts[o.rescind] = opposition_amounts.get(
                         o.rescind, 0
                     ) - (o.amount or 0)
+                else:
+                    raise ImbalancedTransactionError()
             elif o.opposition:
                 opposition_amount = opposition_amounts.get(o.opposition)
                 if opposition_amount and opposition_amount > 0:

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass, field
 from functools import total_ordering
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -233,6 +233,8 @@ class Chain:
         # subtract outflow amounts
         for o in txn.outflows:
             if o.rescind:
+                # rescind_kind is validated to 'opposition'|'support' by
+                # OutflowModel; the else handles 'opposition'.
                 if o.rescind_kind == 'support':
                     support_amounts[o.rescind] = support_amounts.get(
                         o.rescind, 0
@@ -402,7 +404,7 @@ class Chain:
     def unrescinded_outflows(
         self,
         subject: str,
-        kind: str,
+        kind: Literal['opposition', 'support'],
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
         outflow_daos = db.session.execute(
@@ -422,7 +424,7 @@ class Chain:
         self,
         address: str,
         subject: str,
-        kind: str,
+        kind: Literal['opposition', 'support'],
         limit: int | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
@@ -512,7 +514,11 @@ class Chain:
         return t
 
     def create_rescind(
-        self, wallet: Wallet, amount: int, subject: str, kind: str
+        self,
+        wallet: Wallet,
+        amount: int,
+        subject: str,
+        kind: Literal['opposition', 'support'],
     ) -> Transaction:
         address = wallet.address
         balance = 0

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -791,6 +791,12 @@ def create_opposition(
 @click.argument('amount', type=click.FLOAT)
 @click.argument('subject')
 @click.option(
+    '--kind',
+    type=click.Choice(['opposition', 'support']),
+    required=True,
+    help='Which stake to rescind: opposition or support.',
+)
+@click.option(
     '-t',
     '--txn-wallet',
     type=click.Path(exists=True),
@@ -822,6 +828,7 @@ def create_rescind(
     address: str,
     amount: float,
     subject: str,
+    kind: str,
     txn_wallet: str | None,
     host: str | None,
     wallet: str | None,
@@ -841,6 +848,7 @@ def create_rescind(
             txn_wallet_obj.public_key_b64,
             grit_to_grains(amount),
             subject,
+            kind,
         )
         txn = Transaction.from_json(r.text)
         if not (confirm := yes):

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Generator
 from datetime import timedelta
 from http.client import responses
-from typing import Any
+from typing import Any, Literal, cast
 
 import click
 import httpx
@@ -828,7 +828,7 @@ def create_rescind(
     address: str,
     amount: float,
     subject: str,
-    kind: str,
+    kind: str,  # narrowed via cast below; click.Choice enforces the values
     txn_wallet: str | None,
     host: str | None,
     wallet: str | None,
@@ -848,7 +848,7 @@ def create_rescind(
             txn_wallet_obj.public_key_b64,
             grit_to_grains(amount),
             subject,
-            kind,
+            cast(Literal['opposition', 'support'], kind),
         )
         txn = Transaction.from_json(r.text)
         if not (confirm := yes):

--- a/src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py
+++ b/src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py
@@ -110,6 +110,7 @@ def upgrade():
     sa.Column('opposition', sa.String(length=500), nullable=True),
     sa.Column('rescind', sa.String(length=500), nullable=True),
     sa.Column('support', sa.String(length=500), nullable=True),
+    sa.Column('rescind_kind', sa.String(length=16), nullable=True),
     sa.Column('transaction_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['transaction_id'], ['transaction.id'], name=op.f('fk_outflow_transaction_transaction_id')),
     sa.PrimaryKeyConstraint('id', name=op.f('pk_outflow')),

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -572,11 +572,15 @@ class ChainDAO(Base):
     def unrescinded_outflows(
         self,
         subject: str,
+        kind: str,
         address: str | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Select[tuple[OutflowDAO]]:
+        column = (
+            OutflowDAO.support if kind == 'support' else OutflowDAO.opposition
+        )
         inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
-        stmt = self.outflows.where(OutflowDAO.opposition == subject)
+        stmt = self.outflows.where(column == subject)
         stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
         stmt = stmt.where(inflows_alias.id.is_(None))
         if address is not None:
@@ -599,7 +603,10 @@ class ChainDAO(Base):
         return db.session.scalar(sum_stmt) or 0
 
     def support_balance(self, subject: str) -> int:
+        inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
         stmt = self.outflows.where(OutflowDAO.support == subject)
+        stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
+        stmt = stmt.where(inflows_alias.id.is_(None))
         outflows_alias = db.aliased(OutflowDAO, stmt.subquery())
         sum_stmt = db.select(db.func.sum(OutflowDAO.amount)).join(
             outflows_alias, OutflowDAO.id == outflows_alias.id

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -126,6 +126,7 @@ class OutflowDAO(Base):
     opposition: Mapped[str | None] = mapped_column(String(500))
     rescind: Mapped[str | None] = mapped_column(String(500))
     support: Mapped[str | None] = mapped_column(String(500))
+    rescind_kind: Mapped[str | None] = mapped_column(String(16))
     transaction_id: Mapped[int] = mapped_column(
         Integer, ForeignKey('transaction.id')
     )
@@ -150,6 +151,7 @@ class OutflowDAO(Base):
         opposition: str | None = None,
         rescind: str | None = None,
         support: str | None = None,
+        rescind_kind: str | None = None,
         transaction_dao: TransactionDAO | None = None,
     ) -> None:
         with db.session.no_autoflush:
@@ -160,6 +162,7 @@ class OutflowDAO(Base):
             self.opposition = opposition
             self.rescind = rescind
             self.support = support
+            self.rescind_kind = rescind_kind
             self.transaction = transaction_dao or None  # type: ignore[assignment]
 
     @classmethod

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Generator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from sqlalchemy import (
     CTE,
@@ -572,7 +572,7 @@ class ChainDAO(Base):
     def unrescinded_outflows(
         self,
         subject: str,
-        kind: str,
+        kind: Literal['opposition', 'support'],
         address: str | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Select[tuple[OutflowDAO]]:

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import (
     AfterValidator,
@@ -21,6 +21,9 @@ from gumptionchain.schema import (
 MIN_SUBJECT_LENGTH = 1
 MAX_SUBJECT_LENGTH = 79
 INVALID_DESTINATION_MSG = 'Invalid destinations'
+INVALID_RESCIND_KIND_MSG = (
+    'rescind_kind must be set if and only if rescind is set'
+)
 INVALID_PADDING_MSG = 'Invalid padding'
 
 
@@ -80,6 +83,7 @@ class OutflowModel(BaseModel):
     opposition: Subject | None = None
     rescind: Subject | None = None
     support: Subject | None = None
+    rescind_kind: Literal['opposition', 'support'] | None = None
 
     @model_validator(mode='after')
     def validate_destinations(self) -> Self:
@@ -93,6 +97,8 @@ class OutflowModel(BaseModel):
             or (options and len(options) == 1 and not self.address)
         ):
             raise ValueError(INVALID_DESTINATION_MSG)
+        if (self.rescind is not None) != (self.rescind_kind is not None):
+            raise ValueError(INVALID_RESCIND_KIND_MSG)
         return self
 
 
@@ -110,6 +116,7 @@ class Outflow:
     opposition: str | None = None
     rescind: str | None = None
     support: str | None = None
+    rescind_kind: str | None = None
 
     @property
     def data_csv(self) -> str:
@@ -120,6 +127,7 @@ class Outflow:
                 self.opposition if self.opposition is not None else '',
                 self.rescind if self.rescind is not None else '',
                 self.support if self.support is not None else '',
+                self.rescind_kind if self.rescind_kind is not None else '',
             ]
         )
 

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -134,7 +134,7 @@ class Outflow:
     @property
     def schadenfreude(self) -> int:
         if self.opposition is not None and self.amount is not None:
-            return int(self.amount / 2)
+            return self.amount // 2
         return 0
 
     @property
@@ -144,13 +144,13 @@ class Outflow:
             and self.rescind_kind == 'opposition'
             and self.amount is not None
         ):
-            return int(self.amount / 2)
+            return self.amount // 2
         return 0
 
     @property
     def mudita(self) -> int:
         if self.support is not None and self.amount is not None:
-            return int(self.amount / 2)
+            return self.amount // 2
         return 0
 
     @property
@@ -160,7 +160,7 @@ class Outflow:
             and self.rescind_kind == 'support'
             and self.amount is not None
         ):
-            return int(self.amount / 2)
+            return self.amount // 2
         return 0
 
 

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -139,14 +139,28 @@ class Outflow:
 
     @property
     def grace(self) -> int:
-        if self.rescind is not None and self.amount is not None:
+        if (
+            self.rescind is not None
+            and self.rescind_kind == 'opposition'
+            and self.amount is not None
+        ):
             return int(self.amount / 2)
         return 0
 
     @property
     def mudita(self) -> int:
         if self.support is not None and self.amount is not None:
-            return self.amount
+            return int(self.amount / 2)
+        return 0
+
+    @property
+    def regret(self) -> int:
+        if (
+            self.rescind is not None
+            and self.rescind_kind == 'support'
+            and self.amount is not None
+        ):
+            return int(self.amount / 2)
         return 0
 
 

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -99,7 +99,7 @@
                 <td class="col-1">{{ loop.index0 }}</td>
                 <td class="col-3">{{ o.address or None }}</td>
                 <td class="col-2">{{ o.opposition }}{% if o.opposition %} <em>({{ o.opposition | human_subject }})</em>{% endif %}</td>
-                <td class="col-2">{{ o.rescind }}{% if o.rescind %} <em>({{ o.rescind | human_subject }})</em>{% endif %}</td>
+                <td class="col-2">{{ o.rescind }}{% if o.rescind %} <em>({{ o.rescind | human_subject }})</em>{% endif %}{% if o.rescind_kind %} <em>({{ o.rescind_kind }})</em>{% endif %}</td>
                 <td class="col-2">{{ o.support }}{% if o.support %} <em>({{ o.support | human_subject }})</em>{% endif %}</td>
                 <td class="col-2">{{ o.amount }}</td>
               </tr>

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -285,6 +285,7 @@ class Transaction:
                     opposition=outflow.opposition,
                     rescind=outflow.rescind,
                     support=outflow.support,
+                    rescind_kind=outflow.rescind_kind,
                 )
                 for idx, outflow in enumerate(self.outflows)
             ],
@@ -337,6 +338,7 @@ class Transaction:
                     opposition=outflow_dao.opposition,
                     rescind=outflow_dao.rescind,
                     support=outflow_dao.support,
+                    rescind_kind=outflow_dao.rescind_kind,
                 )
                 for outflow_dao in dao.outflows
             ],

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -109,7 +109,7 @@ class RegularTransactionModel(TransactionModel):
 
 class CoinbaseTransactionModel(TransactionModel):
     inflows: Annotated[list[InflowModel], Field(min_length=0, max_length=0)]
-    outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=4)]
+    outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=5)]
     # Coinbases must carry their block's prev_hash binding.
     prev_hash: MillHashType
 
@@ -174,6 +174,10 @@ class Transaction:
     @property
     def mudita(self) -> int:
         return sum([o.mudita for o in self.outflows])
+
+    @property
+    def regret(self) -> int:
+        return sum([o.regret for o in self.outflows])
 
     def set_wallet(self, wallet: Wallet) -> None:
         self.wallet = wallet
@@ -358,6 +362,7 @@ class Transaction:
         schadenfreude: int,
         grace: int,
         mudita: int,
+        regret: int,
         prev_hash: str,
     ) -> Self:
         outflows: list[Outflow] = []
@@ -371,6 +376,8 @@ class Transaction:
             outflows.append(Outflow(amount=grace, address=wallet.address))
         if mudita:
             outflows.append(Outflow(amount=mudita, address=wallet.address))
+        if regret:
+            outflows.append(Outflow(amount=regret, address=wallet.address))
         cb = cls(outflows=outflows, prev_hash=prev_hash)
         cb.set_wallet(wallet)
         cb.seal()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,11 +216,11 @@ def reward():
 
 @pytest.fixture(
     params=[
-        (2, True, None, None, None),
-        (2, True, None, None, None),
-        (2, False, SUBJECT_1, None, None),
-        (2, False, None, SUBJECT_1, None),
-        (2, False, None, None, SUBJECT_1),
+        (2, True, None, None, None, None),
+        (2, True, None, None, None, None),
+        (2, False, SUBJECT_1, None, None, None),
+        (2, False, None, SUBJECT_1, None, 'opposition'),
+        (2, False, None, None, SUBJECT_1, None),
     ]
 )
 def valid_outflow(request, wallet):
@@ -231,6 +231,7 @@ def valid_outflow(request, wallet):
         opposition=request.param[2],
         rescind=request.param[3],
         support=request.param[4],
+        rescind_kind=request.param[5],
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,10 +289,11 @@ def invalid_txn(wallet):
 
 @pytest.fixture(
     params=[
-        (10, None, None, None),
-        (10, 5, None, None),
-        (10, 5, 5, None),
-        (10, 5, 5, 5),
+        (10, None, None, None, None),
+        (10, 5, None, None, None),
+        (10, 5, 5, None, None),
+        (10, 5, 5, 5, None),
+        (10, 5, 5, 5, 5),
     ]
 )
 def valid_coinbase_txn(request, wallet):

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -16,6 +16,7 @@ from gumptionchain.exceptions import (
     FutureBlockError,
     ImbalancedTransactionError,
     InflowOutflowAddressMismatchError,
+    InsufficientFundsError,
     InvalidBlockError,
     InvalidBlockIndexError,
     InvalidChainError,
@@ -685,6 +686,69 @@ def test_validate_opposition_ioflows(app, subject, wallet):
         chain.seal_block(block3, wallet)
         block3.mill()
         chain.add_block(block3)
+
+
+def test_rescind_support_drops_support_balance(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+        assert chain.support_balance(subject) == amt
+
+        # rescind support
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, amt, subject, 'support')
+        rescind_txn.sign()
+        block3 = Block()
+        block3.add_txn(rescind_txn)
+        add_chain_block(chain=chain, block=block3)
+        chain.to_db()
+        assert chain.support_balance(subject) == 0
+
+
+def test_rescind_support_insufficient_when_only_opposition(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake opposition only
+        _ = next(time_step)
+        t_opp = Transaction()
+        t_opp.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_opp.add_outflow(Outflow(amount=amt, opposition=subject))
+        t_opp.set_wallet(wallet)
+        t_opp.seal()
+        t_opp.sign()
+        block2 = Block()
+        block2.add_txn(t_opp)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # trying to rescind 'support' when only opposition was staked → error
+        with pytest.raises(InsufficientFundsError):
+            chain.create_rescind(wallet, amt, subject, 'support')
 
 
 def test_to_dao_create_without_block_hash_raises():

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -592,7 +592,11 @@ def test_validate_block_coinbase(add_chain_block, app, subject, txid, wallet):
 
         t2 = Transaction()
         t2.add_inflow(Inflow(outflow_txid=t.txid, outflow_idx=0))
-        t2.add_outflow(Outflow(amount=cb_amount, rescind=subject))
+        t2.add_outflow(
+            Outflow(
+                amount=cb_amount, rescind=subject, rescind_kind='opposition'
+            )
+        )
         t2.set_wallet(wallet)
         t2.seal()
         t2.sign()
@@ -669,7 +673,11 @@ def test_validate_opposition_ioflows(app, subject, wallet):
         chain.link_block(block3)
         t2 = Transaction()
         t2.add_inflow(Inflow(outflow_txid=t.txid, outflow_idx=0))
-        t2.add_outflow(Outflow(amount=cb_amount, rescind=subject))
+        t2.add_outflow(
+            Outflow(
+                amount=cb_amount, rescind=subject, rescind_kind='opposition'
+            )
+        )
         t2.set_wallet(wallet)
         t2.seal()
         t2.sign()

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -751,6 +751,132 @@ def test_rescind_support_insufficient_when_only_opposition(
             chain.create_rescind(wallet, amt, subject, 'support')
 
 
+def test_rescind_kind_mismatch_rejected(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Cross-kind rescind (support outflow, opposition kind) is rejected."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # hand-build a cross-kind rescind: consumes support outflow but
+        # claims kind='opposition', misrouting to the opposition pool
+        _ = next(time_step)
+        bad_rescind = Transaction()
+        bad_rescind.add_inflow(
+            Inflow(outflow_txid=t_support.txid, outflow_idx=0)
+        )
+        bad_rescind.add_outflow(
+            Outflow(amount=amt, rescind=subject, rescind_kind='opposition')
+        )
+        bad_rescind.set_wallet(wallet)
+        bad_rescind.seal()
+        bad_rescind.sign()
+        block3 = Block()
+        block3.add_txn(bad_rescind)
+        chain.link_block(block3)
+        chain.seal_block(block3, wallet)
+        block3.mill()
+        with pytest.raises(ImbalancedTransactionError):
+            chain.add_block(block3)
+
+
+def test_support_outflow_cannot_reach_address(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Staked support grains cannot be claimed to a wallet address."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # try to reclaim support grains to a wallet address
+        _ = next(time_step)
+        bad_txn = Transaction()
+        bad_txn.add_inflow(Inflow(outflow_txid=t_support.txid, outflow_idx=0))
+        bad_txn.add_outflow(Outflow(amount=amt, address=wallet.address))
+        bad_txn.set_wallet(wallet)
+        bad_txn.seal()
+        bad_txn.sign()
+        block3 = Block()
+        block3.add_txn(bad_txn)
+        chain.link_block(block3)
+        chain.seal_block(block3, wallet)
+        block3.mill()
+        with pytest.raises(ImbalancedTransactionError):
+            chain.add_block(block3)
+
+
+def test_partial_support_rescind_change_back(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Partial rescind of support keeps remainder in the support pool."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+        # use an even amount so the halving is exact
+        assert amt % 2 == 0, 'REWARD must be even for this test'
+        half = amt // 2
+
+        # stake support
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+        assert chain.support_balance(subject) == amt
+
+        # rescind half
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, half, subject, 'support')
+        rescind_txn.sign()
+        block3 = Block()
+        block3.add_txn(rescind_txn)
+        add_chain_block(chain=chain, block=block3)
+        chain.to_db()
+        assert chain.support_balance(subject) == amt - half
+
+
 def test_to_dao_create_without_block_hash_raises():
     """to_dao(create=True) raises InvalidChainError on None block_hash."""
     chain = Chain()

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -723,6 +723,47 @@ def test_rescind_support_drops_support_balance(
         assert chain.support_balance(subject) == 0
 
 
+def test_support_rescind_mints_regret(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Block with a support-rescind txn mints regret == rescind_amount // 2."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # rescind support — amt is even (genesis reward), so // 2 is exact
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, amt, subject, 'support')
+        rescind_txn.sign()
+        block3 = Block()
+        block3.add_txn(rescind_txn)
+        _, milled_block = add_chain_block(chain=chain, block=block3)
+
+        expected_regret = amt // 2
+        assert milled_block.regret == expected_regret
+        coinbase_outflows = list(milled_block.coinbase.outflows)
+        regret_outflows = [
+            o for o in coinbase_outflows if o.address == wallet.address
+        ]
+        assert any(o.amount == expected_regret for o in regret_outflows)
+
+
 def test_rescind_support_insufficient_when_only_opposition(
     add_chain_block, app, subject, time_stepper, wallet
 ):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -162,7 +162,14 @@ def test_empty_chain(app, runner, requests_proxy, subject_raw, wallet):
         assert 'Opposition failed: EmptyChainError' in result.output
 
 
-def run_txn_rescind(runner, subject, txn_wallet, txn_wallet_file, confirm=True):
+def run_txn_rescind(
+    runner,
+    subject,
+    txn_wallet,
+    txn_wallet_file,
+    confirm=True,
+    kind='opposition',
+):
     return runner.invoke(
         args=[
             'txn',
@@ -170,6 +177,8 @@ def run_txn_rescind(runner, subject, txn_wallet, txn_wallet_file, confirm=True):
             txn_wallet.address,
             str(SUBJECT_GRIT),
             subject,
+            '--kind',
+            kind,
             '--txn-wallet',
             txn_wallet_file,
         ],

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -262,6 +262,43 @@ def test_invalid_support(
         assert len(m.pending_txns) == 0
 
 
+def test_rescind_support_kind(
+    app,
+    mill_block,
+    runner,
+    requests_proxy,
+    subject_raw,
+    time_stepper,
+    wallet,
+):
+    """txn rescind --kind support creates a support rescind transaction."""
+    with app.app_context():
+        time_step = time_stepper()
+        txn_wallet = Wallet()
+        txnwf = txn_wallet.to_file(walletdir=app.config.get('WALLET_DIR'))
+        m, _ = mill_block(txn_wallet)
+        _ = next(time_step)
+        result = run_txn_support(runner, subject_raw, txn_wallet, txnwf)
+        assert 'Support created' in result.output
+        assert len(m.pending_txns) == 1
+        m, _ = mill_block(txn_wallet)
+        result = run_txn_rescind(
+            runner,
+            subject_raw,
+            txn_wallet,
+            txnwf,
+            confirm=False,
+            kind='support',
+        )
+        assert 'Rescind aborted' in result.output
+        assert len(m.pending_txns) == 1
+        result = run_txn_rescind(
+            runner, subject_raw, txn_wallet, txnwf, kind='support'
+        )
+        assert 'Rescind created' in result.output
+        assert len(m.pending_txns) == 2
+
+
 def test_create_wallet(app, runner):
     with app.app_context(), TemporaryDirectory() as walletdir:
         result = runner.invoke(

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -221,7 +221,9 @@ def test_opposition_rescind_txns(app, subject, time_machine, wallet):
         assert m.longest_chain.opposition_balance(subject) == amount
         when_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
-        t1 = m.longest_chain.create_rescind(wallet, amount, subject)
+        t1 = m.longest_chain.create_rescind(
+            wallet, amount, subject, 'opposition'
+        )
         t1.sign()
         m.receive_transaction(t1.txid, t1.to_json())
         b2 = m.create_block()
@@ -253,8 +255,12 @@ def test_invalid_opposition_rescind_txns(app, subject, time_machine, wallet):
         when_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
         with pytest.raises(InsufficientFundsError):
-            t1 = m.longest_chain.create_rescind(wallet, amount + 1, subject)
-        t1 = m.longest_chain.create_rescind(wallet, amount - 1, subject)
+            t1 = m.longest_chain.create_rescind(
+                wallet, amount + 1, subject, 'opposition'
+            )
+        t1 = m.longest_chain.create_rescind(
+            wallet, amount - 1, subject, 'opposition'
+        )
         t1.sign()
         m.receive_transaction(t1.txid, t1.to_json())
         b2 = m.create_block()
@@ -263,8 +269,10 @@ def test_invalid_opposition_rescind_txns(app, subject, time_machine, wallet):
         when_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
         with pytest.raises(InsufficientFundsError):
-            t2 = m.longest_chain.create_rescind(wallet, 2, subject)
-        t2 = m.longest_chain.create_rescind(wallet, 1, subject)
+            t2 = m.longest_chain.create_rescind(
+                wallet, 2, subject, 'opposition'
+            )
+        t2 = m.longest_chain.create_rescind(wallet, 1, subject, 'opposition')
         t2.sign()
         m.receive_transaction(t2.txid, t2.to_json())
         b3 = m.create_block()
@@ -272,7 +280,7 @@ def test_invalid_opposition_rescind_txns(app, subject, time_machine, wallet):
         when_dt += datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
         with pytest.raises(InsufficientFundsError):
-            m.longest_chain.create_rescind(wallet, 1, subject)
+            m.longest_chain.create_rescind(wallet, 1, subject, 'opposition')
 
 
 def test_pending_chain_txns_boundary_alive(app, time_machine, wallet):

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -18,13 +18,13 @@ from gumptionchain.payload import (
 
 def test_outflow_data_csv(subject, wallet):
     outflow = Outflow(amount=9, address=wallet.address)
-    assert outflow.data_csv == f'9,{wallet.address},,,'
+    assert outflow.data_csv == f'9,{wallet.address},,,,'
     outflow = Outflow(amount=9, opposition=subject)
-    assert outflow.data_csv == f'9,,{subject},,'
-    outflow = Outflow(amount=9, rescind=subject)
-    assert outflow.data_csv == f'9,,,{subject},'
+    assert outflow.data_csv == f'9,,{subject},,,'
+    outflow = Outflow(amount=9, rescind=subject, rescind_kind='opposition')
+    assert outflow.data_csv == f'9,,,{subject},,opposition'
     outflow = Outflow(amount=9, support=subject)
-    assert outflow.data_csv == f'9,,,,{subject}'
+    assert outflow.data_csv == f'9,,,,{subject},'
 
 
 def test_outflow_schadenfreude(subject):
@@ -79,7 +79,7 @@ def test_outflow_model_accepts_opposition_only():
 
 def test_outflow_model_accepts_rescind_only():
     subject = encode_subject('forgiven one')
-    m = OutflowModel(amount=3, rescind=subject)
+    m = OutflowModel(amount=3, rescind=subject, rescind_kind='opposition')
     assert m.rescind == subject
     assert m.address is None
 
@@ -174,3 +174,25 @@ def test_valid_raw_subject_helper():
     assert _valid_raw_subject('\x1b') is False  # control char
     assert _valid_raw_subject('') is False  # below min length
     assert _valid_raw_subject('x' * 80) is False  # above max length
+
+
+def test_outflow_rescind_carries_kind():
+    o = Outflow(amount=10, rescind='Zm9v', rescind_kind='opposition')
+    assert o.rescind == 'Zm9v'
+    assert o.rescind_kind == 'opposition'
+
+
+def test_outflow_model_rescind_requires_kind():
+    with pytest.raises(PydanticValidationError):
+        OutflowModel(amount=10, rescind='Zm9v')  # missing rescind_kind
+
+
+def test_outflow_model_rescind_kind_requires_rescind():
+    subject = encode_subject('cancel me')
+    with pytest.raises(PydanticValidationError):
+        OutflowModel(amount=10, opposition=subject, rescind_kind='opposition')
+
+
+def test_outflow_model_accepts_rescind_with_kind():
+    m = OutflowModel(amount=10, rescind='Zm9v', rescind_kind='support')
+    assert m.rescind_kind == 'support'

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -33,13 +33,30 @@ def test_outflow_schadenfreude(subject):
 
 
 def test_outflow_grace(subject):
-    outflow = Outflow(amount=9, rescind=subject)
+    outflow = Outflow(amount=9, rescind=subject, rescind_kind='opposition')
     assert outflow.grace == 4
 
 
 def test_outflow_mudita(subject):
     outflow = Outflow(amount=9, support=subject)
-    assert outflow.mudita == 9
+    assert outflow.mudita == 4
+
+
+def test_outflow_mudita_is_half_weight(subject):
+    outflow = Outflow(amount=10, support=subject)
+    assert outflow.mudita == 5
+
+
+def test_outflow_grace_only_for_opposition_rescind(subject):
+    o = Outflow(amount=10, rescind=subject, rescind_kind='opposition')
+    assert o.grace == 5
+    assert o.regret == 0
+
+
+def test_outflow_regret_for_support_rescind(subject):
+    o = Outflow(amount=10, rescind=subject, rescind_kind='support')
+    assert o.regret == 5
+    assert o.grace == 0
 
 
 def test_inflow_data_csv(txid):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -64,8 +64,12 @@ def test_txn_schadenfreude(subject, txid, wallet):
 def test_txn_grace(subject, txid, wallet):
     txn = Transaction()
     txn.add_inflow(Inflow(outflow_txid=txid, outflow_idx=0))
-    txn.add_outflow(Outflow(amount=9, rescind=subject))
-    txn.add_outflow(Outflow(amount=10, rescind=subject))
+    txn.add_outflow(
+        Outflow(amount=9, rescind=subject, rescind_kind='opposition')
+    )
+    txn.add_outflow(
+        Outflow(amount=10, rescind=subject, rescind_kind='opposition')
+    )
     txn.set_wallet(wallet)
     assert txn.grace == 9
 
@@ -76,7 +80,7 @@ def test_txn_mudita(subject, txid, wallet):
     txn.add_outflow(Outflow(amount=9, support=subject))
     txn.add_outflow(Outflow(amount=10, support=subject))
     txn.set_wallet(wallet)
-    assert txn.mudita == 19
+    assert txn.mudita == 9
 
 
 def test_coinbase_txn_valid(valid_coinbase_txn):
@@ -122,7 +126,9 @@ def test_txn_invalid_signature(single_txn):
 
 def test_db(app, wallet):
     with app.app_context():
-        cb = Transaction.coinbase(wallet, 20, 10, 9, 8, prev_hash=GENESIS_HASH)
+        cb = Transaction.coinbase(
+            wallet, 20, 10, 9, 8, 7, prev_hash=GENESIS_HASH
+        )
         cb.to_db()
         cb_copy = Transaction.from_db(cb.txid)
         assert cb_copy == cb
@@ -134,7 +140,7 @@ def test_db(app, wallet):
 
 
 def test_pending_txns(app, subject, wallet):
-    cb = Transaction.coinbase(wallet, 10, 0, 0, 0, prev_hash=GENESIS_HASH)
+    cb = Transaction.coinbase(wallet, 10, 0, 0, 0, 0, prev_hash=GENESIS_HASH)
     with app.app_context():
         cb.to_db()
         pending = PendingTxnSet()


### PR DESCRIPTION
## Summary
PR 2 of 2 from the design in #141 (PR 1 was #142/#143). Makes `rescind` work for **both** opposition and support, and rebalances the coinbase economics. **This is a hard fork** (data_csv gains `rescind_kind`; `mudita` weight changes) — acceptable because the chain is greenfield/pre-launch.

- **`rescind_kind`** (`opposition`|`support`) added to `Outflow`, validated present-iff-`rescind`; column **folded into the single baseline migration** (greenfield policy from #143 — no incremental migration).
- **Rescind is single-kind & self-describing**: `create_rescind(wallet, amount, subject, kind)`, CLI `txn rescind --kind opposition|support`, API `kind` param; `kind` typed `Literal['opposition','support']` through the domain/DAO layer.
- **Support is now rescindable** — support outflows are consumable, but only into a rescind (rescind outflows stay terminal). `support_balance` → unspent-only.
- **Per-kind validation pools** in `validate_block_txn`: the single "every pool nets to zero" check enforces — for free — the **burn invariant** (staked grains can't reach an `address` outflow), the **rescind-kind cross-check**, and **single-kind** rescinds.
- **Symmetric-halves coinbase**: `schadenfreude`/`grace`/`mudita`/`regret` each `amount//2` (`mudita` dropped from full; new `regret` = rescind-support). Every stake now pays the miller ½ at mint and ½ at rescind — supply-neutral over a lifecycle. `validate_coinbase` enforces `[reward, schadenfreude, grace, mudita, regret]`; `CoinbaseTransactionModel` max outflows 4→5.

### Invariants (independently re-derived in review, and adversarially tested)
- `test_rescind_kind_mismatch_rejected` — wrong-kind rescind → `ImbalancedTransactionError`
- `test_support_outflow_cannot_reach_address` — staked grains can't escape to a wallet
- partial support-rescind change-back; `test_support_rescind_mints_regret`; CLI `--kind support`

## Test Plan
- [x] Full suite: **314 passed, 1 skipped**
- [x] `gumptionchain db upgrade` + `db check`: schema parity (single baseline migration)
- [x] `ruff check`, `ruff format --check`, `mypy`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)