### PR TITLE
refactor: PR 2 review cleanups (StakeKind alias, balance dedup, defensive dispatch, tests)

### DIFF
--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from enum import Enum
 from functools import wraps
-from typing import Annotated, Any, Literal, NoReturn, cast
+from typing import Annotated, Any, NoReturn, cast
 
 from flask import (
     Blueprint,
@@ -38,7 +38,11 @@ from gumptionchain.exceptions import (
     MissingBlockError,
 )
 from gumptionchain.node import Node
-from gumptionchain.payload import encode_subject, validate_raw_subject
+from gumptionchain.payload import (
+    StakeKind,
+    encode_subject,
+    validate_raw_subject,
+)
 from gumptionchain.schema import (
     AddressType,
     PublicKeyType,
@@ -477,7 +481,7 @@ class SubjectTxnQueryModel(BaseModel):
 
 
 class RescindTxnQueryModel(SubjectTxnQueryModel):
-    kind: Literal['opposition', 'support']
+    kind: StakeKind
 
 
 class OppositionTxnView(MethodView):

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass, field
 from functools import total_ordering
-from typing import Any, Literal, Self
+from typing import Any, Self, assert_never
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -33,7 +33,7 @@ from gumptionchain.exceptions import (
 )
 from gumptionchain.milling import mill_hash_str
 from gumptionchain.models import BlockDAO, ChainDAO
-from gumptionchain.payload import Inflow, Outflow
+from gumptionchain.payload import Inflow, Outflow, StakeKind
 from gumptionchain.transaction import Transaction
 from gumptionchain.util import dt_2_iso, now
 from gumptionchain.wallet import Wallet
@@ -406,7 +406,7 @@ class Chain:
     def unrescinded_outflows(
         self,
         subject: str,
-        kind: Literal['opposition', 'support'],
+        kind: StakeKind,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
         outflow_daos = db.session.execute(
@@ -426,7 +426,7 @@ class Chain:
         self,
         address: str,
         subject: str,
-        kind: Literal['opposition', 'support'],
+        kind: StakeKind,
         limit: int | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Iterator[tuple[str, int, Outflow]]:
@@ -520,7 +520,7 @@ class Chain:
         wallet: Wallet,
         amount: int,
         subject: str,
-        kind: Literal['opposition', 'support'],
+        kind: StakeKind,
     ) -> Transaction:
         address = wallet.address
         balance = 0
@@ -540,8 +540,10 @@ class Chain:
             change = balance - amount
             if kind == 'support':
                 t.add_outflow(Outflow(amount=change, support=subject))
-            else:
+            elif kind == 'opposition':
                 t.add_outflow(Outflow(amount=change, opposition=subject))
+            else:
+                assert_never(kind)
         t.set_wallet(wallet)
         t.seal()
         return t

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Generator
 from datetime import timedelta
 from http.client import responses
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import click
 import httpx
@@ -37,7 +37,7 @@ from gumptionchain.console import console
 from gumptionchain.database import db
 from gumptionchain.miller import Miller
 from gumptionchain.node import Node
-from gumptionchain.payload import encode_subject
+from gumptionchain.payload import StakeKind, encode_subject
 from gumptionchain.transaction import Transaction
 from gumptionchain.util import host_address, now_iso
 from gumptionchain.wallet import Wallet
@@ -848,7 +848,7 @@ def create_rescind(
             txn_wallet_obj.public_key_b64,
             grit_to_grains(amount),
             subject,
-            cast(Literal['opposition', 'support'], kind),
+            cast(StakeKind, kind),
         )
         txn = Transaction.from_json(r.text)
         if not (confirm := yes):

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Generator
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar
 
 from sqlalchemy import (
     CTE,
@@ -17,6 +17,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from gumptionchain.database import Base, db
+from gumptionchain.payload import StakeKind
 
 # Chain-factory returns below carry `# type: ignore[no-any-return]` because
 # Flask-SQLAlchemy's `db.select` / `db.aliased` / `db.desc` facade methods
@@ -572,7 +573,7 @@ class ChainDAO(Base):
     def unrescinded_outflows(
         self,
         subject: str,
-        kind: Literal['opposition', 'support'],
+        kind: StakeKind,
         address: str | None = None,
         filter_pending: bool = False,  # noqa: FBT001
     ) -> Select[tuple[OutflowDAO]]:
@@ -591,9 +592,12 @@ class ChainDAO(Base):
             stmt = stmt.where(~OutflowDAO.pending.any())
         return stmt
 
-    def opposition_balance(self, subject: str) -> int:
+    def _stake_balance(self, subject: str, kind: StakeKind) -> int:
+        column = (
+            OutflowDAO.support if kind == 'support' else OutflowDAO.opposition
+        )
         inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
-        stmt = self.outflows.where(OutflowDAO.opposition == subject)
+        stmt = self.outflows.where(column == subject)
         stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
         stmt = stmt.where(inflows_alias.id.is_(None))
         outflows_alias = db.aliased(OutflowDAO, stmt.subquery())
@@ -602,16 +606,11 @@ class ChainDAO(Base):
         )
         return db.session.scalar(sum_stmt) or 0
 
+    def opposition_balance(self, subject: str) -> int:
+        return self._stake_balance(subject, 'opposition')
+
     def support_balance(self, subject: str) -> int:
-        inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
-        stmt = self.outflows.where(OutflowDAO.support == subject)
-        stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
-        stmt = stmt.where(inflows_alias.id.is_(None))
-        outflows_alias = db.aliased(OutflowDAO, stmt.subquery())
-        sum_stmt = db.select(db.func.sum(OutflowDAO.amount)).join(
-            outflows_alias, OutflowDAO.id == outflows_alias.id
-        )
-        return db.session.scalar(sum_stmt) or 0
+        return self._stake_balance(subject, 'support')
 
     def wallet_leaderboard(
         self,

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -74,6 +74,8 @@ def _check_subject(s: str) -> str:
 
 Subject = Annotated[str, AfterValidator(_check_subject)]
 
+StakeKind = Literal['opposition', 'support']
+
 
 class OutflowModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -83,7 +85,7 @@ class OutflowModel(BaseModel):
     opposition: Subject | None = None
     rescind: Subject | None = None
     support: Subject | None = None
-    rescind_kind: Literal['opposition', 'support'] | None = None
+    rescind_kind: StakeKind | None = None
 
     @model_validator(mode='after')
     def validate_destinations(self) -> Self:
@@ -116,7 +118,7 @@ class Outflow:
     opposition: str | None = None
     rescind: str | None = None
     support: str | None = None
-    rescind_kind: str | None = None
+    rescind_kind: StakeKind | None = None
 
     @property
     def data_csv(self) -> str:

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Iterator, MutableSet
 from dataclasses import dataclass, field
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal, Self, cast
 
 from pydantic import (
     BaseModel,
@@ -35,6 +35,7 @@ from gumptionchain.payload import (
     InflowModel,
     Outflow,
     OutflowModel,
+    StakeKind,
 )
 from gumptionchain.schema import (
     AddressType,
@@ -109,6 +110,7 @@ class RegularTransactionModel(TransactionModel):
 
 class CoinbaseTransactionModel(TransactionModel):
     inflows: Annotated[list[InflowModel], Field(min_length=0, max_length=0)]
+    # reward + up to 4 sentiment metrics: schadenfreude, grace, mudita, regret
     outflows: Annotated[list[OutflowModel], Field(min_length=1, max_length=5)]
     # Coinbases must carry their block's prev_hash binding.
     prev_hash: MillHashType
@@ -342,7 +344,9 @@ class Transaction:
                     opposition=outflow_dao.opposition,
                     rescind=outflow_dao.rescind,
                     support=outflow_dao.support,
-                    rescind_kind=outflow_dao.rescind_kind,
+                    rescind_kind=cast(
+                        'StakeKind | None', outflow_dao.rescind_kind
+                    ),
                 )
                 for outflow_dao in dao.outflows
             ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -505,3 +505,42 @@ def test_post_process_signs_at_send_time(
             data=b.to_json(),
             vhosts=None,
         )
+
+
+def test_rescind_missing_kind_returns_validation_error(
+    app, host, mill_block, requests_proxy, subject_raw, transactor_wallet
+):
+    """Regression guard: /api/transaction/rescind without `kind` returns 400."""
+    with app.app_context():
+        mill_block(transactor_wallet)
+        client = ApiClient(host, transactor_wallet)
+        # Omit `kind` entirely — Pydantic validation must reject the request.
+        with pytest.raises(httpx.HTTPStatusError, match='400'):
+            client.get(
+                '/api/transaction/rescind',
+                params={
+                    'public_key': transactor_wallet.public_key_b64,
+                    'amount': '1',
+                    'subject': subject_raw,
+                    # `kind` deliberately absent
+                },
+            )
+
+
+def test_rescind_invalid_kind_returns_validation_error(
+    app, host, mill_block, requests_proxy, subject_raw, transactor_wallet
+):
+    """A `kind` value outside {'opposition','support'} returns 400."""
+    with app.app_context():
+        mill_block(transactor_wallet)
+        client = ApiClient(host, transactor_wallet)
+        with pytest.raises(httpx.HTTPStatusError, match='400'):
+            client.get(
+                '/api/transaction/rescind',
+                params={
+                    'public_key': transactor_wallet.public_key_b64,
+                    'amount': '1',
+                    'subject': subject_raw,
+                    'kind': 'invalid',
+                },
+            )

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -758,10 +758,18 @@ def test_support_rescind_mints_regret(
         expected_regret = amt // 2
         assert milled_block.regret == expected_regret
         coinbase_outflows = list(milled_block.coinbase.outflows)
-        regret_outflows = [
-            o for o in coinbase_outflows if o.address == wallet.address
-        ]
-        assert any(o.amount == expected_regret for o in regret_outflows)
+        # Only reward + regret should be present (schadenfreude/grace/mudita
+        # are 0 in this test), and exactly one outflow should carry the regret
+        # amount to the miner — not the reward outflow.
+        assert len(coinbase_outflows) == 2
+        assert (
+            sum(
+                1
+                for o in coinbase_outflows
+                if o.amount == expected_regret and o.address == wallet.address
+            )
+            == 1
+        )
 
 
 def test_rescind_support_insufficient_when_only_opposition(


### PR DESCRIPTION
## Summary
Addresses the actionable quality/safety findings from the high-effort `/code-review` of #144. **No consensus-behavior change** (verified: balance dedup is byte-identical, the type narrowing is a runtime no-op).

- **`StakeKind` type alias** (`Literal['opposition','support']`) in `payload.py`, threaded through `chain.py`/`models.py`/`api.py`/`command.py`. Narrows `Outflow.rescind_kind` from `str` so mypy now type-checks the `kind` literals (a typo in `grace`/`regret`'s comparison would previously have silently returned 0). `from_dao` casts at the DAO↔domain boundary.
- **Defensive `create_rescind` change-back**: bare `else` → `elif 'opposition'` + `else: assert_never(kind)` (matches the defensive dispatch in `validate_block_txn`).
- **De-duplicated `opposition_balance` / `support_balance`** into a `_stake_balance(subject, kind)` helper — this duplication was *why* `support_balance` was missing the unspent join before PR 2.
- **Comment** tying `CoinbaseTransactionModel.max_length=5` to its derivation (reward + 4 metrics).
- **Tightened `test_support_rescind_mints_regret`** — was insufficiently discriminating (could pass if reward == regret amount).
- **New `/api/transaction/rescind` tests** — missing-`kind` and invalid-`kind` both rejected (HTTP-layer regression guard).

## Out of scope (tracked separately)
- The stake-recycle / restake double-mint inflation (net-stake metric redesign) — **#145** (re-scoped + severity-raised by this review).
- The pre-existing N+1 in `unrescinded_outflows` (perf, not introduced here).

## Test Plan
- [x] Full suite: **316 passed, 1 skipped** (2 new endpoint tests)
- [x] `ruff` / `ruff format` / `mypy` clean (mypy now enforces `StakeKind`)
- [x] `db check`: schema parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)