### PR TITLE
fix(test): de-flake future-timestamp auth freshness test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -435,7 +435,10 @@ def test_future_timestamp_rejected(
 ):
     with app.app_context():
         mill_block(reader_wallet)
-        future = int(now().timestamp()) + (signing.FRESHNESS_SECONDS + 1)
+        # Sit well past the freshness window's far edge. A tight +1s margin
+        # is flaky: if >1s elapses before the server re-reads now() at verify,
+        # the "future" timestamp drifts back inside the window and is accepted.
+        future = int(now().timestamp()) + (signing.FRESHNESS_SECONDS + 60)
         headers = signing.sign_headers(
             reader_wallet,
             method='GET',


### PR DESCRIPTION
## Summary
`tests/test_api.py::test_future_timestamp_rejected` was intermittently failing in CI (asserting 401, getting 200). Root cause: it built a future timestamp only **1 second** past the ±300s signature-freshness window (`FRESHNESS_SECONDS + 1`). The server re-reads `now()` when verifying; if >1s elapses between building the timestamp and that verification (likely under CI load), the timestamp drifts back *inside* the window and the request is correctly accepted → spurious 200.

Fix: widen the offset to **+60s** past the window edge so execution-time clock drift can't reach it. The sibling `test_stale_timestamp_rejected` is immune (forward drift only makes a *past* timestamp more stale) and is left unchanged.

Surfaced as a CI failure on an unrelated docs PR (#146); affects any PR.

## Test Plan
- [x] `tests/test_api.py` green (31 passed), including both timestamp tests
- [x] ruff clean