### PR TITLE
perf(validation): materialize the consensus-validation hot path — CTE-free ancestry (#157)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-egu-1b-pre-validation-materialization.md
+++ b/docs/superpowers/plans/2026-06-05-egu-1b-pre-validation-materialization.md
@@ -1,0 +1,554 @@
+# EGU 1b-pre — materialize the consensus-validation hot path — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the recursive `BlockDAO._block_chain` CTE from the three consensus-validation hot-path lookups (`get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain`), making block validation O(reorg-depth + result) instead of O(chain-height) — on both the canonical chain and forks.
+
+**Architecture:** A new `BlockDAO._ancestry()` helper resolves a block's ancestry against the `LongestChainBlockDAO` materialization without recursion: it returns the ids of the short divergent suffix (blocks not yet materialized, walked via indexed `prev` links) plus the position of the common ancestor. The three methods answer queries as (divergent id-set query) + (position-scoped indexed query). Canonical anchors take zero divergent steps. The recursive CTE properties remain defined (still used by Tier-2 read paths) but are no longer reached by these three methods; their deletion is the capstone follow-up #158.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]`), pytest, uv, ruff, mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-egu-1b-pre-validation-materialization-design.md` (issue #157)
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/models.py` | Add `BlockDAO._ancestry`; rewrite `BlockDAO.get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain` to use `_ancestry` (no `_block_chain` reference). |
+| `tests/test_models.py` | CTE-guard test (canonical + fork), canonical/fork/bootstrap equivalence tests. |
+
+No `chain.py` change — `Chain.get_transaction` / `get_inflows_count` / `get_block_by_reverse_index` call these BlockDAO methods, which now route internally. No schema/migration; `db check` unaffected.
+
+---
+
+## Background the implementer needs
+
+These three `BlockDAO` methods (in `src/gumptionchain/models.py`) currently each
+build on the recursive `_block_chain` CTE. They are called from
+`Chain.validate_block` on **every** block validated — once per block
+(`get_block_in_chain`, via the difficulty-retarget lookup) and twice per inflow
+(`get_transaction_in_chain` + `inflows_in_chain_count`, via `validate_txn_inflow`
+in `chain.py`). Each CTE call walks tip→genesis = O(chain-height), so validation
+is O(inflows × height). This plan replaces that with bounded ancestry resolution.
+
+**Current bodies (for reference — you are replacing these):**
+
+```python
+def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
+    return db.session.execute(
+        self.transactions_chain.where(TransactionDAO.txid == txid)
+    ).scalar_one_or_none()
+
+def get_block_in_chain(
+    self, block_hash: str | None = None, idx: int | None = None
+) -> BlockDAO | None:
+    block_alias = db.aliased(BlockDAO, self.block_chain.subquery())
+    stmt = db.select(BlockDAO).join(
+        block_alias, BlockDAO.id == block_alias.id
+    )
+    if block_hash is not None:
+        stmt = stmt.where(BlockDAO.block_hash == block_hash)
+    if idx is not None:
+        stmt = stmt.where(BlockDAO.idx == idx)
+    return db.session.execute(stmt).scalar_one_or_none()
+
+def inflows_in_chain_count(
+    self, outflow_txid: str, outflow_idx: int
+) -> int:
+    stmt = self.inflows_chain.where(
+        InflowDAO.outflow_txid == outflow_txid,
+        InflowDAO.outflow_idx == outflow_idx,
+    )
+    return (
+        1 if db.session.execute(stmt).scalars().first() is not None else 0
+    )
+```
+
+Note `inflows_in_chain_count` returns **0/1** (existence), not a true count —
+preserve that exactly. `LongestChainBlockDAO`, `TransactionDAO`, `InflowDAO` are
+all defined in the same module; no new imports needed.
+
+Useful existing test fixtures (in `tests/conftest.py`):
+- `mill_block(wallet)` → `(miller, block)`: builds, mills, and adds a canonical block.
+- `add_chain_block(chain=None, block=None, milling_wallet=None)` → `(chain, block)`: links, seals (computing coinbase metrics), mills, and adds a block to a chain.
+- Spend pattern (from `tests/test_chain.py::test_db`): build a `Transaction`, `add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))`, `add_outflow(...)`, `set_wallet(wallet)`, `seal()`, `sign()`, `to_db()`, then `block.add_txn(t)` and add the block.
+- Fork pattern (from `tests/test_models.py::test_non_longest_chain_blocks_uses_cte`): two blocks sharing a parent; add one to its chain, the other via a second `Chain`, producing a non-longest `ChainDAO`/fork block.
+
+---
+
+## Task 1: `_ancestry` helper + convert the three methods
+
+**Files:**
+- Modify: `src/gumptionchain/models.py` (`BlockDAO`)
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Write the failing CTE-guard test**
+
+Add to `tests/test_models.py`. The imports `from unittest.mock import patch` and the model imports already exist at the top of the file; add `PropertyMock` to the mock import line so it reads `from unittest.mock import PropertyMock, patch`. Also confirm `Wallet` is importable — add `from gumptionchain.wallet import Wallet` if not already imported.
+
+```python
+def _build_canonical_chain_with_spend(add_chain_block, time_stepper, wallet):
+    """Build a 2-block canonical chain where block 2 contains a txn that
+    spends block 1's coinbase. Returns (chain, block1, block2, spend_txid)."""
+    import datetime
+
+    from gumptionchain.payload import Inflow, Outflow
+    from gumptionchain.transaction import Transaction
+
+    time_step = time_stepper(
+        start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    )
+    _ = next(time_step)
+    chain, block1 = add_chain_block(milling_wallet=wallet)
+    cb = block1.coinbase
+    cb_amount = next(iter(cb.outflows)).amount
+    _ = next(time_step)
+    t = Transaction()
+    t.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+    t.add_outflow(Outflow(amount=cb_amount, address=wallet.address))
+    t.set_wallet(wallet)
+    t.seal()
+    t.sign()
+    t.to_db()
+    _ = next(time_step)
+    block2 = Block()
+    block2.add_txn(t)
+    _, block2 = add_chain_block(
+        chain=chain, block=block2, milling_wallet=wallet
+    )
+    chain.to_db()
+    return chain, block1, block2, t.txid
+
+
+def test_hot_path_methods_never_touch_recursive_cte(
+    app, add_chain_block, time_stepper, wallet
+):
+    """get_transaction_in_chain / inflows_in_chain_count / get_block_in_chain
+    must not access the recursive _block_chain CTE on canonical OR fork
+    anchors. Booby-trap _block_chain to raise; the three methods must still
+    return correct results.
+    """
+    with app.app_context():
+        chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        cb1_txid = block1.coinbase.txid
+        tip_dao = BlockDAO.get(block2.block_hash)
+        genesis_dao = BlockDAO.get(block1.block_hash)
+        assert tip_dao is not None
+        assert genesis_dao is not None
+
+        with patch.object(
+            BlockDAO, '_block_chain', new_callable=PropertyMock
+        ) as cte_mock:
+            cte_mock.side_effect = AssertionError(
+                'hot-path method accessed the recursive CTE'
+            )
+            # canonical anchor (the tip)
+            assert (
+                tip_dao.get_transaction_in_chain(spend_txid) is not None
+            )
+            assert tip_dao.get_transaction_in_chain('does-not-exist') is None
+            # the spend consumed block1's coinbase outflow → counted once
+            assert tip_dao.inflows_in_chain_count(cb1_txid, 0) == 1
+            assert tip_dao.inflows_in_chain_count('nope', 0) == 0
+            assert (
+                tip_dao.get_block_in_chain(block_hash=block1.block_hash)
+                is not None
+            )
+            assert tip_dao.get_block_in_chain(idx=0) is not None
+            # an ancestor anchor still resolves its own ancestry
+            assert (
+                genesis_dao.get_transaction_in_chain(cb1_txid) is not None
+            )
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_models.py::test_hot_path_methods_never_touch_recursive_cte -q`
+Expected: FAIL — the current methods build on `_block_chain`, so accessing the booby-trapped property raises `AssertionError`.
+
+- [ ] **Step 3: Add the `_ancestry` helper**
+
+In `src/gumptionchain/models.py`, inside `BlockDAO`, add this method (place it just above `get_transaction_in_chain`):
+
+```python
+def _ancestry(self) -> tuple[list[int], int | None]:
+    """Resolve this block's ancestry against LongestChainBlockDAO without
+    recursion.
+
+    Returns (divergent_ids, cap_position):
+    - divergent_ids: ids of blocks on the divergent suffix (not in the
+      materialization), nearest-first. Empty when this block is canonical.
+    - cap_position: position of the common ancestor in the materialization;
+      the canonical prefix is everything with position <= cap_position.
+      None only when the materialization is empty (bootstrap), in which
+      case divergent_ids covers the whole walked chain.
+
+    Cost: O(divergent-suffix length) indexed `prev` lookups — 0 extra for a
+    canonical anchor (first lookup hits), reorg-depth for a fork. Never
+    O(chain-height) except transient bootstrap.
+    """
+    divergent: list[int] = []
+    current: BlockDAO | None = self
+    while current is not None:
+        position = db.session.scalar(
+            db.select(LongestChainBlockDAO.position).where(
+                LongestChainBlockDAO.block_id == current.id
+            )
+        )
+        if position is not None:
+            return divergent, position
+        divergent.append(current.id)
+        current = current.prev
+    return divergent, None
+```
+
+- [ ] **Step 4: Rewrite `get_transaction_in_chain`**
+
+Replace the current body with:
+
+```python
+def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
+    divergent, cap = self._ancestry()
+    if divergent:
+        hit = (
+            db.session.execute(
+                db.select(TransactionDAO)
+                .join(TransactionDAO.blocks)
+                .where(BlockDAO.id.in_(divergent))
+                .where(TransactionDAO.txid == txid)
+            )
+            .scalars()
+            .first()
+        )
+        if hit is not None:
+            return hit
+    if cap is not None:
+        return db.session.execute(
+            db.select(TransactionDAO)
+            .join(TransactionDAO.blocks)
+            .join(
+                LongestChainBlockDAO,
+                LongestChainBlockDAO.block_id == BlockDAO.id,
+            )
+            .where(LongestChainBlockDAO.position <= cap)
+            .where(TransactionDAO.txid == txid)
+        ).scalar_one_or_none()
+    return None
+```
+
+- [ ] **Step 5: Rewrite `inflows_in_chain_count`**
+
+Replace the current body with (preserving the 0/1 existence semantics):
+
+```python
+def inflows_in_chain_count(
+    self, outflow_txid: str, outflow_idx: int
+) -> int:
+    divergent, cap = self._ancestry()
+    if divergent:
+        hit = (
+            db.session.execute(
+                db.select(InflowDAO)
+                .join(InflowDAO.transaction)
+                .join(TransactionDAO.blocks)
+                .where(BlockDAO.id.in_(divergent))
+                .where(InflowDAO.outflow_txid == outflow_txid)
+                .where(InflowDAO.outflow_idx == outflow_idx)
+            )
+            .scalars()
+            .first()
+        )
+        if hit is not None:
+            return 1
+    if cap is not None:
+        hit = (
+            db.session.execute(
+                db.select(InflowDAO)
+                .join(InflowDAO.transaction)
+                .join(TransactionDAO.blocks)
+                .join(
+                    LongestChainBlockDAO,
+                    LongestChainBlockDAO.block_id == BlockDAO.id,
+                )
+                .where(LongestChainBlockDAO.position <= cap)
+                .where(InflowDAO.outflow_txid == outflow_txid)
+                .where(InflowDAO.outflow_idx == outflow_idx)
+            )
+            .scalars()
+            .first()
+        )
+        if hit is not None:
+            return 1
+    return 0
+```
+
+- [ ] **Step 6: Rewrite `get_block_in_chain`**
+
+Replace the current body with:
+
+```python
+def get_block_in_chain(
+    self, block_hash: str | None = None, idx: int | None = None
+) -> BlockDAO | None:
+    divergent, cap = self._ancestry()
+    if divergent:
+        stmt = db.select(BlockDAO).where(BlockDAO.id.in_(divergent))
+        if block_hash is not None:
+            stmt = stmt.where(BlockDAO.block_hash == block_hash)
+        if idx is not None:
+            stmt = stmt.where(BlockDAO.idx == idx)
+        hit = db.session.execute(stmt).scalars().first()
+        if hit is not None:
+            return hit
+    if cap is not None:
+        stmt = (
+            db.select(BlockDAO)
+            .join(
+                LongestChainBlockDAO,
+                LongestChainBlockDAO.block_id == BlockDAO.id,
+            )
+            .where(LongestChainBlockDAO.position <= cap)
+        )
+        if block_hash is not None:
+            stmt = stmt.where(BlockDAO.block_hash == block_hash)
+        if idx is not None:
+            stmt = stmt.where(BlockDAO.idx == idx)
+        return db.session.execute(stmt).scalar_one_or_none()
+    return None
+```
+
+- [ ] **Step 7: Run the guard test, expect PASS**
+
+Run: `uv run pytest tests/test_models.py::test_hot_path_methods_never_touch_recursive_cte -q`
+Expected: PASS — none of the three methods touches `_block_chain` now.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gumptionchain/models.py tests/test_models.py
+git commit -m "perf(validation): resolve ancestry via materialization, not recursive CTE (#157)"
+```
+
+---
+
+## Task 2: Equivalence + fork + bootstrap coverage
+
+**Files:**
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Write canonical equivalence test**
+
+Add to `tests/test_models.py`. Ground truth is the still-defined recursive CTE
+(`block.transactions_chain` / `block_chain` / `inflows_chain`); the new methods
+must agree with it on the canonical chain.
+
+```python
+def test_hot_path_methods_match_cte_canonical(
+    app, add_chain_block, time_stepper, wallet
+):
+    with app.app_context():
+        chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        cb1_txid = block1.coinbase.txid
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+
+        # get_transaction_in_chain matches the CTE (hit + miss)
+        for txid in (spend_txid, cb1_txid, 'missing'):
+            cte = db.session.execute(
+                tip.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = tip.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+
+        # inflows_in_chain_count matches the CTE existence (0/1)
+        for otxid, oidx in ((cb1_txid, 0), ('missing', 0)):
+            cte_exists = (
+                1
+                if db.session.execute(
+                    tip.inflows_chain.where(
+                        InflowDAO.outflow_txid == otxid,
+                        InflowDAO.outflow_idx == oidx,
+                    )
+                )
+                .scalars()
+                .first()
+                is not None
+                else 0
+            )
+            assert tip.inflows_in_chain_count(otxid, oidx) == cte_exists
+
+        # get_block_in_chain matches the CTE (by hash and by idx)
+        for kwargs in (
+            {'block_hash': block1.block_hash},
+            {'idx': 0},
+            {'idx': 1},
+            {'block_hash': 'missing'},
+        ):
+            cte_block = _cte_get_block_in_chain(tip, **kwargs)
+            new_block = tip.get_block_in_chain(**kwargs)
+            assert (new_block.id if new_block else None) == (
+                cte_block.id if cte_block else None
+            )
+
+
+def _cte_get_block_in_chain(block_dao, block_hash=None, idx=None):
+    """Ground-truth get_block_in_chain via the recursive CTE."""
+    block_alias = db.aliased(BlockDAO, block_dao.block_chain.subquery())
+    stmt = db.select(BlockDAO).join(
+        block_alias, BlockDAO.id == block_alias.id
+    )
+    if block_hash is not None:
+        stmt = stmt.where(BlockDAO.block_hash == block_hash)
+    if idx is not None:
+        stmt = stmt.where(BlockDAO.idx == idx)
+    return db.session.execute(stmt).scalar_one_or_none()
+```
+
+- [ ] **Step 2: Write fork equivalence test**
+
+```python
+def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet):
+    """A fork (non-longest) block resolves its divergent-suffix ancestry the
+    same as the recursive CTE would.
+    """
+    import datetime
+
+    with app.app_context():
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+        block_2a.mill()
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        fork = BlockDAO.get(block_2b.block_hash)
+        assert fork is not None
+        # confirm it is genuinely a fork: not in the materialization
+        assert fork._ancestry()[0]  # non-empty divergent suffix
+
+        fork_cb_txid = block_2b.coinbase.txid  # only in the divergent suffix
+        ancestor_cb_txid = block_1.coinbase.txid  # below the common ancestor
+        for txid in (fork_cb_txid, ancestor_cb_txid, 'missing'):
+            cte = db.session.execute(
+                fork.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = fork.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+
+        # block lookup across the fork boundary
+        for kwargs in (
+            {'block_hash': block_2b.block_hash},
+            {'block_hash': block_1.block_hash},
+            {'idx': 0},
+        ):
+            cte_block = _cte_get_block_in_chain(fork, **kwargs)
+            new_block = fork.get_block_in_chain(**kwargs)
+            assert (new_block.id if new_block else None) == (
+                cte_block.id if cte_block else None
+            )
+```
+
+- [ ] **Step 3: Write bootstrap (empty materialization) test**
+
+```python
+def test_hot_path_methods_match_cte_empty_materialization(
+    app, add_chain_block, time_stepper, wallet
+):
+    """With an empty LongestChainBlockDAO (bootstrap), _ancestry walks the
+    whole chain into divergent_ids and the methods still match the CTE.
+    """
+    with app.app_context():
+        chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        db.session.execute(db.delete(LongestChainBlockDAO))
+        db.session.commit()
+        assert _count(LongestChainBlockDAO) == 0
+
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        divergent, cap = tip._ancestry()
+        assert cap is None
+        assert len(divergent) == 2  # whole chain is "divergent"
+
+        for txid in (spend_txid, block1.coinbase.txid, 'missing'):
+            cte = db.session.execute(
+                tip.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = tip.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+        assert tip.get_block_in_chain(idx=0) is not None
+        assert tip.inflows_in_chain_count(block1.coinbase.txid, 0) == 1
+```
+
+- [ ] **Step 4: Run the new tests, expect PASS**
+
+Run: `uv run pytest tests/test_models.py -k "hot_path_methods" -q`
+Expected: PASS (4 tests: guard, canonical, fork, bootstrap).
+
+- [ ] **Step 5: Full suite + lint + format + types**
+
+Run: `uv run pytest -q && uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all green. The existing chain/validation/miller tests must still pass unchanged — the three methods' behavior is preserved, only their implementation changed.
+
+- [ ] **Step 6: Confirm `db check` is unaffected (no schema drift)**
+
+Run (requires a DB URI; mirrors the CI gate):
+```bash
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///_dbcheck.db uv run gumptionchain db upgrade
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///_dbcheck.db uv run gumptionchain db check
+rm -f _dbcheck.db
+```
+Expected: `db check` reports no differences (this change adds no columns/tables).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_models.py
+git commit -m "test(validation): equivalence + bootstrap coverage for materialized ancestry (#157)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** all three call sites converted (Task 1); CTE-free fork fallback via `_ancestry` (Task 1); equivalence + CTE-guard over canonical *and* fork + bootstrap (Tasks 1–2). Tier-2 read paths + CTE deletion are explicitly #158 (out of scope here).
+- **Behavior preservation:** `inflows_in_chain_count` keeps 0/1 existence semantics; `get_block_in_chain` keeps `block_hash`/`idx` filters and `scalar_one_or_none`; `get_transaction_in_chain` keeps single-result semantics. Canonical-chain uniqueness guarantees ≤1 row on the `cap` branch.
+- **Type consistency:** `_ancestry` → `tuple[list[int], int | None]`; the three methods keep their existing signatures and return types. `LongestChainBlockDAO`/`TransactionDAO`/`InflowDAO` are in-module; no new imports in `models.py`.
+- **No schema/migration** — `db check` step confirms.
+
+## Definition of done
+
+- `_ancestry` added; the three hot-path methods resolve ancestry via materialization (canonical) + divergent-suffix (fork), with **no** `_block_chain` reference.
+- CTE-guard test passes on canonical and fork anchors (recursive CTE never accessed by the three methods).
+- Canonical, fork, and bootstrap equivalence tests pass (results bit-identical to the CTE).
+- Full suite + ruff + ruff-format + mypy green; `db check` shows no drift.
+- Recursive CTE properties left in place for #158 to delete.

--- a/docs/superpowers/specs/2026-06-05-egu-1b-pre-validation-materialization-design.md
+++ b/docs/superpowers/specs/2026-06-05-egu-1b-pre-validation-materialization-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-05
 **Status:** Approved design, pre-implementation
-**Issue:** #157 (prerequisite to EGU 1b, part of #151)
+**Issue:** #157 (prerequisite to EGU 1b, part of #151); capstone follow-up #158
 **Type:** Performance / read-path refactor — no schema, no migration, no consensus rule change
 
 ## Summary
@@ -16,10 +16,18 @@ O(inflows × height): invisible at small N, lethal at large N. It is the scaling
 cliff that previously shelved the project, and it **gates EGU 1b** (cutting block
 time ~20× grows the chain ~20× faster and reaches the wall ~20× sooner).
 
-The fix routes those three lookups through the existing materialization using a
-**position-scoped indexed query**, falling back to the recursive CTE only when
-the anchor block is off the canonical chain (fork / off-tip validation). No
-schema change, no consensus-rule change — results are bit-identical to the CTE.
+This task converts those three lookups so they **never run the recursive CTE**:
+
+- **Canonical anchor** (the steady-state hot path) → position-scoped indexed
+  query against `LongestChainBlockDAO`.
+- **Fork / off-tip anchor** → a **bounded divergent-suffix walk** (the same
+  primitive `sync_longest_chain_blocks` already uses), **not** the recursive CTE.
+
+So after this task, the three hot-path methods are O(reorg-depth + result), never
+O(height). The recursive CTE property itself still exists (it is reached only by
+the single-pass *read* paths — `address_transactions`, non-longest accessors)
+and is **deleted in the capstone follow-up #158**. No schema change, no
+consensus-rule change — results are bit-identical to the CTE.
 
 ## The three O(N) call sites
 
@@ -33,22 +41,58 @@ block milled or received**:
 | `validate_txn_inflow` → `get_inflows_count` → `block_dao.inflows_in_chain_count` | `inflows_in_chain_count` (`models.py:366`) → `inflows_chain` CTE | once per inflow |
 
 Per block: ≈ `1 + 2·(num inflows)` recursive tip→genesis walks. Linear in chain
-height, on the hottest path.
+height, on the hottest path. **A fork fallback that kept the recursive CTE would
+not fix this** — a CTE walks fork-tip→genesis regardless of how shallowly the
+fork diverges, so a 1-block fork at height N still triggers an N-row recursion.
+The fork path must be CTE-free too.
 
-## Core mechanism: position-scoped ancestry
+## Core mechanism: ancestry without recursion
 
 Every block on the canonical chain has a `LongestChainBlockDAO.position`
 (0 = genesis, increasing toward tip). A canonical block's **ancestry is exactly
-the canonical blocks with `position <= anchor.position`**. So "is X in this
-block's ancestry?" becomes an indexed join against `longest_chain_block` —
-no recursion:
+the canonical blocks with `position <= anchor.position`** — answerable by an
+indexed join, no recursion.
 
-1. Look up the anchor's position: one indexed PK query on
-   `longest_chain_block.block_id`.
-2. **If found (anchor is canonical):** answer via a join filtered by
-   `position <= pos` — the materialized, indexed path.
-3. **If `None` (anchor is a fork / not yet materialized):** fall back to the
-   existing recursive CTE. Correct and safe for the off-tip case.
+A *fork* block's ancestry is its short **divergent suffix** (the blocks above the
+common ancestor, none of which are in the materialization) plus the canonical
+prefix at/below the common ancestor. Genesis is always materialized, so a common
+ancestor always exists (post-bootstrap).
+
+A single helper resolves both cases by walking `prev` links only across the
+divergent suffix:
+
+```python
+def _ancestry(self) -> tuple[list[int], int | None]:
+    """Resolve this block's ancestry against the materialization without
+    recursion.
+
+    Returns (divergent_ids, cap_position):
+    - divergent_ids: ids of blocks on the divergent suffix (not in
+      LongestChainBlockDAO), nearest-first. Empty when this block is
+      canonical.
+    - cap_position: position of the common ancestor in
+      LongestChainBlockDAO; the canonical prefix is `position <= cap`.
+      None only when the materialization is empty (bootstrap), in which
+      case divergent_ids covers the whole walked chain.
+
+    Cost is O(divergent-suffix length) indexed `prev` lookups: 0 extra for
+    a canonical anchor (first lookup hits), reorg-depth for a fork. Never
+    O(chain-height) except transient bootstrap (empty materialization).
+    """
+    divergent: list[int] = []
+    current: BlockDAO | None = self
+    while current is not None:
+        pos = db.session.scalar(
+            db.select(LongestChainBlockDAO.position).where(
+                LongestChainBlockDAO.block_id == current.id
+            )
+        )
+        if pos is not None:
+            return divergent, pos
+        divergent.append(current.id)
+        current = current.prev
+    return divergent, None
+```
 
 ### Why the anchor is canonical on the hot path
 
@@ -56,17 +100,17 @@ When validating a new tip block N+1 (not yet persisted), `get_transaction`
 (`chain.py:406`) and `get_inflows_count` (`chain.py:424`) walk the unpersisted
 block(s) in memory, then anchor on the first **persisted** block — the current
 tip, block N. Block N was materialized by `sync_longest_chain_blocks` when it was
-saved (`Chain.to_db`), so its position lookup succeeds → materialized path.
-`block_target`'s `get_block_in_chain` anchors on the tip likewise. Bootstrap
-(empty materialization) and genuine fork validation hit the `None` branch and use
-the CTE — exactly when recursion is actually required.
+saved (`Chain.to_db`), so `_ancestry` returns `([], tip_position)` on its first
+lookup — zero divergent walk, one indexed query. `block_target`'s
+`get_block_in_chain` anchors on the tip likewise. Fork validation (sync/reorg)
+hits the divergent-suffix branch, bounded by reorg depth.
 
 ## File-by-file changes
 
 | File | Change |
 |---|---|
-| `models.py` | `BlockDAO.get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain` each gain a position lookup + materialized branch; CTE retained as the `pos is None` fallback. A small private helper resolves the anchor's canonical position. |
-| `tests/test_models.py` (or the existing chain/validation test module) | equivalence tests (materialized result == CTE result) + a CTE-guard test (recursive `_block_chain` is **not** touched on the canonical validation path) + a fork-fallback test. |
+| `models.py` | Add `BlockDAO._ancestry` helper. Rewrite `get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain` to use canonical (position-scoped) + divergent-suffix queries — **no `_block_chain` reference in any of the three**. The recursive `_block_chain` / `*_chain` properties remain in the file (still used by Tier-2 read paths) until #158 deletes them. |
+| `tests/test_models.py` (or the chain/validation test module) | equivalence tests (new path == old CTE result, canonical & fork) + a CTE-guard test (recursive `_block_chain` is **not** touched on the validation path, **canonical or fork**) + a bootstrap test. |
 
 No changes to `chain.py` — `Chain.get_transaction` / `get_inflows_count` /
 `get_block_by_reverse_index` call the BlockDAO methods, which now route
@@ -75,77 +119,82 @@ internally. No schema, no migration, no consensus rule change.
 ### Sketch (illustrative, not final code)
 
 ```python
