### PR TITLE
feat(auth): open transacting — wildcard TRANSACTOR (EGU 1a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Two stacked layers, both read by `create_app()` in `src/gumptionchain/__init__.p
 1. **`FLASK_*` env vars** → injected into `app.config` via `Flask.config.from_prefixed_env()` (strips the `FLASK_` prefix). This is how `SECRET_KEY`, `SQLALCHEMY_DATABASE_URI`, etc. get set.
 2. **`GC_*` env vars** → loaded into `EnvAppSettings` (`src/gumptionchain/config.py`, dataclass), then `app.config.from_object`. Values are JSON-parsed when possible, so list/bool settings (`GC_PEERS`, `GC_MILLER_ADDRESSES`, `GC_API_ASYNC_PROCESSING`) must be valid JSON strings in the env.
 
-Key `GC_*` settings: `NODE_HOST`, `PEERS` (list of `http(s)://<address>@host` URLs — `host` identifies the peer node, but the username `<address>` is the **local** wallet address this node signs requests *as* when talking to that peer: `create_clients` looks it up in `app.wallets`, so this node must hold that wallet's private key and the peer must list the address in its role allowlist), `WALLET_DIR`, `DEFAULT_COMMAND_HOST`, `{ADMIN,MILLER,TRANSACTOR,READER}_ADDRESSES` (exact-address allowlists matched against the authenticated address in `api.Role.address_role`; `READER_ADDRESSES` may contain the literal `"*"` to grant READER to any authenticated wallet; a non-address entry, or `"*"` outside `READER_ADDRESSES`, is rejected at startup via `Role.validate_config` → `InvalidRoleConfigError`), `MAX_CHAIN_FILL_DEPTH` (env `GC_MAX_CHAIN_FILL_DEPTH`, default 50000 — caps a single `fill_chain` ancestor walk), `MAX_PENDING_TXNS` (env `GC_MAX_PENDING_TXNS`, default 10000 — caps `pending_txns` mempool admission; a full pool returns HTTP 503). `WALLET_DIR` is walked at startup; every `*.pem` becomes an in-memory `Wallet` in `app.wallets`, keyed by address.
+Key `GC_*` settings: `NODE_HOST`, `PEERS` (list of `http(s)://<address>@host` URLs — `host` identifies the peer node, but the username `<address>` is the **local** wallet address this node signs requests *as* when talking to that peer: `create_clients` looks it up in `app.wallets`, so this node must hold that wallet's private key and the peer must list the address in its role allowlist), `WALLET_DIR`, `DEFAULT_COMMAND_HOST`, `{ADMIN,MILLER,TRANSACTOR,READER}_ADDRESSES` (exact-address allowlists matched against the authenticated address in `api.Role.address_role`; `READER_ADDRESSES` and `TRANSACTOR_ADDRESSES` may contain the literal `"*"` to grant that role to any authenticated wallet; a non-address entry, or `"*"` outside `READER_ADDRESSES`/`TRANSACTOR_ADDRESSES`, is rejected at startup via `Role.validate_config` → `InvalidRoleConfigError`), `MAX_CHAIN_FILL_DEPTH` (env `GC_MAX_CHAIN_FILL_DEPTH`, default 50000 — caps a single `fill_chain` ancestor walk), `MAX_PENDING_TXNS` (env `GC_MAX_PENDING_TXNS`, default 10000 — caps `pending_txns` mempool admission; a full pool returns HTTP 503). `WALLET_DIR` is walked at startup; every `*.pem` becomes an in-memory `Wallet` in `app.wallets`, keyed by address.
 
 ## Architecture
 
@@ -164,3 +164,17 @@ When `GC_API_ASYNC_PROCESSING=true`, block/txn POSTs return `202` without doing 
 - **Pin third-party GitHub Actions to commit SHAs**, not tags — tags can be retargeted to point at malicious code. Keep the `# vX.Y.Z` trailing comment for human readability and let Dependabot bump the SHA + comment together.
 - **Validate Dockerfile changes locally** with `docker build --target builder -t cc-test .` (or a full build for later stages) before pushing. CI workflows here don't run the Docker build — syntax errors will silently pass and break the deploy. Specific gotcha: in Dockerfiles, `#` only starts a comment at the *beginning* of a line; trailing `# whatever` on a `COPY`/`RUN` line is parsed as additional arguments.
 - **Avoid ad-hoc Node/npm tooling.** The npm ecosystem is under sustained supply-chain attack (typosquats, post-install hooks, compromised maintainer tokens). Prefer Python/uvx or plain text alternatives; if a Node dep is unavoidable, surface it explicitly so the dependency surface is reviewable.
+
+## Open transacting & anti-spam (EGU)
+
+`TRANSACTOR_ADDRESSES` accepts the `"*"` match-all sentinel (like `READER`), so
+any authenticated wallet may submit transactions — opt in with
+`GC_TRANSACTOR_ADDRESSES='["*"]'`. This exposes *load, not theft*: balance /
+ownership / double-spend validation still hold, and `MILLER`/`ADMIN` stay
+exact-allowlist. Operators running with the wildcard should:
+- keep the `MAX_PENDING_TXNS` cap (a full pool returns HTTP 503 — graceful), and
+- put a **per-IP rate limit at the reverse proxy** in front of the node.
+
+A heavier defense — a hashcash-style **submit-PoW** verified before
+signature/validation work — is specced (issue #151) as the escalation if real
+flooding appears; it is intentionally **not** built yet.

--- a/docs/superpowers/plans/2026-06-04-egu-1a-open-transacting.md
+++ b/docs/superpowers/plans/2026-06-04-egu-1a-open-transacting.md
@@ -1,0 +1,243 @@
+# EGU 1a — open transacting — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permit the `"*"` match-all sentinel in `TRANSACTOR_ADDRESSES` (mirroring `READER`) so any authenticated wallet can spend grit it holds, unblocking open EGU participation.
+
+**Architecture:** A two-line extension of the existing READER-wildcard in `Role` (`src/gumptionchain/api.py`) — honored at match-time (`address_roles`) and accepted at startup (`validate_config`) for `READER` and `TRANSACTOR` only; `MILLER`/`ADMIN` stay exact-allowlist. Auth-config capability change: no schema, no migration, opt-in via config.
+
+**Tech Stack:** Python 3.12, Flask, Pydantic, pytest, uv, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-egu-1a-open-transacting-design.md` (issue #151)
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/api.py` | `Role.address_roles` + `Role.validate_config` honor/accept `"*"` for `TRANSACTOR` too |
+| `tests/test_auth_audit.py` | unit + integration tests for the TRANSACTOR wildcard |
+| `CLAUDE.md` | deployment note: edge rate-limit guidance + submit-PoW deferred |
+
+---
+
+## Task 1: Wildcard `TRANSACTOR`
+
+**Files:**
+- Modify: `src/gumptionchain/api.py` (`Role.address_roles`, `Role.validate_config`)
+- Test: `tests/test_auth_audit.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_auth_audit.py`. At the top, ensure imports: `import pytest`, `from gumptionchain.api import Role`, `from gumptionchain.exceptions import InvalidRoleConfigError` (add any not already present — check the existing import block first).
+
+```python
+def test_validate_config_allows_wildcard_in_transactor():
+    # Should not raise.
+    Role.validate_config({'TRANSACTOR_ADDRESSES': ['*']})
+
+
+def test_validate_config_allows_wildcard_in_reader():
+    Role.validate_config({'READER_ADDRESSES': ['*']})
+
+
+def test_validate_config_rejects_wildcard_in_miller():
+    with pytest.raises(InvalidRoleConfigError):
+        Role.validate_config({'MILLER_ADDRESSES': ['*']})
+
+
+def test_validate_config_rejects_wildcard_in_admin():
+    with pytest.raises(InvalidRoleConfigError):
+        Role.validate_config({'ADMIN_ADDRESSES': ['*']})
+
+
+def test_wildcard_transactor_grants_transactor_role(app):
+    with app.app_context():
+        app.config['TRANSACTOR_ADDRESSES'] = ['*']
+        # an address in no exact allowlist resolves to TRANSACTOR via "*"
+        assert Role.address_role('not-a-listed-address') is Role.TRANSACTOR
+
+
+def test_no_wildcard_unlisted_is_not_transactor(app):
+    with app.app_context():
+        app.config['TRANSACTOR_ADDRESSES'] = []
+        assert Role.address_role('not-a-listed-address') is not Role.TRANSACTOR
+
+
+def test_wildcard_not_honored_for_miller_at_match_time(app):
+    # Defense-in-depth: even if MILLER_ADDRESSES were mutated to contain "*"
+    # at runtime, address_roles must not grant MILLER.
+    with app.app_context():
+        app.config['MILLER_ADDRESSES'] = ['*']
+        assert Role.MILLER not in Role.address_roles('not-a-listed-address')
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_auth_audit.py -k "wildcard or validate_config" -q`
+Expected: FAIL — `test_validate_config_allows_wildcard_in_transactor` raises `InvalidRoleConfigError` (currently rejected), and `test_wildcard_transactor_grants_transactor_role` returns `None`/`READER` not `TRANSACTOR`.
+
+- [ ] **Step 3: Honor `"*"` for TRANSACTOR at match-time**
+
+In `src/gumptionchain/api.py`, `Role.address_roles`, change the comprehension's wildcard clause from:
+```python
+            and (address in addrs or (role is cls.READER and '*' in addrs))
+```
+to:
+```python
+            and (
+                address in addrs
+                or (role in (cls.READER, cls.TRANSACTOR) and '*' in addrs)
+            )
+```
+
+- [ ] **Step 4: Accept `"*"` for TRANSACTOR at startup**
+
+In `Role.validate_config`, change:
+```python
+                if entry == '*':
+                    if role is not cls.READER:
+                        msg = (
+                            f'{role.name}_ADDRESSES contains "*" '
+                            '(match-all is permitted only in '
+                            'READER_ADDRESSES)'
+                        )
+                        raise InvalidRoleConfigError(msg)
+```
+to:
+```python
+                if entry == '*':
+                    if role not in (cls.READER, cls.TRANSACTOR):
+                        msg = (
+                            f'{role.name}_ADDRESSES contains "*" '
+                            '(match-all is permitted only in '
+                            'READER_ADDRESSES or TRANSACTOR_ADDRESSES)'
+                        )
+                        raise InvalidRoleConfigError(msg)
+```
+
+- [ ] **Step 5: Run, expect PASS**
+
+Run: `uv run pytest tests/test_auth_audit.py -k "wildcard or validate_config" -q`
+Expected: PASS.
+
+- [ ] **Step 6: Full suite + lint + types**
+
+Run: `uv run pytest -q && uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all green. (Existing `test_auth_audit.py` cases — forged-claim, stale-role, overbroad-admin — must still pass; the change only adds a permitted wildcard for TRANSACTOR.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(auth): permit wildcard \"*\" in TRANSACTOR_ADDRESSES (open transacting)"
+```
+
+---
+
+## Task 2: Integration test + deployment docs
+
+**Files:**
+- Test: `tests/test_auth_audit.py`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Write a failing end-to-end test**
+
+Mirror the existing harness in `tests/test_auth_audit.py` (see `test_a5_b_stale_role_rejected_after_config_revocation` for the `app.config` mutation + `requests_proxy` + `signing.sign_headers` pattern, and how it picks an endpoint + asserts status). Add a test that an arbitrary wallet — one NOT in `TRANSACTOR_ADDRESSES` by exact match — is authorized at a `authorize_transactor` endpoint when `TRANSACTOR_ADDRESSES=['*']`, and is rejected (`403`) when it is `[]`.
+
+```python
+def test_wildcard_transactor_authorizes_arbitrary_wallet(
+    app, host, requests_proxy, reader_wallet, mill_block
+):
+    # reader_wallet is configured READER-only (not in TRANSACTOR_ADDRESSES).
+    with app.app_context():
+        mill_block(reader_wallet)
+        # pick any authorize_transactor-gated endpoint; the rescind txn-build
+        # endpoint is one. Sign a GET to it the way the other tests sign.
+        path = '/api/transaction/opposition'
+        # without the wildcard, an unlisted wallet is 403 at a transactor route
+        app.config['TRANSACTOR_ADDRESSES'] = []
+        headers = signing.sign_headers(
+            reader_wallet,
+            method='GET',
+            path=path,
+            query='',
+            body=b'',
+            node_host=_node(host),
+        )
+        denied = requests_proxy.get(path, headers=headers, timeout=60)
+        assert denied.status_code == httpx.codes.FORBIDDEN
+
+        # with the wildcard, the same wallet gets past auth (no 403); it may
+        # still get a 4xx for missing query params, but NOT 403.
+        app.config['TRANSACTOR_ADDRESSES'] = ['*']
+        headers = signing.sign_headers(
+            reader_wallet,
+            method='GET',
+            path=path,
+            query='',
+            body=b'',
+            node_host=_node(host),
+        )
+        allowed = requests_proxy.get(path, headers=headers, timeout=60)
+        assert allowed.status_code != httpx.codes.FORBIDDEN
+```
+Adapt imports/helpers (`signing`, `_node`, `httpx`) to whatever the file already uses — check the top of `test_auth_audit.py` and copy its exact patterns (e.g. how `_node(host)` / `signing.sign_headers` are referenced in the existing tests). If `/api/transaction/opposition` is awkward to sign as a GET in this harness, use whichever transactor-gated endpoint the existing tests already exercise.
+
+- [ ] **Step 2: Run, expect (initially) FAIL or PASS-after-Task-1**
+
+Run: `uv run pytest tests/test_auth_audit.py -k wildcard_transactor_authorizes -q`
+Expected: PASS (Task 1 already landed the behavior). If it FAILS, the wildcard wiring from Task 1 is incomplete — fix before proceeding. (This test is end-to-end confirmation of Task 1 through the real auth decorator.)
+
+- [ ] **Step 3: Add deployment note to `CLAUDE.md`**
+
+In `CLAUDE.md`, under the supply-chain/deployment area (near the Dockerfile/production notes), add a short subsection:
+
+```markdown
+## Open transacting & anti-spam (EGU)
+
+`TRANSACTOR_ADDRESSES` accepts the `"*"` match-all sentinel (like `READER`), so
+any authenticated wallet may submit transactions — opt in with
+`GC_TRANSACTOR_ADDRESSES='["*"]'`. This exposes *load, not theft*: balance /
+ownership / double-spend validation still hold, and `MILLER`/`ADMIN` stay
+exact-allowlist. Operators running with the wildcard should:
+- keep the `MAX_PENDING_TXNS` cap (full pool → `503`, graceful), and
+- put a **per-IP rate limit at the reverse proxy** in front of the node.
+
+A heavier defense — a hashcash-style **submit-PoW** verified before
+signature/validation work — is specced (issue #151) as the escalation if real
+flooding appears; it is intentionally **not** built yet.
+```
+
+- [ ] **Step 4: Cheap-reject ordering check (verify; reorder only if needed)**
+
+Read the transaction-submission path (`Node.receive_transaction` in `node.py` and the `/api/transaction` POST view in `api.py`). Confirm cheap structural validation (`Transaction.validate()` — Pydantic model + signature + txid) runs **before** any expensive chain resolution (`get_transaction` / inflow walks / balance checks). If it already does (likely — `validate()` is structural and runs first), make **no code change** and note the finding in the commit message. Only if expensive chain work currently precedes cheap structural rejection, reorder so the cheap check is first. Do not add new mechanisms.
+
+- [ ] **Step 5: Full suite + lint + types**
+
+Run: `uv run pytest -q && uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "docs+test(auth): open-transacting deployment note + e2e wildcard test"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: wildcard `TRANSACTOR` (Task 1) + safety/posture (the change is additive; `MILLER`/`ADMIN` unaffected) + anti-spam docs/cheap-reject (Task 2). Submit-PoW + 1b retune are explicitly out of scope per the spec.
+- The match-time and startup edits both gate on `(cls.READER, cls.TRANSACTOR)` — kept identical so the two layers can't drift.
+- `validate_config` takes a plain config `Mapping`, so its tests need no app context; `address_roles`/`address_role` read `current_app.config`, so those tests use `app.app_context()`.
+- No schema/migration; `db check` is unaffected (not run in this plan).
+
+## Definition of done
+
+- `"*"` permitted in `TRANSACTOR_ADDRESSES` (match-time + startup), `MILLER`/`ADMIN` still reject it.
+- Any authenticated wallet resolves to `TRANSACTOR` (and, by hierarchy, READER) when `TRANSACTOR_ADDRESSES=['*']`; exact-match behavior unchanged without `"*"`.
+- Deployment anti-spam note in `CLAUDE.md`; submit-PoW documented as deferred.
+- Full suite + ruff + ruff-format + mypy green. No schema/migration.

--- a/docs/superpowers/specs/2026-06-04-egu-1a-open-transacting-design.md
+++ b/docs/superpowers/specs/2026-06-04-egu-1a-open-transacting-design.md
@@ -1,0 +1,124 @@
+# EGU 1a — open transacting — design
+
+**Date:** 2026-06-04
+**Status:** Approved design, pre-implementation
+**Issue:** #151 (EGU #1, part 1a)
+**Type:** Auth-config capability change — no schema, no migration
+
+## Summary
+
+Let **any authenticated wallet act as a `TRANSACTOR`** by permitting the `"*"`
+match-all sentinel in `TRANSACTOR_ADDRESSES`, exactly as it already works for
+`READER_ADDRESSES`. This unblocks the EGU model: arbitrary players (holding a
+non-custodial wallet, EGU #2) can spend the grit they've earned — stake
+support/opposition, rescind, transfer — without being hand-listed in config.
+`MILLER`/`ADMIN` stay curated. Plus a documented, minimal anti-spam posture.
+
+## Why this is safe (load, not theft)
+
+Opening `TRANSACTOR` does **not** let anyone steal or mint grit. The chain
+already enforces, on every transaction, that it is balanced, consumes only the
+caller's *own* unspent outflows (`InflowOutflowAddressMismatchError`), and is not
+a double-spend. So "any wallet can transact" means only "any wallet can spend
+grit it already holds." The control point for the economy is **grit issuance**
+(curated `MILLER` mining + per-app faucets), not the transactor allowlist. The
+incremental exposure is **load** (unknown wallets reach validation + mempool
+admission instead of a quick `403`), addressed by the anti-spam posture below.
+
+Mining (`MILLER`) and admin (`ADMIN`) remain exact-allowlist only — the wildcard
+is permitted for `READER` and `TRANSACTOR` *only*.
+
+## The change
+
+Two precise edits to `Role` in `src/gumptionchain/api.py`, mirroring the existing
+READER wildcard (and its defense-in-depth split between match-time and startup):
+
+1. **Match time** — `Role.address_roles` currently honors `"*"` for `READER`
+   only:
+   ```python
+   and (address in addrs or (role is cls.READER and '*' in addrs))
+   ```
+   Extend to `READER` and `TRANSACTOR`:
+   ```python
+   and (
+       address in addrs
+       or (role in (cls.READER, cls.TRANSACTOR) and '*' in addrs)
+   )
+   ```
+
+2. **Startup** — `Role.validate_config` currently rejects `"*"` outside
+   `READER_ADDRESSES`:
+   ```python
+   if entry == '*':
+       if role is not cls.READER:
+           raise InvalidRoleConfigError(...)
+   ```
+   Permit it in `READER` and `TRANSACTOR`, still reject in `MILLER`/`ADMIN`:
+   ```python
+   if entry == '*':
+       if role not in (cls.READER, cls.TRANSACTOR):
+           raise InvalidRoleConfigError(...)
+   ```
+   (Update the error message to say match-all is permitted in READER or
+   TRANSACTOR.)
+
+Because authorization is hierarchical (`authorize` rejects on
+`role.value < required_role.value`), a wallet that matches `TRANSACTOR` via `"*"`
+also satisfies READER-gated endpoints. No view/route changes are needed — every
+transactor endpoint already uses `authorize_transactor`.
+
+This is **config-driven**: an operator opts in by setting
+`GC_TRANSACTOR_ADDRESSES='["*"]'`. The default/permissioned posture (exact
+allowlist) is unchanged when `"*"` is absent.
+
+## Anti-spam posture (decided in the EGU brainstorm)
+
+Minimal now; the heavy tool stays in reserve. For this PR:
+
+- **Mempool cap — already present.** `MAX_PENDING_TXNS` bounds the blast radius:
+  a full pool returns HTTP `503`, graceful degradation, no crash. No change.
+- **Cheap-reject ordering — light review.** Confirm the transaction-submission
+  path performs cheap structural/signature validation before the expensive
+  inflow/chain-resolution work, so malformed or unsigned submissions are rejected
+  cheaply. Reorder only if it currently does expensive work first; if it's
+  already cheap-first, no change. (Low-risk hygiene; not required for safety.)
+- **Edge rate-limit — deployment guidance (docs, not chain code).** Recommend a
+  per-IP rate limit at the reverse proxy in front of the node. Documented in
+  `CLAUDE.md`/README deployment notes; no application code or dependency added.
+- **Submit-PoW — explicitly deferred (YAGNI).** A hashcash-style per-transaction
+  proof, checked before sig-verify/validation and computed by the wallet module
+  (EGU #2), is the *ready escalation* the moment real flooding appears. Specced
+  in #151; **not built here.**
+
+## Testing
+
+In the role/auth test suite (`tests/test_auth_audit.py`, where `validate_config` / `address_role` are already exercised):
+- `TRANSACTOR_ADDRESSES=["*"]` → an arbitrary authenticated wallet resolves to
+  `Role.TRANSACTOR` and is authorized at a `authorize_transactor` endpoint (and,
+  via hierarchy, a reader endpoint).
+- `validate_config` **accepts** `"*"` in `TRANSACTOR_ADDRESSES` and in
+  `READER_ADDRESSES`.
+- `validate_config` still **rejects** `"*"` in `MILLER_ADDRESSES` and
+  `ADMIN_ADDRESSES` (`InvalidRoleConfigError`).
+- Existing exact-match behavior is unchanged when no `"*"` is present (a wallet
+  not in the list still gets `403` at a transactor endpoint).
+- The match-time defense-in-depth holds: `address_roles` honors `"*"` for
+  TRANSACTOR but not for MILLER/ADMIN even if a config were mutated at runtime.
+
+## Out of scope
+
+- **EGU #1b** — the constant retune (block time, retarget interval, difficulty
+  floor, base-reward magnitude, RSA→2048). Sibling spec.
+- **Submit-PoW** — deferred escalation (above).
+- **Faucet/issuance operations** — running millers, funding per-app faucets,
+  awarding grit on game-finish (EGU #4). Operational, not a chain change.
+
+## Decisions log
+
+- Wildcard permitted for `READER` **and** `TRANSACTOR` only; `MILLER`/`ADMIN`
+  stay exact-allowlist (mining + admin remain curated/governance-gated).
+- Opt-in via config (`GC_TRANSACTOR_ADDRESSES='["*"]'`); permissioned default
+  preserved.
+- Anti-spam: cap (exists) + cheap-reject review + edge rate-limit (docs);
+  submit-PoW deferred; no grit fee.
+- No schema/migration (auth-config only).

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -198,14 +198,17 @@ class Role(Enum):
     def address_roles(cls, address: str) -> list[Role]:
         # Fail closed if a list is not configured (None / a stray string):
         # `isinstance` excludes both, avoiding silent substring semantics.
-        # The '*' match-all sentinel is honored only for READER at match
-        # time too (defense-in-depth: startup validation forbids it in
+        # The '*' match-all sentinel is honored only for READER or TRANSACTOR
+        # at match time too (defense-in-depth: startup validation forbids it in
         # higher tiers, but a runtime config mutation must not escalate).
         return [
             role
             for role in Role
             if isinstance(addrs := role.addresses(), (list, tuple))
-            and (address in addrs or (role is cls.READER and '*' in addrs))
+            and (
+                address in addrs
+                or (role in (cls.READER, cls.TRANSACTOR) and '*' in addrs)
+            )
         ]
 
     @classmethod
@@ -219,7 +222,8 @@ class Role(Enum):
 
         Each *_ADDRESSES entry must be a valid gumptionchain address,
         except the '*' match-all sentinel which is permitted only in
-        READER_ADDRESSES. Raises InvalidRoleConfigError on any violation.
+        READER_ADDRESSES or TRANSACTOR_ADDRESSES. Raises
+        InvalidRoleConfigError on any violation.
         """
         for role in cls:
             entries = config.get(f'{role.name}_ADDRESSES', []) or []
@@ -231,11 +235,11 @@ class Role(Enum):
                 raise InvalidRoleConfigError(msg)
             for entry in entries:
                 if entry == '*':
-                    if role is not cls.READER:
+                    if role not in (cls.READER, cls.TRANSACTOR):
                         msg = (
                             f'{role.name}_ADDRESSES contains "*" '
                             '(match-all is permitted only in '
-                            'READER_ADDRESSES)'
+                            'READER_ADDRESSES or TRANSACTOR_ADDRESSES)'
                         )
                         raise InvalidRoleConfigError(msg)
                 elif not validate_address_format(entry):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -293,6 +293,13 @@ def test_validate_config_accepts_reader_wildcard_and_exact(app, wallet):
     Role.validate_config(app.config)  # must not raise
 
 
+def test_validate_config_accepts_transactor_wildcard_and_exact(app, wallet):
+    # "*" in TRANSACTOR plus an exact entry in a higher tier is valid.
+    app.config['TRANSACTOR_ADDRESSES'] = ['*']
+    app.config['ADMIN_ADDRESSES'] = [wallet.address]
+    Role.validate_config(app.config)  # must not raise
+
+
 def test_create_app_rejects_overbroad_admin_config():
     with pytest.raises(InvalidRoleConfigError, match='ADMIN_ADDRESSES'):
         create_app(
@@ -306,10 +313,10 @@ def test_create_app_rejects_overbroad_admin_config():
         )
 
 
-def test_address_role_wildcard_ignored_outside_reader(app, wallet):
+def test_address_role_wildcard_ignored_for_miller_and_admin(app, wallet):
     # Defense-in-depth: even if '*' is injected into a higher tier at
     # runtime (bypassing startup validation), match-time honors '*' only
-    # for READER — it must not escalate.
+    # for READER or TRANSACTOR — MILLER/ADMIN must never escalate via '*'.
     with app.app_context():
         _clear_role_config(app)
         app.config['MILLER_ADDRESSES'] = ['*']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -275,9 +275,9 @@ def test_validate_config_rejects_nonaddress(app):
         Role.validate_config(app.config)
 
 
-def test_validate_config_rejects_wildcard_outside_reader(app):
+def test_validate_config_rejects_wildcard_in_miller_and_admin(app):
+    # READER and TRANSACTOR permit "*"; MILLER and ADMIN must not.
     for role_key in (
-        'TRANSACTOR_ADDRESSES',
         'MILLER_ADDRESSES',
         'ADMIN_ADDRESSES',
     ):

--- a/tests/test_auth_audit.py
+++ b/tests/test_auth_audit.py
@@ -200,3 +200,52 @@ def test_wildcard_not_honored_for_miller_at_match_time(app):
     with app.app_context():
         app.config['MILLER_ADDRESSES'] = ['*']
         assert Role.MILLER not in Role.address_roles('not-a-listed-address')
+
+
+def test_wildcard_not_honored_for_admin_at_match_time(app):
+    # Defense-in-depth: a runtime-mutated ADMIN "*" must NOT grant ADMIN.
+    with app.app_context():
+        app.config['ADMIN_ADDRESSES'] = ['*']
+        assert Role.ADMIN not in Role.address_roles('not-a-listed-address')
+
+
+def test_wildcard_transactor_authorizes_arbitrary_wallet(
+    app, host, requests_proxy, reader_wallet, mill_block
+):
+    """End-to-end: wildcard TRANSACTOR_ADDRESSES grants access through
+    the real authorize_transactor decorator.
+
+    reader_wallet is configured READER-only (not in TRANSACTOR_ADDRESSES).
+    Without the wildcard it is 403 at a transactor-gated GET endpoint;
+    with TRANSACTOR_ADDRESSES=['*'] the same signed request gets past auth
+    (the endpoint may still 400 on missing query params, but NOT 403).
+    """
+    with app.app_context():
+        mill_block(reader_wallet)
+        path = '/api/transaction/opposition'
+        # Without the wildcard: reader_wallet has no TRANSACTOR role -> 403.
+        app.config['TRANSACTOR_ADDRESSES'] = []
+        headers = signing.sign_headers(
+            reader_wallet,
+            method='GET',
+            path=path,
+            query='',
+            body=b'',
+            node_host=_node(host),
+        )
+        denied = requests_proxy.get(path, headers=headers, timeout=60)
+        assert denied.status_code == httpx.codes.FORBIDDEN
+        # With the wildcard: any authenticated wallet -> TRANSACTOR.
+        # The endpoint may 400 on missing query params; that still proves
+        # authorize_transactor did NOT reject the request (not 403).
+        app.config['TRANSACTOR_ADDRESSES'] = ['*']
+        headers = signing.sign_headers(
+            reader_wallet,
+            method='GET',
+            path=path,
+            query='',
+            body=b'',
+            node_host=_node(host),
+        )
+        allowed = requests_proxy.get(path, headers=headers, timeout=60)
+        assert allowed.status_code != httpx.codes.FORBIDDEN

--- a/tests/test_auth_audit.py
+++ b/tests/test_auth_audit.py
@@ -14,9 +14,12 @@ matching the audit document's per-adversary sections.
 """
 
 import httpx
+import pytest
 
 from gumptionchain import signing
+from gumptionchain.api import Role
 from gumptionchain.api_client import ApiClient
+from gumptionchain.exceptions import InvalidRoleConfigError
 from gumptionchain.miller import Miller
 from gumptionchain.util import host_address
 
@@ -159,3 +162,41 @@ def test_a5_b_stale_role_rejected_after_config_revocation(
             assert r2.status_code == httpx.codes.FORBIDDEN
         finally:
             app.config['MILLER_ADDRESSES'] = original_miller_addresses
+
+
+def test_validate_config_allows_wildcard_in_transactor():
+    # Should not raise.
+    Role.validate_config({'TRANSACTOR_ADDRESSES': ['*']})
+
+
+def test_validate_config_allows_wildcard_in_reader():
+    Role.validate_config({'READER_ADDRESSES': ['*']})
+
+
+def test_validate_config_rejects_wildcard_in_miller():
+    with pytest.raises(InvalidRoleConfigError):
+        Role.validate_config({'MILLER_ADDRESSES': ['*']})
+
+
+def test_validate_config_rejects_wildcard_in_admin():
+    with pytest.raises(InvalidRoleConfigError):
+        Role.validate_config({'ADMIN_ADDRESSES': ['*']})
+
+
+def test_wildcard_transactor_grants_transactor_role(app):
+    with app.app_context():
+        app.config['TRANSACTOR_ADDRESSES'] = ['*']
+        assert Role.address_role('not-a-listed-address') is Role.TRANSACTOR
+
+
+def test_no_wildcard_unlisted_is_not_transactor(app):
+    with app.app_context():
+        app.config['TRANSACTOR_ADDRESSES'] = []
+        assert Role.address_role('not-a-listed-address') is not Role.TRANSACTOR
+
+
+def test_wildcard_not_honored_for_miller_at_match_time(app):
+    # Defense-in-depth: a runtime-mutated MILLER "*" must NOT grant MILLER.
+    with app.app_context():
+        app.config['MILLER_ADDRESSES'] = ['*']
+        assert Role.MILLER not in Role.address_roles('not-a-listed-address')


### PR DESCRIPTION
EGU 1a — the first slice of #151 (does **not** close it; #1b constant-retune remains).

## Summary
Permit the `"*"` match-all sentinel in `TRANSACTOR_ADDRESSES`, mirroring the existing `READER` wildcard, so **any authenticated wallet can submit transactions** (spend the grit it holds). This unblocks open EGU participation — players holding a non-custodial wallet (EGU #2) can stake/rescind without being hand-listed in config.

- Two-line extension of `Role` in `api.py`: `"*"` honored at match-time (`address_roles`) and accepted at startup (`validate_config`) for `(READER, TRANSACTOR)` only — the same tuple at both layers so they can't drift.
- **`MILLER`/`ADMIN` stay exact-allowlist** — rejected at startup *and* at match-time (defense-in-depth against runtime config mutation).
- **Safe: load, not theft.** Balance / ownership / double-spend validation is unchanged, so an open transactor can only ever spend grit it already holds; the economy's control point is grit *issuance* (curated `MILLER` + faucets), not the transactor list.
- Opt-in via `GC_TRANSACTOR_ADDRESSES='["*"]'`; the permissioned default (exact allowlist) is untouched.
- Anti-spam posture documented in `CLAUDE.md` (keep `MAX_PENDING_TXNS` cap + per-IP edge rate-limit; submit-PoW specced-but-deferred). Verified the txn-submission path is already cheap-reject-first.

Auth-config change only — **no schema, no migration**.

## Test Plan
- [x] Unit: `validate_config` accepts `"*"` in READER+TRANSACTOR, rejects in MILLER+ADMIN; `address_role` resolves an arbitrary wallet to TRANSACTOR under `"*"`; defense-in-depth (MILLER/ADMIN `"*"` not honored at match-time)
- [x] E2E: arbitrary wallet `403` at a transactor endpoint without `"*"`, authorized with it (through the real `authorize` decorator)
- [x] Existing auth-audit regressions (forged-claim, stale-role, overbroad-admin, cross-node) still pass
- [x] Full suite **336 passed, 1 skipped**; ruff / format / mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)