### PR TITLE
perf(chain): convert outflow DAOs directly — kill the unrescinded/unspent N+1 (#150)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-fix-unrescinded-outflows-n-plus-1.md
+++ b/docs/superpowers/plans/2026-06-05-fix-unrescinded-outflows-n-plus-1.md
@@ -1,0 +1,421 @@
+# Fix the N+1 in the unspent/unrescinded outflow generators — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the N+1 in `Chain.unspent_outflows` / `unrescinded_outflows` / `unrescinded_address_outflows` by converting each matched `OutflowDAO` directly to a domain `Outflow`, instead of rebuilding the entire parent `Transaction` (≈3 lazy-load queries) per row just to extract one outflow.
+
+**Architecture:** Add `Outflow.from_dao` / `Inflow.from_dao` classmethods (payload.py); make `Transaction.from_dao` reuse them (DRY); replace the per-row `Transaction.from_dao(outflow_dao.transaction).get_outflow(idx)` round-trip in the three generators with `Outflow.from_dao(outflow_dao)`. Behavior-identical, zero extra queries per row. Guarded by a query-count regression test.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0, pytest, uv, ruff (line-length 80, single quotes), mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-fix-unrescinded-outflows-n-plus-1-design.md` (issue #150)
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/gumptionchain/payload.py` | Add `Outflow.from_dao` and `Inflow.from_dao` classmethods (+ `Any`, `cast` to the typing import). |
+| `src/gumptionchain/transaction.py` | Refactor `Transaction.from_dao` to build inflows/outflows via the new converters (DRY, no behavior change). |
+| `src/gumptionchain/chain.py` | Replace the round-trip in `unspent_outflows`, `unrescinded_outflows`, `unrescinded_address_outflows` with `Outflow.from_dao(outflow_dao)`; drop the dead `None` guard. |
+| `tests/test_chain.py` (or a new `tests/test_n_plus_1.py`) | Query-count regression test + converter-equivalence test. |
+
+No schema, no consensus change, no public return-shape change.
+
+---
+
+## Background the implementer needs
+
+The conversion `OutflowDAO → Outflow` is the flat copy already inlined in
+`Transaction.from_dao` (`transaction.py:348-360`):
+```python
+Outflow(
+    amount=outflow_dao.amount,
+    address=outflow_dao.address,
+    opposition=outflow_dao.opposition,
+    rescind=outflow_dao.rescind,
+    support=outflow_dao.support,
+    rescind_kind=cast('StakeKind | None', outflow_dao.rescind_kind),
+)
+```
+and `Inflow` (`transaction.py:341-347`):
+```python
+Inflow(outflow_txid=inflow_dao.outflow_txid, outflow_idx=inflow_dao.outflow_idx)
+```
+`StakeKind = Literal['opposition', 'support']` is defined in `payload.py:77`
+(in-module). `payload.py` currently imports `from typing import Annotated,
+Literal, Self` — add `Any` and `cast`. `Outflow` / `Inflow` are `@dataclass`es
+(payload.py:115, 137). `chain.py` already imports `Outflow` (`chain.py:38`), so
+the generators need no new import.
+
+The three generators (`chain.py:447-512`) share this loop body — the waste:
+```python
+for outflow_dao in outflow_daos:
+    txn = Transaction.from_dao(outflow_dao.transaction)  # lazy-load txn + its inflows + outflows
+    index = outflow_dao.idx
+    outflow = txn.get_outflow(index=index)
+    if outflow is None:
+        continue
+    ...
+    yield (outflow_dao.txid, outflow_dao.idx, outflow)
+```
+`get_outflow(index)` is `self.outflows[index]` over an idx-ordered list, so it
+returns exactly the `outflow_dao` already in hand — the round-trip is equivalent
+to `Outflow.from_dao(outflow_dao)`, and the `None` guard is unreachable for a
+present dao.
+
+Test fixtures: `add_chain_block(chain=None, block=None, milling_wallet=None)` →
+`(chain, block)` adds a milled block; `mill_block(wallet)` → `(miller, block)`.
+Stake-spend pattern (from `tests/test_models.py`): build a `Transaction`,
+`add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))`,
+`add_outflow(Outflow(amount=cb_amount, opposition=subject))`, `set_wallet(wallet)`,
+`seal()`, `sign()`, `to_db()`, then `block.add_txn(spend)` and add the block.
+The `subject` fixture exists. A stake's matching address (for
+`unrescinded_address_outflows(address, ...)`) is the spend transaction's address
+(set via `set_wallet`), not the outflow's.
+
+---
+
+## Task 1: Add the direct converters; make `Transaction.from_dao` reuse them
+
+**Files:**
+- Modify: `src/gumptionchain/payload.py`, `src/gumptionchain/transaction.py`
+- Test: `tests/test_chain.py` (or new `tests/test_n_plus_1.py`)
+
+- [ ] **Step 1: Write the converter-equivalence test (failing)**
+
+Add to the test module. It asserts `Outflow.from_dao` produces the SAME domain
+object the old `Transaction.from_dao(...).get_outflow(...)` path produced, for a
+real outflow on a built chain.
+
+```python
+def test_outflow_from_dao_matches_transaction_roundtrip(
+    app, add_chain_block, time_stepper, wallet, subject
+):
+    import datetime
+
+    from gumptionchain.models import OutflowDAO, TransactionDAO
+    from gumptionchain.payload import Inflow, Outflow
+    from gumptionchain.transaction import Transaction
+
+    with app.app_context():
+        time_step = time_stepper(
+            start=datetime.datetime.now(datetime.UTC)
+            - datetime.timedelta(hours=1)
+        )
+        _ = next(time_step)
+        chain, block1 = add_chain_block(milling_wallet=wallet)
+        cb = block1.coinbase
+        cb_amount = next(iter(cb.outflows)).amount
+        _ = next(time_step)
+        spend = Transaction()
+        spend.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        spend.add_outflow(Outflow(amount=cb_amount, opposition=subject))
+        spend.set_wallet(wallet)
+        spend.seal()
+        spend.sign()
+        spend.to_db()
+        from gumptionchain.block import Block
+
+        block2 = Block()
+        block2.add_txn(spend)
+        _ = next(time_step)
+        add_chain_block(chain=chain, block=block2, milling_wallet=wallet)
+
+        txn_dao = TransactionDAO.get(spend.txid)
+        assert txn_dao is not None
+        outflow_dao = next(
+            o for o in txn_dao.outflows if o.opposition == subject
+        )
+
+        # new direct converter
+        direct = Outflow.from_dao(outflow_dao)
+        # old round-trip path
+        roundtrip = Transaction.from_dao(outflow_dao.transaction).get_outflow(
+            index=outflow_dao.idx
+        )
+        assert direct == roundtrip
+        assert direct.opposition == subject
+        assert direct.amount == cb_amount
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_chain.py::test_outflow_from_dao_matches_transaction_roundtrip -q`
+(or the path you chose)
+Expected: FAIL — `Outflow.from_dao` does not exist yet (`AttributeError`).
+
+- [ ] **Step 3: Add the converters to `payload.py`**
+
+Add `Any` and `cast` to the typing import:
+```python
+from typing import Annotated, Any, Literal, Self, cast
+```
+Add a classmethod to the `Outflow` dataclass:
+```python
+@classmethod
+def from_dao(cls, dao: Any) -> Self:
+    return cls(
+        amount=dao.amount,
+        address=dao.address,
+        opposition=dao.opposition,
+        rescind=dao.rescind,
+        support=dao.support,
+        rescind_kind=cast('StakeKind | None', dao.rescind_kind),
+    )
+```
+and to the `Inflow` dataclass:
+```python
+@classmethod
+def from_dao(cls, dao: Any) -> Self:
+    return cls(
+        outflow_txid=dao.outflow_txid,
+        outflow_idx=dao.outflow_idx,
+    )
+```
+
+- [ ] **Step 4: Refactor `Transaction.from_dao` to reuse them (DRY)**
+
+In `transaction.py`, replace the inline `inflows=[...]` / `outflows=[...]`
+comprehensions (lines 341-360) with:
+```python
+            inflows=[
+                Inflow.from_dao(inflow_dao) for inflow_dao in dao.inflows
+            ],
+            outflows=[
+                Outflow.from_dao(outflow_dao) for outflow_dao in dao.outflows
+            ],
+```
+Leave the rest of `from_dao` unchanged. The `cast` import in transaction.py may
+become unused after this — remove it if ruff flags it (and confirm nothing else
+in the file uses `cast`).
+
+- [ ] **Step 5: Run the equivalence test + full suite, expect PASS**
+
+Run: `uv run pytest tests/test_chain.py::test_outflow_from_dao_matches_transaction_roundtrip -q`
+Expected: PASS.
+Run: `uv run pytest -q`
+Expected: green — `Transaction.from_dao` behavior is unchanged (the existing
+serialization/round-trip tests cover it).
+
+- [ ] **Step 6: Lint, format, types**
+
+Run: `uv run ruff format src tests && uv run ruff check src tests && uv run mypy`
+Expected: all green. (Watch for an unused `cast` in transaction.py.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gumptionchain/payload.py src/gumptionchain/transaction.py tests/
+git commit -m "$(cat <<'EOF'
+refactor(payload): add Outflow.from_dao / Inflow.from_dao; reuse in Transaction.from_dao (#150)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Convert the three generators; add the N+1 regression guard
+
+**Files:**
+- Modify: `src/gumptionchain/chain.py`
+- Test: `tests/test_chain.py` (or the new test module)
+
+- [ ] **Step 1: Write the N+1 query-count regression test (failing)**
+
+Add a query-count helper (mirrors the `before_cursor_execute` pattern from
+`tests/test_query_plans.py`) and a test that builds a chain with **3
+distinct-transaction** unrescinded opposition stakes for one subject/address,
+then asserts that draining `unrescinded_address_outflows` issues a small
+**constant** number of SELECTs — not ≈3 per matched outflow.
+
+```python
+def _count_selects(fn):
+    from sqlalchemy import event
+
+    from gumptionchain.database import db
+
+    bind = db.session.get_bind()
+    count = 0
+
+    def _rec(conn, cursor, statement, parameters, context, executemany):
+        nonlocal count
+        if statement.lstrip().upper().startswith('SELECT'):
+            count += 1
+
+    event.listen(bind, 'before_cursor_execute', _rec)
+    try:
+        fn()
+    finally:
+        event.remove(bind, 'before_cursor_execute', _rec)
+    return count
+
+
+def _build_chain_with_stakes(add_chain_block, time_stepper, wallet, subject, n):
+    """Build a canonical chain where n distinct transactions each spend the
+    previous block's coinbase into one opposition stake on `subject`. Returns
+    the Chain. Each stake is in its own block/transaction so the pre-fix N+1
+    issues a fresh lazy-load per matched outflow.
+    """
+    import datetime
+
+    from gumptionchain.block import Block
+    from gumptionchain.payload import Inflow, Outflow
+    from gumptionchain.transaction import Transaction
+
+    time_step = time_stepper(
+        start=datetime.datetime.now(datetime.UTC)
+        - datetime.timedelta(hours=2)
+    )
+    _ = next(time_step)
+    chain, prev_block = add_chain_block(milling_wallet=wallet)
+    for _i in range(n):
+        cb = prev_block.coinbase
+        cb_amount = next(iter(cb.outflows)).amount
+        _ = next(time_step)
+        spend = Transaction()
+        spend.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        spend.add_outflow(Outflow(amount=cb_amount, opposition=subject))
+        spend.set_wallet(wallet)
+        spend.seal()
+        spend.sign()
+        spend.to_db()
+        block = Block()
+        block.add_txn(spend)
+        _ = next(time_step)
+        chain, prev_block = add_chain_block(
+            chain=chain, block=block, milling_wallet=wallet
+        )
+    chain.to_db()
+    return chain
+
+
+def test_unrescinded_address_outflows_no_n_plus_1(
+    app, add_chain_block, time_stepper, wallet, subject
+):
+    """Draining the generator must issue a constant number of SELECTs,
+    independent of the matched-outflow count (no per-row Transaction
+    reconstruction).
+    """
+    with app.app_context():
+        chain = _build_chain_with_stakes(
+            add_chain_block, time_stepper, wallet, subject, n=3
+        )
+
+        def _drain():
+            return list(
+                chain.unrescinded_address_outflows(
+                    wallet.address, subject, 'opposition'
+                )
+            )
+
+        # Sanity: all 3 stakes are matched.
+        assert len(_drain()) == 3
+        # No N+1: the pre-fix path issued ~3 lazy-loads per matched outflow
+        # (>= ~10 SELECTs for 3 stakes); the direct convert keeps it constant.
+        assert _count_selects(_drain) <= 5
+```
+
+Note: confirm the matched count is 3 (the `assert len(...) == 3`). If the build
+yields a different count (e.g. coinbase indexing differs), adjust the builder so
+exactly `n` distinct-transaction stakes match, then keep the bound at `<= 5`
+(comfortably below the pre-fix `~3*n + overhead`). Do NOT relax the bound to make
+a still-N+1 implementation pass — the bound must FAIL on the pre-fix code.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `uv run pytest tests/test_chain.py::test_unrescinded_address_outflows_no_n_plus_1 -q`
+Expected: FAIL on the `<= 5` assertion — the current generator rebuilds a
+Transaction per matched outflow (≈10+ SELECTs for 3 stakes). (The `len == 3`
+sanity assert should already pass.)
+
+- [ ] **Step 3: Convert the three generators**
+
+In `src/gumptionchain/chain.py`, in each of `unspent_outflows`,
+`unrescinded_outflows`, `unrescinded_address_outflows`, replace the loop body's
+round-trip. The `unspent_outflows` loop becomes:
+```python
+        for outflow_dao in outflow_daos:
+            outflow = Outflow.from_dao(outflow_dao)
+            amount += outflow.amount or 0
+            yield (outflow_dao.txid, outflow_dao.idx, outflow)
+            if limit is not None and amount >= limit:
+                break
+```
+`unrescinded_outflows` (no amount/limit):
+```python
+        for outflow_dao in outflow_daos:
+            outflow = Outflow.from_dao(outflow_dao)
+            yield (outflow_dao.txid, outflow_dao.idx, outflow)
+```
+`unrescinded_address_outflows` (amount/limit, like `unspent_outflows`):
+```python
+        for outflow_dao in outflow_daos:
+            outflow = Outflow.from_dao(outflow_dao)
+            amount += outflow.amount or 0
+            yield (outflow_dao.txid, outflow_dao.idx, outflow)
+            if limit is not None and amount >= limit:
+                break
+```
+Each drops the `txn = Transaction.from_dao(...)`, `index = outflow_dao.idx`,
+`outflow = txn.get_outflow(...)`, and the `if outflow is None: continue` guard.
+If `Transaction` is no longer referenced anywhere else in `chain.py`, leave the
+import (it is used elsewhere — `CoinbaseMetrics`, milling); do NOT remove it
+without grepping.
+
+- [ ] **Step 4: Run the regression test + full suite, expect PASS**
+
+Run: `uv run pytest tests/test_chain.py::test_unrescinded_address_outflows_no_n_plus_1 -q`
+Expected: PASS (`<= 5` SELECTs).
+Run: `uv run pytest -q`
+Expected: green — the yielded `(txid, idx, Outflow)` tuples are identical, so the
+existing rescind/transfer/stake/balance tests pass unchanged.
+
+- [ ] **Step 5: Lint, format, types, db check**
+
+Run: `uv run ruff format src tests && uv run ruff check src tests && uv run mypy`
+Expected: all green.
+db check (no schema change, but confirm): `FLASK_SQLALCHEMY_DATABASE_URI=sqlite:////tmp/_dbck.db uv run gumptionchain db upgrade && FLASK_SQLALCHEMY_DATABASE_URI=sqlite:////tmp/_dbck.db uv run gumptionchain db check && rm -f /tmp/_dbck.db`
+Expected: no drift.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/chain.py tests/
+git commit -m "$(cat <<'EOF'
+perf(chain): convert outflow_dao directly — kill the unrescinded/unspent N+1 (#150)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `Outflow.from_dao`/`Inflow.from_dao` added (Task 1);
+  `Transaction.from_dao` reuses them (Task 1); all three generators convert
+  directly with the dead `None` guard removed (Task 2); query-count regression
+  guard + converter equivalence (Tasks 1-2).
+- **Behavior preservation:** the equivalence test asserts the direct convert ==
+  the old round-trip output; the yield tuple shape and amount/limit logic are
+  unchanged; the existing suite is the broad guard.
+- **Type consistency:** `from_dao(cls, dao: Any) -> Self` on both dataclasses;
+  `cast('StakeKind | None', ...)` preserved; `cast` moves from transaction.py to
+  payload.py (remove the now-unused transaction.py `cast` if ruff flags it).
+- **No schema/consensus change.**
+
+## Definition of done
+
+- `Outflow.from_dao` / `Inflow.from_dao` exist; `Transaction.from_dao` uses them;
+  the three generators no longer reconstruct a `Transaction` per matched outflow
+  and have no dead `None` guard.
+- The query-count test proves draining the generator issues O(1) SELECTs, not
+  O(matched-outflows); it fails on the pre-fix code.
+- Converter-equivalence test passes; existing rescind/transfer/stake/balance
+  tests pass unchanged.
+- Full suite + ruff + ruff-format + mypy green; `db check` no drift.

--- a/docs/superpowers/specs/2026-06-05-fix-unrescinded-outflows-n-plus-1-design.md
+++ b/docs/superpowers/specs/2026-06-05-fix-unrescinded-outflows-n-plus-1-design.md
@@ -1,0 +1,115 @@
+# Fix the N+1 in the unspent/unrescinded outflow generators — design
+
+**Date:** 2026-06-05
+**Status:** Approved design, pre-implementation
+**Issue:** #150
+**Type:** Performance / correctness-neutral refactor — no schema, no consensus change
+
+## Summary
+
+Three domain-layer generators in `chain.py` — `unspent_outflows`,
+`unrescinded_outflows`, `unrescinded_address_outflows` — rebuild the **entire
+parent `Transaction`** for every matched outflow just to extract the one outflow
+they already hold. Each iteration lazy-loads `outflow_dao.transaction`, then
+`Transaction.from_dao` lazy-loads that transaction's `.inflows` and `.outflows`
+— ≈3 extra queries per matched outflow (the #150 N+1), plus wasted object
+construction.
+
+The fix is a direct `OutflowDAO → Outflow` converter so the loop converts the
+outflow it already has, with **zero extra queries**. Root-cause, not a batching
+patch.
+
+## Current code (the waste)
+
+All three generators share this loop body (`chain.py`):
+
+```python
+for outflow_dao in outflow_daos:
+    txn = Transaction.from_dao(outflow_dao.transaction)  # lazy-load txn
+    index = outflow_dao.idx
+    outflow = txn.get_outflow(index=index)               # rebuilds .inflows + .outflows
+    if outflow is None:
+        continue
+    ...
+    yield (outflow_dao.txid, outflow_dao.idx, outflow)
+```
+
+`Transaction.from_dao` (`transaction.py:333`) already converts an `OutflowDAO`
+into a domain `Outflow` via a flat 6-field copy. `get_outflow(index)` is just
+`self.outflows[index]`, and the outflows list is built from `dao.outflows`
+ordered by `idx`, so `get_outflow(outflow_dao.idx)` returns exactly the
+`outflow_dao` the loop already holds. The whole round-trip is equivalent to a
+direct conversion of `outflow_dao` — but pays ≈3 queries to get there.
+
+## Change
+
+1. **Add `Outflow.from_dao(cls, dao)`** to `payload.py` — the same flat 6-field
+   copy `Transaction.from_dao` does inline (`amount`, `address`, `opposition`,
+   `rescind`, `support`, `rescind_kind` with the existing `StakeKind` cast).
+   Add `Inflow.from_dao(cls, dao)` for symmetry (`outflow_txid`, `outflow_idx`).
+2. **Refactor `Transaction.from_dao`** (`transaction.py`) to build its `inflows`
+   / `outflows` via `Inflow.from_dao` / `Outflow.from_dao` — one source of truth
+   for the conversion (DRY), no behavior change.
+3. **Replace the round-trip** in all three generators with the direct convert:
+   ```python
+   for outflow_dao in outflow_daos:
+       outflow = Outflow.from_dao(outflow_dao)
+       ...
+       yield (outflow_dao.txid, outflow_dao.idx, outflow)
+   ```
+   The `if outflow is None: continue` guard becomes dead (the dao is always
+   present) and is removed. Loop-local `txn` / `index` variables go away. The
+   `amount`/`limit` accumulation and the yield tuple are unchanged.
+
+No change to the underlying DAO queries (`to_dao().unspent_outflows(...)` /
+`unrescinded_outflows(...)`), no schema, no consensus rule, no public return
+shape (`Iterator[tuple[str, int, Outflow]]` unchanged).
+
+## Testing
+
+1. **N+1 regression guard (the point of the fix).** Reusing the
+   `before_cursor_execute` query-capture pattern from `tests/test_query_plans.py`,
+   build a chain with several (e.g. 3+) unrescinded stake outflows for one
+   subject/address, then assert that fully draining
+   `unrescinded_address_outflows` (and `unrescinded_outflows`, `unspent_outflows`)
+   issues a **constant** number of SQL statements independent of the match count
+   — i.e. it does **not** scale with M. (Assert an exact small bound, or compare
+   the count for M=1 vs M=3 and require equality.) This is the structural "no
+   N+1" analog of the EXPLAIN guards.
+2. **Behavior-equivalence.** The existing rescind/transfer/stake tests
+   (`create_rescind`, balance/stake-balance, transfer build) must pass unchanged
+   — the yielded `(txid, idx, Outflow)` tuples are identical. Add/confirm a test
+   that the converted `Outflow` for a representative outflow equals what the old
+   `Transaction.from_dao(...).get_outflow(...)` path produced (same fields).
+3. Full suite + ruff + ruff-format + mypy green; `db check` unaffected (no schema
+   change).
+
+## Out of scope
+
+- The chain-wide *scan* cost of the underlying balance/unspent SQL (the
+  materialized-subquery `anon_` cost noted in #161) — that's a query-restructure,
+  not this N+1.
+- EGU 1b constant retune (#151) and the sync/pruning items (#163/#164).
+
+## Decisions log
+
+- **Root-cause converter, not eager-load.** A direct `Outflow.from_dao` removes
+  both the N+1 *and* the wasted full-transaction reconstruction; eager-loading
+  would only batch the queries while still rebuilding transactions to extract one
+  outflow. Simpler and faster.
+- **Add `Inflow.from_dao` too** so `Transaction.from_dao` is fully DRY and the two
+  converters are symmetric.
+- **Behavior-identical:** `get_outflow(idx)` == `self.outflows[idx]` over an
+  idx-ordered list == the held `outflow_dao`, so the direct convert yields the
+  same domain `Outflow`; the `None` guard was unreachable for a present dao and is
+  removed.
+
+## Definition of done
+
+- `Outflow.from_dao` / `Inflow.from_dao` added; `Transaction.from_dao` reuses
+  them; the three generators convert `outflow_dao` directly with no per-row
+  transaction reconstruction and no dead `None` guard.
+- A query-count regression test proves the generators issue O(1) statements, not
+  O(matched-outflows).
+- Existing rescind/transfer/stake/balance tests pass unchanged; full suite + ruff
+  + mypy green.

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -457,11 +457,7 @@ class Chain:
             )
         ).scalars()
         for outflow_dao in outflow_daos:
-            txn = Transaction.from_dao(outflow_dao.transaction)
-            index = outflow_dao.idx
-            outflow = txn.get_outflow(index=index)
-            if outflow is None:
-                continue
+            outflow = Outflow.from_dao(outflow_dao)
             amount += outflow.amount or 0
             yield (outflow_dao.txid, outflow_dao.idx, outflow)
             if limit is not None and amount >= limit:
@@ -479,11 +475,7 @@ class Chain:
             )
         ).scalars()
         for outflow_dao in outflow_daos:
-            txn = Transaction.from_dao(outflow_dao.transaction)
-            index = outflow_dao.idx
-            outflow = txn.get_outflow(index=index)
-            if outflow is None:
-                continue
+            outflow = Outflow.from_dao(outflow_dao)
             yield (outflow_dao.txid, outflow_dao.idx, outflow)
 
     def unrescinded_address_outflows(
@@ -501,11 +493,7 @@ class Chain:
             )
         ).scalars()
         for outflow_dao in outflow_daos:
-            txn = Transaction.from_dao(outflow_dao.transaction)
-            index = outflow_dao.idx
-            outflow = txn.get_outflow(index=index)
-            if outflow is None:
-                continue
+            outflow = Outflow.from_dao(outflow_dao)
             amount += outflow.amount or 0
             yield (outflow_dao.txid, outflow_dao.idx, outflow)
             if limit is not None and amount >= limit:

--- a/src/gumptionchain/payload.py
+++ b/src/gumptionchain/payload.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self, cast
 
 from pydantic import (
     AfterValidator,
@@ -120,6 +120,17 @@ class Outflow:
     support: str | None = None
     rescind_kind: StakeKind | None = None
 
+    @classmethod
+    def from_dao(cls, dao: Any) -> Self:
+        return cls(
+            amount=dao.amount,
+            address=dao.address,
+            opposition=dao.opposition,
+            rescind=dao.rescind,
+            support=dao.support,
+            rescind_kind=cast('StakeKind | None', dao.rescind_kind),
+        )
+
     @property
     def data_csv(self) -> str:
         return ','.join(
@@ -138,6 +149,13 @@ class Outflow:
 class Inflow:
     outflow_txid: str | None = None
     outflow_idx: int | None = None
+
+    @classmethod
+    def from_dao(cls, dao: Any) -> Self:
+        return cls(
+            outflow_txid=dao.outflow_txid,
+            outflow_idx=dao.outflow_idx,
+        )
 
     @property
     def data_csv(self) -> str:

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Iterator, MutableSet
 from dataclasses import dataclass, field
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Annotated, Any, Literal, Self, cast
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
     BaseModel,
@@ -35,7 +35,6 @@ from gumptionchain.payload import (
     InflowModel,
     Outflow,
     OutflowModel,
-    StakeKind,
 )
 from gumptionchain.schema import (
     AddressType,
@@ -338,25 +337,9 @@ class Transaction:
             public_key=dao.public_key,
             signature=dao.signature,
             prev_hash=dao.prev_hash,
-            inflows=[
-                Inflow(
-                    outflow_txid=inflow_dao.outflow_txid,
-                    outflow_idx=inflow_dao.outflow_idx,
-                )
-                for inflow_dao in dao.inflows
-            ],
+            inflows=[Inflow.from_dao(inflow_dao) for inflow_dao in dao.inflows],
             outflows=[
-                Outflow(
-                    amount=outflow_dao.amount,
-                    address=outflow_dao.address,
-                    opposition=outflow_dao.opposition,
-                    rescind=outflow_dao.rescind,
-                    support=outflow_dao.support,
-                    rescind_kind=cast(
-                        'StakeKind | None', outflow_dao.rescind_kind
-                    ),
-                )
-                for outflow_dao in dao.outflows
+                Outflow.from_dao(outflow_dao) for outflow_dao in dao.outflows
             ],
             version=dao.version,
         )

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -28,6 +28,7 @@ from gumptionchain.exceptions import (
     SpentTransactionError,
 )
 from gumptionchain.milling import mill_hash_str
+from gumptionchain.models import TransactionDAO
 from gumptionchain.payload import Inflow, Outflow
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import now, now_iso
@@ -1508,3 +1509,43 @@ def test_forged_gross_coinbase_opposition_rejected(
 
         with pytest.raises(InvalidBlockError):
             chain.add_block(block3)
+
+
+def test_outflow_from_dao_matches_transaction_roundtrip(
+    app, add_chain_block, time_stepper, wallet, subject
+):
+    with app.app_context():
+        time_step = time_stepper(
+            start=datetime.datetime.now(datetime.UTC)
+            - datetime.timedelta(hours=1)
+        )
+        _ = next(time_step)
+        chain, block1 = add_chain_block(milling_wallet=wallet)
+        cb = block1.coinbase
+        cb_amount = next(iter(cb.outflows)).amount
+        _ = next(time_step)
+        spend = Transaction()
+        spend.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        spend.add_outflow(Outflow(amount=cb_amount, opposition=subject))
+        spend.set_wallet(wallet)
+        spend.seal()
+        spend.sign()
+        spend.to_db()
+        block2 = Block()
+        block2.add_txn(spend)
+        _ = next(time_step)
+        add_chain_block(chain=chain, block=block2, milling_wallet=wallet)
+
+        txn_dao = TransactionDAO.get(spend.txid)
+        assert txn_dao is not None
+        outflow_dao = next(
+            o for o in txn_dao.outflows if o.opposition == subject
+        )
+
+        direct = Outflow.from_dao(outflow_dao)
+        roundtrip = Transaction.from_dao(outflow_dao.transaction).get_outflow(
+            index=outflow_dao.idx
+        )
+        assert direct == roundtrip
+        assert direct.opposition == subject
+        assert direct.amount == cb_amount

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from _sa_helpers import _count_select
+from sqlalchemy import event
 
 from gumptionchain.block import TXN_TIMEOUT, Block
 from gumptionchain.chain import (
@@ -1549,3 +1550,75 @@ def test_outflow_from_dao_matches_transaction_roundtrip(
         assert direct == roundtrip
         assert direct.opposition == subject
         assert direct.amount == cb_amount
+
+
+def _count_selects(fn):
+    bind = db.session.get_bind()
+    count = 0
+
+    def _rec(conn, cursor, statement, parameters, context, executemany):
+        nonlocal count
+        if statement.lstrip().upper().startswith('SELECT'):
+            count += 1
+
+    event.listen(bind, 'before_cursor_execute', _rec)
+    try:
+        fn()
+    finally:
+        event.remove(bind, 'before_cursor_execute', _rec)
+    return count
+
+
+def _build_chain_with_stakes(add_chain_block, time_stepper, wallet, subject, n):
+    """Build a canonical chain where n distinct transactions each spend the
+    previous block's coinbase into one opposition stake on `subject`. Each
+    stake is in its own block/transaction so the pre-fix N+1 issues a fresh
+    lazy-load per matched outflow.
+    """
+    time_step = time_stepper(
+        start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
+    )
+    _ = next(time_step)
+    chain, prev_block = add_chain_block(milling_wallet=wallet)
+    for _i in range(n):
+        cb = prev_block.coinbase
+        cb_amount = next(iter(cb.outflows)).amount
+        _ = next(time_step)
+        spend = Transaction()
+        spend.add_inflow(Inflow(outflow_txid=cb.txid, outflow_idx=0))
+        spend.add_outflow(Outflow(amount=cb_amount, opposition=subject))
+        spend.set_wallet(wallet)
+        spend.seal()
+        spend.sign()
+        spend.to_db()
+        block = Block()
+        block.add_txn(spend)
+        _ = next(time_step)
+        chain, prev_block = add_chain_block(
+            chain=chain, block=block, milling_wallet=wallet
+        )
+    chain.to_db()
+    return chain
+
+
+def test_unrescinded_address_outflows_no_n_plus_1(
+    app, add_chain_block, time_stepper, wallet, subject
+):
+    """Draining the generator must issue a constant number of SELECTs,
+    independent of the matched-outflow count (no per-row Transaction
+    reconstruction).
+    """
+    with app.app_context():
+        chain = _build_chain_with_stakes(
+            add_chain_block, time_stepper, wallet, subject, n=3
+        )
+
+        def _drain():
+            return list(
+                chain.unrescinded_address_outflows(
+                    wallet.address, subject, 'opposition'
+                )
+            )
+
+        assert len(_drain()) == 3
+        assert _count_selects(_drain) <= 5

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1552,7 +1552,7 @@ def test_outflow_from_dao_matches_transaction_roundtrip(
         assert direct.amount == cb_amount
 
 
-def _count_selects(fn):
+def _count_select_statements(fn):
     bind = db.session.get_bind()
     count = 0
 
@@ -1621,4 +1621,7 @@ def test_unrescinded_address_outflows_no_n_plus_1(
             )
 
         assert len(_drain()) == 3
-        assert _count_selects(_drain) <= 5
+        # post-fix: 3 SELECTs; the pre-fix N+1 was ~12 (3 stakes x ~4 lazy
+        # loads). Bound leaves slack for incidental queries without
+        # re-admitting per-row Transaction loads.
+        assert _count_select_statements(_drain) <= 5

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1558,7 +1558,9 @@ def _count_select_statements(fn):
 
     def _rec(conn, cursor, statement, parameters, context, executemany):
         nonlocal count
-        if statement.lstrip().upper().startswith('SELECT'):
+        # Count read queries: plain SELECTs and CTE queries (WITH / WITH
+        # RECURSIVE), so a future CTE-shaped query can't slip the count.
+        if statement.lstrip().upper().startswith(('SELECT', 'WITH')):
             count += 1
 
     event.listen(bind, 'before_cursor_execute', _rec)
@@ -1621,7 +1623,11 @@ def test_unrescinded_address_outflows_no_n_plus_1(
             )
 
         assert len(_drain()) == 3
-        # post-fix: 3 SELECTs; the pre-fix N+1 was ~12 (3 stakes x ~4 lazy
-        # loads). Bound leaves slack for incidental queries without
-        # re-admitting per-row Transaction loads.
+        # Expire the session so the counted drain runs cold — a warm identity
+        # map / relationship cache from the sanity drain above could otherwise
+        # mask a per-row N+1 and let a regressed implementation pass.
+        db.session.expire_all()
+        # post-fix: constant SELECTs regardless of match count; the pre-fix
+        # N+1 was ~12 (3 stakes x ~4 lazy loads). Bound leaves slack for
+        # incidental queries without re-admitting per-row Transaction loads.
         assert _count_select_statements(_drain) <= 5


### PR DESCRIPTION
## Summary

Kills the N+1 in the three domain-layer outflow generators — `Chain.unspent_outflows`, `unrescinded_outflows`, `unrescinded_address_outflows`. Each rebuilt the **entire parent `Transaction`** for every matched outflow (lazy-loading the transaction, then *all* its inflows and outflows) just to call `get_outflow(idx)` and pull back the one outflow it already held — ≈3 extra queries per matched row, plus wasted object construction.

The fix converts the `OutflowDAO` directly via a new `Outflow.from_dao`, with **zero extra queries per row**. Root-cause, not a `selectinload` batch.

Closes #150. Last of the EGU 1b-pre query-cost cleanups (sibling to #157/#158/#161); the remaining audit items are tracked in #163/#164/#165.

## Change

1. **`Outflow.from_dao` / `Inflow.from_dao`** (payload.py) — the flat field copy `Transaction.from_dao` already did inline.
2. **`Transaction.from_dao`** refactored to reuse them (DRY — one source of truth for DAO→domain conversion; behavior byte-identical).
3. **The three generators** convert `outflow_dao` directly (`Outflow.from_dao(outflow_dao)`), dropping the per-row `Transaction` reconstruction and the now-dead `if outflow is None: continue` guard. Yield tuples, amount accumulation, and limit-break logic are unchanged.

`get_outflow(idx)` is `self.outflows[idx]` over an idx-ordered list = exactly the held `outflow_dao`, so the direct convert is behavior-identical (the Task-1 equivalence test asserts `Outflow.from_dao(dao) == Transaction.from_dao(dao.transaction).get_outflow(dao.idx)`).

## Measured win

Draining `unrescinded_address_outflows` over 3 distinct-transaction stakes:

```
BEFORE:  12 SELECTs   (3 stakes × ~4 lazy loads + overhead)
AFTER:    3 SELECTs   (constant — independent of matched-outflow count)
```

## Test plan

- [x] **Converter equivalence** — `Outflow.from_dao(dao)` equals the old full-transaction-roundtrip output for a real persisted outflow.
- [x] **N+1 regression guard** (`tests/test_chain.py`) — builds 3 *distinct-transaction* opposition stakes (so the identity map can't mask repeated reconstruction), drains the generator, asserts a constant SELECT bound (`<= 5`). **Fails on the pre-fix code (12), passes after (3)** — confirmed by a revert experiment during review. The "no N+1" structural analog of the EXPLAIN guards, using the same `before_cursor_execute` listener.
- [x] Existing rescind/transfer/stake/balance suite passes unchanged (behavior identical).
- [x] Full suite **347 passed / 1 skipped**; ruff + format + mypy clean; `db check` no drift; scope 4 files, no schema/consensus touch.

Reviewed via the local subagent pipeline (per-task spec + code-quality reviews with a revert experiment, plus a holistic final pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
