### PR TITLE
perf(models): delete the recursive _block_chain CTE — capstone (#158)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-egu-1b-pre-capstone-delete-recursive-cte.md
+++ b/docs/superpowers/plans/2026-06-05-egu-1b-pre-capstone-delete-recursive-cte.md
@@ -1,0 +1,583 @@
+# EGU 1b-pre capstone — delete the recursive `_block_chain` CTE — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the remaining Tier-2 read-path consumers of the recursive `BlockDAO._block_chain` CTE (the non-longest `ChainDAO` accessors and `address_transactions`) to the divergent-suffix + position-scoped primitive from #157, then delete the recursive CTE and its `*_chain` builders entirely — zero recursive-CTE code in the tree.
+
+**Architecture:** Add four CTE-free query builders on `BlockDAO` (`ancestry_blocks_q` / `ancestry_transactions_q` / `ancestry_outflows_q` / `ancestry_inflows_q`) that express a block's ancestry as a composable `Select` using a divergent-suffix-OR-materialized-prefix predicate over `LongestChainBlockDAO`. Repoint the non-longest branch of the `ChainDAO` read accessors and `address_transactions` at these. Then delete `BlockDAO._block_chain`, the four `*_chain` properties, and the three classmethod `*_chain` builders. Read results stay bit-identical; the test oracle moves from the CTE to a pure-Python `prev`-walk.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]`), pytest, uv, ruff (line-length 80, single quotes), mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-egu-1b-pre-capstone-delete-recursive-cte-design.md` (issue #158)
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/models.py` | Add `ancestry_blocks_q` / `ancestry_transactions_q` / `ancestry_outflows_q` / `ancestry_inflows_q` to `BlockDAO`. Rewrite `BlockDAO.address_transactions`. Repoint the non-longest branch of `ChainDAO.{blocks,transactions,outflows,inflows}`. Then delete `BlockDAO._block_chain`, `.block_chain`, `.transactions_chain`, `.outflows_chain`, `.inflows_chain`; the classmethods `TransactionDAO.transactions_chain`, `OutflowDAO.outflows_chain`, `InflowDAO.inflows_chain`; the `CTE` import; add `false, or_` to the sqlalchemy import; trim the `*_chain` mention in the module docstring. |
+| `tests/test_models.py` | Add `_pythonic_ancestry_ids` + `_oracle_*` helpers. Rewrite the Phase-6 materialization tests and the #157 equivalence tests to use the Python oracle instead of the CTE. Flip `test_non_longest_chain_blocks_uses_cte` → `test_non_longest_chain_blocks_is_cte_free`. Add fork/canonical read-path equivalence tests. Replace the two `_block_chain` booby-trap guard tests with one structural-absence test. |
+
+No `chain.py` change — `Chain.block_chain` there is a Python `prev`-walk generator, unrelated to the SQL CTE, and stays. No schema/migration; `db check` unaffected.
+
+---
+
+## Background the implementer needs
+
+After #157, the recursive CTE survives only on **read paths**:
+
+- `ChainDAO.{blocks,transactions,outflows,inflows}` (`models.py:625–647`) each have an `if self._is_longest():` fast path that returns `BlockDAO.longest_chain_*_q()` (the materialization JOIN), and a fallback `return self.block.<x>_chain` that is the **recursive CTE** — reached only for a **non-longest (fork)** chain.
+- `BlockDAO.address_transactions` (`models.py:400`) returns `self.transactions_chain.where(...)` — the CTE, unconditionally. It currently has **zero live callers** but is kept and converted.
+
+The CTE machinery to be deleted:
+- `BlockDAO._block_chain` (`models.py:308–317`, recursive CTE), `.block_chain` (319–322), `.transactions_chain` (324–326), `.outflows_chain` (328–330), `.inflows_chain` (332–334).
+- Classmethod builders: `TransactionDAO.transactions_chain` (`models.py:105–114`), `OutflowDAO.outflows_chain` (`models.py:175–188`), `InflowDAO.inflows_chain` (`models.py:236–249`). These are used **only** by the deleted `BlockDAO` properties (`longest_chain_*_q` build their own inline joins).
+- The `CTE` import (`models.py:8`).
+
+The replacement primitive (`BlockDAO._ancestry()`, added in #157, `models.py:343`) returns `(divergent_ids, cap_position)`: ids of the short divergent suffix not in the materialization (empty for a canonical anchor), and the common-ancestor position (`None` only in the empty-materialization bootstrap). The materialized query helpers `longest_chain_blocks_q` etc. (`models.py:502–567`) show the join structure to mirror.
+
+Useful existing test fixtures/helpers (`tests/test_models.py`):
+- `_build_canonical_chain_with_spend(add_chain_block, time_stepper, wallet)` → `(chain, block1, block2, spend_txid)`.
+- `_build_fork(time_stepper, wallet, subject)` → dict with `fork` (the non-longest tip BlockDAO), `block_1`, `block_2a`, `block_2b`, `fork_cb_txid`, `ancestor_cb_txid`, `spend_txid`, `spend_outflow_txid`.
+- Fixtures: `app`, `mill_block`, `add_chain_block`, `time_stepper`, `wallet`, `subject`, `_count`.
+
+---
+
+## Task 1: CTE-free ancestry builders + convert the read paths
+
+**Files:**
+- Modify: `src/gumptionchain/models.py` (`BlockDAO`, `ChainDAO`)
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Flip the SQL-shape test to expect no CTE (failing test)**
+
+Replace the whole `test_non_longest_chain_blocks_uses_cte` function (`tests/test_models.py:291–349`) with this. It keeps the identical fork-construction body and only changes the final assertions — the non-longest `.blocks` SQL must now be CTE-free and reference the materialization predicate.
+
+```python
+def test_non_longest_chain_blocks_is_cte_free(app, time_stepper, wallet):
+    """A non-longest ChainDAO's .blocks must NOT emit a recursive CTE after
+    #158 — it resolves ancestry via the divergent-suffix + materialization
+    predicate. Verified by emitted SQL.
+
+    Builds a real fork (chain_a + chain_b sharing block_1) so that a
+    non-longest ChainDAO row genuinely exists.
+    """
+    with app.app_context():
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        longest = ChainDAO.longest()
+        assert longest is not None
+        non_longest = next(
+            (
+                d
+                for d in db.session.execute(ChainDAO.chains()).scalars()
+                if d.id != longest.id
+            ),
+            None,
+        )
+        assert non_longest is not None, (
+            'fixture did not produce a non-longest ChainDAO row'
+        )
+        assert non_longest._is_longest() is False
+
+        compiled_sql = str(
+            non_longest.blocks.compile(compile_kwargs={'literal_binds': True})
+        )
+        assert 'RECURSIVE' not in compiled_sql.upper(), (
+            f'non-longest .blocks should be CTE-free, got:\n{compiled_sql}'
+        )
+        assert 'longest_chain_block' in compiled_sql.lower()
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_models.py::test_non_longest_chain_blocks_is_cte_free -q`
+Expected: FAIL — the non-longest `.blocks` path still returns the recursive CTE, so the SQL contains `RECURSIVE` and the assertion trips.
+
+- [ ] **Step 3: Add `false, or_` to the sqlalchemy import**
+
+In `src/gumptionchain/models.py`, edit the `from sqlalchemy import (...)` block (lines 7–16) to add `false` and `or_` (keep `CTE` for now — it is removed in Task 2). Resulting import, alphabetically consistent with the existing style:
+
+```python
+from sqlalchemy import (
+    CTE,
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Select,
+    String,
+    Text,
+    false,
+    or_,
+)
+```
+
+- [ ] **Step 4: Add the four `ancestry_*_q` builders to `BlockDAO`**
+
+In `src/gumptionchain/models.py`, place these immediately **after** `_ancestry` (i.e. just before `get_transaction_in_chain`, around line 372):
+
+```python
+def ancestry_blocks_q(self) -> Select[tuple[BlockDAO]]:
+    """Blocks in this block's ancestry, CTE-free.
+
+    Combines the short divergent suffix (ids not in the materialization)
+    with the canonical prefix (`LongestChainBlockDAO.position <= cap`) as a
+    single composable predicate. Degenerates to materialized membership for
+    a canonical anchor (`divergent` empty, `cap` = tip position). Unordered:
+    every consumer wraps this in `.subquery()` for membership/aggregation.
+    """
+    divergent, cap = self._ancestry()
+    clauses = []
+    if divergent:
+        clauses.append(BlockDAO.id.in_(divergent))
+    if cap is not None:
+        clauses.append(
+            db.select(LongestChainBlockDAO.id)
+            .where(
+                LongestChainBlockDAO.block_id == BlockDAO.id,
+                LongestChainBlockDAO.position <= cap,
+            )
+            .exists()
+        )
+    # or_(false(), *clauses) is always-false when clauses is empty (the
+    # unreachable divergent-empty + cap-None case) and a no-op wrapper
+    # otherwise.
+    return db.select(BlockDAO).where(or_(false(), *clauses))  # type: ignore[no-any-return]
+
+def ancestry_transactions_q(self) -> Select[tuple[TransactionDAO]]:
+    blocks_subq = self.ancestry_blocks_q().subquery()
+    block_alias = db.aliased(BlockDAO, blocks_subq)
+    return db.select(TransactionDAO).join(  # type: ignore[no-any-return]
+        block_alias, TransactionDAO.blocks
+    )
+
+def ancestry_outflows_q(self) -> Select[tuple[OutflowDAO]]:
+    txn_subq = self.ancestry_transactions_q().subquery()
+    txn_alias = db.aliased(TransactionDAO, txn_subq)
+    return db.select(OutflowDAO).join(  # type: ignore[no-any-return]
+        txn_alias, OutflowDAO.transaction
+    )
+
+def ancestry_inflows_q(self) -> Select[tuple[InflowDAO]]:
+    txn_subq = self.ancestry_transactions_q().subquery()
+    txn_alias = db.aliased(TransactionDAO, txn_subq)
+    return db.select(InflowDAO).join(  # type: ignore[no-any-return]
+        txn_alias, InflowDAO.transaction
+    )
+```
+
+- [ ] **Step 5: Rewrite `address_transactions`**
+
+Replace the current body (`models.py:400–403`):
+
+```python
+def address_transactions(
+    self, address: str
+) -> Select[tuple[TransactionDAO]]:
+    return self.ancestry_transactions_q().where(
+        TransactionDAO.address == address
+    )
+```
+
+- [ ] **Step 6: Repoint the non-longest `ChainDAO` accessors**
+
+In `ChainDAO` (`models.py:625–647`), change only the **fallback** (non-longest) return of each of the four accessors. The `if self._is_longest():` branch stays untouched.
+
+```python
+@property
+def blocks(self) -> Select[tuple[BlockDAO]]:
+    if self._is_longest():
+        return BlockDAO.longest_chain_blocks_q()
+    return self.block.ancestry_blocks_q()
+
+@property
+def transactions(self) -> Select[tuple[TransactionDAO]]:
+    if self._is_longest():
+        return BlockDAO.longest_chain_transactions_q()
+    return self.block.ancestry_transactions_q()
+
+@property
+def outflows(self) -> Select[tuple[OutflowDAO]]:
+    if self._is_longest():
+        return BlockDAO.longest_chain_outflows_q()
+    return self.block.ancestry_outflows_q()
+
+@property
+def inflows(self) -> Select[tuple[InflowDAO]]:
+    if self._is_longest():
+        return BlockDAO.longest_chain_inflows_q()
+    return self.block.ancestry_inflows_q()
+```
+
+- [ ] **Step 7: Run the SQL-shape test, expect PASS**
+
+Run: `uv run pytest tests/test_models.py::test_non_longest_chain_blocks_is_cte_free -q`
+Expected: PASS — the non-longest `.blocks` SQL is now CTE-free and references `longest_chain_block`.
+
+- [ ] **Step 8: Add read-path equivalence tests (Python oracle)**
+
+Add to `tests/test_models.py`. First the oracle helper (place it near the top of the module's helper section, after the imports):
+
+```python
+def _pythonic_ancestry_ids(block_dao):
+    """Ground-truth ancestry: block ids from this block back to genesis via
+    `prev`, computed in pure Python — independent of the CTE and the
+    materialization, so it cannot share a bug with the code under test.
+    """
+    ids = []
+    current = block_dao
+    while current is not None:
+        ids.append(current.id)
+        current = current.prev
+    return ids
+
+
+def _oracle_block_ids(select_stmt):
+    return sorted(
+        b.id for b in db.session.execute(select_stmt).scalars().all()
+    )
+```
+
+Then the equivalence tests:
+
+```python
+def test_ancestry_read_paths_match_oracle_canonical(
+    app, add_chain_block, time_stepper, wallet
+):
+    """ChainDAO read accessors + address_transactions on a canonical tip
+    return exactly the ancestry computed by the Python prev-walk oracle.
+    """
+    with app.app_context():
+        chain, _block1, block2, _spend = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        oracle_ids = sorted(_pythonic_ancestry_ids(tip))
+
+        chain_dao = ChainDAO.get(block2.block_hash)
+        assert chain_dao is not None
+        assert _oracle_block_ids(chain_dao.blocks) == oracle_ids
+
+        # transactions/outflows/inflows: every returned row belongs to a
+        # block in the oracle ancestry, and the row sets are non-empty.
+        txn_ids = {
+            t.id
+            for t in db.session.execute(chain_dao.transactions).scalars().all()
+        }
+        assert txn_ids
+        for t in db.session.execute(chain_dao.transactions).scalars().all():
+            assert {b.id for b in t.blocks} & set(oracle_ids)
+
+        # address_transactions filters the same ancestry by address.
+        addr_txns = list(
+            db.session.execute(
+                tip.address_transactions(wallet.address)
+            ).scalars()
+        )
+        assert all(t.address == wallet.address for t in addr_txns)
+
+
+def test_ancestry_read_paths_match_oracle_fork(
+    app, time_stepper, wallet, subject
+):
+    """The non-longest (fork) read accessors resolve the fork tip's ancestry
+    (divergent suffix + shared prefix) identically to the Python oracle, and
+    fork balances/outflows are correct.
+    """
+    with app.app_context():
+        f = _build_fork(time_stepper, wallet, subject)
+        fork = f['fork']
+        assert fork is not None
+        assert fork._ancestry()[0]  # genuine non-empty divergent suffix
+        oracle_ids = sorted(_pythonic_ancestry_ids(fork))
+
+        chain_dao = ChainDAO.get(f['block_2b'].block_hash)
+        assert chain_dao is not None
+        assert chain_dao._is_longest() is False
+        assert _oracle_block_ids(chain_dao.blocks) == oracle_ids
+
+        # The fork tip's coinbase outflow lives only on the divergent suffix;
+        # the opposition stake it created is visible on the fork chain.
+        opp = chain_dao.opposition_balance(subject)
+        assert opp > 0
+
+        # unspent_outflows on the fork: every row's parent block is in the
+        # oracle ancestry.
+        unspent = list(
+            db.session.execute(
+                chain_dao.unspent_outflows(wallet.address)
+            ).scalars()
+        )
+        for o in unspent:
+            assert {b.id for b in o.transaction.blocks} & set(oracle_ids)
+
+
+def test_ancestry_read_paths_match_oracle_bootstrap(
+    app, add_chain_block, time_stepper, wallet
+):
+    """With an empty materialization, ancestry_*_q resolve via the
+    all-divergent predicate and still match the oracle.
+    """
+    with app.app_context():
+        _chain, _block1, block2, _spend = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        db.session.execute(db.delete(LongestChainBlockDAO))
+        db.session.commit()
+        assert _count(LongestChainBlockDAO) == 0
+
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        oracle_ids = sorted(_pythonic_ancestry_ids(tip))
+        assert _oracle_block_ids(tip.ancestry_blocks_q()) == oracle_ids
+```
+
+- [ ] **Step 9: Run the new tests + full suite, expect PASS**
+
+Run: `uv run pytest tests/test_models.py -k "ancestry_read_paths or is_cte_free" -q`
+Expected: PASS (4 tests).
+Run: `uv run pytest -q`
+Expected: green — the CTE-oracle tests still pass here because the CTE is still defined (Task 2 swaps their oracle).
+
+- [ ] **Step 10: Lint, format, types**
+
+Run: `uv run ruff format src tests && uv run ruff check src tests && uv run mypy`
+Expected: all green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/gumptionchain/models.py tests/test_models.py
+git commit -m "$(cat <<'EOF'
+perf(models): CTE-free ancestry read paths via divergent-suffix predicate (#158)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Swap the test oracle to the Python prev-walk, then delete the CTE
+
+**Files:**
+- Modify: `src/gumptionchain/models.py`
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Repoint the Phase-6 materialization tests off the CTE oracle**
+
+In `tests/test_models.py`, three tests use `db.session.execute(longest.block.block_chain).scalars()` as ground truth. Replace each `cte_ids = [...]` block with the Python oracle. The oracle returns tip→genesis order (self first, then `prev`), matching `position.desc()`.
+
+In `test_longest_chain_block_property_matches_cte` (around lines 255–258), replace:
+
+```python
+        cte_ids = [
+            b.id
+            for b in db.session.execute(longest.block.block_chain).scalars()
+        ]
+```
+with:
+```python
+        oracle_ids = _pythonic_ancestry_ids(longest.block)
+```
+and change the final assertion `assert cte_ids == mat_ids` → `assert oracle_ids == mat_ids`. Rename the function to `test_longest_chain_block_property_matches_prev_walk` and update its docstring to say "prev-walk" instead of "CTE".
+
+In `test_longest_chain_block_rebuild_on_reorg` (around lines 381–384), replace the same `cte_ids = [...]` block with `oracle_ids = _pythonic_ancestry_ids(longest.block)` and `assert cte_ids == mat_ids` → `assert oracle_ids == mat_ids`.
+
+In `test_iterative_walk_matches_cte` (around lines 412–415), replace the `cte_ids = [...]` capture with `oracle_ids = _pythonic_ancestry_ids(longest.block)` (capture it before the rebuild, same position) and update both `assert cte_ids == mat_ids` → `assert oracle_ids == mat_ids`. Rename the function to `test_iterative_walk_matches_prev_walk` and update its docstring.
+
+- [ ] **Step 2: Repoint the #157 equivalence tests + `_cte_get_block_in_chain` off the CTE oracle**
+
+Replace the `_cte_get_block_in_chain` helper (`tests/test_models.py:792–800`) with an oracle-based version:
+
+```python
+def _oracle_get_block_in_chain(block_dao, block_hash=None, idx=None):
+    """Ground-truth get_block_in_chain via the Python prev-walk ancestry."""
+    ids = _pythonic_ancestry_ids(block_dao)
+    stmt = db.select(BlockDAO).where(BlockDAO.id.in_(ids))
+    if block_hash is not None:
+        stmt = stmt.where(BlockDAO.block_hash == block_hash)
+    if idx is not None:
+        stmt = stmt.where(BlockDAO.idx == idx)
+    return db.session.execute(stmt).scalar_one_or_none()
+
+
+def _oracle_txn_in_chain(block_dao, txid):
+    ids = _pythonic_ancestry_ids(block_dao)
+    return db.session.execute(
+        db.select(TransactionDAO)
+        .join(TransactionDAO.blocks)
+        .where(BlockDAO.id.in_(ids))
+        .where(TransactionDAO.txid == txid)
+    ).scalar_one_or_none()
+
+
+def _oracle_inflow_exists(block_dao, outflow_txid, outflow_idx):
+    ids = _pythonic_ancestry_ids(block_dao)
+    hit = (
+        db.session.execute(
+            db.select(InflowDAO)
+            .join(InflowDAO.transaction)
+            .join(TransactionDAO.blocks)
+            .where(BlockDAO.id.in_(ids))
+            .where(InflowDAO.outflow_txid == outflow_txid)
+            .where(InflowDAO.outflow_idx == outflow_idx)
+        )
+        .scalars()
+        .first()
+    )
+    return 1 if hit is not None else 0
+```
+
+Then update the three equivalence tests to call these helpers instead of the CTE properties:
+
+In `test_hot_path_methods_match_cte_canonical` (lines 875–923):
+- The txn loop: replace the `cte = db.session.execute(tip.transactions_chain.where(...)).scalar_one_or_none()` with `cte = _oracle_txn_in_chain(tip, txid)`.
+- The inflow loop: replace the `cte_exists = (1 if db.session.execute(tip.inflows_chain.where(...)).scalars().first() is not None else 0)` block with `cte_exists = _oracle_inflow_exists(tip, otxid, oidx)`.
+- The block loop: replace `_cte_get_block_in_chain(tip, **kwargs)` with `_oracle_get_block_in_chain(tip, **kwargs)`.
+
+In `test_hot_path_methods_match_cte_fork` (lines 926–981):
+- txn loop: `cte = db.session.execute(fork.transactions_chain.where(...)).scalar_one_or_none()` → `cte = _oracle_txn_in_chain(fork, txid)`.
+- block loop: `_cte_get_block_in_chain(fork, **kwargs)` → `_oracle_get_block_in_chain(fork, **kwargs)`.
+- inflow loop: replace the `cte_exists = (1 if db.session.execute(fork.inflows_chain.where(...)).scalars().first() is not None else 0)` block with `cte_exists = _oracle_inflow_exists(fork, otxid, oidx)`.
+
+In `test_hot_path_methods_match_cte_empty_materialization` (lines 984–1013):
+- txn loop: `cte = db.session.execute(tip.transactions_chain.where(...)).scalar_one_or_none()` → `cte = _oracle_txn_in_chain(tip, txid)`.
+
+(Optionally rename these three tests' `_cte_` suffix to `_oracle_` for accuracy; not required.)
+
+- [ ] **Step 3: Replace the two booby-trap guard tests with one structural-absence test**
+
+Delete `test_hot_path_methods_never_touch_recursive_cte` (lines 1016–1053) and `test_hot_path_methods_never_touch_recursive_cte_fork` (lines 1056–1093) — their behavioral coverage is now fully provided by the oracle equivalence tests, and they patch `_block_chain`, which is about to be deleted. Add in their place:
+
+```python
+def test_recursive_cte_is_deleted():
+    """#158 capstone: the recursive CTE and its *_chain builders must be
+    gone from every DAO — no reachable recursive-CTE code remains.
+    """
+    for attr in (
+        '_block_chain',
+        'block_chain',
+        'transactions_chain',
+        'outflows_chain',
+        'inflows_chain',
+    ):
+        assert not hasattr(BlockDAO, attr), (
+            f'BlockDAO.{attr} should be deleted in #158'
+        )
+    assert not hasattr(TransactionDAO, 'transactions_chain')
+    assert not hasattr(OutflowDAO, 'outflows_chain')
+    assert not hasattr(InflowDAO, 'inflows_chain')
+```
+
+Also check `PropertyMock` is still used elsewhere in the file; if these were its only uses, drop it from the `from unittest.mock import PropertyMock, patch` import (and `patch` if likewise unused) to keep ruff happy.
+
+- [ ] **Step 4: Run the absence test, expect FAIL**
+
+Run: `uv run pytest tests/test_models.py::test_recursive_cte_is_deleted -q`
+Expected: FAIL — the CTE attributes still exist (deletion happens next).
+
+- [ ] **Step 5: Delete the CTE properties and classmethod builders**
+
+In `src/gumptionchain/models.py`:
+
+1. Delete `TransactionDAO.transactions_chain` (the classmethod, lines 105–114).
+2. Delete `OutflowDAO.outflows_chain` (the classmethod, lines 175–188).
+3. Delete `InflowDAO.inflows_chain` (the classmethod, lines 236–249).
+4. Delete the five `BlockDAO` CTE members (lines 308–334): the `_block_chain` property, `block_chain`, `transactions_chain`, `outflows_chain`, `inflows_chain`.
+5. Remove `CTE` from the `from sqlalchemy import (...)` block (added `false, or_` remain).
+6. Trim the module docstring (lines 22–27): it explains the `# type: ignore[no-any-return]` on "Chain-factory returns". Keep the explanation (still applies to `longest_chain_*_q` and the new `ancestry_*_q`), but it needs no edit unless it names the deleted methods — leave as-is if generic.
+
+- [ ] **Step 6: Run the absence test + full suite, expect PASS**
+
+Run: `uv run pytest tests/test_models.py::test_recursive_cte_is_deleted -q`
+Expected: PASS.
+Run: `uv run pytest -q`
+Expected: green — all oracle-based equivalence tests pass against the Python prev-walk; no test references the deleted CTE.
+
+- [ ] **Step 7: grep clean + lint + format + types**
+
+Run:
+```bash
+grep -n "_block_chain\|\.transactions_chain\|\.outflows_chain\|\.inflows_chain\|block_alias.*_block_chain" src/gumptionchain/models.py
+```
+Expected: no matches (the only remaining `block_chain` token in the codebase is `chain.py`'s domain `Chain.block_chain` generator, which is intentionally separate).
+
+Run: `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: all green. (`CTE` no longer imported; `false`/`or_` used; no unused `# type: ignore`.)
+
+- [ ] **Step 8: Confirm `db check` is unaffected (no schema drift)**
+
+```bash
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///_dbcheck.db uv run gumptionchain db upgrade
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///_dbcheck.db uv run gumptionchain db check
+rm -f _dbcheck.db
+```
+Expected: no differences.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/gumptionchain/models.py tests/test_models.py
+git commit -m "$(cat <<'EOF'
+perf(models): delete the recursive _block_chain CTE — capstone (#158)
+
+Remove BlockDAO._block_chain and the block_chain/transactions_chain/
+outflows_chain/inflows_chain builders now that all read paths resolve
+ancestry via the materialization + divergent-suffix predicate. Equivalence
+tests' oracle moves to a pure-Python prev-walk; a structural-absence test
+gates that no recursive-CTE code remains.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** non-longest `ChainDAO` accessors + `address_transactions` converted (Task 1); CTE + builders deleted (Task 2); Python-oracle equivalence on canonical/fork/bootstrap (Task 1 Step 8); structural-absence "CTE is gone" gate (Task 2 Step 3); grep-clean (Task 2 Step 7). `chain.py` `Chain.block_chain` correctly left alone.
+- **Behavior preservation:** only the non-longest branch and the (dead) `address_transactions` change; the canonical `_is_longest()` → `longest_chain_*_q` fast path is byte-for-byte unchanged. Consumers (`wallet_balance`, `unspent_outflows`, `unrescinded_outflows`, `_stake_balance`, `wallet_leaderboard`) inherit the conversion through `self.inflows/outflows/transactions` and are exercised by the fork equivalence test.
+- **Ordering:** `ancestry_*_q` are deliberately unordered (consumers wrap in `.subquery()`); documented in the `ancestry_blocks_q` docstring.
+- **Type consistency:** new builders return `Select[tuple[...]]` with the module's `# type: ignore[no-any-return]` convention; `false`/`or_` imported from sqlalchemy; `CTE` removed.
+- **TDD drivers:** Task 1 is driven red→green by the SQL-shape test (`is_cte_free`); Task 2's deletion is driven red→green by the structural-absence test. The oracle swap (Task 2 Steps 1–2) stays green throughout (oracle returns identical answers while the CTE is still defined), so the deletion in Step 5 is safe.
+
+## Definition of done
+
+- `ancestry_blocks_q` / `ancestry_transactions_q` / `ancestry_outflows_q` / `ancestry_inflows_q` added; non-longest `ChainDAO` accessors and `address_transactions` route through them; **no** `_block_chain`/`*_chain` reference remains.
+- `BlockDAO._block_chain`, the four `*_chain` properties, the three classmethod builders, and the `CTE` import are deleted; grep clean in `models.py`.
+- `test_non_longest_chain_blocks_is_cte_free`, the oracle-based equivalence tests (canonical/fork/bootstrap), and `test_recursive_cte_is_deleted` pass; the Phase-6 and #157 tests pass against the Python prev-walk oracle.
+- Full suite + ruff + ruff-format + mypy green; `db check` shows no drift.

--- a/docs/superpowers/specs/2026-06-05-egu-1b-pre-capstone-delete-recursive-cte-design.md
+++ b/docs/superpowers/specs/2026-06-05-egu-1b-pre-capstone-delete-recursive-cte-design.md
@@ -1,0 +1,166 @@
+# EGU 1b-pre capstone — delete the recursive `_block_chain` CTE — design
+
+**Date:** 2026-06-05
+**Status:** Approved design, pre-implementation
+**Issue:** #158 (capstone to #157; part of EGU 1b readiness, #151)
+**Type:** Performance / read-path refactor + dead-CTE removal — no schema, no migration, no consensus rule change
+
+## Summary
+
+#157 removed the recursive `BlockDAO._block_chain` CTE from the
+consensus-validation **hot path** (Tier 1). The CTE is still reachable from the
+single-pass **read paths** (Tier 2): the non-longest branch of the `ChainDAO`
+read accessors, and `address_transactions`. A recursive CTE on *any* reachable
+path is a latent O(chain-height) failure at height. This task converts the
+remaining consumers to the divergent-suffix + position-scoped primitive from
+#157 and then **deletes the recursive CTE entirely**, so it can never run.
+
+Goal: **zero recursive-CTE code in the tree.** No schema change, no
+consensus-rule change — read results are bit-identical to the pre-deletion CTE.
+
+## Tier-2 consumers converted
+
+| Consumer | Location | Notes |
+|---|---|---|
+| `ChainDAO.{blocks,transactions,outflows,inflows}` non-longest branch | `models.py:629–647` | Only reached for a **fork** chain (the `_is_longest()` fast path already routes canonical chains to `longest_chain_*_q`). Consumers (`unspent_outflows`, `wallet_balance`, `unrescinded_outflows`, `_stake_balance`, `wallet_leaderboard`) all wrap these `Select`s in `.subquery()` for membership/aggregation, so their row **ordering is unobservable**. |
+| `BlockDAO.address_transactions` + `ChainDAO.address_transactions` | `models.py:400`, `:897` | Wallet transaction-history query. Currently has **zero live callers** anywhere in the tree, but is being **kept and converted** (not deleted) per decision, so a future wallet-history feature lands on a CTE-free path. |
+
+## Decisions log
+
+- **`address_transactions`: convert, don't delete.** It is currently dead code
+  (no callers in views/api/cli/templates/tests), but we keep the method and
+  route it CTE-free so wallet-history can be wired up later without reintroducing
+  the CTE.
+- **Test oracle after deletion: a pure-Python `prev`-walk.** The #157 equivalence
+  tests and the Phase-6 materialization tests currently use the recursive CTE
+  (`block.block_chain` / `transactions_chain` / `inflows_chain`) as their
+  ground-truth oracle. Deleting the CTE removes that oracle. Replace it with a
+  test-only helper that walks `block.prev` in Python — fully independent of all
+  production SQL (both the CTE and the materialization), so the oracle cannot
+  share a bug with the code under test.
+- **Touch only the non-longest branch.** The canonical `_is_longest()` →
+  `longest_chain_*_q` fast path is left exactly as-is; only the fork fallback and
+  `address_transactions` change.
+- **No ordering on the non-longest read builders.** Every consumer wraps them in
+  `.subquery()` for set membership/aggregation; tip→genesis order is unobservable
+  there. The ordered canonical path is untouched.
+- **One PR, ordered commits** (convert → delete → test-rework). Deletion must be
+  atomic with the last consumer's conversion: the CTE can't be deleted while
+  referenced, and leaving it converted-but-present would not satisfy the
+  grep-clean acceptance goal.
+- No schema / migration / consensus-rule change; read results bit-identical to
+  the CTE.
+
+## Core mechanism: ancestry as a composable `Select`
+
+#157 added `BlockDAO._ancestry() -> (divergent_ids, cap_position)`, resolving a
+block's ancestry against `LongestChainBlockDAO` without recursion. This task
+exposes that ancestry as `Select`s for the read paths via a composable block
+predicate:
+
+```
+block.id IN (:divergent_ids)
+  OR EXISTS (SELECT 1 FROM longest_chain_block lcb
+             WHERE lcb.block_id = block.id AND lcb.position <= :cap)
+```
+
+For a canonical anchor `divergent_ids` is empty and `:cap` is the tip position,
+so the predicate degenerates to materialized membership (equivalent to today's
+`longest_chain_*_q`). For a fork it is the short divergent suffix OR the
+canonical prefix at/below the common ancestor. Genesis is always materialized,
+so a common ancestor always exists post-bootstrap; in the transient empty
+materialization (`cap is None`) the predicate is `block.id IN (:divergent_ids)`
+over the whole walked chain.
+
+### New `BlockDAO` query builders (sketch — illustrative, not final)
+
+```python
+def ancestry_blocks_q(self) -> Select[tuple[BlockDAO]]:
+    divergent, cap = self._ancestry()
+    clauses = []
+    if divergent:
+        clauses.append(BlockDAO.id.in_(divergent))
+    if cap is not None:
+        clauses.append(
+            db.select(LongestChainBlockDAO.id)
+            .where(
+                LongestChainBlockDAO.block_id == BlockDAO.id,
+                LongestChainBlockDAO.position <= cap,
+            )
+            .exists()
+        )
+    predicate = db.or_(*clauses) if clauses else db.false()
+    return db.select(BlockDAO).where(predicate)
+
+def ancestry_transactions_q(self) -> Select[tuple[TransactionDAO]]:
+    blocks_subq = self.ancestry_blocks_q().subquery()
+    block_alias = db.aliased(BlockDAO, blocks_subq)
+    return db.select(TransactionDAO).join(block_alias, TransactionDAO.blocks)
+
+def ancestry_outflows_q(self) -> Select[tuple[OutflowDAO]]:
+    txn_subq = self.ancestry_transactions_q().subquery()
+    txn_alias = db.aliased(TransactionDAO, txn_subq)
+    return db.select(OutflowDAO).join(txn_alias, OutflowDAO.transaction)
+
+def ancestry_inflows_q(self) -> Select[tuple[InflowDAO]]:
+    txn_subq = self.ancestry_transactions_q().subquery()
+    txn_alias = db.aliased(TransactionDAO, txn_subq)
+    return db.select(InflowDAO).join(txn_alias, InflowDAO.transaction)
+```
+
+These mirror the `longest_chain_*_q` join structure (blocks → transactions →
+outflows/inflows) and reuse the FSA-facade `# type: ignore[no-any-return]`
+convention already established in the module.
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/models.py` | Add `ancestry_blocks_q` / `ancestry_transactions_q` / `ancestry_outflows_q` / `ancestry_inflows_q` to `BlockDAO`. Rewrite `address_transactions` to use `ancestry_transactions_q`. Repoint the `ChainDAO.{blocks,transactions,outflows,inflows}` **non-longest** branches from `self.block.<x>_chain` to `self.block.ancestry_<x>_q()`. Then **delete** `BlockDAO._block_chain`, `.block_chain`, `.transactions_chain`, `.outflows_chain`, `.inflows_chain`; the classmethod builders `TransactionDAO.transactions_chain`, `OutflowDAO.outflows_chain`, `InflowDAO.inflows_chain`; the now-unused `CTE` import; and trim the `*_chain` mention in the module docstring (lines ~22–27). |
+| `tests/test_models.py` | Add a `_pythonic_ancestry_ids(block_dao)` oracle. Rewrite the #157 equivalence tests and the Phase-6 materialization tests that use `block.block_chain`/`transactions_chain`/`inflows_chain` as oracle to use it instead. Replace the `_block_chain` booby-trap guard tests with structural absence assertions. Add fork read-path equivalence tests for the `ChainDAO` accessors + `wallet_balance`/`unspent_outflows`. |
+
+No `chain.py` change — `Chain.block_chain` there is a Python `prev`-walk
+generator, unrelated to the SQL CTE. No schema/migration; `db check` unaffected.
+
+## Testing (equivalence + structural absence)
+
+1. **Read-path equivalence (canonical + fork)** — for a mined canonical chain
+   and a genuine fork, assert `ChainDAO.{blocks,transactions,outflows,inflows}`,
+   `address_transactions`, `wallet_balance`, and `unspent_outflows` return the
+   **same** rows/values as computed from the `_pythonic_ancestry_ids` oracle
+   (the set of blocks reachable via `prev` from the chain tip). Cover the fork
+   case specifically: a balance/outflow that exists only on the divergent suffix,
+   and one below the common ancestor.
+2. **Bootstrap** — with an empty `longest_chain_block`, the `ancestry_*_q`
+   builders resolve via the all-divergent predicate and still match the oracle.
+3. **Structural absence (the "CTE is gone" gate)** — assert the recursive-CTE
+   attributes no longer exist: `not hasattr(BlockDAO, '_block_chain')`, and the
+   four `*_chain` properties, and the three classmethod builders. This replaces
+   the #157 booby-trap guard tests.
+4. **Full suite green** — the existing chain/validation/balance/miller tests must
+   pass unchanged; behavior is preserved, only the CTE implementation is removed.
+5. **`db check`** — no schema drift (this change adds no columns/tables).
+
+No wall-clock perf assertion (CI-flaky); the structural-absence test plus the
+equivalence tests are the proof that no path recurses.
+
+## Out of scope
+
+- **EGU 1b constant retune** (block time, retarget interval, difficulty floor,
+  base-reward magnitude, RSA→2048) — the sibling task this unblocks.
+- **#150** — the N+1 in `unrescinded_outflows` on the cold rescind-*build* path.
+  (`unrescinded_outflows` is touched here only to repoint its `self.inflows` /
+  `self.transactions` / `self.outflows` sources through the converted accessors;
+  the N+1 itself is a separate concern.)
+
+## Definition of done
+
+- `ancestry_*_q` builders added; the non-longest `ChainDAO` accessors and
+  `address_transactions` resolve ancestry via materialization (canonical) +
+  divergent-suffix (fork), with **no** `_block_chain` reference.
+- `BlockDAO._block_chain`, the four `*_chain` properties, and the three
+  classmethod builders are **deleted**; the `CTE` import is removed.
+- grep for `_block_chain` / `*_chain` CTE props is clean across `src`.
+- Structural-absence test confirms the CTE attributes are gone; read-path
+  equivalence (canonical + fork + bootstrap) passes against the Python oracle.
+- Full suite + ruff + ruff-format + mypy green; `db check` shows no drift.

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -309,9 +309,8 @@ class BlockDAO(Base):
         with the canonical prefix (`LongestChainBlockDAO.position <= cap`) as a
         single composable predicate. Degenerates to materialized membership for
         a canonical anchor (`divergent` empty, `cap` = tip position). Ordered
-        by `idx` desc to match the recursive `block_chain` CTE's tip-first
-        ordering, so consumers that read rows directly (not just as a
-        membership subquery) see the same order.
+        by `idx` desc (tip→genesis), so consumers that read rows directly
+        (not just as a membership subquery) see a consistent order.
         """
         divergent, cap = self._ancestry()
         clauses = []
@@ -505,9 +504,9 @@ class BlockDAO(Base):
     def longest_chain_blocks_q(cls) -> Select[tuple[BlockDAO]]:
         """Blocks in the longest chain, ordered tip→genesis.
 
-        Matches BlockDAO.block_chain's tip-first ordering so consumers
-        that compose on the result (subquery / filter / first) see the
-        same row order.
+        Ordered by `position` desc (tip→genesis) so consumers that
+        compose on the result (subquery / filter / first) see a
+        consistent row order.
         """
         return (  # type: ignore[no-any-return]
             db.select(BlockDAO)

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -5,7 +5,6 @@ from collections.abc import Generator
 from typing import Any, ClassVar
 
 from sqlalchemy import (
-    CTE,
     BigInteger,
     DateTime,
     ForeignKey,
@@ -104,17 +103,6 @@ class TransactionDAO(Base):
             db.select(cls).filter_by(txid=txid)
         ).scalar_one_or_none()
 
-    @classmethod
-    def transactions_chain(
-        cls, block_chain: Select[tuple[BlockDAO]]
-    ) -> Select[tuple[TransactionDAO]]:
-        block_alias = db.aliased(BlockDAO, block_chain.subquery())
-        return (  # type: ignore[no-any-return]
-            db.select(TransactionDAO)
-            .join(block_alias, TransactionDAO.blocks)
-            .order_by(TransactionDAO.timestamp.desc(), TransactionDAO.id)
-        )
-
 
 class OutflowDAO(Base):
     __tablename__ = 'outflow'
@@ -174,21 +162,6 @@ class OutflowDAO(Base):
             db.select(cls).filter_by(txid=outflow_txid, idx=outflow_idx)
         ).scalar_one_or_none()
 
-    @classmethod
-    def outflows_chain(
-        cls, transactions_chain: Select[tuple[TransactionDAO]]
-    ) -> Select[tuple[OutflowDAO]]:
-        txn_alias = db.aliased(TransactionDAO, transactions_chain.subquery())
-        return (  # type: ignore[no-any-return]
-            db.select(OutflowDAO)
-            .join(txn_alias, OutflowDAO.transaction)
-            .order_by(
-                txn_alias.timestamp.desc(),
-                txn_alias.txid,
-                OutflowDAO.idx,
-            )
-        )
-
 
 class InflowDAO(Base):
     __tablename__ = 'inflow'
@@ -234,21 +207,6 @@ class InflowDAO(Base):
                 ).scalar_one_or_none()
             self.outflow = outflow_dao  # type: ignore[assignment]
             self.transaction = transaction_dao  # type: ignore[assignment]
-
-    @classmethod
-    def inflows_chain(
-        cls, transactions_chain: Select[tuple[TransactionDAO]]
-    ) -> Select[tuple[InflowDAO]]:
-        txn_alias = db.aliased(TransactionDAO, transactions_chain.subquery())
-        return (  # type: ignore[no-any-return]
-            db.select(InflowDAO)
-            .join(txn_alias, InflowDAO.transaction)
-            .order_by(
-                txn_alias.timestamp.desc(),
-                txn_alias.txid,
-                InflowDAO.idx,
-            )
-        )
 
 
 class BlockDAO(Base):
@@ -306,34 +264,6 @@ class BlockDAO(Base):
         self.prev = prev_dao or BlockDAO.get(prev_hash)
         for transaction_dao in transaction_daos or []:
             self.transactions.append(transaction_dao)
-
-    @property
-    def _block_chain(self) -> CTE:
-        base = (
-            db.select(BlockDAO)
-            .where(BlockDAO.id == self.id)
-            .cte(recursive=True)
-        )
-        return base.union_all(  # type: ignore[no-any-return]
-            db.select(BlockDAO).where(BlockDAO.id == base.c.prev_id)
-        )
-
-    @property
-    def block_chain(self) -> Select[tuple[BlockDAO]]:
-        block_alias = db.aliased(BlockDAO, self._block_chain)
-        return db.select(block_alias)  # type: ignore[no-any-return]
-
-    @property
-    def transactions_chain(self) -> Select[tuple[TransactionDAO]]:
-        return TransactionDAO.transactions_chain(self.block_chain)
-
-    @property
-    def outflows_chain(self) -> Select[tuple[OutflowDAO]]:
-        return OutflowDAO.outflows_chain(self.transactions_chain)
-
-    @property
-    def inflows_chain(self) -> Select[tuple[InflowDAO]]:
-        return InflowDAO.inflows_chain(self.transactions_chain)
 
     def commit(self, *, commit: bool = True) -> None:
         db.session.add(self)
@@ -592,8 +522,8 @@ class BlockDAO(Base):
     def longest_chain_transactions_q(cls) -> Select[tuple[TransactionDAO]]:
         """Transactions in the longest chain, ordered tip→genesis.
 
-        Matches TransactionDAO.transactions_chain's ordering
-        (timestamp.desc, id) within the longest chain's block set.
+        Ordered by (timestamp.desc, id) within the longest chain's
+        block set.
         """
         blocks_subq = cls.longest_chain_blocks_q().subquery()
         block_alias = db.aliased(BlockDAO, blocks_subq)
@@ -606,8 +536,7 @@ class BlockDAO(Base):
     @classmethod
     def longest_chain_outflows_q(cls) -> Select[tuple[OutflowDAO]]:
         """Outflows in the longest chain, ordered by their parent txn's
-        timestamp desc, then txid, then outflow idx — matching
-        OutflowDAO.outflows_chain's ordering.
+        timestamp desc, then txid, then outflow idx.
         """
         txn_subq = cls.longest_chain_transactions_q().subquery()
         txn_alias = db.aliased(TransactionDAO, txn_subq)
@@ -623,8 +552,8 @@ class BlockDAO(Base):
 
     @classmethod
     def longest_chain_inflows_q(cls) -> Select[tuple[InflowDAO]]:
-        """Inflows in the longest chain, ordered analogously to
-        InflowDAO.inflows_chain (timestamp desc, txid, inflow idx).
+        """Inflows in the longest chain, ordered by their parent txn's
+        timestamp desc, then txid, then inflow idx.
         """
         txn_subq = cls.longest_chain_transactions_q().subquery()
         txn_alias = db.aliased(TransactionDAO, txn_subq)
@@ -646,7 +575,8 @@ class LongestChainBlockDAO(Base):
     with `position` 0 at genesis and increasing toward the tip. Maintained
     by ChainDAO.sync_longest_chain_blocks() — never written from anywhere
     else. Phase 6 (2026-05-27) introduced this table to eliminate the
-    recursive `BlockDAO._block_chain` CTE from hot-path reads.
+    recursive block-ancestry CTE (since deleted in #158) from hot-path
+    reads.
     """
 
     __tablename__ = 'longest_chain_block'

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -13,6 +13,8 @@ from sqlalchemy import (
     Select,
     String,
     Text,
+    false,
+    or_,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -370,6 +372,74 @@ class BlockDAO(Base):
             current = current.prev
         return divergent, None
 
+    def ancestry_blocks_q(self) -> Select[tuple[BlockDAO]]:
+        """Blocks in this block's ancestry, CTE-free, ordered tip→genesis.
+
+        Combines the short divergent suffix (ids not in the materialization)
+        with the canonical prefix (`LongestChainBlockDAO.position <= cap`) as a
+        single composable predicate. Degenerates to materialized membership for
+        a canonical anchor (`divergent` empty, `cap` = tip position). Ordered
+        by `idx` desc to match the recursive `block_chain` CTE's tip-first
+        ordering, so consumers that read rows directly (not just as a
+        membership subquery) see the same order.
+        """
+        divergent, cap = self._ancestry()
+        clauses = []
+        if divergent:
+            clauses.append(BlockDAO.id.in_(divergent))
+        if cap is not None:
+            clauses.append(
+                db.select(LongestChainBlockDAO.block_id)
+                .where(
+                    LongestChainBlockDAO.block_id == BlockDAO.id,
+                    LongestChainBlockDAO.position <= cap,
+                )
+                .exists()
+            )
+        # or_(false(), *clauses) is always-false when clauses is empty (the
+        # unreachable divergent-empty + cap-None case) and a no-op wrapper
+        # otherwise.
+        return (  # type: ignore[no-any-return]
+            db.select(BlockDAO)
+            .where(or_(false(), *clauses))
+            .order_by(BlockDAO.idx.desc())
+        )
+
+    def ancestry_transactions_q(self) -> Select[tuple[TransactionDAO]]:
+        blocks_subq = self.ancestry_blocks_q().subquery()
+        block_alias = db.aliased(BlockDAO, blocks_subq)
+        return (  # type: ignore[no-any-return]
+            db.select(TransactionDAO)
+            .join(block_alias, TransactionDAO.blocks)
+            .order_by(TransactionDAO.timestamp.desc(), TransactionDAO.id)
+        )
+
+    def ancestry_outflows_q(self) -> Select[tuple[OutflowDAO]]:
+        txn_subq = self.ancestry_transactions_q().subquery()
+        txn_alias = db.aliased(TransactionDAO, txn_subq)
+        return (  # type: ignore[no-any-return]
+            db.select(OutflowDAO)
+            .join(txn_alias, OutflowDAO.transaction)
+            .order_by(
+                txn_alias.timestamp.desc(),
+                txn_alias.txid,
+                OutflowDAO.idx,
+            )
+        )
+
+    def ancestry_inflows_q(self) -> Select[tuple[InflowDAO]]:
+        txn_subq = self.ancestry_transactions_q().subquery()
+        txn_alias = db.aliased(TransactionDAO, txn_subq)
+        return (  # type: ignore[no-any-return]
+            db.select(InflowDAO)
+            .join(txn_alias, InflowDAO.transaction)
+            .order_by(
+                txn_alias.timestamp.desc(),
+                txn_alias.txid,
+                InflowDAO.idx,
+            )
+        )
+
     def get_transaction_in_chain(self, txid: str) -> TransactionDAO | None:
         divergent, cap = self._ancestry()
         if divergent:
@@ -400,7 +470,9 @@ class BlockDAO(Base):
     def address_transactions(
         self, address: str
     ) -> Select[tuple[TransactionDAO]]:
-        return self.transactions_chain.where(TransactionDAO.address == address)
+        return self.ancestry_transactions_q().where(
+            TransactionDAO.address == address
+        )
 
     def get_block_in_chain(
         self, block_hash: str | None = None, idx: int | None = None
@@ -626,25 +698,25 @@ class ChainDAO(Base):
     def blocks(self) -> Select[tuple[BlockDAO]]:
         if self._is_longest():
             return BlockDAO.longest_chain_blocks_q()
-        return self.block.block_chain
+        return self.block.ancestry_blocks_q()
 
     @property
     def transactions(self) -> Select[tuple[TransactionDAO]]:
         if self._is_longest():
             return BlockDAO.longest_chain_transactions_q()
-        return self.block.transactions_chain
+        return self.block.ancestry_transactions_q()
 
     @property
     def outflows(self) -> Select[tuple[OutflowDAO]]:
         if self._is_longest():
             return BlockDAO.longest_chain_outflows_q()
-        return self.block.outflows_chain
+        return self.block.ancestry_outflows_q()
 
     @property
     def inflows(self) -> Select[tuple[InflowDAO]]:
         if self._is_longest():
             return BlockDAO.longest_chain_inflows_q()
-        return self.block.inflows_chain
+        return self.block.ancestry_inflows_q()
 
     def unspent_outflows(
         self,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -912,7 +912,7 @@ def _build_fork(time_stepper, wallet, subject):
     }
 
 
-def test_hot_path_methods_match_cte_canonical(
+def test_hot_path_methods_match_oracle_canonical(
     app, add_chain_block, time_stepper, wallet
 ):
     with app.app_context():
@@ -949,9 +949,9 @@ def test_hot_path_methods_match_cte_canonical(
             ), f'block mismatch for {kwargs!r}'
 
 
-def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
+def test_hot_path_methods_match_oracle_fork(app, time_stepper, wallet, subject):
     """A fork (non-longest) block resolves its divergent-suffix ancestry the
-    same as the recursive CTE would.
+    same as the prev-walk oracle.
     """
     with app.app_context():
         f = _build_fork(time_stepper, wallet, subject)
@@ -993,7 +993,7 @@ def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
             )
 
 
-def test_hot_path_methods_match_cte_empty_materialization(
+def test_hot_path_methods_match_oracle_empty_materialization(
     app, add_chain_block, time_stepper, wallet
 ):
     """With an empty LongestChainBlockDAO (bootstrap), _ancestry walks the

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1144,7 +1144,10 @@ def test_ancestry_read_paths_match_oracle_canonical(
                 tip.address_transactions(wallet.address)
             ).scalars()
         )
+        assert addr_txns
         assert all(t.address == wallet.address for t in addr_txns)
+        for t in addr_txns:
+            assert {b.id for b in t.blocks} & set(oracle_ids)
 
 
 def test_ancestry_read_paths_match_oracle_fork(
@@ -1174,6 +1177,7 @@ def test_ancestry_read_paths_match_oracle_fork(
                 chain_dao.unspent_outflows(wallet.address)
             ).scalars()
         )
+        assert unspent
         for o in unspent:
             assert {b.id for b in o.transaction.blocks} & set(oracle_ids)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from _sa_helpers import _count, _count_select
 
@@ -11,6 +11,7 @@ from gumptionchain.models import (
     ChainDAO,
     InflowDAO,
     LongestChainBlockDAO,
+    OutflowDAO,
     TransactionDAO,
 )
 from gumptionchain.payload import Inflow, Outflow
@@ -259,20 +260,19 @@ def test_longest_chain_block_non_longest_extend_noop(app, time_stepper, wallet):
         ]
 
 
-def test_longest_chain_block_property_matches_cte(app, mill_block, wallet):
+def test_longest_chain_block_property_matches_prev_walk(
+    app, mill_block, wallet
+):
     """After any chain build, the materialization table contents
-    (ordered position DESC, i.e. tip→genesis) must match the recursive
-    CTE walk. Uses block_chain (the CTE) as ground truth.
+    (ordered position DESC, i.e. tip→genesis) must match the pure-Python
+    prev-walk. Uses the prev-walk oracle as ground truth.
     """
     with app.app_context():
         for _ in range(5):
             mill_block(wallet)
         longest = ChainDAO.longest()
         assert longest is not None
-        cte_ids = [
-            b.id
-            for b in db.session.execute(longest.block.block_chain).scalars()
-        ]
+        oracle_ids = _pythonic_ancestry_ids(longest.block)
         mat_ids = [
             r.block_id
             for r in db.session.execute(
@@ -283,7 +283,7 @@ def test_longest_chain_block_property_matches_cte(app, mill_block, wallet):
             .scalars()
             .all()
         ]
-        assert cte_ids == mat_ids
+        assert oracle_ids == mat_ids
 
 
 def test_longest_chain_blocks_q_fast_path_skips_cte(app, mill_block, wallet):
@@ -371,7 +371,7 @@ def test_non_longest_chain_blocks_is_cte_free(app, time_stepper, wallet):
 
 def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
     """Forcing a rebuild (via _rebuild_longest_chain_blocks) wipes
-    the table and repopulates it from the longest chain's CTE walk
+    the table and repopulates it from the longest chain's prev-walk
     so the contents match exactly.
     """
     with app.app_context():
@@ -397,11 +397,9 @@ def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
         longest._rebuild_longest_chain_blocks()
         db.session.commit()
 
-        # Table is back to 3 rows in tip→genesis order matching CTE.
-        cte_ids = [
-            b.id
-            for b in db.session.execute(longest.block.block_chain).scalars()
-        ]
+        # Table is back to 3 rows in tip→genesis order matching the
+        # prev-walk oracle.
+        oracle_ids = _pythonic_ancestry_ids(longest.block)
         mat_ids = [
             r.block_id
             for r in db.session.execute(
@@ -412,15 +410,13 @@ def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
             .scalars()
             .all()
         ]
-        assert cte_ids == mat_ids
+        assert oracle_ids == mat_ids
         assert len(mat_ids) == 3
 
 
-def test_iterative_walk_matches_cte(app, mill_block, wallet):
+def test_iterative_walk_matches_prev_walk(app, mill_block, wallet):
     """_rebuild_longest_chain_blocks via current.prev produces the
-    same block ordering as the prior recursive-CTE walk would have.
-    Uses self.block.block_chain (still defined; used as fallback)
-    as ground truth.
+    same block ordering as the pure-Python prev-walk oracle.
     """
     with app.app_context():
         for _ in range(10):
@@ -428,11 +424,8 @@ def test_iterative_walk_matches_cte(app, mill_block, wallet):
         longest = ChainDAO.longest()
         assert longest is not None
 
-        # Capture CTE ground truth before rebuild.
-        cte_ids = [
-            b.id
-            for b in db.session.execute(longest.block.block_chain).scalars()
-        ]
+        # Capture prev-walk ground truth before rebuild.
+        oracle_ids = _pythonic_ancestry_ids(longest.block)
 
         # Force a rebuild via the iterative walk (also runs on bootstrap
         # by sync_longest_chain_blocks; here we exercise it directly).
@@ -449,7 +442,7 @@ def test_iterative_walk_matches_cte(app, mill_block, wallet):
             .scalars()
             .all()
         ]
-        assert cte_ids == mat_ids
+        assert oracle_ids == mat_ids
         assert len(mat_ids) == 10
 
 
@@ -809,15 +802,42 @@ def _build_canonical_chain_with_spend(add_chain_block, time_stepper, wallet):
     return chain, block1, block2, t.txid
 
 
-def _cte_get_block_in_chain(block_dao, block_hash=None, idx=None):
-    """Ground-truth get_block_in_chain via the recursive CTE."""
-    block_alias = db.aliased(BlockDAO, block_dao.block_chain.subquery())
-    stmt = db.select(BlockDAO).join(block_alias, BlockDAO.id == block_alias.id)
+def _oracle_get_block_in_chain(block_dao, block_hash=None, idx=None):
+    """Ground-truth get_block_in_chain via the Python prev-walk ancestry."""
+    ids = _pythonic_ancestry_ids(block_dao)
+    stmt = db.select(BlockDAO).where(BlockDAO.id.in_(ids))
     if block_hash is not None:
         stmt = stmt.where(BlockDAO.block_hash == block_hash)
     if idx is not None:
         stmt = stmt.where(BlockDAO.idx == idx)
     return db.session.execute(stmt).scalar_one_or_none()
+
+
+def _oracle_txn_in_chain(block_dao, txid):
+    ids = _pythonic_ancestry_ids(block_dao)
+    return db.session.execute(
+        db.select(TransactionDAO)
+        .join(TransactionDAO.blocks)
+        .where(BlockDAO.id.in_(ids))
+        .where(TransactionDAO.txid == txid)
+    ).scalar_one_or_none()
+
+
+def _oracle_inflow_exists(block_dao, outflow_txid, outflow_idx):
+    ids = _pythonic_ancestry_ids(block_dao)
+    hit = (
+        db.session.execute(
+            db.select(InflowDAO)
+            .join(InflowDAO.transaction)
+            .join(TransactionDAO.blocks)
+            .where(BlockDAO.id.in_(ids))
+            .where(InflowDAO.outflow_txid == outflow_txid)
+            .where(InflowDAO.outflow_idx == outflow_idx)
+        )
+        .scalars()
+        .first()
+    )
+    return 1 if hit is not None else 0
 
 
 def _build_fork(time_stepper, wallet, subject):
@@ -904,29 +924,15 @@ def test_hot_path_methods_match_cte_canonical(
         assert tip is not None
 
         for txid in (spend_txid, cb1_txid, 'missing'):
-            cte = db.session.execute(
-                tip.transactions_chain.where(TransactionDAO.txid == txid)
-            ).scalar_one_or_none()
+            oracle = _oracle_txn_in_chain(tip, txid)
             new = tip.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None), (
-                f'txn mismatch for txid={txid!r}'
-            )
+            assert (new.id if new else None) == (
+                oracle.id if oracle else None
+            ), f'txn mismatch for txid={txid!r}'
 
         for otxid, oidx in ((cb1_txid, 0), ('missing', 0)):
-            cte_exists = (
-                1
-                if db.session.execute(
-                    tip.inflows_chain.where(
-                        InflowDAO.outflow_txid == otxid,
-                        InflowDAO.outflow_idx == oidx,
-                    )
-                )
-                .scalars()
-                .first()
-                is not None
-                else 0
-            )
-            assert tip.inflows_in_chain_count(otxid, oidx) == cte_exists, (
+            oracle_exists = _oracle_inflow_exists(tip, otxid, oidx)
+            assert tip.inflows_in_chain_count(otxid, oidx) == oracle_exists, (
                 f'inflow-existence mismatch for outflow=({otxid!r}, {oidx})'
             )
 
@@ -936,10 +942,10 @@ def test_hot_path_methods_match_cte_canonical(
             {'idx': 1},
             {'block_hash': 'missing'},
         ):
-            cte_block = _cte_get_block_in_chain(tip, **kwargs)
+            oracle_block = _oracle_get_block_in_chain(tip, **kwargs)
             new_block = tip.get_block_in_chain(**kwargs)
             assert (new_block.id if new_block else None) == (
-                cte_block.id if cte_block else None
+                oracle_block.id if oracle_block else None
             ), f'block mismatch for {kwargs!r}'
 
 
@@ -954,49 +960,35 @@ def test_hot_path_methods_match_cte_fork(app, time_stepper, wallet, subject):
         assert fork._ancestry()[0]  # non-empty divergent suffix
 
         for txid in (f['fork_cb_txid'], f['ancestor_cb_txid'], 'missing'):
-            cte = db.session.execute(
-                fork.transactions_chain.where(TransactionDAO.txid == txid)
-            ).scalar_one_or_none()
+            oracle = _oracle_txn_in_chain(fork, txid)
             new = fork.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None), (
-                f'txn mismatch for txid={txid!r}'
-            )
+            assert (new.id if new else None) == (
+                oracle.id if oracle else None
+            ), f'txn mismatch for txid={txid!r}'
 
         for kwargs in (
             {'block_hash': f['block_2b'].block_hash},
             {'block_hash': f['block_1'].block_hash},
             {'idx': 0},
         ):
-            cte_block = _cte_get_block_in_chain(fork, **kwargs)
+            oracle_block = _oracle_get_block_in_chain(fork, **kwargs)
             new_block = fork.get_block_in_chain(**kwargs)
             assert (new_block.id if new_block else None) == (
-                cte_block.id if cte_block else None
+                oracle_block.id if oracle_block else None
             ), f'block mismatch for {kwargs!r}'
 
         # The fork's divergent suffix consumes block_1's coinbase; check it
-        # against the CTE ground truth (hit) plus a miss. inflows_in_chain_count
-        # is 0/1 existence, not a true count.
+        # against the prev-walk oracle (hit) plus a miss.
+        # inflows_in_chain_count is 0/1 existence, not a true count.
         for otxid, oidx, expected in (
             (f['spend_outflow_txid'], 0, 1),
             ('missing', 0, 0),
         ):
-            cte_exists = (
-                1
-                if db.session.execute(
-                    fork.inflows_chain.where(
-                        InflowDAO.outflow_txid == otxid,
-                        InflowDAO.outflow_idx == oidx,
-                    )
-                )
-                .scalars()
-                .first()
-                is not None
-                else 0
+            oracle_exists = _oracle_inflow_exists(fork, otxid, oidx)
+            assert oracle_exists == expected, (
+                f'oracle ground-truth mismatch for outflow=({otxid!r}, {oidx})'
             )
-            assert cte_exists == expected, (
-                f'CTE ground-truth mismatch for outflow=({otxid!r}, {oidx})'
-            )
-            assert fork.inflows_in_chain_count(otxid, oidx) == cte_exists, (
+            assert fork.inflows_in_chain_count(otxid, oidx) == oracle_exists, (
                 f'inflow-existence mismatch for outflow=({otxid!r}, {oidx})'
             )
 
@@ -1005,7 +997,7 @@ def test_hot_path_methods_match_cte_empty_materialization(
     app, add_chain_block, time_stepper, wallet
 ):
     """With an empty LongestChainBlockDAO (bootstrap), _ancestry walks the
-    whole chain into divergent_ids and the methods still match the CTE.
+    whole chain into divergent_ids and the methods still match the oracle.
     """
     with app.app_context():
         _chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
@@ -1022,95 +1014,32 @@ def test_hot_path_methods_match_cte_empty_materialization(
         assert len(divergent) == 2  # whole chain is "divergent"
 
         for txid in (spend_txid, block1.coinbase.txid, 'missing'):
-            cte = db.session.execute(
-                tip.transactions_chain.where(TransactionDAO.txid == txid)
-            ).scalar_one_or_none()
+            oracle = _oracle_txn_in_chain(tip, txid)
             new = tip.get_transaction_in_chain(txid)
-            assert (new.id if new else None) == (cte.id if cte else None), (
-                f'txn mismatch for txid={txid!r}'
-            )
+            assert (new.id if new else None) == (
+                oracle.id if oracle else None
+            ), f'txn mismatch for txid={txid!r}'
         assert tip.get_block_in_chain(idx=0) is not None
         assert tip.inflows_in_chain_count(block1.coinbase.txid, 0) == 1
 
 
-def test_hot_path_methods_never_touch_recursive_cte(
-    app, add_chain_block, time_stepper, wallet
-):
-    """get_transaction_in_chain / inflows_in_chain_count / get_block_in_chain
-    must not access the recursive _block_chain CTE on canonical OR fork
-    anchors. Booby-trap _block_chain to raise; the three methods must still
-    return correct results.
+def test_recursive_cte_is_deleted():
+    """#158 capstone: the recursive CTE and its *_chain builders must be
+    gone from every DAO — no reachable recursive-CTE code remains.
     """
-    with app.app_context():
-        _chain, block1, block2, spend_txid = _build_canonical_chain_with_spend(
-            add_chain_block, time_stepper, wallet
+    for attr in (
+        '_block_chain',
+        'block_chain',
+        'transactions_chain',
+        'outflows_chain',
+        'inflows_chain',
+    ):
+        assert not hasattr(BlockDAO, attr), (
+            f'BlockDAO.{attr} should be deleted in #158'
         )
-        cb1_txid = block1.coinbase.txid
-        tip_dao = BlockDAO.get(block2.block_hash)
-        genesis_dao = BlockDAO.get(block1.block_hash)
-        assert tip_dao is not None
-        assert genesis_dao is not None
-
-        with patch.object(
-            BlockDAO, '_block_chain', new_callable=PropertyMock
-        ) as cte_mock:
-            cte_mock.side_effect = AssertionError(
-                'hot-path method accessed the recursive CTE'
-            )
-            # canonical anchor (the tip)
-            assert tip_dao.get_transaction_in_chain(spend_txid) is not None
-            assert tip_dao.get_transaction_in_chain('does-not-exist') is None
-            # the spend consumed block1's coinbase outflow → present (0/1
-            # existence, not a true count)
-            assert tip_dao.inflows_in_chain_count(cb1_txid, 0) == 1
-            assert tip_dao.inflows_in_chain_count('nope', 0) == 0
-            assert (
-                tip_dao.get_block_in_chain(block_hash=block1.block_hash)
-                is not None
-            )
-            assert tip_dao.get_block_in_chain(idx=0) is not None
-            # an ancestor anchor still resolves its own ancestry
-            assert genesis_dao.get_transaction_in_chain(cb1_txid) is not None
-
-
-def test_hot_path_methods_never_touch_recursive_cte_fork(
-    app, time_stepper, wallet, subject
-):
-    """The divergent (fork) branch of all three methods — including
-    get_block_in_chain's `if divergent:` block — must execute CTE-free.
-    Booby-trap _block_chain over a genuine fork anchor.
-    """
-    with app.app_context():
-        f = _build_fork(time_stepper, wallet, subject)
-        fork = f['fork']
-        assert fork is not None
-        # Confirm a real divergent suffix BEFORE arming the trap.
-        assert fork._ancestry()[0]
-
-        with patch.object(
-            BlockDAO, '_block_chain', new_callable=PropertyMock
-        ) as cte_mock:
-            cte_mock.side_effect = AssertionError(
-                'hot-path method accessed the recursive CTE'
-            )
-            # get_transaction_in_chain — divergent-suffix hit + miss.
-            assert fork.get_transaction_in_chain(f['fork_cb_txid']) is not None
-            assert fork.get_transaction_in_chain('does-not-exist') is None
-            # get_block_in_chain — fork tip (divergent) and shared prefix.
-            assert (
-                fork.get_block_in_chain(block_hash=f['block_2b'].block_hash)
-                is not None
-            )
-            assert (
-                fork.get_block_in_chain(block_hash=f['block_1'].block_hash)
-                is not None
-            )
-            assert fork.get_block_in_chain(idx=0) is not None
-            # inflows_in_chain_count — inflow consumed in the divergent
-            # suffix is present; a missing one is absent (0/1 existence,
-            # not a true count).
-            assert fork.inflows_in_chain_count(f['spend_outflow_txid'], 0) == 1
-            assert fork.inflows_in_chain_count('nope', 0) == 0
+    assert not hasattr(TransactionDAO, 'transactions_chain')
+    assert not hasattr(OutflowDAO, 'outflows_chain')
+    assert not hasattr(InflowDAO, 'inflows_chain')
 
 
 def test_ancestry_read_paths_match_oracle_canonical(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,23 @@ from gumptionchain.payload import Inflow, Outflow
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 
 
+def _pythonic_ancestry_ids(block_dao):
+    """Ground-truth ancestry: block ids from this block back to genesis via
+    `prev`, computed in pure Python — independent of the CTE and the
+    materialization, so it cannot share a bug with the code under test.
+    """
+    ids = []
+    current = block_dao
+    while current is not None:
+        ids.append(current.id)
+        current = current.prev
+    return ids
+
+
+def _oracle_block_ids(select_stmt):
+    return sorted(b.id for b in db.session.execute(select_stmt).scalars().all())
+
+
 def test_unspent_outflows(app, subject, time_stepper, wallet):
     with app.app_context():
         time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
@@ -288,9 +305,10 @@ def test_longest_chain_blocks_q_fast_path_skips_cte(app, mill_block, wallet):
         assert 'longest_chain_block' in compiled_sql.lower()
 
 
-def test_non_longest_chain_blocks_uses_cte(app, time_stepper, wallet):
-    """A non-longest ChainDAO's .blocks still emits the recursive CTE
-    (we did not optimize that path). Verified by emitted SQL.
+def test_non_longest_chain_blocks_is_cte_free(app, time_stepper, wallet):
+    """A non-longest ChainDAO's .blocks must NOT emit a recursive CTE after
+    #158 — it resolves ancestry via the divergent-suffix + materialization
+    predicate. Verified by emitted SQL.
 
     Builds a real fork (chain_a + chain_b sharing block_1) so that a
     non-longest ChainDAO row genuinely exists.
@@ -345,8 +363,10 @@ def test_non_longest_chain_blocks_uses_cte(app, time_stepper, wallet):
         compiled_sql = str(
             non_longest.blocks.compile(compile_kwargs={'literal_binds': True})
         )
-        # CTE fallback uses 'WITH RECURSIVE' on SQLite/Postgres.
-        assert 'RECURSIVE' in compiled_sql.upper()
+        assert 'RECURSIVE' not in compiled_sql.upper(), (
+            f'non-longest .blocks should be CTE-free, got:\n{compiled_sql}'
+        )
+        assert 'longest_chain_block' in compiled_sql.lower()
 
 
 def test_longest_chain_block_rebuild_on_reorg(app, mill_block, wallet):
@@ -1091,3 +1111,88 @@ def test_hot_path_methods_never_touch_recursive_cte_fork(
             # not a true count).
             assert fork.inflows_in_chain_count(f['spend_outflow_txid'], 0) == 1
             assert fork.inflows_in_chain_count('nope', 0) == 0
+
+
+def test_ancestry_read_paths_match_oracle_canonical(
+    app, add_chain_block, time_stepper, wallet
+):
+    """ChainDAO read accessors + address_transactions on a canonical tip
+    return exactly the ancestry computed by the Python prev-walk oracle.
+    """
+    with app.app_context():
+        _chain, _block1, block2, _spend = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        oracle_ids = sorted(_pythonic_ancestry_ids(tip))
+
+        chain_dao = ChainDAO.get(block2.block_hash)
+        assert chain_dao is not None
+        assert _oracle_block_ids(chain_dao.blocks) == oracle_ids
+
+        txn_ids = {
+            t.id
+            for t in db.session.execute(chain_dao.transactions).scalars().all()
+        }
+        assert txn_ids
+        for t in db.session.execute(chain_dao.transactions).scalars().all():
+            assert {b.id for b in t.blocks} & set(oracle_ids)
+
+        addr_txns = list(
+            db.session.execute(
+                tip.address_transactions(wallet.address)
+            ).scalars()
+        )
+        assert all(t.address == wallet.address for t in addr_txns)
+
+
+def test_ancestry_read_paths_match_oracle_fork(
+    app, time_stepper, wallet, subject
+):
+    """The non-longest (fork) read accessors resolve the fork tip's ancestry
+    (divergent suffix + shared prefix) identically to the Python oracle, and
+    fork balances/outflows are correct.
+    """
+    with app.app_context():
+        f = _build_fork(time_stepper, wallet, subject)
+        fork = f['fork']
+        assert fork is not None
+        assert fork._ancestry()[0]  # genuine non-empty divergent suffix
+        oracle_ids = sorted(_pythonic_ancestry_ids(fork))
+
+        chain_dao = ChainDAO.get(f['block_2b'].block_hash)
+        assert chain_dao is not None
+        assert chain_dao._is_longest() is False
+        assert _oracle_block_ids(chain_dao.blocks) == oracle_ids
+
+        opp = chain_dao.opposition_balance(subject)
+        assert opp > 0
+
+        unspent = list(
+            db.session.execute(
+                chain_dao.unspent_outflows(wallet.address)
+            ).scalars()
+        )
+        for o in unspent:
+            assert {b.id for b in o.transaction.blocks} & set(oracle_ids)
+
+
+def test_ancestry_read_paths_match_oracle_bootstrap(
+    app, add_chain_block, time_stepper, wallet
+):
+    """With an empty materialization, ancestry_*_q resolve via the
+    all-divergent predicate and still match the oracle.
+    """
+    with app.app_context():
+        _chain, _block1, block2, _spend = _build_canonical_chain_with_spend(
+            add_chain_block, time_stepper, wallet
+        )
+        db.session.execute(db.delete(LongestChainBlockDAO))
+        db.session.commit()
+        assert _count(LongestChainBlockDAO) == 0
+
+        tip = BlockDAO.get(block2.block_hash)
+        assert tip is not None
+        oracle_ids = sorted(_pythonic_ancestry_ids(tip))
+        assert _oracle_block_ids(tip.ancestry_blocks_q()) == oracle_ids


### PR DESCRIPTION
## Summary

Capstone to #157 (PR #159). #157 removed the recursive `BlockDAO._block_chain` CTE from the consensus-validation **hot path**; the CTE survived only on the **read paths** (the non-longest `ChainDAO` accessors and `address_transactions`). A recursive CTE on *any* reachable path is a latent O(chain-height) failure at height. This PR converts those last consumers to the divergent-suffix + position-scoped primitive from #157 and then **deletes the recursive CTE entirely**.

**Goal reached: zero recursive-CTE code in the tree.** No schema change, no consensus-rule change — read results are bit-identical to the deleted CTE on canonical, mid-chain, fork, and bootstrap anchors.

Closes #158.

## What changed

- **Four CTE-free builders on `BlockDAO`** — `ancestry_blocks_q` / `ancestry_transactions_q` / `ancestry_outflows_q` / `ancestry_inflows_q`. `ancestry_blocks_q` resolves a block's ancestry as a composable predicate: `id IN (divergent_suffix) OR EXISTS(LongestChainBlockDAO WHERE block_id = block.id AND position <= cap)`, using `_ancestry()` from #157. Degenerates to indexed materialized membership for a canonical anchor; bounded by reorg-depth for a fork. Never O(height).
- **Repointed the non-longest read paths** — the fork fallback of `ChainDAO.{blocks,transactions,outflows,inflows}` and `address_transactions` now route through the builders. The canonical `_is_longest()` → `longest_chain_*_q` fast path is **untouched**.
- **Deleted the CTE** — `BlockDAO._block_chain`, the four `*_chain` properties, the three classmethod `*_chain` builders, and the `CTE` import. (`chain.py`'s `Chain.block_chain` is an unrelated domain-layer `prev`-walk generator and is untouched.)

## Notable correctness details

- **Ordering preserved.** The deleted CTE properties returned tip→genesis order, and `test_chain.py::test_dao` reads these accessors directly and asserts that order on a fork. The builders carry matching `order_by` (`idx desc` for blocks; `timestamp desc, …` for txns/outflows/inflows), so they're true drop-in replacements — confirmed against the fork `[5,3,2,1]` assertion.
- **No fork leak.** The materialization is a single linear canonical chain, so `position <= cap` selects exactly the canonical prefix up to the common ancestor; a competing sibling fork's blocks are in neither the divergent walk nor the materialized prefix.

## Test plan

- [x] **Read-path equivalence (canonical / fork / bootstrap)** — `ChainDAO` accessors + `address_transactions` + `wallet_balance`/`unspent_outflows`/`opposition_balance` compared against a **pure-Python `prev`-walk oracle** (`_pythonic_ancestry_ids`), independent of all production SQL so it can't share a bug with the code under test.
- [x] **SQL-shape** — `test_non_longest_chain_blocks_is_cte_free` asserts the non-longest `.blocks` SQL has no `RECURSIVE` and references the materialization.
- [x] **Structural absence** — `test_recursive_cte_is_deleted` asserts every CTE attribute/builder is gone (the "CTE is truly gone" gate). The #157 booby-trap guard tests are replaced by this + the oracle equivalence tests.
- [x] Full suite **343 passed / 1 skipped**; `ruff check` + `ruff format --check` clean; `mypy` clean; `db check` no drift; grep-clean of `_block_chain`/`*_chain` in `src`.

Reviewed via the local subagent pipeline (per-task spec + code-quality reviews, plus a holistic final correctness pass over the whole diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