-def _canonical_position(self) -> int | None:
-    return db.session.scalar(
-        db.select(LongestChainBlockDAO.position).where(
-            LongestChainBlockDAO.block_id == self.id
-        )
-    )
-
 def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
-    pos = self._canonical_position()
-    if pos is None:  # fork / un-materialized → recursive fallback
+    divergent, cap = self._ancestry()
+    if divergent:  # short fork suffix: direct id-set lookup
+        hit = db.session.execute(
+            db.select(TransactionDAO)
+            .join(TransactionDAO.blocks)
+            .where(BlockDAO.id.in_(divergent))
+            .where(TransactionDAO.txid == txid)
+        ).scalars().first()
+        if hit is not None:
+            return hit
+    if cap is not None:  # canonical prefix: indexed, position-bounded
         return db.session.execute(
-            self.transactions_chain.where(TransactionDAO.txid == txid)
+            db.select(TransactionDAO)
+            .join(TransactionDAO.blocks)
+            .join(LongestChainBlockDAO, LongestChainBlockDAO.block_id == BlockDAO.id)
+            .where(LongestChainBlockDAO.position <= cap)
+            .where(TransactionDAO.txid == txid)
         ).scalar_one_or_none()
-    stmt = (
-        db.select(TransactionDAO)
-        .join(TransactionDAO.blocks)
-        .join(LongestChainBlockDAO, LongestChainBlockDAO.block_id == BlockDAO.id)
-        .where(LongestChainBlockDAO.position <= pos)
-        .where(TransactionDAO.txid == txid)
-    )
-    return db.session.execute(stmt).scalar_one_or_none()
+    return None
 ```
 
-`inflows_in_chain_count` and `get_block_in_chain` follow the same shape
-(`inflow → transaction → blocks → longest_chain_block`, and
-`block → longest_chain_block` respectively), each preserving its existing
-return semantics (`inflows_in_chain_count` returns `1`/`0` existence, not a true
-count; `get_block_in_chain` filters by `block_hash` and/or `idx`). Canonical-chain
-uniqueness guarantees ≤1 row for the single-result lookups, so `scalar_one_or_none`
-parity holds.
+`inflows_in_chain_count` and `get_block_in_chain` follow the same two-part shape
+(`inflow → transaction → blocks`, and `block` directly), preserving existing
+return semantics: `inflows_in_chain_count` returns `1`/`0` existence (not a true
+count); `get_block_in_chain` filters by `block_hash` and/or `idx`.
+Canonical-chain uniqueness guarantees ≤1 row for the single-result lookups, so
+`scalar_one_or_none` parity holds on the canonical branch.
 
 ## Testing (equivalence + CTE-guard)
 
-1. **Equivalence** — on a mined canonical chain, for representative
-   txids / (outflow_txid, idx) / block hashes & idxs, assert the materialized
-   method returns the **same** result as the recursive CTE computed directly
+1. **Equivalence (canonical)** — on a mined canonical chain, for representative
+   txids / (outflow_txid, idx) / block hashes & idxs, assert the new method
+   returns the **same** result as the recursive CTE computed directly
    (`block.transactions_chain.where(...)`, etc.). Cover hit and miss cases.
-2. **CTE-guard** — patch `BlockDAO._block_chain` to raise, then run a full
-   `Chain.validate_block` over a canonical block (with inflows and a target
-   check). It must succeed — proving none of the three hot-path lookups touched
-   the recursive CTE.
-3. **Fork fallback** — build a non-canonical (fork) block; assert its
-   `get_transaction_in_chain` / `inflows_in_chain_count` / `get_block_in_chain`
-   still return correct results via the CTE fallback (position lookup returns
-   `None`).
-4. **Bootstrap** — with an empty `longest_chain_block`, the methods fall back to
-   the CTE and return correct results.
+2. **Equivalence (fork)** — build a fork block whose `_ancestry` returns a
+   non-empty divergent suffix; assert the new methods return the same results as
+   the CTE for txns/inflows/blocks that live in the divergent suffix *and* below
+   the common ancestor.
+3. **CTE-guard** — patch `BlockDAO._block_chain` to raise, then run a full
+   `Chain.validate_block` over (a) a canonical block and (b) a fork block, each
+   with inflows and a target check. Both must succeed — proving none of the three
+   hot-path lookups touched the recursive CTE on either path.
+4. **Bootstrap** — with an empty `longest_chain_block`, the methods resolve via
+   the all-divergent walk and return correct results.
 
 No wall-clock perf assertion (CI-flaky); the CTE-guard test is the structural
-proof that validation no longer recurses on the canonical path, which is what
-makes it flat in N.
+proof that validation no longer recurses on any path, which is what makes it flat
+in N.
 
 ## Out of scope
 
+- **Tier 2 + CTE deletion (#158)** — routing `address_transactions` and the
+  non-longest read accessors through materialized/divergent-suffix queries, then
+  deleting `_block_chain` and the four `*_chain` properties. This task leaves
+  those properties in place (Tier-2 read paths still reference them) but ensures
+  the hot path no longer does.
 - **EGU 1b constant retune** (block time, retarget interval, difficulty floor,
   base-reward magnitude, RSA→2048) — the sibling task this unblocks.
 - **#150** — the N+1 in `unrescinded_outflows` on the cold rescind-*build* path.
-  Different path, different fix.
-- Refactoring the recursive CTE itself or removing it (still needed for forks).
 
 ## Decisions log
 
 - **Scope: all three call sites** (`get_transaction_in_chain`,
   `inflows_in_chain_count`, `get_block_in_chain`). Leaving the per-block target
-  lookup on the CTE would keep validation linear in N; fixing all three makes the
-  whole `validate_block` path flat on the canonical chain.
-- **Mechanism: position-scoped ancestry** (`position <= anchor.position`) against
-  `LongestChainBlockDAO`, mirroring the existing `_is_longest()` routing; CTE
-  retained as the off-canonical fallback.
-- **Proof: equivalence + CTE-guard** (no wall-clock perf test; deterministic,
-  CI-stable).
+  lookup on the CTE would keep validation linear in N.
+- **Fork fallback is CTE-free** — a bounded divergent-suffix walk
+  (`_ancestry`), not the recursive CTE. A CTE fork fallback would re-arm the
+  O(height)-per-fork-block bomb. PR1 therefore ships with **zero** per-block CTE
+  calls; the quadratic dies the moment it merges.
+- **Mechanism: ancestry without recursion** — position-scoped query for the
+  canonical prefix (`position <= cap`) + id-set query for the short divergent
+  suffix.
+- **Proof: equivalence + CTE-guard over canonical *and* fork** (no wall-clock
+  perf test; deterministic, CI-stable).
+- **CTE deletion deferred to #158** (capstone), since Tier-2 read paths still
+  reference `_block_chain` until they are converted. Two coupled PRs, smaller
+  blast radius each.
 - No schema / migration / consensus-rule change; results bit-identical to the CTE.
-- Sequenced as a **prerequisite to EGU 1b** — fix and verify before reducing
-  block time.

--- a/docs/superpowers/specs/2026-06-05-egu-1b-pre-validation-materialization-design.md
+++ b/docs/superpowers/specs/2026-06-05-egu-1b-pre-validation-materialization-design.md
@@ -1,0 +1,151 @@
+# EGU 1b-pre — materialize the consensus-validation hot path — design
+
+**Date:** 2026-06-05
+**Status:** Approved design, pre-implementation
+**Issue:** #157 (prerequisite to EGU 1b, part of #151)
+**Type:** Performance / read-path refactor — no schema, no migration, no consensus rule change
+
+## Summary
+
+Eliminate the recursive `BlockDAO._block_chain` CTE from the
+**consensus-validation hot path**. Phase 6's `LongestChainBlockDAO`
+materialization already removed the CTE from the read/balance paths, but three
+lookups invoked by `Chain.validate_block` — once per block plus twice per inflow
+— still run the recursive CTE, each O(chain-height). This makes block validation
+O(inflows × height): invisible at small N, lethal at large N. It is the scaling
+cliff that previously shelved the project, and it **gates EGU 1b** (cutting block
+time ~20× grows the chain ~20× faster and reaches the wall ~20× sooner).
+
+The fix routes those three lookups through the existing materialization using a
+**position-scoped indexed query**, falling back to the recursive CTE only when
+the anchor block is off the canonical chain (fork / off-tip validation). No
+schema change, no consensus-rule change — results are bit-identical to the CTE.
+
+## The three O(N) call sites
+
+All three are reached from `Chain.validate_block` (`chain.py:195`) on **every
+block milled or received**:
+
+| Path | DAO method (CTE) | Frequency |
+|---|---|---|
+| `block_target` → `get_block_by_reverse_index` → `ChainDAO.get_block` → `block.get_block_in_chain` | `get_block_in_chain` (`models.py:353`) → `block_chain` CTE | once per block (target retarget check) |
+| `validate_txn_inflow` → `get_transaction` → `block_dao.get_transaction_in_chain` | `get_transaction_in_chain` (`models.py:343`) → `transactions_chain` CTE | once per inflow |
+| `validate_txn_inflow` → `get_inflows_count` → `block_dao.inflows_in_chain_count` | `inflows_in_chain_count` (`models.py:366`) → `inflows_chain` CTE | once per inflow |
+
+Per block: ≈ `1 + 2·(num inflows)` recursive tip→genesis walks. Linear in chain
+height, on the hottest path.
+
+## Core mechanism: position-scoped ancestry
+
+Every block on the canonical chain has a `LongestChainBlockDAO.position`
+(0 = genesis, increasing toward tip). A canonical block's **ancestry is exactly
+the canonical blocks with `position <= anchor.position`**. So "is X in this
+block's ancestry?" becomes an indexed join against `longest_chain_block` —
+no recursion:
+
+1. Look up the anchor's position: one indexed PK query on
+   `longest_chain_block.block_id`.
+2. **If found (anchor is canonical):** answer via a join filtered by
+   `position <= pos` — the materialized, indexed path.
+3. **If `None` (anchor is a fork / not yet materialized):** fall back to the
+   existing recursive CTE. Correct and safe for the off-tip case.
+
+### Why the anchor is canonical on the hot path
+
+When validating a new tip block N+1 (not yet persisted), `get_transaction`
+(`chain.py:406`) and `get_inflows_count` (`chain.py:424`) walk the unpersisted
+block(s) in memory, then anchor on the first **persisted** block — the current
+tip, block N. Block N was materialized by `sync_longest_chain_blocks` when it was
+saved (`Chain.to_db`), so its position lookup succeeds → materialized path.
+`block_target`'s `get_block_in_chain` anchors on the tip likewise. Bootstrap
+(empty materialization) and genuine fork validation hit the `None` branch and use
+the CTE — exactly when recursion is actually required.
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `models.py` | `BlockDAO.get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain` each gain a position lookup + materialized branch; CTE retained as the `pos is None` fallback. A small private helper resolves the anchor's canonical position. |
+| `tests/test_models.py` (or the existing chain/validation test module) | equivalence tests (materialized result == CTE result) + a CTE-guard test (recursive `_block_chain` is **not** touched on the canonical validation path) + a fork-fallback test. |
+
+No changes to `chain.py` — `Chain.get_transaction` / `get_inflows_count` /
+`get_block_by_reverse_index` call the BlockDAO methods, which now route
+internally. No schema, no migration, no consensus rule change.
+
+### Sketch (illustrative, not final code)
+
+```python
+def _canonical_position(self) -> int | None:
+    return db.session.scalar(
+        db.select(LongestChainBlockDAO.position).where(
+            LongestChainBlockDAO.block_id == self.id
+        )
+    )
+
+def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
+    pos = self._canonical_position()
+    if pos is None:  # fork / un-materialized → recursive fallback
+        return db.session.execute(
+            self.transactions_chain.where(TransactionDAO.txid == txid)
+        ).scalar_one_or_none()
+    stmt = (
+        db.select(TransactionDAO)
+        .join(TransactionDAO.blocks)
+        .join(LongestChainBlockDAO, LongestChainBlockDAO.block_id == BlockDAO.id)
+        .where(LongestChainBlockDAO.position <= pos)
+        .where(TransactionDAO.txid == txid)
+    )
+    return db.session.execute(stmt).scalar_one_or_none()
+```
+
+`inflows_in_chain_count` and `get_block_in_chain` follow the same shape
+(`inflow → transaction → blocks → longest_chain_block`, and
+`block → longest_chain_block` respectively), each preserving its existing
+return semantics (`inflows_in_chain_count` returns `1`/`0` existence, not a true
+count; `get_block_in_chain` filters by `block_hash` and/or `idx`). Canonical-chain
+uniqueness guarantees ≤1 row for the single-result lookups, so `scalar_one_or_none`
+parity holds.
+
+## Testing (equivalence + CTE-guard)
+
+1. **Equivalence** — on a mined canonical chain, for representative
+   txids / (outflow_txid, idx) / block hashes & idxs, assert the materialized
+   method returns the **same** result as the recursive CTE computed directly
+   (`block.transactions_chain.where(...)`, etc.). Cover hit and miss cases.
+2. **CTE-guard** — patch `BlockDAO._block_chain` to raise, then run a full
+   `Chain.validate_block` over a canonical block (with inflows and a target
+   check). It must succeed — proving none of the three hot-path lookups touched
+   the recursive CTE.
+3. **Fork fallback** — build a non-canonical (fork) block; assert its
+   `get_transaction_in_chain` / `inflows_in_chain_count` / `get_block_in_chain`
+   still return correct results via the CTE fallback (position lookup returns
+   `None`).
+4. **Bootstrap** — with an empty `longest_chain_block`, the methods fall back to
+   the CTE and return correct results.
+
+No wall-clock perf assertion (CI-flaky); the CTE-guard test is the structural
+proof that validation no longer recurses on the canonical path, which is what
+makes it flat in N.
+
+## Out of scope
+
+- **EGU 1b constant retune** (block time, retarget interval, difficulty floor,
+  base-reward magnitude, RSA→2048) — the sibling task this unblocks.
+- **#150** — the N+1 in `unrescinded_outflows` on the cold rescind-*build* path.
+  Different path, different fix.
+- Refactoring the recursive CTE itself or removing it (still needed for forks).
+
+## Decisions log
+
+- **Scope: all three call sites** (`get_transaction_in_chain`,
+  `inflows_in_chain_count`, `get_block_in_chain`). Leaving the per-block target
+  lookup on the CTE would keep validation linear in N; fixing all three makes the
+  whole `validate_block` path flat on the canonical chain.
+- **Mechanism: position-scoped ancestry** (`position <= anchor.position`) against
+  `LongestChainBlockDAO`, mirroring the existing `_is_longest()` routing; CTE
+  retained as the off-canonical fallback.
+- **Proof: equivalence + CTE-guard** (no wall-clock perf test; deterministic,
+  CI-stable).
+- No schema / migration / consensus-rule change; results bit-identical to the CTE.
+- Sequenced as a **prerequisite to EGU 1b** — fix and verify before reducing
+  block time.

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -340,10 +340,63 @@ class BlockDAO(Base):
         else:
             db.session.flush()
 
+    def _ancestry(self) -> tuple[list[int], int | None]:
+        """Resolve this block's ancestry against LongestChainBlockDAO without
+        recursion.
+
+        Returns (divergent_ids, cap_position):
+        - divergent_ids: ids of blocks on the divergent suffix (not in the
+          materialization), nearest-first. Empty when this block is canonical.
+        - cap_position: position of the common ancestor in the materialization;
+          the canonical prefix is everything with position <= cap_position.
+          None only when the materialization is empty (bootstrap), in which
+          case divergent_ids covers the whole walked chain.
+
+        Cost: O(divergent-suffix length) indexed `prev` lookups — 0 extra for a
+        canonical anchor (first lookup hits), reorg-depth for a fork. Never
+        O(chain-height) except transient bootstrap.
+        """
+        divergent: list[int] = []
+        current: BlockDAO | None = self
+        while current is not None:
+            position = db.session.scalar(
+                db.select(LongestChainBlockDAO.position).where(
+                    LongestChainBlockDAO.block_id == current.id
+                )
+            )
+            if position is not None:
+                return divergent, position
+            divergent.append(current.id)
+            current = current.prev
+        return divergent, None
+
     def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
-        return db.session.execute(
-            self.transactions_chain.where(TransactionDAO.txid == txid)
-        ).scalar_one_or_none()
+        divergent, cap = self._ancestry()
+        if divergent:
+            hit = (
+                db.session.execute(
+                    db.select(TransactionDAO)
+                    .join(TransactionDAO.blocks)
+                    .where(BlockDAO.id.in_(divergent))
+                    .where(TransactionDAO.txid == txid)
+                )
+                .scalars()
+                .first()
+            )
+            if hit is not None:
+                return hit  # type: ignore[no-any-return]
+        if cap is not None:
+            return db.session.execute(
+                db.select(TransactionDAO)
+                .join(TransactionDAO.blocks)
+                .join(
+                    LongestChainBlockDAO,
+                    LongestChainBlockDAO.block_id == BlockDAO.id,
+                )
+                .where(LongestChainBlockDAO.position <= cap)
+                .where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+        return None
 
     def address_transactions(
         self, address: str
@@ -353,26 +406,71 @@ class BlockDAO(Base):
     def get_block_in_chain(
         self, block_hash: str | None = None, idx: int | None = None
     ) -> BlockDAO | None:
-        block_alias = db.aliased(BlockDAO, self.block_chain.subquery())
-        stmt = db.select(BlockDAO).join(
-            block_alias, BlockDAO.id == block_alias.id
-        )
-        if block_hash is not None:
-            stmt = stmt.where(BlockDAO.block_hash == block_hash)
-        if idx is not None:
-            stmt = stmt.where(BlockDAO.idx == idx)
-        return db.session.execute(stmt).scalar_one_or_none()
+        divergent, cap = self._ancestry()
+        if divergent:
+            stmt = db.select(BlockDAO).where(BlockDAO.id.in_(divergent))
+            if block_hash is not None:
+                stmt = stmt.where(BlockDAO.block_hash == block_hash)
+            if idx is not None:
+                stmt = stmt.where(BlockDAO.idx == idx)
+            hit = db.session.execute(stmt).scalars().first()
+            if hit is not None:
+                return hit  # type: ignore[no-any-return]
+        if cap is not None:
+            stmt = (
+                db.select(BlockDAO)
+                .join(
+                    LongestChainBlockDAO,
+                    LongestChainBlockDAO.block_id == BlockDAO.id,
+                )
+                .where(LongestChainBlockDAO.position <= cap)
+            )
+            if block_hash is not None:
+                stmt = stmt.where(BlockDAO.block_hash == block_hash)
+            if idx is not None:
+                stmt = stmt.where(BlockDAO.idx == idx)
+            return db.session.execute(stmt).scalar_one_or_none()
+        return None
 
     def inflows_in_chain_count(
         self, outflow_txid: str, outflow_idx: int
     ) -> int:
-        stmt = self.inflows_chain.where(
-            InflowDAO.outflow_txid == outflow_txid,
-            InflowDAO.outflow_idx == outflow_idx,
-        )
-        return (
-            1 if db.session.execute(stmt).scalars().first() is not None else 0
-        )
+        divergent, cap = self._ancestry()
+        if divergent:
+            hit = (
+                db.session.execute(
+                    db.select(InflowDAO)
+                    .join(InflowDAO.transaction)
+                    .join(TransactionDAO.blocks)
+                    .where(BlockDAO.id.in_(divergent))
+                    .where(InflowDAO.outflow_txid == outflow_txid)
+                    .where(InflowDAO.outflow_idx == outflow_idx)
+                )
+                .scalars()
+                .first()
+            )
+            if hit is not None:
+                return 1
+        if cap is not None:
+            hit = (
+                db.session.execute(
+                    db.select(InflowDAO)
+                    .join(InflowDAO.transaction)
+                    .join(TransactionDAO.blocks)
+                    .join(
+                        LongestChainBlockDAO,
+                        LongestChainBlockDAO.block_id == BlockDAO.id,
+                    )
+                    .where(LongestChainBlockDAO.position <= cap)
+                    .where(InflowDAO.outflow_txid == outflow_txid)
+                    .where(InflowDAO.outflow_idx == outflow_idx)
+                )
+                .scalars()
+                .first()
+            )
+            if hit is not None:
+                return 1
+        return 0
 
     @classmethod
     def count(cls) -> int:

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -373,18 +373,17 @@ class BlockDAO(Base):
     def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
         divergent, cap = self._ancestry()
         if divergent:
-            hit = (
-                db.session.execute(
-                    db.select(TransactionDAO)
-                    .join(TransactionDAO.blocks)
-                    .where(BlockDAO.id.in_(divergent))
-                    .where(TransactionDAO.txid == txid)
-                )
-                .scalars()
-                .first()
-            )
+            # scalar_one_or_none (not first): a txid is unique within a valid
+            # chain, so >1 match signals corrupt block<->txn associations and
+            # should raise, matching the prior CTE behaviour.
+            hit: TransactionDAO | None = db.session.execute(
+                db.select(TransactionDAO)
+                .join(TransactionDAO.blocks)
+                .where(BlockDAO.id.in_(divergent))
+                .where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
             if hit is not None:
-                return hit  # type: ignore[no-any-return]
+                return hit
         if cap is not None:
             return db.session.execute(
                 db.select(TransactionDAO)
@@ -413,9 +412,12 @@ class BlockDAO(Base):
                 stmt = stmt.where(BlockDAO.block_hash == block_hash)
             if idx is not None:
                 stmt = stmt.where(BlockDAO.idx == idx)
-            hit = db.session.execute(stmt).scalars().first()
+            # scalar_one_or_none (not first): preserves the prior CTE
+            # single-result semantics — a degenerate/corrupt >1 match raises
+            # rather than silently returning an arbitrary block.
+            hit: BlockDAO | None = db.session.execute(stmt).scalar_one_or_none()
             if hit is not None:
-                return hit  # type: ignore[no-any-return]
+                return hit
         if cap is not None:
             stmt = (
                 db.select(BlockDAO)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from _sa_helpers import _count, _count_select
 
@@ -753,3 +753,70 @@ def test_smart_reorg_deep_reorg_with_no_common_ancestor_falls_back(
         assert all(r.block_id not in fork_block_ids for r in rows)
         # Positions 0, 1, 2 (genesis-first).
         assert [r.position for r in rows] == [0, 1, 2]
+
+
+def _build_canonical_chain_with_spend(add_chain_block, time_stepper, wallet):
+    """Build a 2-block canonical chain where block 2 contains a txn that
+    spends block 1's coinbase. Returns (chain, block1, block2, spend_txid)."""
+    time_step = time_stepper(
+        start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    )
+    _ = next(time_step)
+    chain, block1 = add_chain_block(milling_wallet=wallet)
+    cb = block1.coinbase
+    cb_amount = next(iter(cb.outflows)).amount
+    _ = next(time_step)
+    t = Transaction()
+    t.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+    t.add_outflow(Outflow(amount=cb_amount, address=wallet.address))
+    t.set_wallet(wallet)
+    t.seal()
+    t.sign()
+    t.to_db()
+    _ = next(time_step)
+    block2 = Block()
+    block2.add_txn(t)
+    _, block2 = add_chain_block(
+        chain=chain, block=block2, milling_wallet=wallet
+    )
+    chain.to_db()
+    return chain, block1, block2, t.txid
+
+
+def test_hot_path_methods_never_touch_recursive_cte(
+    app, add_chain_block, time_stepper, wallet
+):
+    """get_transaction_in_chain / inflows_in_chain_count / get_block_in_chain
+    must not access the recursive _block_chain CTE on canonical OR fork
+    anchors. Booby-trap _block_chain to raise; the three methods must still
+    return correct results.
+    """
+    with app.app_context():
+        _chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        cb1_txid = block1.coinbase.txid
+        tip_dao = BlockDAO.get(block2.block_hash)
+        genesis_dao = BlockDAO.get(block1.block_hash)
+        assert tip_dao is not None
+        assert genesis_dao is not None
+
+        with patch.object(
+            BlockDAO, '_block_chain', new_callable=PropertyMock
+        ) as cte_mock:
+            cte_mock.side_effect = AssertionError(
+                'hot-path method accessed the recursive CTE'
+            )
+            # canonical anchor (the tip)
+            assert tip_dao.get_transaction_in_chain(spend_txid) is not None
+            assert tip_dao.get_transaction_in_chain('does-not-exist') is None
+            # the spend consumed block1's coinbase outflow → counted once
+            assert tip_dao.inflows_in_chain_count(cb1_txid, 0) == 1
+            assert tip_dao.inflows_in_chain_count('nope', 0) == 0
+            assert (
+                tip_dao.get_block_in_chain(block_hash=block1.block_hash)
+                is not None
+            )
+            assert tip_dao.get_block_in_chain(idx=0) is not None
+            # an ancestor anchor still resolves its own ancestry
+            assert genesis_dao.get_transaction_in_chain(cb1_txid) is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -847,8 +847,9 @@ def _build_fork(time_stepper, wallet, subject):
     chain_a.seal_block(block_2b, wallet, metrics_2b)
     block_2b.mill()
 
-    # chain_a wins the (idx DESC, timestamp ASC) tiebreaker because block_2a
-    # has the earlier timestamp; add it first so it becomes canonical.
+    # block_2a has the earlier seal timestamp, so chain_a wins the
+    # (idx DESC, timestamp ASC) tiebreaker in ChainDAO.chains() and is
+    # canonical regardless of add order (timestamp is fixed at seal()).
     _ = next(time_step)
     chain_a.add_block(block_2a)
     chain_a.to_db()
@@ -887,7 +888,9 @@ def test_hot_path_methods_match_cte_canonical(
                 tip.transactions_chain.where(TransactionDAO.txid == txid)
             ).scalar_one_or_none()
             new = tip.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None)
+            assert (new.id if new else None) == (cte.id if cte else None), (
+                f'txn mismatch for txid={txid!r}'
+            )
 
         for otxid, oidx in ((cb1_txid, 0), ('missing', 0)):
             cte_exists = (
@@ -903,7 +906,9 @@ def test_hot_path_methods_match_cte_canonical(
                 is not None
                 else 0
             )
-            assert tip.inflows_in_chain_count(otxid, oidx) == cte_exists
+            assert tip.inflows_in_chain_count(otxid, oidx) == cte_exists, (
+                f'inflow-existence mismatch for outflow=({otxid!r}, {oidx})'
+            )
 
         for kwargs in (
             {'block_hash': block1.block_hash},
@@ -915,7 +920,7 @@ def test_hot_path_methods_match_cte_canonical(
             new_block = tip.get_block_in_chain(**kwargs)
             assert (new_block.id if new_block else None) == (
                 cte_block.id if cte_block else None
-            )
+            ), f'block mismatch for {kwargs!r}'
 
 
 def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
@@ -933,7 +938,9 @@ def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
                 fork.transactions_chain.where(TransactionDAO.txid == txid)
             ).scalar_one_or_none()
             new = fork.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None)
+            assert (new.id if new else None) == (cte.id if cte else None), (
+                f'txn mismatch for txid={txid!r}'
+            )
 
         for kwargs in (
             {'block_hash': f['block_2b'].block_hash},
@@ -944,10 +951,11 @@ def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
             new_block = fork.get_block_in_chain(**kwargs)
             assert (new_block.id if new_block else None) == (
                 cte_block.id if cte_block else None
-            )
+            ), f'block mismatch for {kwargs!r}'
 
-        # The fork's divergent suffix consumes block_1's coinbase; count it
-        # against the CTE ground truth (hit) plus a miss.
+        # The fork's divergent suffix consumes block_1's coinbase; check it
+        # against the CTE ground truth (hit) plus a miss. inflows_in_chain_count
+        # is 0/1 existence, not a true count.
         for otxid, oidx, expected in (
             (f['spend_outflow_txid'], 0, 1),
             ('missing', 0, 0),
@@ -965,8 +973,12 @@ def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
                 is not None
                 else 0
             )
-            assert cte_exists == expected
-            assert fork.inflows_in_chain_count(otxid, oidx) == cte_exists
+            assert cte_exists == expected, (
+                f'CTE ground-truth mismatch for outflow=({otxid!r}, {oidx})'
+            )
+            assert fork.inflows_in_chain_count(otxid, oidx) == cte_exists, (
+                f'inflow-existence mismatch for outflow=({otxid!r}, {oidx})'
+            )
 
 
 def test_hot_path_methods_match_cte_empty_materialization(
@@ -994,7 +1006,9 @@ def test_hot_path_methods_match_cte_empty_materialization(
                 tip.transactions_chain.where(TransactionDAO.txid == txid)
             ).scalar_one_or_none()
             new = tip.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None)
+            assert (new.id if new else None) == (cte.id if cte else None), (
+                f'txn mismatch for txid={txid!r}'
+            )
         assert tip.get_block_in_chain(idx=0) is not None
         assert tip.inflows_in_chain_count(block1.coinbase.txid, 0) == 1
 
@@ -1026,7 +1040,8 @@ def test_hot_path_methods_never_touch_recursive_cte(
             # canonical anchor (the tip)
             assert tip_dao.get_transaction_in_chain(spend_txid) is not None
             assert tip_dao.get_transaction_in_chain('does-not-exist') is None
-            # the spend consumed block1's coinbase outflow → counted once
+            # the spend consumed block1's coinbase outflow → present (0/1
+            # existence, not a true count)
             assert tip_dao.inflows_in_chain_count(cb1_txid, 0) == 1
             assert tip_dao.inflows_in_chain_count('nope', 0) == 0
             assert (
@@ -1072,6 +1087,7 @@ def test_hot_path_methods_never_touch_recursive_cte_fork(
             )
             assert fork.get_block_in_chain(idx=0) is not None
             # inflows_in_chain_count — inflow consumed in the divergent
-            # suffix counts once; a missing one is zero.
+            # suffix is present; a missing one is absent (0/1 existence,
+            # not a true count).
             assert fork.inflows_in_chain_count(f['spend_outflow_txid'], 0) == 1
             assert fork.inflows_in_chain_count('nope', 0) == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,13 @@ from _sa_helpers import _count, _count_select
 from gumptionchain.block import Block
 from gumptionchain.chain import Chain
 from gumptionchain.database import db
-from gumptionchain.models import BlockDAO, ChainDAO, LongestChainBlockDAO
+from gumptionchain.models import (
+    BlockDAO,
+    ChainDAO,
+    InflowDAO,
+    LongestChainBlockDAO,
+    TransactionDAO,
+)
 from gumptionchain.payload import Inflow, Outflow
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 
@@ -783,6 +789,216 @@ def _build_canonical_chain_with_spend(add_chain_block, time_stepper, wallet):
     return chain, block1, block2, t.txid
 
 
+def _cte_get_block_in_chain(block_dao, block_hash=None, idx=None):
+    """Ground-truth get_block_in_chain via the recursive CTE."""
+    block_alias = db.aliased(BlockDAO, block_dao.block_chain.subquery())
+    stmt = db.select(BlockDAO).join(block_alias, BlockDAO.id == block_alias.id)
+    if block_hash is not None:
+        stmt = stmt.where(BlockDAO.block_hash == block_hash)
+    if idx is not None:
+        stmt = stmt.where(BlockDAO.idx == idx)
+    return db.session.execute(stmt).scalar_one_or_none()
+
+
+def _build_fork(time_stepper, wallet, subject):
+    """Build a real fork: chain_a (canonical, longest) and chain_b (fork)
+    both share block_1. chain_b's tip block_2b spends block_1's coinbase, so
+    the divergent suffix carries a genuine inflow. Returns a dict with the
+    fork tip BlockDAO and the txids/hashes the tests assert against.
+    """
+    time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+    _ = next(time_step)
+    chain_a = Chain()
+    block_1 = Block()
+    chain_a.link_block(block_1)
+    chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+    block_1.mill()
+    chain_a.add_block(block_1)
+    chain_a.to_db()
+    cb_1 = block_1.coinbase
+    cb_1_amount = next(iter(cb_1.outflows)).amount
+
+    _ = next(time_step)
+    block_2a = Block()
+    chain_a.link_block(block_2a)
+    chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+    block_2a.mill()
+
+    # Fork tip spends block_1's coinbase, so the divergent suffix has a
+    # real inflow to count.
+    _ = next(time_step)
+    spend = Transaction()
+    spend.add_inflow(Inflow(outflow_txid=cb_1.txid, outflow_idx=0))
+    spend.add_outflow(Outflow(amount=cb_1_amount, opposition=subject))
+    spend.set_wallet(wallet)
+    spend.seal()
+    spend.sign()
+
+    # chain_a's tip is still block_1 here (block_2a is milled but not yet
+    # added), so linking block_2b against chain_a chains it onto block_1 as
+    # an alternate child — the fork point.
+    block_2b = Block()
+    block_2b.add_txn(spend)
+    chain_a.link_block(block_2b)
+    metrics_2b = sum(
+        (chain_a.validate_block_txn(block_2b, txn) for txn in block_2b.txns),
+        CoinbaseMetrics(),
+    )
+    chain_a.seal_block(block_2b, wallet, metrics_2b)
+    block_2b.mill()
+
+    # chain_a wins the (idx DESC, timestamp ASC) tiebreaker because block_2a
+    # has the earlier timestamp; add it first so it becomes canonical.
+    _ = next(time_step)
+    chain_a.add_block(block_2a)
+    chain_a.to_db()
+
+    _ = next(time_step)
+    chain_b = Chain()
+    chain_b.add_block(block_2b)
+    chain_b.to_db()
+
+    fork = BlockDAO.get(block_2b.block_hash)
+    return {
+        'fork': fork,
+        'block_1': block_1,
+        'block_2a': block_2a,
+        'block_2b': block_2b,
+        'fork_cb_txid': block_2b.coinbase.txid,
+        'ancestor_cb_txid': block_1.coinbase.txid,
+        'spend_txid': spend.txid,
+        'spend_outflow_txid': cb_1.txid,
+    }
+
+
+def test_hot_path_methods_match_cte_canonical(
+    app, add_chain_block, time_stepper, wallet
+):
+    with app.app_context():
+        _chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        cb1_txid = block1.coinbase.txid
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+
+        for txid in (spend_txid, cb1_txid, 'missing'):
+            cte = db.session.execute(
+                tip.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = tip.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+
+        for otxid, oidx in ((cb1_txid, 0), ('missing', 0)):
+            cte_exists = (
+                1
+                if db.session.execute(
+                    tip.inflows_chain.where(
+                        InflowDAO.outflow_txid == otxid,
+                        InflowDAO.outflow_idx == oidx,
+                    )
+                )
+                .scalars()
+                .first()
+                is not None
+                else 0
+            )
+            assert tip.inflows_in_chain_count(otxid, oidx) == cte_exists
+
+        for kwargs in (
+            {'block_hash': block1.block_hash},
+            {'idx': 0},
+            {'idx': 1},
+            {'block_hash': 'missing'},
+        ):
+            cte_block = _cte_get_block_in_chain(tip, **kwargs)
+            new_block = tip.get_block_in_chain(**kwargs)
+            assert (new_block.id if new_block else None) == (
+                cte_block.id if cte_block else None
+            )
+
+
+def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
+    """A fork (non-longest) block resolves its divergent-suffix ancestry the
+    same as the recursive CTE would.
+    """
+    with app.app_context():
+        f = _build_fork(time_stepper, wallet, subject)
+        fork = f['fork']
+        assert fork is not None
+        assert fork._ancestry()[0]  # non-empty divergent suffix
+
+        for txid in (f['fork_cb_txid'], f['ancestor_cb_txid'], 'missing'):
+            cte = db.session.execute(
+                fork.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = fork.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+
+        for kwargs in (
+            {'block_hash': f['block_2b'].block_hash},
+            {'block_hash': f['block_1'].block_hash},
+            {'idx': 0},
+        ):
+            cte_block = _cte_get_block_in_chain(fork, **kwargs)
+            new_block = fork.get_block_in_chain(**kwargs)
+            assert (new_block.id if new_block else None) == (
+                cte_block.id if cte_block else None
+            )
+
+        # The fork's divergent suffix consumes block_1's coinbase; count it
+        # against the CTE ground truth (hit) plus a miss.
+        for otxid, oidx, expected in (
+            (f['spend_outflow_txid'], 0, 1),
+            ('missing', 0, 0),
+        ):
+            cte_exists = (
+                1
+                if db.session.execute(
+                    fork.inflows_chain.where(
+                        InflowDAO.outflow_txid == otxid,
+                        InflowDAO.outflow_idx == oidx,
+                    )
+                )
+                .scalars()
+                .first()
+                is not None
+                else 0
+            )
+            assert cte_exists == expected
+            assert fork.inflows_in_chain_count(otxid, oidx) == cte_exists
+
+
+def test_hot_path_methods_match_cte_empty_materialization(
+    app, add_chain_block, time_stepper, wallet
+):
+    """With an empty LongestChainBlockDAO (bootstrap), _ancestry walks the
+    whole chain into divergent_ids and the methods still match the CTE.
+    """
+    with app.app_context():
+        _chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        db.session.execute(db.delete(LongestChainBlockDAO))
+        db.session.commit()
+        assert _count(LongestChainBlockDAO) == 0
+
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        divergent, cap = tip._ancestry()
+        assert cap is None
+        assert len(divergent) == 2  # whole chain is "divergent"
+
+        for txid in (spend_txid, block1.coinbase.txid, 'missing'):
+            cte = db.session.execute(
+                tip.transactions_chain.where(TransactionDAO.txid == txid)
+            ).scalar_one_or_none()
+            new = tip.get_transaction_in_chain(txid)
+            assert (new.id if new else None) == (cte.id if cte else None)
+        assert tip.get_block_in_chain(idx=0) is not None
+        assert tip.inflows_in_chain_count(block1.coinbase.txid, 0) == 1
+
+
 def test_hot_path_methods_never_touch_recursive_cte(
     app, add_chain_block, time_stepper, wallet
 ):
@@ -820,3 +1036,42 @@ def test_hot_path_methods_never_touch_recursive_cte(
             assert tip_dao.get_block_in_chain(idx=0) is not None
             # an ancestor anchor still resolves its own ancestry
             assert genesis_dao.get_transaction_in_chain(cb1_txid) is not None
+
+
+def test_hot_path_methods_never_touch_recursive_cte_fork(
+    app, time_stepper, wallet, subject
+):
+    """The divergent (fork) branch of all three methods — including
+    get_block_in_chain's `if divergent:` block — must execute CTE-free.
+    Booby-trap _block_chain over a genuine fork anchor.
+    """
+    with app.app_context():
+        f = _build_fork(time_stepper, wallet, subject)
+        fork = f['fork']
+        assert fork is not None
+        # Confirm a real divergent suffix BEFORE arming the trap.
+        assert fork._ancestry()[0]
+
+        with patch.object(
+            BlockDAO, '_block_chain', new_callable=PropertyMock
+        ) as cte_mock:
+            cte_mock.side_effect = AssertionError(
+                'hot-path method accessed the recursive CTE'
+            )
+            # get_transaction_in_chain — divergent-suffix hit + miss.
+            assert fork.get_transaction_in_chain(f['fork_cb_txid']) is not None
+            assert fork.get_transaction_in_chain('does-not-exist') is None
+            # get_block_in_chain — fork tip (divergent) and shared prefix.
+            assert (
+                fork.get_block_in_chain(block_hash=f['block_2b'].block_hash)
+                is not None
+            )
+            assert (
+                fork.get_block_in_chain(block_hash=f['block_1'].block_hash)
+                is not None
+            )
+            assert fork.get_block_in_chain(idx=0) is not None
+            # inflows_in_chain_count — inflow consumed in the divergent
+            # suffix counts once; a missing one is zero.
+            assert fork.inflows_in_chain_count(f['spend_outflow_txid'], 0) == 1
+            assert fork.inflows_in_chain_count('nope', 0) == 0


### PR DESCRIPTION
## Summary

Eliminates the recursive `BlockDAO._block_chain` CTE from the **consensus-validation hot path**. Phase 6's `LongestChainBlockDAO` materialization already removed the CTE from read/balance paths, but three lookups invoked by `Chain.validate_block` — once per block plus twice per inflow — still ran the recursive CTE, each O(chain-height). That made block validation **O(inflows × height)**: invisible at small N, lethal at large N. It is the scaling cliff that previously shelved the project, and it **gates EGU 1b** (cutting block time ~20× grows the chain ~20× faster, reaching the wall ~20× sooner).

This is **PR1 of 2** (issue #157). The recursive CTE properties remain defined — still used by Tier-2 read paths — and are deleted in the capstone follow-up #158.

## What changed

- **New `BlockDAO._ancestry()`** — resolves a block's ancestry against the materialization *without recursion*: walks `prev` links across only the (short) divergent suffix not yet materialized, returning `(divergent_block_ids, common_ancestor_position | None)`. Cost is O(reorg-depth): zero divergent steps for a canonical anchor (one indexed lookup), reorg-depth for a fork, never O(height) except transient bootstrap (empty materialization).
- **Rewrote three hot-path methods** — `get_transaction_in_chain`, `inflows_in_chain_count`, `get_block_in_chain` — to answer via a divergent id-set query + a position-scoped canonical query (`LongestChainBlockDAO.position <= cap`). **Zero** `_block_chain` references remain in these three; the fork fallback is CTE-free too (a CTE fork fallback would re-arm the O(height)-per-fork-block bomb).

After this PR the three methods are **O(reorg-depth + result)**, never O(height). Results are **bit-identical** to the old CTE.

## Behavior preservation

- `inflows_in_chain_count` keeps 0/1 existence semantics (never a true count).
- `get_block_in_chain` keeps both `block_hash`/`idx` filters and `scalar_one_or_none` on the canonical branch.
- `get_transaction_in_chain` keeps single-result semantics.
- No `chain.py` change, no schema/migration, no consensus-rule change.

## Test plan

- [x] **CTE-guard** — booby-traps `_block_chain` with a raising `PropertyMock`; the three methods must still return correct results on canonical tip, ancestor, **and fork** anchors (proves the divergent branch is CTE-free, not just the canonical one).
- [x] **Equivalence** — new methods vs. the still-defined recursive CTE as ground truth, hit + miss, on canonical, fork (non-empty divergent suffix), and bootstrap (empty materialization) anchors.
- [x] Full suite **341 passed / 1 skipped**; `ruff check` + `ruff format --check` clean; `mypy` clean; `db check` no drift.

Reviewed via the local subagent pipeline (per-task spec + code-quality reviews, plus a holistic final correctness pass over the whole diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
