### PR TITLE
fix: mint coinbase metrics on net new stake — close stake-recycle inflation (#145)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-net-stake-coinbase.md
+++ b/docs/superpowers/plans/2026-06-04-net-stake-coinbase.md
@@ -1,0 +1,417 @@
+# Net-stake coinbase metrics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mint the coinbase sentiment metrics on *net new stake* instead of outflow existence, closing the stake-recycle inflation hole (#145).
+
+**Architecture:** `validate_block_txn` becomes the single source of truth for per-transaction coinbase metrics: it keeps its balance check unchanged, additionally tallies `(kind,subject)` in/out/rescind sums, and returns a `CoinbaseMetrics`. Both the validation path (`validate_block`) and the miller (`create_block`) accumulate those returns and feed them to coinbase build (`seal_block`→`block.seal`) and verify (`validate_block_coinbase`). The per-outflow/txn/block metric properties are removed.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0, Pydantic v2, pytest, uv, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-net-stake-coinbase-design.md`
+
+---
+
+## The rule (reference for all tasks)
+
+Per `(kind, subject)` in a transaction: `in_K[S]` = consumed same-kind inflows, `out_K[S]` = stake outflows, `rescind_K[S]` = rescind outflows. Then:
+- `new_K[S] = max(0, out_K[S] − in_K[S] + rescind_K[S])`
+- mint-side: `schadenfreude = Σ_S new_opp[S] // 2`, `mudita = Σ_S new_sup[S] // 2`
+- rescind-side: `grace = Σ_S rescind_opp[S] // 2`, `regret = Σ_S rescind_sup[S] // 2`
+
+Examples: new stake `(out=100,in=0,resc=0)→new 100→mint 50`; restake `(100,100,0)→0`; partial-rescind-40-of-100 change-back `(out=60,in=100,resc=40)→new 0`, rescind-side `40//2=20`.
+
+## Consensus / greenfield
+
+This changes coinbase amounts only for blocks that recycle stake; normal blocks (new stakes + full rescinds) are bit-identical. Greenfield → no migration, no schema change. `data_csv`/txids untouched.
+
+## File map
+
+| File | Change |
+|---|---|
+| `transaction.py` | add `CoinbaseMetrics` dataclass; remove `Transaction.schadenfreude/grace/mudita/regret` |
+| `chain.py` | `validate_block_txn` tallies + returns `CoinbaseMetrics`; `validate_block` accumulates; `validate_block_coinbase(block, metrics)`; `seal_block(block, wallet, metrics)` |
+| `miller.py` | `create_block` accumulates metrics, passes to `seal_block` |
+| `block.py` | `seal`/`add_coinbase`/`create_coinbase` take `CoinbaseMetrics`; remove `Block.schadenfreude/grace/mudita/regret` and `Block.validate_coinbase` |
+| `payload.py` | remove `Outflow.schadenfreude/grace/mudita/regret` |
+| tests | conservation + adversarial coinbase tests; update existing coinbase-amount expectations |
+
+Task order keeps each commit green: Task 1 adds the computation (callers ignore the return) → Task 2 wires it through build+verify (behavior flips to net) → Task 3 deletes the now-dead properties → Task 4 final verification.
+
+---
+
+## Task 1: `CoinbaseMetrics` + `validate_block_txn` returns per-txn net metrics
+
+Add the carrier and the net tally. Callers still ignore the return, so behavior is unchanged and the suite stays green; the net math is unit-tested directly via `validate_block_txn`.
+
+**Files:** `src/gumptionchain/transaction.py`, `src/gumptionchain/chain.py`, `tests/test_chain.py`
+
+- [ ] **Step 1: Add `CoinbaseMetrics` to `transaction.py`**
+
+Near the top of `src/gumptionchain/transaction.py` (after imports, before/after the `Transaction` class — module level), add:
+```python
+@dataclass(frozen=True)
+class CoinbaseMetrics:
+    schadenfreude: int = 0
+    grace: int = 0
+    mudita: int = 0
+    regret: int = 0
+
+    def __add__(self, other: 'CoinbaseMetrics') -> 'CoinbaseMetrics':
+        return CoinbaseMetrics(
+            self.schadenfreude + other.schadenfreude,
+            self.grace + other.grace,
+            self.mudita + other.mudita,
+            self.regret + other.regret,
+        )
+
+    def nonzero_amounts(self) -> list[int]:
+        return [
+            v
+            for v in (self.schadenfreude, self.grace, self.mudita, self.regret)
+            if v
+        ]
+```
+Ensure `from dataclasses import dataclass` is imported (it almost certainly is for `@dataclass` elsewhere; check the top of the file).
+
+- [ ] **Step 2: Write the failing unit tests for the returned metrics**
+
+In `tests/test_chain.py`, first READ the existing helpers used by `test_rescind_support_drops_support_balance` and `test_support_rescind_mints_regret` (how they build a chain, fund a wallet, stake/mine, and access a `Chain`/`Block`). Mirror that harness. Add tests that call `chain.validate_block_txn(block, txn)` and assert the returned `CoinbaseMetrics` (import it: `from gumptionchain.transaction import CoinbaseMetrics`):
+
+```python
+def test_validate_block_txn_returns_new_stake_metric(...):
+    # build a NEW support stake txn of `amt` (funded from wallet/general outflows)
+    # call chain.validate_block_txn(block, stake_txn) and assert:
+    m = chain.validate_block_txn(block, stake_txn)
+    assert m.mudita == amt // 2
+    assert m.schadenfreude == 0 and m.grace == 0 and m.regret == 0
+
+
+def test_validate_block_txn_restake_mints_nothing(...):
+    # stake support `amt` and mine it; build a restake txn that consumes that
+    # support outflow and emits a new support outflow of `amt` (same subject)
+    m = chain.validate_block_txn(block, restake_txn)
+    assert m.mudita == 0  # net new stake is zero
+
+
+def test_validate_block_txn_partial_rescind_metrics(...):
+    # stake support `amt` (even) and mine; build a partial rescind of amt//2
+    # via chain.create_rescind(wallet, amt // 2, subject, 'support')
+    m = chain.validate_block_txn(block, rescind_txn)
+    assert m.regret == (amt // 2) // 2   # rescind-side for the rescinded part
+    assert m.mudita == 0                 # change-back remainder mints nothing
+```
+Add the symmetric opposition versions (`schadenfreude`/`grace`) following the same shape with `create_opposition`/`create_rescind(..., 'opposition')`. Adapt names/fixtures to the file.
+
+- [ ] **Step 3: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_chain.py -k "validate_block_txn_returns or restake_mints or partial_rescind_metrics" -q`
+Expected: FAIL (`validate_block_txn` returns `None`; `None` has no `.mudita`).
+
+- [ ] **Step 4: Add the tally + return to `validate_block_txn` (chain.py)**
+
+Do NOT alter the existing balance logic (the `opposition_amounts`/`support_amounts`/`other_amounts` mutation and the three `ImbalancedTransactionError` checks). ADD parallel tally dicts and a final computation.
+
+(a) Change the signature return type from `-> None:` to `-> CoinbaseMetrics:` and import it: in the existing `from gumptionchain.transaction import Transaction` line, make it `from gumptionchain.transaction import CoinbaseMetrics, Transaction`.
+
+(b) At the top of the method, next to the existing `opposition_amounts`/`support_amounts`/`other_amounts` initialisation, add six tally dicts:
+```python
+        in_opp: dict[str, int] = {}
+        in_sup: dict[str, int] = {}
+        out_opp: dict[str, int] = {}
+        out_sup: dict[str, int] = {}
+        resc_opp: dict[str, int] = {}
+        resc_sup: dict[str, int] = {}
+```
+
+(c) In the **inflow loop**, inside the existing `if opposition:` / `elif support:` branches, add the tally alongside the existing pool credit:
+- in the `if opposition:` branch: `in_opp[opposition] = in_opp.get(opposition, 0) + amount`
+- in the `elif support:` branch: `in_sup[support] = in_sup.get(support, 0) + amount`
+
+(d) In the **outflow loop**, add the tally alongside the existing balance handling:
+- in the `if o.rescind:` branch, under `if o.rescind_kind == 'support':` add `resc_sup[o.rescind] = resc_sup.get(o.rescind, 0) + (o.amount or 0)`; under `elif o.rescind_kind == 'opposition':` add `resc_opp[o.rescind] = resc_opp.get(o.rescind, 0) + (o.amount or 0)`
+- in the `elif o.opposition:` branch (first line of it): `out_opp[o.opposition] = out_opp.get(o.opposition, 0) + (o.amount or 0)`
+- in the `elif o.support:` branch (first line of it): `out_sup[o.support] = out_sup.get(o.support, 0) + (o.amount or 0)`
+
+(e) After the existing three balance `ImbalancedTransactionError` checks (at the very end of the method), compute and return the metrics:
+```python
+        schadenfreude = sum(
+            max(0, out_opp.get(s, 0) - in_opp.get(s, 0) + resc_opp.get(s, 0))
+            // 2
+            for s in out_opp.keys() | in_opp.keys() | resc_opp.keys()
+        )
+        mudita = sum(
+            max(0, out_sup.get(s, 0) - in_sup.get(s, 0) + resc_sup.get(s, 0))
+            // 2
+            for s in out_sup.keys() | in_sup.keys() | resc_sup.keys()
+        )
+        grace = sum(v // 2 for v in resc_opp.values())
+        regret = sum(v // 2 for v in resc_sup.values())
+        return CoinbaseMetrics(schadenfreude, grace, mudita, regret)
+```
+
+- [ ] **Step 5: Run, expect PASS**
+
+Run: `uv run pytest tests/test_chain.py -k "validate_block_txn_returns or restake_mints or partial_rescind_metrics" -q`
+Expected: PASS.
+
+- [ ] **Step 6: Full suite + lint + types**
+
+Run: `uv run pytest -q` (the existing suite must stay green — `validate_block_txn`'s return is currently ignored by `validate_block`/`miller`, and the old coinbase path still uses `block.schadenfreude`). Then `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`.
+Expected: all green (existing count + the new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(coinbase): validate_block_txn returns net-stake CoinbaseMetrics"
+```
+
+---
+
+## Task 2: Wire net metrics through coinbase build + verify
+
+Flip the coinbase to use the accumulated net metrics on both the miller (build) and validator (verify) sides. Keep the old `Block`/`Transaction`/`Outflow` properties in place for now (they become unused; Task 3 deletes them) so each change is isolated.
+
+**Files:** `src/gumptionchain/chain.py`, `src/gumptionchain/miller.py`, `src/gumptionchain/block.py`, `tests/test_chain.py`, `tests/test_miller.py`, `tests/test_block.py`
+
+- [ ] **Step 1: Conservation + adversarial tests (failing)**
+
+In `tests/test_chain.py` (mirror the existing mine-a-block harness), add end-to-end tests over real mined blocks:
+```python
+def test_restake_block_mints_no_mudita(...):
+    # stake support `amt` from wallet, mine -> that block's coinbase mints amt//2
+    # restake (consume + re-emit same support), mine -> assert the restake block's
+    # coinbase has NO mudita outflow (only the reward outflow), i.e. the miller
+    # minted 0 mudita for the restake.
+
+def test_partial_rescind_block_conserves(...):
+    # stake 100 support, mine; partial-rescind 40, mine -> assert the rescind
+    # block's coinbase mints regret 20 and mudita 0.
+
+def test_stake_lifecycle_mints_face_value(...):
+    # stake 100 support -> 50; rescind 40 then 60 -> 20 + 30; assert total minted
+    # across all mined blocks == 100.
+
+def test_new_stake_still_mints_half(...):
+    # a plain new stake still mints amt//2 (regression).
+
+def test_forged_gross_coinbase_rejected(...):
+    # build a restake block but hand-forge its coinbase to claim the OLD gross
+    # mudita (amt//2); assert chain.validate_block(block) (or add_block) raises
+    # InvalidCoinbaseError.
+```
+Add the opposition-symmetric versions. Read the existing coinbase/miller tests (`test_miller.py`, `test_block.py`) to learn how blocks are sealed and validated, and how the coinbase outflows are inspected. To hand-forge in the adversarial test, mirror however the existing tests construct/seal a block, then replace/append the coinbase metric outflow.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_chain.py -k "restake_block or partial_rescind_block or lifecycle or forged_gross" -q`
+Expected: FAIL (today the miller mints gross via `block.mudita`, so the restake block still mints `amt//2`).
+
+- [ ] **Step 3: `block.py` — take metrics through the seal path**
+
+Change `seal` / `add_coinbase` / `create_coinbase` to accept a `CoinbaseMetrics` and use it (import: `from gumptionchain.transaction import CoinbaseMetrics, Transaction` — `Transaction` is already imported there). Keep the `Block.schadenfreude` etc. properties for now (Task 3 removes them).
+```python
+    def create_coinbase(
+        self, wallet: Wallet, reward: int, metrics: CoinbaseMetrics
+    ) -> Transaction:
+        if self.prev_hash is None:
+            raise UnlinkedBlockError()
+        return Transaction.coinbase(
+            wallet,
+            reward,
+            metrics.schadenfreude,
+            metrics.grace,
+            metrics.mudita,
+            metrics.regret,
+            prev_hash=self.prev_hash,
+        )
+
+    def add_coinbase(
+        self, wallet: Wallet, reward: int, metrics: CoinbaseMetrics
+    ) -> None:
+        self.add_txn(
+            self.create_coinbase(wallet, reward, metrics), is_coinbase=True
+        )
+
+    def seal(
+        self, wallet: Wallet, reward: int, metrics: CoinbaseMetrics
+    ) -> None:
+        if self.is_sealed:
+            raise SealedBlockError()
+        if (self.prev_hash is None) or (self.idx is None):
+            raise UnlinkedBlockError()
+        self.txns.sort()
+        self.add_coinbase(wallet, reward, metrics)
+        self.merkle_root = self.get_merkle_root()
+        self.timestamp = now_iso()
+```
+
+- [ ] **Step 4: `chain.py` — `seal_block` computes/passes metrics; `validate_block` accumulates; `validate_block_coinbase` checks**
+
+`seal_block` gains a `metrics` param and threads it:
+```python
+    def seal_block(
+        self, block: Block, wallet: Wallet, metrics: CoinbaseMetrics
+    ) -> None:
+        block.seal(wallet, self.block_reward(block), metrics)
+```
+`validate_block` (the `for txn in block.regular_txns:` loop, ~lines 205-207) accumulates and passes:
+```python
+        metrics = CoinbaseMetrics()
+        for txn in block.regular_txns:
+            metrics += self.validate_block_txn(block, txn)
+        self.validate_block_coinbase(block, metrics)
+```
+`validate_block_coinbase` gains `metrics` and performs the metric comparison itself (moving it off `Block.validate_coinbase`), keeping the existing reward + binding checks:
+```python
+    def validate_block_coinbase(
+        self, block: Block, metrics: CoinbaseMetrics
+    ) -> None:
+        cb = block.coinbase
+        if cb is None:
+            raise MissingCoinbaseError()
+        cb.validate_coinbase()
+        if metrics.nonzero_amounts() != [o.amount for o in cb.outflows[1:]]:
+            raise InvalidCoinbaseError()
+        reward = self.block_reward(block)
+        # A4.c v2: coinbase is bound to the block it rewards via prev_hash.
+        if cb.prev_hash != block.prev_hash:
+            raise MismatchedCoinbaseError()
+        outflow = cb.get_outflow(0)
+        if outflow is not None and outflow.amount != reward:
+            raise InvalidCoinbaseErrorRewardError()
+```
+Add the imports/exceptions used: `MissingCoinbaseError`, `InvalidCoinbaseError` (check `from gumptionchain.exceptions import (...)` — `MismatchedCoinbaseError`, `InvalidCoinbaseErrorRewardError` are already imported; add `MissingCoinbaseError` and `InvalidCoinbaseError`). `CoinbaseMetrics` is already imported from Task 1.
+
+- [ ] **Step 5: `miller.py` — accumulate metrics in `create_block`, pass to `seal_block`**
+
+In `create_block` (the inclusion loop ~lines 84-99), accumulate the returned metrics for txns that are successfully added, and pass them to `seal_block`:
+```python
+        i = 0
+        discard_txns: list[Transaction] = []
+        metrics = CoinbaseMetrics()
+        self.update_pending_txns()
+        for txn in self.pending_chain_txns(chain):
+            try:
+                m = chain.validate_block_txn(block, txn, txn_in_block=False)
+                block.add_txn(txn)
+                metrics += m
+                i += 1
+                if i >= MAX_TRANSACTIONS - 1:
+                    break
+            except Exception as e:
+                discard_txns.append(txn)
+                txn_failed_signal.send(self, txn=txn, e=e)
+        for txn in discard_txns:
+            self.pending_txns.discard(txn)
+        chain.seal_block(block, self.milling_wallet, metrics)  # type: ignore[arg-type]
+        return block
+```
+Import `CoinbaseMetrics` in `miller.py`: `from gumptionchain.transaction import CoinbaseMetrics` (add to existing transaction import if present).
+
+- [ ] **Step 6: Update existing coinbase callers/tests**
+
+Run: `grep -rn "\.seal(\|seal_block(\|create_coinbase(\|add_coinbase(" src tests`
+Update every call to pass a `CoinbaseMetrics`. For tests that seal a block directly via `block.seal(wallet, reward)`, pass the metrics the chain would compute — simplest is to compute them the same way (`metrics = sum((chain.validate_block_txn(block, t) for t in block.regular_txns), CoinbaseMetrics())`) or, for blocks with no metric-bearing txns, `CoinbaseMetrics()`. Prefer routing through `chain.seal_block`/`chain.create_block` where the harness allows. Also update any test asserting concrete coinbase metric amounts for recycled-stake cases (new-stake/full-rescind amounts are unchanged).
+
+- [ ] **Step 7: Run new + full suite + gates**
+
+Run: `uv run pytest tests/test_chain.py -k "restake_block or partial_rescind_block or lifecycle or forged_gross" -q` → PASS.
+Run: `uv run pytest -q` → all green.
+Run: `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy` → clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(coinbase): mint sentiment metrics on net new stake (closes restake/change-back inflation)"
+```
+
+---
+
+## Task 3: Remove the dead block-local metric properties
+
+After Task 2 the coinbase is built and verified from accumulated `CoinbaseMetrics`; the per-`Outflow`/`Transaction`/`Block` metric properties and `Block.validate_coinbase` are now unused. Delete them.
+
+**Files:** `src/gumptionchain/payload.py`, `src/gumptionchain/transaction.py`, `src/gumptionchain/block.py`, `tests/*`
+
+- [ ] **Step 1: Confirm they are unused, then delete**
+
+Run: `grep -rn "\.schadenfreude\|\.grace\b\|\.mudita\|\.regret\|def schadenfreude\|def grace\|def mudita\|def regret\|validate_coinbase" src`
+The only `*.schadenfreude/grace/mudita/regret` references in `src` should now be inside `CoinbaseMetrics` (its fields) and the metric *computation* in `validate_block_txn`/`validate_block_coinbase`. Delete:
+- `Outflow.schadenfreude/grace/mudita/regret` (payload.py)
+- `Transaction.schadenfreude/grace/mudita/regret` (transaction.py)
+- `Block.schadenfreude/grace/mudita/regret` (block.py)
+- `Block.validate_coinbase` (block.py) — its logic now lives in `Chain.validate_block_coinbase`
+
+Keep `Transaction.validate_coinbase` (a different, transaction-structural check) — only `Block.validate_coinbase` is removed.
+
+- [ ] **Step 2: Update tests that referenced the removed properties**
+
+Run: `grep -rn "\.schadenfreude\|\.grace\b\|\.mudita\|\.regret\|\.validate_coinbase()" tests`
+Any test reading `outflow.mudita` / `txn.schadenfreude` / `block.grace` / `block.validate_coinbase()` directly must be rewritten to assert via the coinbase (the block's coinbase outflow amounts) or via `chain.validate_block_txn(...)`'s returned `CoinbaseMetrics` (the Task 1 pattern). Delete tests that only exercised the removed per-outflow properties if they're now redundant with the conservation tests; otherwise port them.
+
+- [ ] **Step 3: Run full suite + gates**
+
+Run: `uv run pytest -q && uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(coinbase): remove dead per-outflow/block sentiment metric properties"
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** verification only.
+
+- [ ] **Step 1: Grep sweep**
+
+Run: `grep -rn "def schadenfreude\|def grace\|def mudita\|def regret\|block.validate_coinbase\|block.schadenfreude\|block.mudita" src`
+Expected: NO matches (the only metric references should be `CoinbaseMetrics` fields and the `validate_block_txn`/`validate_block_coinbase` computation).
+
+- [ ] **Step 2: Full gate**
+
+Run:
+```bash
+uv run pytest -q
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy
+```
+Then schema parity (no schema change expected, but confirm):
+```bash
+set -a; source tests/.test.env; set +a
+export FLASK_SQLALCHEMY_DATABASE_URI="sqlite:///$(pwd)/.dbcheck_tmp.db"; rm -f .dbcheck_tmp.db
+uv run gumptionchain db upgrade && uv run gumptionchain db check; rm -f .dbcheck_tmp.db
+```
+Expected: all clean; db check `No new upgrade operations detected.`
+
+- [ ] **Step 3: Commit (if Step 1/2 required any cleanup)**
+
+```bash
+git add -A
+git commit -m "test: net-stake coinbase final verification"
+```
+
+---
+
+## Definition of done
+
+- Coinbase mints `schadenfreude`/`mudita` on net new stake (`out − in + rescind`, floored, `//2`); `grace`/`regret` per rescind outflow.
+- `validate_block_txn` is the single source of truth (returns per-txn `CoinbaseMetrics`); build (`miller.create_block`→`seal_block`→`block.seal`) and verify (`validate_block`→`validate_block_coinbase`) both consume the accumulated metrics — fused into the existing per-txn pass, no second inflow-resolution walk.
+- Restake and partial-rescind change-back mint nothing; a stake's lifetime minting == face value; new-stake/full-rescind blocks are unchanged.
+- A forged gross-mint coinbase is rejected (`InvalidCoinbaseError`).
+- Per-outflow/txn/block metric properties and `Block.validate_coinbase` removed.
+- Full suite + ruff + ruff-format + mypy + db check green. No migration.
+
+## Self-review notes
+
+- `CoinbaseMetrics` lives in `transaction.py` (below `block`/`chain`) to avoid a circular import; `block.py` and `chain.py` and `miller.py` import it from there.
+- `validate_block_txn`'s existing balance logic is **untouched**; the tally is additive (six parallel dicts), computed into the return after the balance checks pass (so `new ≥ 0`; `max(0, …)` is belt-and-suspenders).
+- The metric is computed per `(kind, subject)` then `//2` (not per-outflow); for the ordinary single-outflow stake this equals today's `amount//2`, so new-stake blocks stay bit-identical.

--- a/docs/superpowers/specs/2026-06-04-net-stake-coinbase-design.md
+++ b/docs/superpowers/specs/2026-06-04-net-stake-coinbase-design.md
@@ -1,0 +1,185 @@
+# Net-stake coinbase metrics — design
+
+**Date:** 2026-06-04
+**Status:** Approved design, pre-implementation
+**Issue:** #145
+**Type:** Consensus change (coinbase rule), greenfield — no migration
+
+## Summary
+
+Close the stake-recycle inflation hole (#145) by minting the coinbase
+"sentiment" metrics on **net new stake** instead of an outflow's mere existence.
+A stake outflow funded by recycling a prior same-kind stake (a restake, or a
+partial-rescind change-back) mints nothing; only stake funded from wallet/general
+funds mints. This makes a stake's **lifetime minting equal its face value** —
+half when first staked, half when rescinded — regardless of how it is recycled in
+between.
+
+## Problem
+
+The four coinbase metrics are minted from an outflow's existence:
+`schadenfreude`/`mudita` from any opposition/support outflow, `grace`/`regret`
+from any rescind outflow (each `amount // 2`). They flow
+`Outflow` property → `Transaction` sum → `Block` sum → coinbase, and the coinbase
+mints them to the miller; `validate_coinbase` enforces the amounts.
+
+Because minting keys off outflow *existence*, recycling a stake re-mints it:
+
+- **Restake loop (severe, no rescind):** consume your own unspent
+  `support='foo'` outflow (100) and emit a new identical `support='foo'` outflow
+  (100). It balances in `validate_block_txn` (the support pool is credited by the
+  inflow and drained by the outflow), and the new outflow mints `mudita = 50`
+  again — repeatable every block, unbounded inflation from a fixed stake. The
+  opposition variant is identical and predates the rename.
+- **Partial-rescind change-back:** a partial rescind emits a `rescind` outflow
+  (mints the rescind-side metric for the rescinded part) **plus** a same-kind
+  change-back outflow for the remainder — which re-mints the mint-side metric for
+  grains already minted at stake time.
+
+These are coinbase-only metrics: no template, leaderboard, or API reads them
+(only `create_coinbase` and `validate_coinbase`).
+
+## The minting rule
+
+For each `(kind, subject)` within a transaction, define three sums:
+- `in_K[S]`  — value of consumed same-kind inflows on `S`
+- `out_K[S]` — value of stake outflows of kind `K` on `S`
+- `rescind_K[S]` — value of rescind outflows of kind `K` on `S`
+
+Then:
+- **net new stake:** `new_K[S] = out_K[S] − in_K[S] + rescind_K[S]` (≥ 0 for any
+  valid transaction)
+- **mint-side:** `schadenfreude += new_opp[S] // 2`, `mudita += new_sup[S] // 2`
+- **rescind-side (unchanged in spirit):** `grace += rescind_opp[S] // 2`,
+  `regret += rescind_sup[S] // 2`
+
+Worked cases:
+
+| Action | out | in | rescind | new (mints `//2`) | rescind-side |
+|---|---|---|---|---|---|
+| New stake (wallet-funded) | 100 | 0 | 0 | **100** → 50 | 0 |
+| Restake (the exploit) | 100 | 100 | 0 | **0** | 0 |
+| Partial rescind 40 of 100 | 60 (change) | 100 | 40 | **0** | 40 → 20 |
+| Full rescind 100 | 0 | 100 | 100 | **0** | 100 → 50 |
+
+Lifetime conservation: stake 100 → mint 50; later rescind (in any number of
+partial steps) → rescind-side totals 50; restakes in between mint 0. Total minted
+== 100 == face value.
+
+### Why metric-only (no validation restriction)
+
+We considered also forbidding "consume a stake outflow except into a rescind."
+Rejected: it blocks only the *naked* restake. A 1-grain rescind that produces a
+99-grain change-back is a legal rescind that recycles 99% of the stake, so the
+restriction adds consensus-validation surface without closing the hole. The
+net-stake metric closes it in every form (naked or disguised), so it is necessary
+and sufficient on its own. Restake remains a permitted but pointless no-op that
+mints nothing.
+
+## Architecture
+
+The mint-side now depends on what each transaction **consumes**, so it can no
+longer be computed from a block in isolation — it needs chain context to resolve
+each inflow's `(kind, subject)`. Coinbase metric computation therefore moves from
+**block-local** to **chain-aware**, with a single source of truth shared by the
+miller (build) and every node (verify).
+
+- **`validate_block_txn` returns the per-transaction metrics.** It keeps its
+  existing, tested balance check **unchanged**, and additionally tallies
+  `in_K[S]` / `out_K[S]` / `rescind_K[S]` in the loops it already runs, then
+  returns a `CoinbaseMetrics(schadenfreude, grace, mudita, regret)` computed by
+  the rule above. A small `CoinbaseMetrics` carrier supports `+` for
+  accumulation.
+- **The validation loop accumulates and checks:**
+  `metrics = sum(validate_block_txn(block, t) for t in block.regular_txns)`, then
+  the **existing** `validate_block_coinbase` (which already checks the reward and
+  the coinbase→block binding) is extended to take `metrics` and compare the
+  coinbase's metric outflows to it (replacing the block-local `Block.validate_coinbase`).
+- **The miller** already validates each candidate transaction in `create_block`;
+  it accumulates the same `CoinbaseMetrics` during that pass and supplies them to
+  sealing.
+
+### Performance
+
+Performance-neutral by construction. The only non-trivial cost is inflow
+resolution (`validate_txn_inflow` → `get_transaction`), which **both block
+validation and block creation already perform** on every transaction. The metric
+tally is computed from data those passes already hold — a handful of integer ops.
+Read/display paths are unaffected because nothing outside coinbase build/validate
+reads these metrics.
+
+**Implementation requirement (non-negotiable):** the metric tally must be *fused*
+into the existing per-transaction validation pass (via `validate_block_txn`'s
+return value). A separate `coinbase_metrics(block)` pass that re-resolves every
+inflow after validation already did would roughly **double** the per-inflow chain
+lookups per block — that is forbidden.
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `chain.py` | `validate_block_txn` keeps its balance check, adds `(kind,subject)` sum tallies, returns `CoinbaseMetrics`; new `CoinbaseMetrics` carrier; validation loop accumulates; **extend** existing `validate_block_coinbase` to take `metrics` and check the coinbase metric outflows; `Miller.create_block` accumulates metrics for sealing |
+| `block.py` | `seal` / `create_coinbase` take the four metric values as parameters (from the chain-aware caller); remove `Block.schadenfreude/grace/mudita/regret` and `Block.validate_coinbase` |
+| `transaction.py` | remove `Transaction.schadenfreude/grace/mudita/regret`; `Transaction.coinbase(...)` unchanged (already takes the four ints) |
+| `payload.py` | remove `Outflow.schadenfreude/grace/mudita/regret` (all four) |
+| tests | conservation + adversarial coinbase tests; update existing coinbase-amount expectations for recycled cases |
+
+Mostly *deletions* of scattered properties plus one focused accounting addition
+in `validate_block_txn` and a relocated coinbase check. No schema/migration
+change — `data_csv` and txids are untouched, so normal blocks (new stakes + full
+rescinds) stay bit-identical; only recycled-stake blocks get different coinbase
+amounts.
+
+The balance check in `validate_block_txn` stays as-is (tested consensus logic);
+the metric tally is purely additive. Refactoring the balance check itself to the
+aggregate `(in/out/rescind)` form is explicitly **out of scope** — additive
+tally only, to minimize consensus risk.
+
+## Consensus / hard fork
+
+A coinbase consensus-rule change, but it only alters blocks that actually recycle
+stake. Greenfield/pre-launch — no chain to preserve, no migration. Normal blocks
+are unchanged (bit-identical coinbase).
+
+## Testing
+
+Conservation tests over real mined blocks (issue #145 acceptance):
+1. **Restake mints nothing:** stake support (block mints `mudita = amt//2`);
+   restake it; assert the restake block's `mudita == 0`; loop N blocks → total
+   minted stays `amt//2`.
+2. **Change-back mints nothing on the remainder:** stake 100 (`mudita 50`);
+   partial-rescind 40 → assert `regret == 20` **and** `mudita == 0` for that
+   block.
+3. **Lifecycle == face value:** stake 100 → 50; partial rescind 40 then 60 →
+   20 + 30; assert total minted across all blocks `== 100`.
+4. **New-stake regression:** a plain new stake still mints `amt//2` (unchanged).
+5. **Opposition symmetric:** repeat 1–4 for opposition / `schadenfreude` /
+   `grace`.
+6. **Consensus safety (adversarial):** a block whose coinbase claims the old
+   *gross* mint for a recycled-stake transaction is **rejected** by
+   `validate_block_coinbase` (the verifier recomputes net; amounts mismatch →
+   `InvalidCoinbaseError`).
+7. **Miller builds correct net coinbase:** a block the miller seals over a
+   recycled-stake transaction carries the net (not gross) coinbase amounts.
+
+## Decisions log
+
+- Mint-side becomes **net new stake** per `(kind, subject)`:
+  `new = out − in + rescind`, minted `// 2`. Rescind-side unchanged
+  (`rescind // 2`).
+- **Metric-only** fix; no "consume-only-to-rescind" validation rule (the disguised
+  restake bypasses it; net metric is necessary and sufficient).
+- Coinbase metric computation moves **block-local → chain-aware**, single source
+  of truth for build + verify, **fused** into the existing per-transaction
+  validation pass (no second resolution pass).
+- Per-outflow/transaction/block metric properties removed (coinbase-only;
+  misleading once minting depends on funding source).
+- Existing `validate_block_txn` balance check left **unchanged**; metric tally is
+  additive. Greenfield → no migration; normal blocks bit-identical.
+
+## Out of scope
+
+- Refactoring the `validate_block_txn` balance check to aggregate form.
+- The pre-existing N+1 in `unrescinded_outflows` (rescind-building path; separate
+  perf item).
+- Any new validation restriction on consuming stake outflows.

--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -20,7 +20,6 @@ from gumptionchain.exceptions import (
     FutureTransactionError,
     InvalidBlockError,
     InvalidBlockHashError,
-    InvalidCoinbaseError,
     InvalidMerkleRootError,
     InvalidProofError,
     InvalidTransactionError,
@@ -38,6 +37,7 @@ from gumptionchain.schema import (
     pydantic_errors_to_messages,
 )
 from gumptionchain.transaction import (
+    CoinbaseMetrics,
     Transaction,
     TransactionModel,
     txn_from_model_data,
@@ -232,34 +232,45 @@ class Block:
             txn.validate_coinbase()
         self.txns.append(txn)
 
-    def create_coinbase(self, wallet: Wallet, reward: int) -> Transaction:
+    def create_coinbase(
+        self, wallet: Wallet, reward: int, metrics: CoinbaseMetrics
+    ) -> Transaction:
         if self.prev_hash is None:
             raise UnlinkedBlockError()
         return Transaction.coinbase(
             wallet,
             reward,
-            self.schadenfreude,
-            self.grace,
-            self.mudita,
-            self.regret,
+            metrics.schadenfreude,
+            metrics.grace,
+            metrics.mudita,
+            metrics.regret,
             prev_hash=self.prev_hash,
         )
 
-    def add_coinbase(self, wallet: Wallet, reward: int) -> None:
-        self.add_txn(self.create_coinbase(wallet, reward), is_coinbase=True)
+    def add_coinbase(
+        self, wallet: Wallet, reward: int, metrics: CoinbaseMetrics
+    ) -> None:
+        self.add_txn(
+            self.create_coinbase(wallet, reward, metrics), is_coinbase=True
+        )
 
     def link(self, idx: int, prev_hash: str, target: str) -> None:
         self.idx = idx
         self.prev_hash = prev_hash
         self.target = target
 
-    def seal(self, wallet: Wallet, reward: int) -> None:
+    def seal(
+        self,
+        wallet: Wallet,
+        reward: int,
+        metrics: CoinbaseMetrics,
+    ) -> None:
         if self.is_sealed:
             raise SealedBlockError()
         if (self.prev_hash is None) or (self.idx is None):
             raise UnlinkedBlockError()
         self.txns.sort()
-        self.add_coinbase(wallet, reward)
+        self.add_coinbase(wallet, reward, metrics)
         self.merkle_root = self.get_merkle_root()
         self.timestamp = now_iso()
 
@@ -311,17 +322,6 @@ class Block:
         if not cb:
             raise MissingCoinbaseError()
         cb.validate_coinbase()
-        comps = []
-        if self.schadenfreude:
-            comps.append(self.schadenfreude)
-        if self.grace:
-            comps.append(self.grace)
-        if self.mudita:
-            comps.append(self.mudita)
-        if self.regret:
-            comps.append(self.regret)
-        if comps != [o.amount for o in cb.outflows[1:]]:
-            raise InvalidCoinbaseError()
 
     def validate(self) -> None:
         try:

--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -144,22 +144,6 @@ class Block:
         return self.last_txn if self.is_sealed else None
 
     @property
-    def schadenfreude(self) -> int:
-        return sum([t.schadenfreude for t in self.txns])
-
-    @property
-    def grace(self) -> int:
-        return sum([t.grace for t in self.txns])
-
-    @property
-    def mudita(self) -> int:
-        return sum([t.mudita for t in self.txns])
-
-    @property
-    def regret(self) -> int:
-        return sum([t.regret for t in self.txns])
-
-    @property
     def is_sealed(self) -> bool:
         return self.timestamp is not None
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -34,7 +34,7 @@ from gumptionchain.exceptions import (
 from gumptionchain.milling import mill_hash_str
 from gumptionchain.models import BlockDAO, ChainDAO
 from gumptionchain.payload import Inflow, Outflow, StakeKind
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import dt_2_iso, now
 from gumptionchain.wallet import Wallet
 
@@ -45,6 +45,22 @@ REWARD = 100 * GRAIN_PER_GRIT
 TARGET_GOAL_SECONDS = 600
 TARGET_INTERVAL = 2016
 TARGET_INTERVAL_SECONDS = TARGET_GOAL_SECONDS * TARGET_INTERVAL
+
+
+def _net_stake_mint(
+    out: dict[str, int],
+    consumed: dict[str, int],
+    rescind: dict[str, int],
+) -> int:
+    # Mint-side coinbase metric: half the NET new stake per subject.
+    # New stake = stake outflows minus recycled (consumed same-kind
+    # inflows that didn't go to a rescind), i.e. out - consumed +
+    # rescind, floored at 0. A restake or a partial-rescind change-back
+    # nets to 0 and mints nothing.
+    return sum(
+        max(0, out.get(s, 0) - consumed.get(s, 0) + rescind.get(s, 0)) // 2
+        for s in out.keys() | consumed.keys() | rescind.keys()
+    )
 
 
 def is_genesis_block(block: Block) -> bool:
@@ -211,11 +227,17 @@ class Chain:
         block: Block,
         txn: Transaction,
         txn_in_block: bool = True,  # noqa: FBT001
-    ) -> None:
+    ) -> CoinbaseMetrics:
         # add inflow amounts, routed by the kind of the consumed outflow
         opposition_amounts: dict[str, int] = {}
         support_amounts: dict[str, int] = {}
         other_amounts = 0
+        in_opp: dict[str, int] = {}
+        in_sup: dict[str, int] = {}
+        out_opp: dict[str, int] = {}
+        out_sup: dict[str, int] = {}
+        resc_opp: dict[str, int] = {}
+        resc_sup: dict[str, int] = {}
         for i in txn.inflows:
             amount, opposition, support = self.validate_txn_inflow(
                 block, txn, i, txn_in_block=txn_in_block
@@ -224,10 +246,12 @@ class Chain:
                 opposition_amounts[opposition] = (
                     opposition_amounts.get(opposition, 0) + amount
                 )
+                in_opp[opposition] = in_opp.get(opposition, 0) + amount
             elif support:
                 support_amounts[support] = (
                     support_amounts.get(support, 0) + amount
                 )
+                in_sup[support] = in_sup.get(support, 0) + amount
             else:
                 other_amounts += amount
         # subtract outflow amounts
@@ -239,13 +263,22 @@ class Chain:
                     support_amounts[o.rescind] = support_amounts.get(
                         o.rescind, 0
                     ) - (o.amount or 0)
+                    resc_sup[o.rescind] = resc_sup.get(o.rescind, 0) + (
+                        o.amount or 0
+                    )
                 elif o.rescind_kind == 'opposition':
                     opposition_amounts[o.rescind] = opposition_amounts.get(
                         o.rescind, 0
                     ) - (o.amount or 0)
+                    resc_opp[o.rescind] = resc_opp.get(o.rescind, 0) + (
+                        o.amount or 0
+                    )
                 else:
                     raise ImbalancedTransactionError()
             elif o.opposition:
+                out_opp[o.opposition] = out_opp.get(o.opposition, 0) + (
+                    o.amount or 0
+                )
                 opposition_amount = opposition_amounts.get(o.opposition)
                 if opposition_amount and opposition_amount > 0:
                     if (o.amount or 0) > opposition_amount:
@@ -258,6 +291,7 @@ class Chain:
                 else:
                     other_amounts -= o.amount or 0
             elif o.support:
+                out_sup[o.support] = out_sup.get(o.support, 0) + (o.amount or 0)
                 support_amount = support_amounts.get(o.support)
                 if support_amount and support_amount > 0:
                     if (o.amount or 0) > support_amount:
@@ -279,6 +313,16 @@ class Chain:
         for _, amount in support_amounts.items():
             if amount != 0:
                 raise ImbalancedTransactionError()
+        # out_opp/out_sup: o.opposition/o.support outflow branches only.
+        # resc_opp/resc_sup: o.rescind branches only.
+        # in_opp/in_sup: consumed inflows only.
+        # The mint-side (schadenfreude/mudita) and rescind-side
+        # (grace/regret) therefore draw on disjoint outflow pools.
+        schadenfreude = _net_stake_mint(out_opp, in_opp, resc_opp)
+        mudita = _net_stake_mint(out_sup, in_sup, resc_sup)
+        grace = sum(v // 2 for v in resc_opp.values())
+        regret = sum(v // 2 for v in resc_sup.values())
+        return CoinbaseMetrics(schadenfreude, grace, mudita, regret)
 
     def validate_txn_inflow(
         self,

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -21,11 +21,13 @@ from gumptionchain.exceptions import (
     InvalidBlockError,
     InvalidBlockIndexError,
     InvalidChainError,
+    InvalidCoinbaseError,
     InvalidCoinbaseErrorRewardError,
     InvalidInflowOutflowError,
     InvalidPreviousHashError,
     InvalidTargetError,
     MismatchedCoinbaseError,
+    MissingCoinbaseError,
     MissingInflowOutflowError,
     MissingPreviousBlockError,
     OutOfOrderBlockError,
@@ -165,8 +167,13 @@ class Chain:
         target = self.target or MAX_TARGET
         block.link(index, prev_hash or GENESIS_HASH, target)
 
-    def seal_block(self, block: Block, wallet: Wallet) -> None:
-        block.seal(wallet, self.block_reward(block))
+    def seal_block(
+        self,
+        block: Block,
+        wallet: Wallet,
+        metrics: CoinbaseMetrics,
+    ) -> None:
+        block.seal(wallet, self.block_reward(block), metrics)
 
     def add_block(self, block: Block, *, commit: bool = True) -> None:
         self.validate_block(block)
@@ -218,9 +225,22 @@ class Chain:
             raise InvalidBlockIndexError()
         if block.target != self.block_target(block=block):
             raise InvalidTargetError()
+        metrics = CoinbaseMetrics()
         for txn in block.regular_txns:
-            self.validate_block_txn(block, txn)
-        self.validate_block_coinbase(block)
+            metrics += self.validate_block_txn(block, txn)
+        try:
+            self.validate_block_coinbase(block, metrics)
+        except (
+            MismatchedCoinbaseError,
+            InvalidCoinbaseErrorRewardError,
+            InvalidBlockError,
+        ):
+            # MismatchedCoinbaseError and InvalidCoinbaseErrorRewardError are
+            # InvalidCoinbaseError subclasses that callers test for by type;
+            # re-raise them before the generic InvalidCoinbaseError wrap.
+            raise
+        except InvalidCoinbaseError as e:
+            raise InvalidBlockError(e.messages) from e
 
     def validate_block_txn(
         self,
@@ -359,22 +379,22 @@ class Chain:
             raise SpentTransactionError()
         return ioflow.amount or 0, ioflow.opposition, ioflow.support
 
-    def validate_block_coinbase(self, block: Block) -> None:
-        block.validate_coinbase()
-        reward = self.block_reward(block)
+    def validate_block_coinbase(
+        self, block: Block, metrics: CoinbaseMetrics
+    ) -> None:
         cb = block.coinbase
-        if cb is not None:
-            # A4.c v2: a coinbase is bound to the block it rewards via its
-            # prev_hash (which is part of the coinbase's hashed txid). A
-            # replay carries the wrong parent; reject on the mismatch. This
-            # is a purely local check — no lineage walk, no self.last_block
-            # dependence — so it is correct in both the add-block path and
-            # Chain.validate() full-chain revalidation.
-            if cb.prev_hash != block.prev_hash:
-                raise MismatchedCoinbaseError()
-            outflow = cb.get_outflow(0)
-            if outflow is not None and outflow.amount != reward:
-                raise InvalidCoinbaseErrorRewardError()
+        if cb is None:
+            raise MissingCoinbaseError()
+        cb.validate_coinbase()
+        if metrics.nonzero_amounts() != [o.amount for o in cb.outflows[1:]]:
+            raise InvalidCoinbaseError()
+        reward = self.block_reward(block)
+        # A4.c v2: coinbase is bound to the block it rewards via prev_hash.
+        if cb.prev_hash != block.prev_hash:
+            raise MismatchedCoinbaseError()
+        outflow = cb.get_outflow(0)
+        if outflow is not None and outflow.amount != reward:
+            raise InvalidCoinbaseErrorRewardError()
 
     def get_block(self, block_hash: str) -> Block | None:
         dao = self.to_dao()

--- a/src/gumptionchain/miller.py
+++ b/src/gumptionchain/miller.py
@@ -12,7 +12,7 @@ from gumptionchain.chain import Chain
 from gumptionchain.milling import milling_generator
 from gumptionchain.node import Node
 from gumptionchain.signals import txn_failed as txn_failed_signal
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import host_address, now
 from gumptionchain.wallet import Wallet
 
@@ -83,11 +83,13 @@ class Miller(Node):
         chain.link_block(block)
         i = 0
         discard_txns: list[Transaction] = []
+        metrics = CoinbaseMetrics()
         self.update_pending_txns()
         for txn in self.pending_chain_txns(chain):
             try:
-                chain.validate_block_txn(block, txn, txn_in_block=False)
+                m = chain.validate_block_txn(block, txn, txn_in_block=False)
                 block.add_txn(txn)
+                metrics += m
                 i += 1
                 if i >= MAX_TRANSACTIONS - 1:
                     break
@@ -96,7 +98,7 @@ class Miller(Node):
                 txn_failed_signal.send(self, txn=txn, e=e)
         for txn in discard_txns:
             self.pending_txns.discard(txn)
-        chain.seal_block(block, self.milling_wallet)  # type: ignore[arg-type]
+        chain.seal_block(block, self.milling_wallet, metrics)  # type: ignore[arg-type]
         return block
 
     def poll_latest_blocks(self, progress: Any | None = None) -> None:

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -133,38 +133,6 @@ class Outflow:
             ]
         )
 
-    @property
-    def schadenfreude(self) -> int:
-        if self.opposition is not None and self.amount is not None:
-            return self.amount // 2
-        return 0
-
-    @property
-    def grace(self) -> int:
-        if (
-            self.rescind is not None
-            and self.rescind_kind == 'opposition'
-            and self.amount is not None
-        ):
-            return self.amount // 2
-        return 0
-
-    @property
-    def mudita(self) -> int:
-        if self.support is not None and self.amount is not None:
-            return self.amount // 2
-        return 0
-
-    @property
-    def regret(self) -> int:
-        if (
-            self.rescind is not None
-            and self.rescind_kind == 'support'
-            and self.amount is not None
-        ):
-            return self.amount // 2
-        return 0
-
 
 @dataclass
 class Inflow:

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -56,6 +56,30 @@ MAX_FLOWS = 50
 ADDRESS_MISMATCH_MSG = 'Address/public key mismatch'
 
 
+@dataclass(frozen=True)
+class CoinbaseMetrics:
+    schadenfreude: int = 0
+    grace: int = 0
+    mudita: int = 0
+    regret: int = 0
+
+    def __add__(self, other: CoinbaseMetrics) -> CoinbaseMetrics:
+        return CoinbaseMetrics(
+            self.schadenfreude + other.schadenfreude,
+            self.grace + other.grace,
+            self.mudita + other.mudita,
+            self.regret + other.regret,
+        )
+
+    def nonzero_amounts(self) -> list[int]:
+        """Nonzero amounts in coinbase order (sf, grace, mudita, regret)."""
+        return [
+            v
+            for v in (self.schadenfreude, self.grace, self.mudita, self.regret)
+            if v
+        ]
+
+
 # ---------------------------------------------------------------------------
 # Pydantic v2 models — canonical validators for all callers.
 # ---------------------------------------------------------------------------

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -189,22 +189,6 @@ class Transaction:
     def signing_data(self) -> bytes:
         return ','.join([self.data_csv, str(self.txid)]).encode()
 
-    @property
-    def schadenfreude(self) -> int:
-        return sum([o.schadenfreude for o in self.outflows])
-
-    @property
-    def grace(self) -> int:
-        return sum([o.grace for o in self.outflows])
-
-    @property
-    def mudita(self) -> int:
-        return sum([o.mudita for o in self.outflows])
-
-    @property
-    def regret(self) -> int:
-        return sum([o.regret for o in self.outflows])
-
     def set_wallet(self, wallet: Wallet) -> None:
         self.wallet = wallet
         self.address = self.wallet.address

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from gumptionchain.chain import GENESIS_HASH, REWARD, Chain
 from gumptionchain.database import db
 from gumptionchain.miller import Miller
 from gumptionchain.payload import Inflow, Outflow, encode_subject
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import now
 from gumptionchain.wallet import Wallet
 
@@ -331,7 +331,13 @@ def add_chain_block(wallet):
         c = chain or Chain()
         b = block or Block()
         c.link_block(b)
-        c.seal_block(b, milling_wallet or wallet)
+        # Compute metrics over all txns in the block (before sealing the
+        # coinbase is not yet appended, so b.txns == future regular_txns).
+        metrics = sum(
+            (c.validate_block_txn(b, t) for t in b.txns),
+            CoinbaseMetrics(),
+        )
+        c.seal_block(b, milling_wallet or wallet, metrics)
         b.mill()
         c.add_block(b)
         return c, b

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -18,7 +18,7 @@ from gumptionchain.exceptions import (
     UnlinkedBlockError,
 )
 from gumptionchain.payload import Inflow, Outflow
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import dt_2_iso, now
 
 TEST_TARGET = 'F' * 64
@@ -36,7 +36,7 @@ def new_txn(txid, subject, wallet):
 
 def test_from(reward, valid_block, wallet):
     valid_block.link(0, GENESIS_HASH, TEST_TARGET)
-    valid_block.seal(wallet, reward)
+    valid_block.seal(wallet, reward, CoinbaseMetrics())
     valid_block.mill()
     new_block = Block.from_dict(valid_block.to_dict())
     assert new_block == valid_block
@@ -46,14 +46,14 @@ def test_from(reward, valid_block, wallet):
 
 def test_coinbase(reward, valid_block, wallet):
     valid_block.link(0, GENESIS_HASH, TEST_TARGET)
-    valid_block.seal(wallet, reward)
+    valid_block.seal(wallet, reward, CoinbaseMetrics())
     cb = valid_block.coinbase
     assert cb.outflows[0].amount == reward
 
 
 def test_timestamp_dt(reward, single_block, wallet):
     single_block.link(0, GENESIS_HASH, TEST_TARGET)
-    single_block.seal(wallet, reward)
+    single_block.seal(wallet, reward, CoinbaseMetrics())
     assert dt_2_iso(single_block.timestamp_dt) == single_block.timestamp
 
 
@@ -63,7 +63,7 @@ def test_valid(reward, valid_block, single_txn, wallet):
     with pytest.raises(InvalidBlockError):
         valid_block.validate()
     valid_block.link(0, GENESIS_HASH, TEST_TARGET)
-    valid_block.seal(wallet, reward)
+    valid_block.seal(wallet, reward, CoinbaseMetrics())
     assert not valid_block.is_proved
     with pytest.raises(InvalidBlockError):
         valid_block.validate()
@@ -75,7 +75,7 @@ def test_valid(reward, valid_block, single_txn, wallet):
 
 def test_in_merkle_tree(reward, single_block, single_txn, wallet):
     single_block.link(0, GENESIS_HASH, TEST_TARGET)
-    single_block.seal(wallet, reward)
+    single_block.seal(wallet, reward, CoinbaseMetrics())
     single_block.mill()
     single_block.validate()
     assert single_block.in_merkle_tree(single_txn.txid)
@@ -90,7 +90,7 @@ def test_add_txn(single_block, subject, time_machine, txid, wallet):
 
 def test_unlinked(reward, single_block, wallet):
     with pytest.raises(UnlinkedBlockError):
-        single_block.seal(wallet, reward)
+        single_block.seal(wallet, reward, CoinbaseMetrics())
 
 
 def test_future_txn(reward, single_block, subject, time_machine, txid, wallet):
@@ -101,7 +101,7 @@ def test_future_txn(reward, single_block, subject, time_machine, txid, wallet):
     time_machine.move_to(now_dt)
     single_block.add_txn(txn)
     single_block.link(0, GENESIS_HASH, TEST_TARGET)
-    single_block.seal(wallet, reward)
+    single_block.seal(wallet, reward, CoinbaseMetrics())
     single_block.mill()
     with pytest.raises(InvalidBlockError, match='FutureTransactionError'):
         single_block.validate()
@@ -113,7 +113,7 @@ def test_invalid_transaction(
     now_dt = now()
     time_machine.move_to(now_dt)
     single_block.link(0, GENESIS_HASH, TEST_TARGET)
-    single_block.seal(wallet, reward)
+    single_block.seal(wallet, reward, CoinbaseMetrics())
     then_dt = now_dt - datetime.timedelta(minutes=1)
     time_machine.move_to(then_dt)
     txn = new_txn(txid, subject, wallet)
@@ -157,7 +157,7 @@ def test_too_many_txns(reward, subject, txid, wallet):
         txn.sign()
         block.add_txn(txn)
     block.link(0, GENESIS_HASH, TEST_TARGET)
-    block.seal(wallet, reward)
+    block.seal(wallet, reward, CoinbaseMetrics())
     block.mill()
     with pytest.raises(
         InvalidBlockError, match='List should have at most 100 items'
@@ -169,7 +169,7 @@ def test_db(app, reward, wallet):
     with app.app_context():
         block = Block()
         block.link(0, GENESIS_HASH, TEST_TARGET)
-        block.seal(wallet, reward)
+        block.seal(wallet, reward, CoinbaseMetrics())
         block.mill()
         block.validate()
         block.to_db()
@@ -192,7 +192,7 @@ def test_genesis_from_db(app, reward, wallet):
         assert Block.genesis_from_db() is None
         block = Block()
         block.link(0, GENESIS_HASH, TEST_TARGET)
-        block.seal(wallet, reward)
+        block.seal(wallet, reward, CoinbaseMetrics())
         block.mill()
         block.validate()
         block.to_db()

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -28,7 +28,7 @@ from gumptionchain.exceptions import (
 )
 from gumptionchain.milling import mill_hash_str
 from gumptionchain.payload import Inflow, Outflow
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import now, now_iso
 from gumptionchain.wallet import Wallet
 
@@ -939,3 +939,198 @@ def test_to_dao_without_block_hash_returns_none():
     chain = Chain()
     assert chain.block_hash is None
     assert chain.to_dao() is None
+
+
+# ---------------------------------------------------------------------------
+# CoinbaseMetrics / validate_block_txn net-stake tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_block_txn_returns_new_stake_metric(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """New support stake → mudita == amt // 2; all other metrics zero."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        _ = next(time_step)
+        stake_txn = Transaction()
+        stake_txn.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        stake_txn.add_outflow(Outflow(amount=amt, support=subject))
+        stake_txn.set_wallet(wallet)
+        stake_txn.seal()
+        stake_txn.sign()
+
+        block2 = Block()
+        chain.link_block(block2)
+
+        m = chain.validate_block_txn(block2, stake_txn, txn_in_block=False)
+        assert isinstance(m, CoinbaseMetrics)
+        assert m.mudita == amt // 2
+        assert m.schadenfreude == 0
+        assert m.grace == 0
+        assert m.regret == 0
+
+
+def test_validate_block_txn_restake_mints_nothing(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Restake (consume+re-emit same support outflow) → mudita == 0."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support and mine it into the chain
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # build a restake: consume the support outflow, emit a new one
+        _ = next(time_step)
+        restake_txn = Transaction()
+        restake_txn.add_inflow(
+            Inflow(outflow_txid=t_support.txid, outflow_idx=0)
+        )
+        restake_txn.add_outflow(Outflow(amount=amt, support=subject))
+        restake_txn.set_wallet(wallet)
+        restake_txn.seal()
+        restake_txn.sign()
+
+        block3 = Block()
+        chain.link_block(block3)
+
+        m = chain.validate_block_txn(block3, restake_txn, txn_in_block=False)
+        assert isinstance(m, CoinbaseMetrics)
+        assert m.mudita == 0
+        assert m.schadenfreude == 0
+        assert m.grace == 0
+        assert m.regret == 0
+
+
+def test_validate_block_txn_partial_rescind_metrics(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Partial support rescind → regret == rescind_amt // 2, mudita == 0."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+        assert amt % 2 == 0, 'REWARD must be even for this test'
+
+        # stake support and mine it
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # rescind half; create_rescind emits rescind + change-back
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, amt // 2, subject, 'support')
+        rescind_txn.sign()
+
+        block3 = Block()
+        chain.link_block(block3)
+
+        m = chain.validate_block_txn(block3, rescind_txn, txn_in_block=False)
+        assert isinstance(m, CoinbaseMetrics)
+        assert m.regret == (amt // 2) // 2
+        assert m.mudita == 0
+        assert m.schadenfreude == 0
+        assert m.grace == 0
+
+
+def test_validate_block_txn_returns_new_opposition_metric(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """New opposition stake → schadenfreude == amt // 2; others zero."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        _ = next(time_step)
+        stake_txn = Transaction()
+        stake_txn.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        stake_txn.add_outflow(Outflow(amount=amt, opposition=subject))
+        stake_txn.set_wallet(wallet)
+        stake_txn.seal()
+        stake_txn.sign()
+
+        block2 = Block()
+        chain.link_block(block2)
+
+        m = chain.validate_block_txn(block2, stake_txn, txn_in_block=False)
+        assert isinstance(m, CoinbaseMetrics)
+        assert m.schadenfreude == amt // 2
+        assert m.mudita == 0
+        assert m.grace == 0
+        assert m.regret == 0
+
+
+def test_validate_block_txn_partial_rescind_opposition_metrics(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Partial opposition rescind → grace == rescind_amt // 2."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+        assert amt % 2 == 0, 'REWARD must be even for this test'
+
+        # stake opposition and mine it
+        _ = next(time_step)
+        t_opp = Transaction()
+        t_opp.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_opp.add_outflow(Outflow(amount=amt, opposition=subject))
+        t_opp.set_wallet(wallet)
+        t_opp.seal()
+        t_opp.sign()
+        block2 = Block()
+        block2.add_txn(t_opp)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # rescind half
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(
+            wallet, amt // 2, subject, 'opposition'
+        )
+        rescind_txn.sign()
+
+        block3 = Block()
+        chain.link_block(block3)
+
+        m = chain.validate_block_txn(block3, rescind_txn, txn_in_block=False)
+        assert isinstance(m, CoinbaseMetrics)
+        assert m.grace == (amt // 2) // 2
+        assert m.schadenfreude == 0
+        assert m.mudita == 0
+        assert m.regret == 0

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -69,7 +69,7 @@ def test_invalid_prev_hash(app, wallet):
         # (CoinbaseTransactionModel) at seal() time, which is a different
         # check than the add_block prev_hash validation under test here.
         block.prev_hash = mill_hash_str('foo')
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         with pytest.raises(InvalidBlockError):
             chain.add_block(block)
@@ -80,7 +80,7 @@ def test_invalid_txn_timestamp(app, time_machine, wallet):
         chain = Chain()
         block = Block()
         chain.link_block(block)
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         chain.add_block(block)
         cb = block.coinbase
@@ -97,7 +97,7 @@ def test_invalid_txn_timestamp(app, time_machine, wallet):
         block = Block()
         block.add_txn(t)
         chain.link_block(block)
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         with pytest.raises(InvalidBlockError, match='FutureTransactionError'):
             chain.add_block(block)
@@ -113,7 +113,7 @@ def test_invalid_txn_timestamp(app, time_machine, wallet):
         block = Block()
         block.add_txn(t)
         chain.link_block(block)
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         with pytest.raises(InvalidBlockError, match='ExpiredTransactionError'):
             chain.add_block(block)
@@ -127,7 +127,7 @@ def test_decrease_target(app, wallet):
         for _i in range(0, 5):
             block = Block()
             chain.link_block(block)
-            block.seal(wallet, chain.block_reward(block))
+            block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
             assert block.target == TEST_TARGET
             assert block.target == chain.target
             block.mill()
@@ -136,7 +136,7 @@ def test_decrease_target(app, wallet):
         assert int(chain.target, 16) == new_target
         block = Block()
         chain.link_block(block)
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         assert block.target == chain.target
         block.mill()
         chain.add_block(block)
@@ -151,14 +151,14 @@ def test_increase_target(app, time_machine, wallet):
         chain = Chain()
         block = Block()
         chain.link_block(block)
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         chain.add_block(block)
         time_machine.move_to(now_dt)
         for _i in range(0, 4):
             block = Block()
             chain.link_block(block)
-            block.seal(wallet, chain.block_reward(block))
+            block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
             assert block.target == chain.target == TEST_TARGET
             block.mill()
             chain.add_block(block)
@@ -177,7 +177,7 @@ def test_invalid_target(app, time_machine, time_stepper, wallet):
             _ = next(time_step)
             block = Block()
             chain.link_block(block)
-            block.seal(wallet, chain.block_reward(block))
+            block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
             assert block.target == chain.target == TEST_TARGET
             block.mill()
             chain.add_block(block)
@@ -187,7 +187,7 @@ def test_invalid_target(app, time_machine, time_stepper, wallet):
         block = Block()
         chain.link_block(block)
         block.target = TEST_TARGET
-        block.seal(wallet, chain.block_reward(block))
+        block.seal(wallet, chain.block_reward(block), CoinbaseMetrics())
         block.mill()
         with pytest.raises(InvalidTargetError):
             chain.add_block(block)
@@ -231,7 +231,7 @@ def test_mill(wallet):
     chain = Chain()
     block = Block()
     chain.link_block(block)
-    chain.seal_block(block, wallet)
+    chain.seal_block(block, wallet, CoinbaseMetrics())
     block.mill()
 
 
@@ -240,7 +240,7 @@ def test_mill_mp(wallet):
     chain = Chain()
     block = Block()
     chain.link_block(block)
-    chain.seal_block(block, wallet)
+    chain.seal_block(block, wallet, CoinbaseMetrics())
     block.mill(mp=True)
 
 
@@ -396,7 +396,7 @@ def test_validate_block(add_chain_block, app, time_machine, wallet):
         time_machine.move_to(then_dt)
         block2 = Block()
         chain.link_block(block2)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.mill()
         time_machine.move_to(now_dt)
         with pytest.raises(FutureBlockError):
@@ -406,7 +406,7 @@ def test_validate_block(add_chain_block, app, time_machine, wallet):
         time_machine.move_to(then_dt)
         block2 = Block()
         chain.link_block(block2)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.mill()
         time_machine.move_to(now_dt)
         with pytest.raises(OutOfOrderBlockError):
@@ -414,7 +414,7 @@ def test_validate_block(add_chain_block, app, time_machine, wallet):
 
         block2 = Block()
         chain.link_block(block2)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.idx += 1
         block2.mill()
         with pytest.raises(InvalidBlockIndexError):
@@ -443,7 +443,7 @@ def test_validate_block_txn(add_chain_block, app, time_machine, wallet):
         t.sign()
         time_machine.move_to(now_dt)
         block2.add_txn(t)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.mill()
         with pytest.raises(InvalidBlockError, match='FutureTransactionError'):
             chain.add_block(block2)
@@ -457,7 +457,7 @@ def test_validate_block_txn(add_chain_block, app, time_machine, wallet):
         t.seal()
         t.sign()
         block2.add_txn(t)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.mill()
         with pytest.raises(ImbalancedTransactionError):
             chain.add_block(block2)
@@ -476,7 +476,7 @@ def test_validate_txn_inflow(add_chain_block, app, time_machine, txid, wallet):
         t.sign()
         block.add_txn(t)
         chain.link_block(block)
-        chain.seal_block(block, wallet)
+        chain.seal_block(block, wallet, CoinbaseMetrics())
         block.mill()
         with pytest.raises(MissingInflowOutflowError):
             chain.add_block(block)
@@ -498,7 +498,7 @@ def test_validate_txn_inflow(add_chain_block, app, time_machine, txid, wallet):
         block2 = Block()
         block2.add_txn(t)
         chain.link_block(block2)
-        chain.seal_block(block2, wallet)
+        chain.seal_block(block2, wallet, CoinbaseMetrics())
         block2.mill()
         with pytest.raises(MissingInflowOutflowError):
             chain.add_block(block2)
@@ -522,7 +522,7 @@ def test_validate_txn_inflow(add_chain_block, app, time_machine, txid, wallet):
         block3 = Block()
         block3.add_txn(t)
         chain.link_block(block3)
-        chain.seal_block(block3, wallet)
+        chain.seal_block(block3, wallet, CoinbaseMetrics())
         block3.mill()
         with pytest.raises(SpentTransactionError):
             chain.add_block(block3)
@@ -549,7 +549,7 @@ def test_validate_block_coinbase(add_chain_block, app, subject, txid, wallet):
         block = Block()
         chain.link_block(block)
         block.link(0, GENESIS_HASH, TEST_TARGET)
-        block.seal(wallet, REWARD + 1)
+        block.seal(wallet, REWARD + 1, CoinbaseMetrics())
         block.mill()
         with pytest.raises(InvalidCoinbaseErrorRewardError):
             chain.add_block(block)
@@ -625,7 +625,7 @@ def test_validate_io_address_mismatch(app, wallet):
         chain = Chain()
         block = Block()
         chain.link_block(block)
-        chain.seal_block(block, wallet)
+        chain.seal_block(block, wallet, CoinbaseMetrics())
         block.mill()
         chain.add_block(block)
         cb = block.coinbase
@@ -640,7 +640,7 @@ def test_validate_io_address_mismatch(app, wallet):
         t2.seal()
         t2.sign()
         block2.add_txn(t2)
-        chain.seal_block(block2, wallet2)
+        chain.seal_block(block2, wallet2, CoinbaseMetrics())
         block2.mill()
         with pytest.raises(InflowOutflowAddressMismatchError):
             chain.add_block(block2)
@@ -651,7 +651,7 @@ def test_validate_opposition_ioflows(app, subject, wallet):
         chain = Chain()
         block = Block()
         chain.link_block(block)
-        chain.seal_block(block, wallet)
+        chain.seal_block(block, wallet, CoinbaseMetrics())
         block.mill()
         chain.add_block(block)
         cb = block.coinbase
@@ -666,7 +666,11 @@ def test_validate_opposition_ioflows(app, subject, wallet):
         t.seal()
         t.sign()
         block2.add_txn(t)
-        chain.seal_block(block2, wallet)
+        metrics2 = sum(
+            (chain.validate_block_txn(block2, txn) for txn in block2.txns),
+            CoinbaseMetrics(),
+        )
+        chain.seal_block(block2, wallet, metrics2)
         block2.mill()
         chain.add_block(block2)
 
@@ -683,7 +687,11 @@ def test_validate_opposition_ioflows(app, subject, wallet):
         t2.seal()
         t2.sign()
         block3.add_txn(t2)
-        chain.seal_block(block3, wallet)
+        metrics3 = sum(
+            (chain.validate_block_txn(block3, txn) for txn in block3.txns),
+            CoinbaseMetrics(),
+        )
+        chain.seal_block(block3, wallet, metrics3)
         block3.mill()
         chain.add_block(block3)
 
@@ -840,7 +848,7 @@ def test_rescind_kind_mismatch_rejected(
         block3 = Block()
         block3.add_txn(bad_rescind)
         chain.link_block(block3)
-        chain.seal_block(block3, wallet)
+        chain.seal_block(block3, wallet, CoinbaseMetrics())
         block3.mill()
         with pytest.raises(ImbalancedTransactionError):
             chain.add_block(block3)
@@ -881,7 +889,7 @@ def test_support_outflow_cannot_reach_address(
         block3 = Block()
         block3.add_txn(bad_txn)
         chain.link_block(block3)
-        chain.seal_block(block3, wallet)
+        chain.seal_block(block3, wallet, CoinbaseMetrics())
         block3.mill()
         with pytest.raises(ImbalancedTransactionError):
             chain.add_block(block3)
@@ -1134,3 +1142,338 @@ def test_validate_block_txn_partial_rescind_opposition_metrics(
         assert m.schadenfreude == 0
         assert m.mudita == 0
         assert m.regret == 0
+
+
+# ---------------------------------------------------------------------------
+# Net-stake coinbase end-to-end tests (Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_new_stake_still_mints_half(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """A plain new support stake mints mudita == amt // 2 (regression)."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        _ = next(time_step)
+        stake_txn = Transaction()
+        stake_txn.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        stake_txn.add_outflow(Outflow(amount=amt, support=subject))
+        stake_txn.set_wallet(wallet)
+        stake_txn.seal()
+        stake_txn.sign()
+        block2 = Block()
+        block2.add_txn(stake_txn)
+        _, milled_block = add_chain_block(chain=chain, block=block2)
+
+        coinbase_outflows = list(milled_block.coinbase.outflows)
+        # reward + mudita
+        assert len(coinbase_outflows) == 2
+        mudita_amount = amt // 2
+        assert any(
+            o.amount == mudita_amount and o.address == wallet.address
+            for o in coinbase_outflows
+        )
+
+
+def test_restake_block_mints_no_mudita(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Restake block (consume + re-emit same support outflow) mints 0 mudita."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support and mine it
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # restake: consume the support outflow, emit a new identical one
+        _ = next(time_step)
+        restake_txn = Transaction()
+        restake_txn.add_inflow(
+            Inflow(outflow_txid=t_support.txid, outflow_idx=0)
+        )
+        restake_txn.add_outflow(Outflow(amount=amt, support=subject))
+        restake_txn.set_wallet(wallet)
+        restake_txn.seal()
+        restake_txn.sign()
+        block3 = Block()
+        block3.add_txn(restake_txn)
+        _, milled_block = add_chain_block(chain=chain, block=block3)
+
+        coinbase_outflows = list(milled_block.coinbase.outflows)
+        # only reward, no metric outflows
+        assert len(coinbase_outflows) == 1
+
+
+def test_partial_rescind_block_conserves(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Partial rescind block mints regret == rescinded // 2, mudita == 0."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+        assert amt % 2 == 0, 'REWARD must be even'
+
+        # stake support and mine it
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # partial rescind: rescind half, change-back is a support outflow
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, amt // 2, subject, 'support')
+        rescind_txn.sign()
+        block3 = Block()
+        block3.add_txn(rescind_txn)
+        _, milled_block = add_chain_block(chain=chain, block=block3)
+
+        coinbase_outflows = list(milled_block.coinbase.outflows)
+        expected_regret = (amt // 2) // 2
+        # reward + regret only — change-back support outflow mints 0 mudita,
+        # so there are exactly 2 coinbase outflows.
+        assert len(coinbase_outflows) == 2
+        assert any(
+            o.amount == expected_regret and o.address == wallet.address
+            for o in coinbase_outflows
+        )
+
+
+def test_stake_lifecycle_mints_face_value(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Total minted across stake + full-rescind blocks == face value (amt)."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+        assert amt % 2 == 0, 'REWARD must be even'
+
+        # stake
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        _, milled_stake_block = add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # full rescind
+        _ = next(time_step)
+        rescind_txn = chain.create_rescind(wallet, amt, subject, 'support')
+        rescind_txn.sign()
+        block3 = Block()
+        block3.add_txn(rescind_txn)
+        _, milled_rescind_block = add_chain_block(chain=chain, block=block3)
+
+        # stake block: mudita == amt // 2
+        stake_coinbase = milled_stake_block.coinbase.outflows
+        stake_minted = (
+            sum(o.amount for o in stake_coinbase if o.address == wallet.address)
+            - REWARD
+        )  # subtract reward to isolate metric mint
+
+        # rescind block: regret == amt // 2
+        rescind_coinbase = milled_rescind_block.coinbase.outflows
+        rescind_minted = (
+            sum(
+                o.amount
+                for o in rescind_coinbase
+                if o.address == wallet.address
+            )
+            - REWARD
+        )
+
+        total_minted = stake_minted + rescind_minted
+        assert total_minted == amt
+
+
+def test_forged_gross_coinbase_rejected(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Restake block whose coinbase is forged with gross mudita is rejected."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake support and mine it
+        _ = next(time_step)
+        t_support = Transaction()
+        t_support.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_support.add_outflow(Outflow(amount=amt, support=subject))
+        t_support.set_wallet(wallet)
+        t_support.seal()
+        t_support.sign()
+        block2 = Block()
+        block2.add_txn(t_support)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # build the restake txn
+        _ = next(time_step)
+        restake_txn = Transaction()
+        restake_txn.add_inflow(
+            Inflow(outflow_txid=t_support.txid, outflow_idx=0)
+        )
+        restake_txn.add_outflow(Outflow(amount=amt, support=subject))
+        restake_txn.set_wallet(wallet)
+        restake_txn.seal()
+        restake_txn.sign()
+
+        # build a block for the restake but DON'T seal normally;
+        # forge its coinbase to claim mudita = amt // 2 (gross, wrong)
+        block3 = Block()
+        block3.add_txn(restake_txn)
+        chain.link_block(block3)
+        reward = chain.block_reward(block3)
+        forged_cb = Transaction.coinbase(
+            wallet,
+            reward,
+            0,
+            0,
+            amt // 2,  # forged mudita (should be 0)
+            0,
+            prev_hash=block3.prev_hash,
+        )
+        block3.add_txn(forged_cb, is_coinbase=True)
+        block3.merkle_root = block3.get_merkle_root()
+        block3.timestamp = now_iso()
+        block3.mill()
+
+        with pytest.raises(InvalidBlockError):
+            chain.add_block(block3)
+
+
+def test_restake_opposition_block_mints_no_schadenfreude(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """A restake opposition block mints 0 schadenfreude."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake opposition and mine it
+        _ = next(time_step)
+        t_opp = Transaction()
+        t_opp.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_opp.add_outflow(Outflow(amount=amt, opposition=subject))
+        t_opp.set_wallet(wallet)
+        t_opp.seal()
+        t_opp.sign()
+        block2 = Block()
+        block2.add_txn(t_opp)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # restake: consume the opposition outflow, emit a new identical one
+        _ = next(time_step)
+        restake_txn = Transaction()
+        restake_txn.add_inflow(Inflow(outflow_txid=t_opp.txid, outflow_idx=0))
+        restake_txn.add_outflow(Outflow(amount=amt, opposition=subject))
+        restake_txn.set_wallet(wallet)
+        restake_txn.seal()
+        restake_txn.sign()
+        block3 = Block()
+        block3.add_txn(restake_txn)
+        _, milled_block = add_chain_block(chain=chain, block=block3)
+
+        coinbase_outflows = list(milled_block.coinbase.outflows)
+        # only reward, no metric outflows
+        assert len(coinbase_outflows) == 1
+
+
+def test_forged_gross_coinbase_opposition_rejected(
+    add_chain_block, app, subject, time_stepper, wallet
+):
+    """Restake-opposition block with forged gross schadenfreude is rejected."""
+    with app.app_context():
+        time_step = time_stepper(start=now() - datetime.timedelta(hours=1))
+        _ = next(time_step)
+        chain, block = add_chain_block()
+        cb = block.coinbase
+        amt = next(iter(cb.outflows)).amount
+
+        # stake opposition and mine it
+        _ = next(time_step)
+        t_opp = Transaction()
+        t_opp.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        t_opp.add_outflow(Outflow(amount=amt, opposition=subject))
+        t_opp.set_wallet(wallet)
+        t_opp.seal()
+        t_opp.sign()
+        block2 = Block()
+        block2.add_txn(t_opp)
+        add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # build the restake
+        _ = next(time_step)
+        restake_txn = Transaction()
+        restake_txn.add_inflow(Inflow(outflow_txid=t_opp.txid, outflow_idx=0))
+        restake_txn.add_outflow(Outflow(amount=amt, opposition=subject))
+        restake_txn.set_wallet(wallet)
+        restake_txn.seal()
+        restake_txn.sign()
+
+        # forge: claim gross schadenfreude instead of 0
+        block3 = Block()
+        block3.add_txn(restake_txn)
+        chain.link_block(block3)
+        reward = chain.block_reward(block3)
+        forged_cb = Transaction.coinbase(
+            wallet,
+            reward,
+            amt // 2,  # forged schadenfreude (should be 0)
+            0,
+            0,
+            0,
+            prev_hash=block3.prev_hash,
+        )
+        block3.add_txn(forged_cb, is_coinbase=True)
+        block3.merkle_root = block3.get_merkle_root()
+        block3.timestamp = now_iso()
+        block3.mill()
+
+        with pytest.raises(InvalidBlockError):
+            chain.add_block(block3)

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -10,6 +10,7 @@ from gumptionchain.chain import (
     GRAIN_PER_GRIT,
     REWARD,
     Chain,
+    _net_stake_mint,
 )
 from gumptionchain.database import db
 from gumptionchain.exceptions import (
@@ -764,11 +765,10 @@ def test_support_rescind_mints_regret(
         _, milled_block = add_chain_block(chain=chain, block=block3)
 
         expected_regret = amt // 2
-        assert milled_block.regret == expected_regret
         coinbase_outflows = list(milled_block.coinbase.outflows)
-        # Only reward + regret should be present (schadenfreude/grace/mudita
-        # are 0 in this test), and exactly one outflow should carry the regret
-        # amount to the miner — not the reward outflow.
+        # This rescind block mints only reward + regret (no opposition/support
+        # stake or opposition rescind), so the coinbase has exactly two outflows
+        # and one carries the regret amount.
         assert len(coinbase_outflows) == 2
         assert (
             sum(
@@ -947,6 +947,37 @@ def test_to_dao_without_block_hash_returns_none():
     chain = Chain()
     assert chain.block_hash is None
     assert chain.to_dao() is None
+
+
+def test_net_stake_mint_new_stake():
+    assert _net_stake_mint({'A': 100}, {}, {}) == 50
+
+
+def test_net_stake_mint_restake_is_zero():
+    assert _net_stake_mint({'A': 100}, {'A': 100}, {}) == 0
+
+
+def test_net_stake_mint_partial_rescind_changeback_is_zero():
+    # out=change 60, consumed 100, rescind 40 -> new 0
+    assert _net_stake_mint({'A': 60}, {'A': 100}, {'A': 40}) == 0
+
+
+def test_net_stake_mint_odd_amount_floors():
+    assert _net_stake_mint({'A': 9}, {}, {}) == 4  # 9 // 2
+
+
+def test_net_stake_mint_sums_across_subjects():
+    assert _net_stake_mint({'A': 10, 'B': 20}, {}, {}) == 15  # 5 + 10
+
+
+def test_net_stake_mint_floors_each_subject_at_zero():
+    # A: consumed > emitted -> floored at 0 (not negative); B contributes
+    assert _net_stake_mint({'A': 10, 'B': 8}, {'A': 100}, {}) == 4  # 0 + 4
+
+
+def test_net_stake_mint_floor_is_per_subject_then_summed():
+    # A: max(0, 30-20+0)=10 -> 5 ; B: 8 -> 4 ; total 9
+    assert _net_stake_mint({'A': 30, 'B': 8}, {'A': 20}, {}) == 9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import BlockDAO, ChainDAO, LongestChainBlockDAO
 from gumptionchain.payload import Inflow, Outflow
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 
 
 def test_unspent_outflows(app, subject, time_stepper, wallet):
@@ -18,7 +18,7 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         chain_a = Chain()
         block_1 = Block()
         chain_a.link_block(block_1)
-        chain_a.seal_block(block_1, wallet)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
         block_1.mill()
         chain_a.add_block(block_1)
         cb_1 = block_1.coinbase
@@ -45,13 +45,20 @@ def test_unspent_outflows(app, subject, time_stepper, wallet):
         block_2a = Block()
         block_2a.add_txn(t_2a)
         chain_a.link_block(block_2a)
-        chain_a.seal_block(block_2a, wallet)
+        metrics_2a = sum(
+            (
+                chain_a.validate_block_txn(block_2a, txn)
+                for txn in block_2a.txns
+            ),
+            CoinbaseMetrics(),
+        )
+        chain_a.seal_block(block_2a, wallet, metrics_2a)
         block_2a.mill()
 
         _ = next(time_step)
         block_2b = Block()
         chain_a.link_block(block_2b)
-        chain_a.seal_block(block_2b, wallet)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
         block_2b.mill()
 
         _ = next(time_step)
@@ -164,7 +171,7 @@ def test_longest_chain_block_non_longest_extend_noop(app, time_stepper, wallet):
         chain_a = Chain()
         block_1 = Block()
         chain_a.link_block(block_1)
-        chain_a.seal_block(block_1, wallet)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
         block_1.mill()
         chain_a.add_block(block_1)
         chain_a.to_db()
@@ -172,13 +179,13 @@ def test_longest_chain_block_non_longest_extend_noop(app, time_stepper, wallet):
         _ = next(time_step)
         block_2a = Block()
         chain_a.link_block(block_2a)
-        chain_a.seal_block(block_2a, wallet)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
         block_2a.mill()
 
         _ = next(time_step)
         block_2b = Block()
         chain_a.link_block(block_2b)
-        chain_a.seal_block(block_2b, wallet)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
         block_2b.mill()
 
         _ = next(time_step)
@@ -288,7 +295,7 @@ def test_non_longest_chain_blocks_uses_cte(app, time_stepper, wallet):
         chain_a = Chain()
         block_1 = Block()
         chain_a.link_block(block_1)
-        chain_a.seal_block(block_1, wallet)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
         block_1.mill()
         chain_a.add_block(block_1)
         chain_a.to_db()
@@ -296,13 +303,13 @@ def test_non_longest_chain_blocks_uses_cte(app, time_stepper, wallet):
         _ = next(time_step)
         block_2a = Block()
         chain_a.link_block(block_2a)
-        chain_a.seal_block(block_2a, wallet)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
         block_2a.mill()
 
         _ = next(time_step)
         block_2b = Block()
         chain_a.link_block(block_2b)
-        chain_a.seal_block(block_2b, wallet)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
         block_2b.mill()
 
         _ = next(time_step)
@@ -683,14 +690,14 @@ def test_smart_reorg_deep_reorg_with_no_common_ancestor_falls_back(
         chain_b = Chain()
         block_b1 = Block()
         chain_b.link_block(block_b1)
-        chain_b.seal_block(block_b1, wallet)
+        chain_b.seal_block(block_b1, wallet, CoinbaseMetrics())
         block_b1.mill()
         block_b1.to_db()
         chain_b.block_hash = block_b1.block_hash
         _ = next(time_step)
         block_b2 = Block()
         chain_b.link_block(block_b2)
-        chain_b.seal_block(block_b2, wallet)
+        chain_b.seal_block(block_b2, wallet, CoinbaseMetrics())
         block_b2.mill()
         block_b2.to_db()
         chain_b.block_hash = block_b2.block_hash

--- a/tests/test_network_audit.py
+++ b/tests/test_network_audit.py
@@ -24,7 +24,7 @@ from gumptionchain.exceptions import MempoolFullError
 from gumptionchain.miller import Miller
 from gumptionchain.payload import Inflow, Outflow, encode_subject
 from gumptionchain.tasks import celery
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import now
 
 # Matches the `easy_mill_chain` session-scoped fixture's patched
@@ -51,7 +51,7 @@ def _hostile_block(prev_block: Block, wallet, idx_offset: int = 1) -> Block:
     assert prev_block.idx is not None
     assert prev_block.block_hash is not None
     b.link(prev_block.idx + idx_offset, prev_block.block_hash, TEST_TARGET)
-    b.seal(wallet, REWARD)
+    b.seal(wallet, REWARD, CoinbaseMetrics())
     b.mill()
     return b
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -27,38 +27,6 @@ def test_outflow_data_csv(subject, wallet):
     assert outflow.data_csv == f'9,,,,{subject},'
 
 
-def test_outflow_schadenfreude(subject):
-    outflow = Outflow(amount=9, opposition=subject)
-    assert outflow.schadenfreude == 4
-
-
-def test_outflow_grace(subject):
-    outflow = Outflow(amount=9, rescind=subject, rescind_kind='opposition')
-    assert outflow.grace == 4
-
-
-def test_outflow_mudita(subject):
-    outflow = Outflow(amount=9, support=subject)
-    assert outflow.mudita == 4
-
-
-def test_outflow_mudita_is_half_weight(subject):
-    outflow = Outflow(amount=10, support=subject)
-    assert outflow.mudita == 5
-
-
-def test_outflow_grace_only_for_opposition_rescind(subject):
-    o = Outflow(amount=10, rescind=subject, rescind_kind='opposition')
-    assert o.grace == 5
-    assert o.regret == 0
-
-
-def test_outflow_regret_for_support_rescind(subject):
-    o = Outflow(amount=10, rescind=subject, rescind_kind='support')
-    assert o.regret == 5
-    assert o.grace == 0
-
-
 def test_inflow_data_csv(txid):
     inflow = Inflow(outflow_txid=txid, outflow_idx=0)
     assert inflow.data_csv == f'{txid},0'

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -52,37 +52,6 @@ def test_txn_invalid(invalid_txn, single_txn):
         single_txn.validate()
 
 
-def test_txn_schadenfreude(subject, txid, wallet):
-    txn = Transaction()
-    txn.add_inflow(Inflow(outflow_txid=txid, outflow_idx=0))
-    txn.add_outflow(Outflow(amount=9, opposition=subject))
-    txn.add_outflow(Outflow(amount=10, opposition=subject))
-    txn.set_wallet(wallet)
-    assert txn.schadenfreude == 9
-
-
-def test_txn_grace(subject, txid, wallet):
-    txn = Transaction()
-    txn.add_inflow(Inflow(outflow_txid=txid, outflow_idx=0))
-    txn.add_outflow(
-        Outflow(amount=9, rescind=subject, rescind_kind='opposition')
-    )
-    txn.add_outflow(
-        Outflow(amount=10, rescind=subject, rescind_kind='opposition')
-    )
-    txn.set_wallet(wallet)
-    assert txn.grace == 9
-
-
-def test_txn_mudita(subject, txid, wallet):
-    txn = Transaction()
-    txn.add_inflow(Inflow(outflow_txid=txid, outflow_idx=0))
-    txn.add_outflow(Outflow(amount=9, support=subject))
-    txn.add_outflow(Outflow(amount=10, support=subject))
-    txn.set_wallet(wallet)
-    assert txn.mudita == 9
-
-
 def test_coinbase_txn_valid(valid_coinbase_txn):
     valid_coinbase_txn.seal()
     valid_coinbase_txn.sign()

--- a/tests/test_verification_audit.py
+++ b/tests/test_verification_audit.py
@@ -47,7 +47,7 @@ from gumptionchain.exceptions import (
 from gumptionchain.miller import Miller
 from gumptionchain.models import ChainDAO
 from gumptionchain.payload import Inflow, Outflow, encode_subject
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import dt_2_iso, now, now_iso
 
 # Matches the `easy_mill_chain` session-scoped fixture's patched
@@ -140,7 +140,7 @@ def _hostile_block(
     assert prev_block.idx is not None
     assert prev_block.block_hash is not None
     b.link(prev_block.idx + idx_offset, prev_block.block_hash, TEST_TARGET)
-    b.seal(wallet, REWARD)
+    b.seal(wallet, REWARD, CoinbaseMetrics())
     b.mill()
     return b
 
@@ -362,7 +362,7 @@ def test_a7_b_alternate_genesis_fragments_chain_registry(
         # fixture's patched value, also returned by Chain.block_target at
         # index=0).
         g2.link(0, GENESIS_HASH, TEST_TARGET)
-        g2.seal(miller_2_wallet, REWARD)
+        g2.seal(miller_2_wallet, REWARD, CoinbaseMetrics())
         g2.mill()
         assert g2.block_hash is not None
         assert g2.block_hash != g1.block_hash
@@ -423,7 +423,7 @@ def test_a7_j_disjoint_genesis_reorg_rejected(
         time_machine.move_to(when_dt)
         g2 = Block()
         g2.link(0, GENESIS_HASH, TEST_TARGET)
-        g2.seal(miller_2_wallet, REWARD)
+        g2.seal(miller_2_wallet, REWARD, CoinbaseMetrics())
         g2.mill()
         assert g2.block_hash is not None
         assert g2.block_hash != g1.block_hash
@@ -433,7 +433,7 @@ def test_a7_j_disjoint_genesis_reorg_rejected(
         time_machine.move_to(when_dt)
         b2 = Block()
         b2.link(1, g2.block_hash, TEST_TARGET)
-        b2.seal(miller_2_wallet, REWARD)
+        b2.seal(miller_2_wallet, REWARD, CoinbaseMetrics())
         b2.mill()
         assert b2.idx == 1
         assert b2.prev_hash == g2.block_hash
@@ -630,4 +630,4 @@ def test_a4_c_coinbase_block_binding(app, time_machine, wallet) -> None:
         b_mismatch.timestamp = now_iso()
         b_mismatch.mill()
         with pytest.raises(MismatchedCoinbaseError):
-            chain.validate_block_coinbase(b_mismatch)
+            chain.validate_block_coinbase(b_mismatch, CoinbaseMetrics())


### PR DESCRIPTION
Closes #145.

## Summary
Closes the stake-recycle inflation hole. The coinbase "sentiment" metrics previously minted on an outflow's *existence*, so a wallet could recycle a stake — restake it, or take the change-back of a partial rescind — and re-mint `mudita`/`schadenfreude` to a miller every block, unbounded. Now the **mint-side mints on net new stake**, so recycling mints nothing and a stake's lifetime minting equals its face value (½ at stake, ½ at rescind).

- **Rule:** per `(kind, subject)`, `new = max(0, out − in + rescind)`; `schadenfreude`/`mudita` = `Σ new // 2`; `grace`/`regret` = `Σ rescind // 2` (rescind-side unchanged — rescind outflows are terminal).
- **Single source of truth:** `validate_block_txn` keeps its (untouched) balance check, additionally tallies per-`(kind,subject)` in/out/rescind sums, and returns a `CoinbaseMetrics`. Both the miller (`create_block`→`seal_block`→`block.seal`) and validators (`validate_block`→`validate_block_coinbase`) accumulate those returns — **fused into the existing per-txn validation pass, no extra inflow-resolution walk.** Build and verify compute identical metrics by construction.
- Removed the now-dead per-`Outflow`/`Transaction`/`Block` metric properties.
- **No migration / no schema change** (pure computation). Normal blocks (new stakes + full rescinds) are bit-identical; only recycled-stake blocks differ. Greenfield → the consensus change is a non-issue.

## Verified (independently re-derived in review)
- Restake → mints 0; partial-rescind change-back → mints 0; new stake → `amt//2`; lifetime total == face value.
- A self-mined block validates (build == verify); a **forged gross-mint coinbase is rejected** (`InvalidCoinbaseError`).
- Balance check unperturbed (additive tally); no double-count (disjoint outflow branches).

## Test Plan
- [x] Conservation + adversarial tests (restake, partial rescind, lifecycle, forged coinbase, both kinds) + direct `_net_stake_mint` edge-case units
- [x] Full suite: **326 passed, 1 skipped**
- [x] `ruff` / `ruff format` / `mypy` clean; `db check` parity (no migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)