### PR TITLE
feat(wallet): headless gc-sig-v1 core signing module — vanilla JS/Web Crypto (#170)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,13 @@ jobs:
       - run: uv sync --group dev --python ${{ matrix.python-version }}
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
+      # Node is needed on PATH for the live JS->Python gc-sig cross-verify in
+      # tests/test_browser_wallet_parity.py (it shells out to `node`). The
+      # browser wallet is pure Web Crypto + vanilla JS — zero npm packages.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '20'
+      - run: node --test clients/wallet/*.test.mjs
       - run: uv run pytest
       - run: uv run mypy
       # Migration drift gate: upgrade a throwaway SQLite file, then compare

--- a/clients/wallet/gc-crypto.mjs
+++ b/clients/wallet/gc-crypto.mjs
@@ -1,0 +1,70 @@
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 19+.
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export function base58encode(bytes) {
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  const digits = [];
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let out = '1'.repeat(zeros);
+  for (let k = digits.length - 1; k >= 0; k--) out += B58[digits[k]];
+  return out;
+}
+
+export function base58decode(str) {
+  let zeros = 0;
+  while (zeros < str.length && str[zeros] === '1') zeros++;
+  const bytes = [];
+  for (let i = zeros; i < str.length; i++) {
+    const val = B58.indexOf(str[i]);
+    if (val < 0) throw new Error(`invalid base58 char: ${str[i]}`);
+    let carry = val;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let k = 0; k < bytes.length; k++) out[zeros + k] = bytes[bytes.length - 1 - k];
+  return out;
+}
+
+export function base64encode(bytes) {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export function base64decode(str) {
+  const bin = atob(str);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function millHash(bytes) {
+  const inner = await crypto.subtle.digest('SHA-512', bytes);
+  const outer = await crypto.subtle.digest('SHA-256', inner);
+  return new Uint8Array(outer);
+}
+
+export async function sha256Hex(bytes) {
+  const d = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  return Array.from(d, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/clients/wallet/gc-crypto.mjs
+++ b/clients/wallet/gc-crypto.mjs
@@ -1,4 +1,4 @@
-// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 19+.
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
 const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
 export function base58encode(bytes) {

--- a/clients/wallet/gc-crypto.test.mjs
+++ b/clients/wallet/gc-crypto.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  base58encode, base58decode, base64encode, base64decode, millHash,
+  base58encode, base58decode, base64encode, base64decode, millHash, sha256Hex,
 } from './gc-crypto.mjs';
 
 const hex = (u8) => Buffer.from(u8).toString('hex');
@@ -24,6 +24,12 @@ test('base58 round-trips arbitrary bytes', () => {
   }
 });
 
+test('base58decode rejects characters outside the alphabet', () => {
+  for (const bad of ['0', 'O', 'I', 'l']) {
+    assert.throws(() => base58decode(`abc${bad}`), /invalid base58 char/);
+  }
+});
+
 test('base64 round-trips', () => {
   const u8 = Uint8Array.from([0, 1, 250, 99, 7]);
   assert.equal(hex(base64decode(base64encode(u8))), hex(u8));
@@ -32,4 +38,9 @@ test('base64 round-trips', () => {
 test('millHash is sha256(sha512(x)) — matches Python', async () => {
   const out = await millHash(new TextEncoder().encode('abc'));
   assert.equal(hex(out), '2b8e2baefea41ddf88d7ccd66550cb9493970ea7854d2e74eb33e57cd3c73d9c');
+});
+
+test('sha256Hex matches the known SHA-256 of "abc"', async () => {
+  const out = await sha256Hex(new TextEncoder().encode('abc'));
+  assert.equal(out, 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
 });

--- a/clients/wallet/gc-crypto.test.mjs
+++ b/clients/wallet/gc-crypto.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  base58encode, base58decode, base64encode, base64decode, millHash,
+} from './gc-crypto.mjs';
+
+const hex = (u8) => Buffer.from(u8).toString('hex');
+
+test('base58 matches the Python base58check lib (plain, no checksum)', () => {
+  const bytes0to31 = Uint8Array.from({ length: 32 }, (_, i) => i);
+  assert.equal(base58encode(bytes0to31), '1thX6LZfHDZZKUs92febYZhYRcXddmzfzF2NvTkPNE');
+  assert.equal(base58encode(new TextEncoder().encode('hello')), 'Cn8eVZg');
+});
+
+test('base58 preserves leading zero bytes as leading 1s', () => {
+  assert.equal(base58encode(Uint8Array.from([0])), '1');
+  assert.equal(base58encode(Uint8Array.from([0, 0, 1])), '112');
+});
+
+test('base58 round-trips arbitrary bytes', () => {
+  for (const sample of [[0], [255], [0, 0, 7, 200], [1, 2, 3, 4, 5]]) {
+    const u8 = Uint8Array.from(sample);
+    assert.equal(hex(base58decode(base58encode(u8))), hex(u8));
+  }
+});
+
+test('base64 round-trips', () => {
+  const u8 = Uint8Array.from([0, 1, 250, 99, 7]);
+  assert.equal(hex(base64decode(base64encode(u8))), hex(u8));
+});
+
+test('millHash is sha256(sha512(x)) — matches Python', async () => {
+  const out = await millHash(new TextEncoder().encode('abc'));
+  assert.equal(hex(out), '2b8e2baefea41ddf88d7ccd66550cb9493970ea7854d2e74eb33e57cd3c73d9c');
+});

--- a/clients/wallet/gc-sig.mjs
+++ b/clients/wallet/gc-sig.mjs
@@ -1,0 +1,52 @@
+// GumptionChain gc-sig-v1 canonical string + GC-* signing headers.
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
+import { sha256Hex } from './gc-crypto.mjs';
+
+const SIG_SCHEME = 'gc-sig-v1';
+const SIG_VERSION = '1';
+
+export async function canonical({
+  method,
+  path,
+  query,
+  body,
+  nodeHost,
+  timestamp,
+  address,
+}) {
+  const bodyDigest = await sha256Hex(body ?? new Uint8Array());
+  const lines = [
+    SIG_SCHEME,
+    method.toUpperCase(),
+    path,
+    query,
+    bodyDigest,
+    nodeHost,
+    timestamp,
+    address,
+  ];
+  return new TextEncoder().encode(lines.join('\n'));
+}
+
+export async function signHeaders(
+  wallet,
+  { method, path, query, body, nodeHost, timestamp },
+) {
+  const address = await wallet.address();
+  const bytes = await canonical({
+    method,
+    path,
+    query,
+    body,
+    nodeHost,
+    timestamp,
+    address,
+  });
+  return {
+    'GC-Sig-Version': SIG_VERSION,
+    'GC-Address': address,
+    'GC-Public-Key': await wallet.publicKeyB64(),
+    'GC-Timestamp': String(timestamp),
+    'GC-Signature': await wallet.sign(bytes),
+  };
+}

--- a/clients/wallet/gc-wallet.mjs
+++ b/clients/wallet/gc-wallet.mjs
@@ -1,0 +1,85 @@
+// GumptionChain browser wallet: keygen, key import/export, address, sign.
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
+import {
+  base58encode, base58decode, base64encode, millHash,
+} from './gc-crypto.mjs';
+
+const ALG = { name: 'RSASSA-PKCS1-v1_5' };
+const KEYGEN = {
+  name: 'RSASSA-PKCS1-v1_5',
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+  hash: 'SHA-384',
+};
+const IMPORT_PARAMS = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' };
+const ADDRESS_TAG = 'GC';
+
+export class Wallet {
+  #privateKey;
+  #publicKey;
+
+  constructor(privateKey, publicKey) {
+    this.#privateKey = privateKey;
+    this.#publicKey = publicKey;
+  }
+
+  static async generate() {
+    const pair = await crypto.subtle.generateKey(KEYGEN, true, [
+      'sign',
+      'verify',
+    ]);
+    return new Wallet(pair.privateKey, pair.publicKey);
+  }
+
+  static async fromPrivateKeyB58(b58) {
+    const pkcs8 = base58decode(b58);
+    const priv = await crypto.subtle.importKey(
+      'pkcs8',
+      pkcs8,
+      IMPORT_PARAMS,
+      true,
+      ['sign'],
+    );
+    const jwk = await crypto.subtle.exportKey('jwk', priv);
+    const pubJwk = { kty: jwk.kty, n: jwk.n, e: jwk.e, ext: true };
+    const pub = await crypto.subtle.importKey(
+      'jwk',
+      pubJwk,
+      IMPORT_PARAMS,
+      true,
+      ['verify'],
+    );
+    return new Wallet(priv, pub);
+  }
+
+  async exportPrivateKeyB58() {
+    if (!this.#privateKey) {
+      throw new Error('no private key');
+    }
+    const pkcs8 = new Uint8Array(
+      await crypto.subtle.exportKey('pkcs8', this.#privateKey),
+    );
+    return base58encode(pkcs8);
+  }
+
+  async #spki() {
+    return new Uint8Array(await crypto.subtle.exportKey('spki', this.#publicKey));
+  }
+
+  async publicKeyB64() {
+    return base64encode(await this.#spki());
+  }
+
+  async address() {
+    const digest = await millHash(await this.#spki());
+    return `${ADDRESS_TAG}${base58encode(digest)}${ADDRESS_TAG}`;
+  }
+
+  async sign(bytes) {
+    if (!this.#privateKey) {
+      throw new Error('no private key');
+    }
+    const sig = await crypto.subtle.sign(ALG, this.#privateKey, bytes);
+    return base64encode(new Uint8Array(sig));
+  }
+}

--- a/clients/wallet/gc-wallet.mjs
+++ b/clients/wallet/gc-wallet.mjs
@@ -13,6 +13,27 @@ const KEYGEN = {
 };
 const IMPORT_PARAMS = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' };
 const ADDRESS_TAG = 'GC';
+const KEY_SIZE = 2048;
+const PUBLIC_EXPONENT = Uint8Array.of(0x01, 0x00, 0x01); // 65537
+
+// Mirror the node's Wallet key-profile guard: reject any imported key that is
+// not RSA-2048 with e=65537, so a client can't mint an identity/signature the
+// Python node will always reject. (Web Crypto exposes both on key.algorithm.)
+function assertKeyProfile(key) {
+  const { modulusLength, publicExponent } = key.algorithm;
+  if (modulusLength !== KEY_SIZE) {
+    throw new Error(
+      `unsupported RSA modulus length ${modulusLength} (want ${KEY_SIZE})`,
+    );
+  }
+  const e = new Uint8Array(publicExponent);
+  const ok =
+    e.length === PUBLIC_EXPONENT.length &&
+    e.every((b, i) => b === PUBLIC_EXPONENT[i]);
+  if (!ok) {
+    throw new Error('unsupported RSA public exponent (want 65537)');
+  }
+}
 
 export class Wallet {
   #privateKey;
@@ -40,6 +61,7 @@ export class Wallet {
       true,
       ['sign'],
     );
+    assertKeyProfile(priv);
     const jwk = await crypto.subtle.exportKey('jwk', priv);
     const pubJwk = { kty: jwk.kty, n: jwk.n, e: jwk.e, ext: true };
     const pub = await crypto.subtle.importKey(

--- a/clients/wallet/gc-wallet.test.mjs
+++ b/clients/wallet/gc-wallet.test.mjs
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { Wallet } from './gc-wallet.mjs';
+import { canonical, signHeaders } from './gc-sig.mjs';
+
+const V = JSON.parse(readFileSync(new URL('./testdata/gc-sig-vectors.json', import.meta.url)));
+
+test('imported fixed key derives the same address + public key as Python', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  assert.equal(await w.address(), V.address);
+  assert.equal(await w.publicKeyB64(), V.public_key_b64);
+});
+
+test('canonical bytes match Python for every case', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  const addr = await w.address();
+  for (const c of V.cases) {
+    const bytes = await canonical({
+      method: c.method, path: c.path, query: c.query,
+      body: new TextEncoder().encode(c.body),
+      nodeHost: c.node_host, timestamp: c.timestamp, address: addr,
+    });
+    assert.equal(new TextDecoder().decode(bytes), c.canonical);
+  }
+});
+
+test('signatures match Python byte-for-byte (deterministic PKCS1v15)', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  for (const c of V.cases) {
+    const sig = await w.sign(new TextEncoder().encode(c.canonical));
+    assert.equal(sig, c.signature);
+  }
+});
+
+test('fresh keygen round-trips and signHeaders has the GC-* shape', async () => {
+  const w = await Wallet.generate();
+  const headers = await signHeaders(w, {
+    method: 'GET', path: '/api/blocks', query: '',
+    body: new Uint8Array(), nodeHost: 'node.example', timestamp: '1700000000',
+  });
+  assert.equal(headers['GC-Sig-Version'], '1');
+  assert.equal(headers['GC-Address'], await w.address());
+  assert.equal(headers['GC-Public-Key'], await w.publicKeyB64());
+  assert.equal(headers['GC-Timestamp'], '1700000000');
+  assert.ok(headers['GC-Signature']);
+});
+
+test('exportPrivateKeyB58 round-trips through fromPrivateKeyB58', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  assert.equal(await w.exportPrivateKeyB58(), V.private_key_b58);
+});

--- a/clients/wallet/gc-wallet.test.mjs
+++ b/clients/wallet/gc-wallet.test.mjs
@@ -3,8 +3,25 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { Wallet } from './gc-wallet.mjs';
 import { canonical, signHeaders } from './gc-sig.mjs';
+import { base58encode } from './gc-crypto.mjs';
 
 const V = JSON.parse(readFileSync(new URL('./testdata/gc-sig-vectors.json', import.meta.url)));
+
+test('fromPrivateKeyB58 rejects a non-2048 RSA key (node would reject it)', async () => {
+  // 3072 is freely generatable in Web Crypto; the node only accepts 2048.
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5', modulusLength: 3072,
+      publicExponent: new Uint8Array([0x01, 0x00, 0x01]), hash: 'SHA-384',
+    },
+    true, ['sign', 'verify'],
+  );
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey('pkcs8', pair.privateKey));
+  await assert.rejects(
+    () => Wallet.fromPrivateKeyB58(base58encode(pkcs8)),
+    /modulus length/,
+  );
+});
 
 test('imported fixed key derives the same address + public key as Python', async () => {
   const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);

--- a/clients/wallet/sign-cli.mjs
+++ b/clients/wallet/sign-cli.mjs
@@ -1,0 +1,21 @@
+// GumptionChain gc-sig-v1 signing CLI (test harness, not a unit test).
+// Reads a JSON request from argv[2], signs it with the given b58 private key,
+// and prints {address, signature} JSON to stdout. Used by the Python live
+// cross-verify test to prove byte-for-byte gc-sig parity without fixtures.
+import { Wallet } from './gc-wallet.mjs';
+import { canonical } from './gc-sig.mjs';
+
+const req = JSON.parse(process.argv[2]);
+const w = await Wallet.fromPrivateKeyB58(req.private_key_b58);
+const address = await w.address();
+const bytes = await canonical({
+  method: req.method,
+  path: req.path,
+  query: req.query,
+  body: new TextEncoder().encode(req.body ?? ''),
+  nodeHost: req.node_host,
+  timestamp: req.timestamp,
+  address,
+});
+const signature = await w.sign(bytes);
+process.stdout.write(JSON.stringify({ address, signature }));

--- a/clients/wallet/testdata/gc-sig-vectors.json
+++ b/clients/wallet/testdata/gc-sig-vectors.json
@@ -1,0 +1,27 @@
+{
+  "private_key_b58": "riiewRJm2wpE3rWTs1ikUc83so8ZXMX8vp9dUTnRgMC8GyfLr99LtkqK8gDNAd1VyihbjWopge9tGR3W9GCbpojrHtjpUqmmuEhHjpehtXGiMF1LqiZedaEE4V3X8X679uzitLTP3m8AzcNGgqbPKWtVEd7VWmVWQdan68EpojZFwqrY3LFLiRnaKSLoNryxLUEFFrxcBNjyTpjL943Rs6YXFRgBs5UDSazh6GLPwu26oAPfLy8NNPqKjPuNHcCXoywopkMUug4bXJaKc93PxdtR6kEWWxCaiNtsCe4JkukbRXNR6NpUrAtrgNgw8uM7Pg2tMP9ThbyaHxHLcaeYs8tfdPs2MX3qfkw37cPX6P5wkFUVqcZhrL4PMzqHF2Hkf79hWYU1c3xwit8Rx2gM8HAQZgq5CGuNjj9YAo3JcAbkVKtTqgFKJqmwY8jVLCtxKkzyBbxAAyuHtyioNQ5LFrxBs5qzoyRATTJwqVfhjoWNEvHNpT3g97htCjtkgMssbfSBq6fmSa7mFpE3vA7dHPUhmjdiwhsdDhDVLnekVk8yxELPEZzjCvKKZ1JW4oaXVcGvgkjFB2RquXCUFX272SYie7b2sEDbB61kC7rTxmrfanLX5Ah2X4PKZK9xCaUKhEcbQsMBMve9uniasFMYecu829v9ELWRaRCjhMDKqnHhsPvvd7xMdLyUcTyCPcbwphc76GhyULAvpqumAoxvsQqXTcWmh4AtFzjjURneezkVa1sA1yfCEvfyEjPynpYv7XWtymfciJ8NNS1SpuXBUrqdFSps2txaVD2F6JBwZE2VBA2SnVdd57cn5z7bcejheQB99mSC69UFqR2vgPQek1VGHEQFsmtQXBWR3jrCeiSKsvW4SLESB3W7vDvhN1es5mjBnQ1rExmpDPHQTAacJSVt1eiijvq8GccQcNsbLgHsJqXNBquvffYgWXTv3jY7kcZj7iCK1wjpLujhCzGXJ8mzTn7h6hu7ouAr3J54317eC4XeyZo7AQgiVSK7YrEyxw61fbsFdqMFMKi3ChmxfckTUk3gNrTK8bXyhNrWpGN4masjADciLRYS7UD5M96nquMJop8hyftXEd2vmJVwqnzsorbePGu7iAdFh26jKfYtDS1rNycLVCxKYR7nB9o6xDPVvEqnnTUUDrPNKf9wE8EbaHoysTeh5FqK7dHupxRJCNp4h46dUnQpUCGtp5QzEZfRa6MLMoecPQ5icwfMMZuzraLpbLfSVdniZyuomZwdW5rPDSqeZwaaWRTBizLaeeJKsfbb4gU27THHzCSxtd8S1pn4obmD5UHLXzBgi5nBCWuwmDduz8mVm2ytQnTYGkAq6LJig8eGtYFtXMzhWuHUfEsj4o6k6rP1hLvVr7bhpp8r59a6m9ZitUCsCiEKxJC1b1TAy2EGLHoC6bwyUXUQe69dPTR981QsuW2CNmUrgtCduFfuGhqwvavxpPNKPXuWVnuYYE2nzVNHZ7Bh2cicnQGF48iFnptWTWN7Nj6v8w6bHE4j9iosu13skYeN63y2j4swwegX36KuEEfbutTBLJ7hq9GpSAqMgACbMKKEVhE7Zz3uzDTEFWHFGobWUYT8hzA9iyfyhVv74B6CX4DS3biGzgPeBK81x6Yn83NSxXCh97wWTd1Q4ewdpwk",
+  "public_key_b64": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt239j0ePdOUAyRhhPoMgKDHE5ZoC67VnnmDVW1YbJ/iEeyneil7HVnHtO1nnS2hjbI4pDC1Z3620lxVSaXttrxV2eIMl9JzfiO6tr9aeIOxNZV81XKOsu5cwwYtepYV2SY8lH4+pSFngySFbmUf3GNdTmeBqzRbG+y5lEdmMHaTqLtCEvfWhY7+5jajPiYWABfKUjtcmTwAdsriEmEfG4MWg8ZKF1WIKzFk6saBbob+koXnoQ73axWryngO+Q/Iqjcqd0EPxoS3p1dsGMOLRcJ6E02cGzixq68jcDm+Ggs9aICL6MH5gCG0ntbcYCjn4NH9mh84P9ozpR5TkNnkwqwIDAQAB",
+  "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC",
+  "cases": [
+    {
+      "method": "GET",
+      "path": "/api/blocks",
+      "query": "",
+      "body": "",
+      "node_host": "node.example",
+      "timestamp": "1700000000",
+      "canonical": "gc-sig-v1\nGET\n/api/blocks\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nnode.example\n1700000000\nGCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC",
+      "signature": "SpxIqkDOgjWatFyoF0jsvZlaZQw17jOi1+a/glX0Sd2frBDRHK1yIi5kD7Kw/pVD5//8zzqjHiZHpDhkdSOlhsIIoMA2dyQUVBpabQhyg4HGqXA+ip1qnbNEfUoihk4b5iEcgucT9kCyjIgJzyxUMWZByoujwEfZ6Wk6PWLbrxU/jFQQa1rLi//WG9ieL+ex21aVrhRKjCaILpKBn2dQ4Sfd6erB9eWckJwI8+GZmXA8/jqgRSk9BGovj5QJG9xNZMwmu2GGCWs4M7GLLsQWb3TxN/ttmXsGeKsiUbMPyo64+9ovFBUJXybShwCAulRqw/U5z8Tfukr7LxD9CDAy2w=="
+    },
+    {
+      "method": "POST",
+      "path": "/api/transactions",
+      "query": "foo=bar",
+      "body": "{\"hello\":\"world\"}",
+      "node_host": "node.example",
+      "timestamp": "1700000001",
+      "canonical": "gc-sig-v1\nPOST\n/api/transactions\nfoo=bar\n93a23971a914e5eacbf0a8d25154cda309c3c1c72fbb9914d47c60f3cb681588\nnode.example\n1700000001\nGCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC",
+      "signature": "GSTE2+t4ZJPjYOaFT9TwpHEM6RWiI40SbF04Cx5WJGU62PoriyAwArvKe/XbAxgUU30vtkxqUz3qqgrtXQWWrumqG86ysNNU+5mybBH541b2vJZ0KYOSUJrDo7mptn4ijNnrtgeZ1vpXAvHZvXZcZ203Fp6BrK9iTRbUBp5I0kb3HjlCjWOeBxFUNV9UjdM2+5/FALBngd+s624hG6wIMaDLpvu2c2naBsirIGN0cJVt1O3pnHxoZPe+SE7pp9D58WYTVkh1LS+5VeciTYP6Ix5JYszT8/EArHGFohAgj3v0r/h22ig7NpwpJZ250B9YqhmhBcdLjirS/0gDPjxLMw=="
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-06-06-egu-2-core-signing-module.md
+++ b/docs/superpowers/plans/2026-06-06-egu-2-core-signing-module.md
@@ -1,0 +1,603 @@
+# EGU #2.1 — headless gc-sig-v1 core signing module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A vanilla-ESM, zero-dependency, zero-build JS module under `clients/wallet/` that produces `gc-sig-v1` signatures, `GC`-tagged addresses, and `GC-*` headers byte-for-byte compatible with the Python node, proven by golden vectors and a live `node`→`signing.verify` cross-check, gated in CI via Node's built-in test runner (no npm).
+
+**Architecture:** Three single-responsibility ESM files (`gc-crypto` → `gc-wallet` → `gc-sig`) using only Web Crypto; a Python golden-vector generator/oracle; JS unit tests via `node --test`; a Python live cross-verify; Node 20 added to CI with zero npm packages.
+
+**Tech Stack:** Vanilla JavaScript (ES modules, Web Crypto `crypto.subtle`), Node 20 (built-in `node --test` only — no `package.json`, no `node_modules`), Python 3.12 (test-side generator/parity), pytest, uv, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md` (issue #170)
+
+---
+
+## Critical parity facts (verified against the Python code)
+
+- **Sign:** `RSASSA-PKCS1-v1_5` + `SHA-384`, base64 of the raw signature. Deterministic — identical bytes Python/JS for a fixed key+input.
+- **Keygen:** RSA modulusLength 2048, publicExponent `0x010001`, hash `SHA-384`.
+- **Public key:** DER **SPKI** (`exportKey('spki')`), base64 for `GC-Public-Key` / `public_key_b64`.
+- **Private key:** DER **PKCS8** unencrypted (`importKey('pkcs8')`), plain base58 for the b58 form.
+- **millHash:** `sha256(sha512(x))` — `subtle.digest('SHA-256', await subtle.digest('SHA-512', x))`.
+- **Address:** `'GC' + base58(millHash(spkiDER)) + 'GC'`.
+- **base58 is PLAIN (no checksum)** — the `base58check` lib's `b58encode` is plain base58 despite its name. Bitcoin alphabet `123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`; big-endian base-256→58; each leading `0x00` byte → one leading `1`. **Do not append a checksum.**
+- **Canonical:** UTF-8 `\n`-join of: `gc-sig-v1`, `METHOD.upper()`, `path`, `query`, `sha256(body or b'').hexdigest()`, `node_host`, `timestamp`, `address`.
+- **Headers:** `GC-Sig-Version`=`1`, `GC-Address`, `GC-Public-Key` (b64 SPKI), `GC-Timestamp`, `GC-Signature` (b64 sig over canonical).
+
+Golden constants (from the real Python lib, for the JS unit tests):
+- `base58(bytes 0x00..0x1f)` = `1thX6LZfHDZZKUs92febYZhYRcXddmzfzF2NvTkPNE`
+- `base58(b'hello')` = `Cn8eVZg`
+- `millHash('abc')` (hex) = `2b8e2baefea41ddf88d7ccd66550cb9493970ea7854d2e74eb33e57cd3c73d9c`
+
+Node has Web Crypto on `globalThis.crypto` (Node 19+); target Node 20 LTS.
+
+---
+
+## Task 1: `gc-crypto.mjs` primitives + JS unit tests
+
+**Files:**
+- Create: `clients/wallet/gc-crypto.mjs`
+- Test: `clients/wallet/gc-crypto.test.mjs`
+
+- [ ] **Step 1: Write the failing JS unit test**
+
+Create `clients/wallet/gc-crypto.test.mjs` using Node's built-in runner:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  base58encode, base58decode, base64encode, base64decode, millHash,
+} from './gc-crypto.mjs';
+
+const hex = (u8) => Buffer.from(u8).toString('hex');
+const unhex = (s) => Uint8Array.from(Buffer.from(s, 'hex'));
+
+test('base58 matches the Python base58check lib (plain, no checksum)', () => {
+  const bytes0to31 = Uint8Array.from({ length: 32 }, (_, i) => i);
+  assert.equal(base58encode(bytes0to31), '1thX6LZfHDZZKUs92febYZhYRcXddmzfzF2NvTkPNE');
+  assert.equal(base58encode(new TextEncoder().encode('hello')), 'Cn8eVZg');
+});
+
+test('base58 preserves leading zero bytes as leading 1s', () => {
+  assert.equal(base58encode(Uint8Array.from([0])), '1');
+  assert.equal(base58encode(Uint8Array.from([0, 0, 1])), '112');
+});
+
+test('base58 round-trips arbitrary bytes', () => {
+  for (const sample of [[0], [255], [0, 0, 7, 200], [1, 2, 3, 4, 5]]) {
+    const u8 = Uint8Array.from(sample);
+    assert.equal(hex(base58decode(base58encode(u8))), hex(u8));
+  }
+});
+
+test('base64 round-trips', () => {
+  const u8 = Uint8Array.from([0, 1, 250, 99, 7]);
+  assert.equal(hex(base64decode(base64encode(u8))), hex(u8));
+});
+
+test('millHash is sha256(sha512(x)) — matches Python', async () => {
+  const out = await millHash(new TextEncoder().encode('abc'));
+  assert.equal(hex(out), '2b8e2baefea41ddf88d7ccd66550cb9493970ea7854d2e74eb33e57cd3c73d9c');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `node --test clients/wallet/gc-crypto.test.mjs`
+Expected: FAIL — `gc-crypto.mjs` does not exist / exports undefined.
+
+- [ ] **Step 3: Implement `gc-crypto.mjs`**
+
+Create `clients/wallet/gc-crypto.mjs`. Plain base58 (Bitcoin alphabet, leading-zero→`1`, no checksum), base64 via standard btoa/atob-free byte math (works in browser + Node), and `millHash` via Web Crypto.
+
+```javascript
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 19+.
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export function base58encode(bytes) {
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  // base-256 -> base-58 (big-endian)
+  const digits = [0];
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let out = '1'.repeat(zeros);
+  for (let k = digits.length - 1; k >= 0; k--) out += B58[digits[k]];
+  return out;
+}
+
+export function base58decode(str) {
+  let zeros = 0;
+  while (zeros < str.length && str[zeros] === '1') zeros++;
+  const bytes = [0];
+  for (let i = zeros; i < str.length; i++) {
+    const val = B58.indexOf(str[i]);
+    if (val < 0) throw new Error(`invalid base58 char: ${str[i]}`);
+    let carry = val;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let k = 0; k < bytes.length; k++) out[zeros + k] = bytes[bytes.length - 1 - k];
+  return out;
+}
+
+export function base64encode(bytes) {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export function base64decode(str) {
+  const bin = atob(str);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function millHash(bytes) {
+  const inner = await crypto.subtle.digest('SHA-512', bytes);
+  const outer = await crypto.subtle.digest('SHA-256', inner);
+  return new Uint8Array(outer);
+}
+```
+Note: `btoa`/`atob` exist in browsers and in Node 16+. If the JS test environment lacks them, the implementer may swap to a small manual base64 — but Node 20 has them globally, so prefer the built-ins.
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `node --test clients/wallet/gc-crypto.test.mjs` → all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-crypto.mjs clients/wallet/gc-crypto.test.mjs
+git commit -m "$(cat <<'EOF'
+feat(wallet): gc-crypto primitives — plain base58, base64, millHash (Web Crypto) (#170)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Python golden-vector generator + oracle test
+
+**Files:**
+- Create: `tests/test_browser_wallet_vectors.py`
+- Create (generated, committed): `clients/wallet/testdata/gc-sig-vectors.json`
+
+- [ ] **Step 1: Generate a fixed test wallet's b58 private key (one-time)**
+
+Run a throwaway to mint a fixed 2048-bit wallet and capture its b58 private key:
+```bash
+uv run python -c "from gumptionchain.wallet import Wallet; print(Wallet().private_key_b58)"
+```
+Copy the output; it becomes the `VECTOR_WALLET_B58` constant below (a committed, test-only key, distinct from conftest's canonical wallet).
+
+- [ ] **Step 2: Write the generator + drift-guard/verify test**
+
+Create `tests/test_browser_wallet_vectors.py`. It builds the fixed wallet, emits the vectors (address, public_key_b64, signing cases over representative canonicals), writes them if missing, and asserts the committed file matches a fresh regeneration (drift guard) and that Python verifies every signature.
+
+```python
+import json
+from pathlib import Path
+
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+
+VECTOR_WALLET_B58 = '<paste from Step 1>'
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'testdata' / 'gc-sig-vectors.json'
+)
+
+# Fixed, representative signing cases (cover empty + non-empty body, query).
+_CASES = [
+    {
+        'method': 'GET', 'path': '/api/blocks', 'query': '',
+        'body': '', 'node_host': 'node.example', 'timestamp': '1700000000',
+    },
+    {
+        'method': 'POST', 'path': '/api/transactions', 'query': 'foo=bar',
+        'body': '{"hello":"world"}', 'node_host': 'node.example',
+        'timestamp': '1700000001',
+    },
+]
+
+
+def _build_vectors():
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    cases = []
+    for c in _CASES:
+        canonical = _canonical(
+            method=c['method'], path=c['path'], query=c['query'],
+            body=c['body'].encode(), node_host=c['node_host'],
+            timestamp=c['timestamp'], address=w.address,
+        )
+        cases.append({
+            **c,
+            'canonical': canonical.decode(),
+            'signature': w.sign(canonical),
+        })
+    return {
+        'private_key_b58': VECTOR_WALLET_B58,
+        'public_key_b64': w.public_key_b64,
+        'address': w.address,
+        'cases': cases,
+    }
+
+
+def test_vectors_committed_and_self_consistent():
+    fresh = _build_vectors()
+    # Write on first run if absent, so the file is generated deterministically.
+    if not VECTORS_PATH.exists():
+        VECTORS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        VECTORS_PATH.write_text(json.dumps(fresh, indent=2) + '\n')
+    committed = json.loads(VECTORS_PATH.read_text())
+    assert committed == fresh, 'gc-sig-vectors.json drifted; regenerate'
+
+    # Python verifies every committed signature (sanity that the oracle is real).
+    w = Wallet(b58ks=committed['private_key_b58'])
+    for case in committed['cases']:
+        assert w.validate_signature(case['canonical'].encode(), case['signature'])
+```
+
+- [ ] **Step 3: Run to generate + verify**
+
+Run: `uv run pytest tests/test_browser_wallet_vectors.py -q`
+Expected: PASS (first run writes the JSON, then asserts equality + verification). Confirm `clients/wallet/testdata/gc-sig-vectors.json` now exists and is committed.
+
+- [ ] **Step 4: Lint/types for the new Python**
+
+Run: `uv run ruff check tests && uv run ruff format --check tests && uv run mypy`
+Expected: green (fix any ruff issues in the new test; `VECTOR_WALLET_B58` is a long string — keep within line length or use implicit concatenation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_browser_wallet_vectors.py clients/wallet/testdata/gc-sig-vectors.json
+git commit -m "$(cat <<'EOF'
+test(wallet): golden gc-sig vectors from a fixed wallet (oracle for JS parity) (#170)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `gc-wallet.mjs` + `gc-sig.mjs` + JS tests against the vectors
+
+**Files:**
+- Create: `clients/wallet/gc-wallet.mjs`, `clients/wallet/gc-sig.mjs`
+- Test: `clients/wallet/gc-wallet.test.mjs`
+
+- [ ] **Step 1: Write the failing JS tests (assert against the golden vectors)**
+
+Create `clients/wallet/gc-wallet.test.mjs`. It loads `testdata/gc-sig-vectors.json`, imports the fixed key, and asserts JS reproduces the committed address, canonical, and signature byte-for-byte, plus a fresh-keygen round-trip and the `GC-*` header shape.
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { Wallet } from './gc-wallet.mjs';
+import { canonical, signHeaders } from './gc-sig.mjs';
+
+const V = JSON.parse(readFileSync(new URL('./testdata/gc-sig-vectors.json', import.meta.url)));
+
+test('imported fixed key derives the same address + public key as Python', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  assert.equal(await w.address(), V.address);
+  assert.equal(await w.publicKeyB64(), V.public_key_b64);
+});
+
+test('canonical bytes match Python for every case', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  const addr = await w.address();
+  for (const c of V.cases) {
+    const bytes = await canonical({
+      method: c.method, path: c.path, query: c.query,
+      body: new TextEncoder().encode(c.body),
+      nodeHost: c.node_host, timestamp: c.timestamp, address: addr,
+    });
+    assert.equal(new TextDecoder().decode(bytes), c.canonical);
+  }
+});
+
+test('signatures match Python byte-for-byte (deterministic PKCS1v15)', async () => {
+  const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
+  for (const c of V.cases) {
+    const sig = await w.sign(new TextEncoder().encode(c.canonical));
+    assert.equal(sig, c.signature);
+  }
+});
+
+test('fresh keygen round-trips and signHeaders has the GC-* shape', async () => {
+  const w = await Wallet.generate();
+  const headers = await signHeaders(w, {
+    method: 'GET', path: '/api/blocks', query: '',
+    body: new Uint8Array(), nodeHost: 'node.example', timestamp: '1700000000',
+  });
+  assert.equal(headers['GC-Sig-Version'], '1');
+  assert.equal(headers['GC-Address'], await w.address());
+  assert.equal(headers['GC-Public-Key'], await w.publicKeyB64());
+  assert.equal(headers['GC-Timestamp'], '1700000000');
+  assert.ok(headers['GC-Signature']);
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `node --test clients/wallet/gc-wallet.test.mjs`
+Expected: FAIL — `gc-wallet.mjs` / `gc-sig.mjs` don't exist.
+
+- [ ] **Step 3: Implement `gc-wallet.mjs`**
+
+```javascript
+import {
+  base58encode, base58decode, base64encode, millHash,
+} from './gc-crypto.mjs';
+
+const ALG = { name: 'RSASSA-PKCS1-v1_5' };
+const KEYGEN = {
+  name: 'RSASSA-PKCS1-v1_5',
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+  hash: 'SHA-384',
+};
+const ADDRESS_TAG = 'GC';
+
+export class Wallet {
+  #privateKey; // CryptoKey | null
+  #publicKey;  // CryptoKey
+
+  constructor(privateKey, publicKey) {
+    this.#privateKey = privateKey;
+    this.#publicKey = publicKey;
+  }
+
+  static async generate() {
+    const pair = await crypto.subtle.generateKey(KEYGEN, true, ['sign', 'verify']);
+    return new Wallet(pair.privateKey, pair.publicKey);
+  }
+
+  static async fromPrivateKeyB58(b58) {
+    const pkcs8 = base58decode(b58);
+    const priv = await crypto.subtle.importKey(
+      'pkcs8', pkcs8, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' }, true, ['sign'],
+    );
+    // Derive the public key from the private (export JWK -> strip private fields).
+    const jwk = await crypto.subtle.exportKey('jwk', priv);
+    const pubJwk = { kty: jwk.kty, n: jwk.n, e: jwk.e, alg: jwk.alg, ext: true };
+    const pub = await crypto.subtle.importKey(
+      'jwk', pubJwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' }, true, ['verify'],
+    );
+    return new Wallet(priv, pub);
+  }
+
+  async exportPrivateKeyB58() {
+    if (!this.#privateKey) throw new Error('no private key');
+    const pkcs8 = new Uint8Array(await crypto.subtle.exportKey('pkcs8', this.#privateKey));
+    return base58encode(pkcs8);
+  }
+
+  async #spki() {
+    return new Uint8Array(await crypto.subtle.exportKey('spki', this.#publicKey));
+  }
+
+  async publicKeyB64() {
+    return base64encode(await this.#spki());
+  }
+
+  async address() {
+    const digest = await millHash(await this.#spki());
+    return `${ADDRESS_TAG}${base58encode(digest)}${ADDRESS_TAG}`;
+  }
+
+  async sign(bytes) {
+    if (!this.#privateKey) throw new Error('no private key');
+    const sig = await crypto.subtle.sign(ALG, this.#privateKey, bytes);
+    return base64encode(new Uint8Array(sig));
+  }
+}
+```
+Note on `fromPrivateKeyB58`: deriving the public key from a PKCS8 private key requires the JWK round-trip shown (Web Crypto has no direct "public from private"). If the implementer finds the JWK `alg` field causes an import mismatch, drop `alg` from `pubJwk` (the algorithm is supplied as the import param). The address/publicKeyB64 tests against the vectors will confirm the SPKI matches Python exactly.
+
+- [ ] **Step 4: Implement `gc-sig.mjs`**
+
+```javascript
+import { sha256Hex } from './gc-crypto.mjs';
+
+const SIG_SCHEME = 'gc-sig-v1';
+const SIG_VERSION = '1';
+
+export async function canonical({ method, path, query, body, nodeHost, timestamp, address }) {
+  const bodyDigest = await sha256Hex(body ?? new Uint8Array());
+  const lines = [
+    SIG_SCHEME, method.toUpperCase(), path, query, bodyDigest,
+    nodeHost, timestamp, address,
+  ];
+  return new TextEncoder().encode(lines.join('\n'));
+}
+
+export async function signHeaders(wallet, { method, path, query, body, nodeHost, timestamp }) {
+  const address = await wallet.address();
+  const bytes = await canonical({ method, path, query, body, nodeHost, timestamp, address });
+  return {
+    'GC-Sig-Version': SIG_VERSION,
+    'GC-Address': address,
+    'GC-Public-Key': await wallet.publicKeyB64(),
+    'GC-Timestamp': String(timestamp),
+    'GC-Signature': await wallet.sign(bytes),
+  };
+}
+```
+Add `sha256Hex` to `gc-crypto.mjs` (it was named in the spec; add it now if not already present):
+```javascript
+export async function sha256Hex(bytes) {
+  const d = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  return Array.from(d, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+```
+
+- [ ] **Step 5: Run, expect PASS**
+
+Run: `node --test clients/wallet/` (runs all `*.test.mjs`)
+Expected: all pass — JS reproduces the golden address/canonical/signature byte-for-byte.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/wallet/gc-wallet.mjs clients/wallet/gc-sig.mjs clients/wallet/gc-wallet.test.mjs clients/wallet/gc-crypto.mjs
+git commit -m "$(cat <<'EOF'
+feat(wallet): gc-wallet + gc-sig — keygen, address, sign, canonical, GC-* headers (#170)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Live cross-verify (node ↔ Python) + CI Node 20
+
+**Files:**
+- Create: `clients/wallet/sign-cli.mjs` (tiny driver), `tests/test_browser_wallet_parity.py`
+- Modify: `.github/workflows/tests.yml`
+
+- [ ] **Step 1: Write the live cross-verify test (failing)**
+
+Add a tiny Node driver `clients/wallet/sign-cli.mjs` that reads a JSON request on argv/stdin, signs with a given b58 key, and prints `{address, signature}`:
+```javascript
+import { Wallet } from './gc-wallet.mjs';
+import { canonical } from './gc-sig.mjs';
+
+const req = JSON.parse(process.argv[2]);
+const w = await Wallet.fromPrivateKeyB58(req.private_key_b58);
+const address = await w.address();
+const bytes = await canonical({
+  method: req.method, path: req.path, query: req.query,
+  body: new TextEncoder().encode(req.body ?? ''),
+  nodeHost: req.node_host, timestamp: req.timestamp, address,
+});
+const signature = await w.sign(bytes);
+process.stdout.write(JSON.stringify({ address, signature }));
+```
+
+Create `tests/test_browser_wallet_parity.py` — shells to `node`, feeds the result into the real verifier:
+```python
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+
+from tests.test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'sign-cli.mjs'
+)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signature_verifies_in_python():
+    req = {
+        'private_key_b58': VECTOR_WALLET_B58,
+        'method': 'POST', 'path': '/api/transactions', 'query': 'a=1',
+        'body': '{"x":1}', 'node_host': 'node.example',
+        'timestamp': '1700000002',
+    }
+    out = subprocess.run(
+        ['node', str(CLI), json.dumps(req)],
+        capture_output=True, text=True, check=True,
+    )
+    result = json.loads(out.stdout)
+
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    # Address parity: JS-derived == Python-derived.
+    assert result['address'] == w.address
+    # Signature parity: the real Python verifier accepts the JS signature.
+    canonical = _canonical(
+        method=req['method'], path=req['path'], query=req['query'],
+        body=req['body'].encode(), node_host=req['node_host'],
+        timestamp=req['timestamp'], address=w.address,
+    )
+    assert w.validate_signature(canonical, result['signature'])
+```
+
+- [ ] **Step 2: Run, expect PASS (locally, with node installed)**
+
+Run: `uv run pytest tests/test_browser_wallet_parity.py -q`
+Expected: PASS — the JS-produced signature verifies in Python and the address matches. (If `node` is absent the test skips; install Node 20 to actually run it.) This is the load-bearing parity proof.
+
+- [ ] **Step 3: Add Node 20 to CI**
+
+Edit `.github/workflows/tests.yml`. In the test job, add a `setup-node` step (PINNED TO A COMMIT SHA per the repo's actions-pinning policy — look up the current `actions/setup-node` v4 SHA and keep the `# v4.x.x` comment) before the `uv run pytest` step, plus a `node --test` step. Example shape:
+
+```yaml
+      - uses: actions/setup-node@<commit-sha>  # v4.x.x
+        with:
+          node-version: '20'
+      - run: node --test clients/wallet/
+      # ... existing uv steps; pytest now has node on PATH for the cross-verify
+```
+Order matters: `setup-node` must come before `uv run pytest` so `node` is on PATH for `test_browser_wallet_parity.py`. Run `node --test clients/wallet/` as its own gating step too. Do NOT add any `package.json`, `npm install`, or `node_modules` — built-in runner only.
+
+- [ ] **Step 4: Validate the workflow locally (syntax) + full local gate**
+
+Run the full local suite to confirm nothing regressed and the parity test passes with node present:
+`node --test clients/wallet/ && uv run pytest -q && uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy`
+Expected: JS tests pass; full pytest (incl. vectors + parity) green; lint/types green. Eyeball the YAML for valid syntax (indentation, the pinned SHA).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/sign-cli.mjs tests/test_browser_wallet_parity.py .github/workflows/tests.yml
+git commit -m "$(cat <<'EOF'
+test(wallet): live node->Python gc-sig cross-verify + Node 20 in CI (no npm) (#170)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** three ESM files (Tasks 1,3); golden vectors oracle (Task 2); JS unit tests via `node --test` (Tasks 1,3); live cross-verify (Task 4); Node 20 in CI, no npm (Task 4). Storage/passkey/backup/UX/packaging explicitly out of scope.
+- **Parity:** base58 is PLAIN (no checksum) — the corrected spec; JS golden constants are real Python outputs; deterministic PKCS1v15 makes signature vectors exact; the live cross-verify is the no-drift proof.
+- **Supply chain:** zero npm packages, no `package.json`/`node_modules`; only the Node runtime is added (pinned `setup-node` SHA), per CLAUDE.md.
+- **No Python runtime change** — only test-side generator + parity tests; no schema/migration; `db check` unaffected.
+- **Type/name consistency:** `Wallet.fromPrivateKeyB58/generate/address/sign/publicKeyB64`, `canonical`, `signHeaders` used consistently across module + tests; `sha256Hex`/`millHash`/`base58encode|decode`/`base64encode|decode` exported from `gc-crypto`.
+
+## Definition of done
+
+- `clients/wallet/{gc-crypto,gc-wallet,gc-sig}.mjs` — vanilla ESM, zero-dep, runnable in browser + Node.
+- `node --test clients/wallet/` green; golden vectors committed + drift-guarded; the live `node`→`signing.verify` cross-check passes (JS signature verifies in Python; JS address == Python address).
+- Node 20 in CI via a SHA-pinned `setup-node`, `node --test` gating step, node on the pytest PATH; **no npm packages**.
+- Full `uv run pytest` + ruff + mypy green; no Python runtime/schema change.

--- a/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
@@ -36,9 +36,9 @@ storage/UX layers can be built against a trusted core.
 | Public key bytes | DER **SubjectPublicKeyInfo** | `subtle.exportKey('spki', pub)` |
 | Public key b64 | base64(SPKI DER) | base64 of the SPKI export |
 | Private key bytes | DER **PKCS8** (unencrypted) | `subtle.importKey('pkcs8', …)` / `exportKey('pkcs8')` |
-| Private key b58 | base58check(PKCS8 DER) | base58check of the PKCS8 bytes |
+| Private key b58 | base58(PKCS8 DER) (plain, no checksum) | plain base58 of the PKCS8 bytes |
 | `millHash` | `sha256(sha512(data)).digest()` | `subtle.digest('SHA-256', await subtle.digest('SHA-512', data))` |
-| Address | `'GC' + base58check(millHash(spki)) + 'GC'` | same, with pure-JS base58check |
+| Address | `'GC' + base58(millHash(spki)) + 'GC'` (plain base58) | same, with pure-JS plain base58 |
 | Canonical | `\n`-join: `gc-sig-v1`, METHOD, path, query, `sha256(body).hexdigest()`, node_host, timestamp, address (UTF-8) | same |
 | Headers | `GC-Sig-Version=1`, `GC-Address`, `GC-Public-Key`(b64 SPKI), `GC-Timestamp`, `GC-Signature`(b64 sig over canonical) | same |
 
@@ -46,18 +46,22 @@ storage/UX layers can be built against a trusted core.
 canonical yields **identical** signature bytes in Python and JS. This makes
 golden-vector parity exact, not approximate.
 
-**The one delicate primitive — base58check.** The JS implementation must
-byte-match the Python `base58check>=1.0.2` package: base58-encode
-`payload + sha256(sha256(payload))[:4]` using the Bitcoin alphabet
-(`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`), preserving
-leading-zero bytes as leading `1`s. The golden vectors and the live cross-verify
-are what prove this is exact; if a mismatch appears, base58check is the first
-suspect.
+**The one delicate primitive — base58 (NOT base58check).** Empirically verified:
+the Python `base58check>=1.0.2` package's `b58encode`/`b58decode` are **plain
+base58 with no checksum**, despite the package name — `b58encode(b'\x00') == '1'`
+(a 4-byte checksum would lengthen it) and the 32-byte address hash encodes to 42
+chars, not the ~48 a checksum would add. So the JS must implement **plain
+base58**: the Bitcoin alphabet
+(`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`), big-endian
+base-256→base-58 conversion, preserving each leading `0x00` byte as a leading
+`1`. **Do not add a double-sha256 checksum** — that would break parity. The
+golden vectors and live cross-verify prove the byte-match; if a mismatch appears,
+base58 is the first suspect.
 
 ## Components (small, single-responsibility files under `clients/wallet/`)
 
 - **`gc-crypto.mjs`** — primitives, no protocol knowledge: `base64encode/decode`,
-  `base58checkEncode/Decode`, `millHash(bytes) -> Uint8Array` (sha256∘sha512),
+  `base58encode/decode` (plain base58, no checksum), `millHash(bytes) -> Uint8Array` (sha256∘sha512),
   `sha256Hex(bytes)`.
 - **`gc-wallet.mjs`** — the `Wallet`-equivalent: `generate()` (RSA-2048 keypair),
   `fromPrivateKeyB58(b58)` / `exportPrivateKeyB58()`, `publicKeyB64()`,

--- a/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
@@ -1,0 +1,159 @@
+# EGU #2.1 — headless gc-sig-v1 core signing module — design
+
+**Date:** 2026-06-06
+**Status:** Approved design, pre-implementation
+**Issue:** #170 (sub-project 1 of EGU #2 / #152)
+**Type:** New client module (vanilla JS / Web Crypto) — additive; no change to the Python chain.
+
+## Summary
+
+The first sub-project of the dependency-free browser wallet (#152): a headless
+JS module that produces **`gc-sig-v1`** signatures, **`GC`-tagged addresses**, and
+**`GC-*` request headers** that the Python node verifies **byte-for-byte**. It is
+**vanilla ESM, zero-dependency, zero-build**, using only Web Crypto
+(`crypto.subtle`) — browser-target, but runs identically under Node for tests.
+
+This sub-project is **crypto/signing parity only**. Passkey-anchored storage,
+backup/recovery, generic-message-signing UX, and packaging/hosting are deferred
+to later sub-projects of #152. The `sign(bytes)` primitive built here is what all
+of those later layers build on.
+
+Depends on EGU 1b (#167, merged): RSA key size 2048 and signing-scheme stability.
+
+## Why this first
+
+It is small, self-contained, and unblocks everything else in #152, and it carries
+the hardest correctness bar — a JS-produced signature must verify in the Python
+`signing.verify`. Getting parity nailed and CI-gated first means the
+storage/UX layers can be built against a trusted core.
+
+## Verified parity mappings (from `wallet.py` / `signing.py` / `milling.py`)
+
+| Concern | Python | Web Crypto / JS |
+|---|---|---|
+| Signature | `private_key.sign(data, PKCS1v15(), SHA384())` → base64 | `subtle.sign({name:'RSASSA-PKCS1-v1_5'}, key, data)` → base64 |
+| Keygen | RSA 2048, public exponent 65537 | `subtle.generateKey` modulusLength 2048, publicExponent `[0x01,0x00,0x01]`, hash `SHA-384` |
+| Public key bytes | DER **SubjectPublicKeyInfo** | `subtle.exportKey('spki', pub)` |
+| Public key b64 | base64(SPKI DER) | base64 of the SPKI export |
+| Private key bytes | DER **PKCS8** (unencrypted) | `subtle.importKey('pkcs8', …)` / `exportKey('pkcs8')` |
+| Private key b58 | base58check(PKCS8 DER) | base58check of the PKCS8 bytes |
+| `millHash` | `sha256(sha512(data)).digest()` | `subtle.digest('SHA-256', await subtle.digest('SHA-512', data))` |
+| Address | `'GC' + base58check(millHash(spki)) + 'GC'` | same, with pure-JS base58check |
+| Canonical | `\n`-join: `gc-sig-v1`, METHOD, path, query, `sha256(body).hexdigest()`, node_host, timestamp, address (UTF-8) | same |
+| Headers | `GC-Sig-Version=1`, `GC-Address`, `GC-Public-Key`(b64 SPKI), `GC-Timestamp`, `GC-Signature`(b64 sig over canonical) | same |
+
+**Determinism:** `PKCS1v15` signing has no randomness, so a fixed key + fixed
+canonical yields **identical** signature bytes in Python and JS. This makes
+golden-vector parity exact, not approximate.
+
+**The one delicate primitive — base58check.** The JS implementation must
+byte-match the Python `base58check>=1.0.2` package: base58-encode
+`payload + sha256(sha256(payload))[:4]` using the Bitcoin alphabet
+(`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`), preserving
+leading-zero bytes as leading `1`s. The golden vectors and the live cross-verify
+are what prove this is exact; if a mismatch appears, base58check is the first
+suspect.
+
+## Components (small, single-responsibility files under `clients/wallet/`)
+
+- **`gc-crypto.mjs`** — primitives, no protocol knowledge: `base64encode/decode`,
+  `base58checkEncode/Decode`, `millHash(bytes) -> Uint8Array` (sha256∘sha512),
+  `sha256Hex(bytes)`.
+- **`gc-wallet.mjs`** — the `Wallet`-equivalent: `generate()` (RSA-2048 keypair),
+  `fromPrivateKeyB58(b58)` / `exportPrivateKeyB58()`, `publicKeyB64()`,
+  `address()`, `sign(bytes) -> base64`. Pure crypto identity; no storage.
+- **`gc-sig.mjs`** — protocol layer: `canonical({method, path, query, body,
+  nodeHost, timestamp, address}) -> Uint8Array` and `signHeaders(wallet, {…})
+  -> {GC-Sig-Version, GC-Address, GC-Public-Key, GC-Timestamp, GC-Signature}`,
+  mirroring `signing.py` `_canonical` / `sign_headers`.
+
+Each is independently testable; `gc-sig` depends on `gc-wallet` depends on
+`gc-crypto`. All are async where Web Crypto is (keygen/sign/digest return
+promises).
+
+## Data flow (signing a request)
+
+`signHeaders` builds the canonical bytes from the request parts → `wallet.sign`
+runs `subtle.sign` (PKCS1v15/SHA-384) → base64 → assembled into the `GC-*`
+headers alongside the b64 SPKI public key and the address. The Python
+`authorize()` / `signing.verify` recomputes the same canonical and verifies.
+
+## Error handling
+
+The module is pure crypto; errors are programmer errors surfaced as thrown
+`Error`s (mirroring the Python `NoPrivateKeyError` / import-failure semantics):
+`sign` without a private key throws; malformed key import throws. Callers (later
+sub-projects) handle UX. No silent fallback.
+
+## Testing — three layers
+
+1. **JS unit tests** — `clients/wallet/*.test.mjs`, run with Node's built-in
+   runner (`node --test`), **zero npm dependencies**. Cover: keygen shape (2048,
+   e=65537), `millHash` against a known digest, base58check round-trip + against
+   golden values, address derivation, `sign` against golden signature, canonical
+   string bytes, and `signHeaders` shape/values.
+2. **Golden vectors** — `clients/wallet/testdata/gc-sig-vectors.json`, emitted by
+   a Python generator from a **fixed test wallet** (a checked-in private key,
+   distinct from the conftest canonical wallet): `{private_key_b58,
+   public_key_b64, address, cases: [{method, path, query, body, node_host,
+   timestamp, canonical, signature}]}`. A pytest (`tests/test_browser_wallet_
+   vectors.py`) regenerates from the fixed key and asserts the committed vectors
+   match (so they can't silently drift), and that Python verifies each vector
+   signature. The JS unit tests assert JS reproduces the same address/canonical/
+   signature for the same inputs.
+3. **Live cross-verify** — `tests/test_browser_wallet_parity.py`: pytest shells
+   out to `node` running a tiny `gc-wallet` driver that signs a canonical with
+   the fixed key and prints the b64 signature + derived address; pytest asserts
+   the real `Wallet(public_key).validate_signature(canonical, sig)` (and/or
+   `signing.verify`) accepts it, and `address == Python address`. This is the
+   no-fixture-drift proof that the actual JS code interoperates with the actual
+   Python verifier.
+
+## CI
+
+Add **Node 20 LTS** to the CI workflow as the one new tool:
+- a step running `node --test clients/wallet/`,
+- Node also on the `pytest` job's PATH so `test_browser_wallet_parity.py` runs
+  (or it skips with a clear marker if `node` is absent — but the intent is it
+  runs).
+
+**No `package.json`, no `node_modules`, no npm install** — Node's built-in test
+runner + Web Crypto only. This is the supply-chain-safe path: the only new
+dependency surface is the Node runtime itself, explicitly surfaced, with zero npm
+packages (per the CLAUDE.md npm-caution).
+
+## Out of scope (later sub-projects of #152)
+
+- **Passkey-anchored storage** (WebAuthn PRF → at-rest key → IndexedDB).
+- **Backup / recovery** (encrypted export + passkey-synced restore).
+- **Generic message-signing UX** (the `sign(bytes)` primitive is built here; the
+  off-chain "address X is me" envelope/format is later).
+- **Packaging / hosting** (distribution; gumption.com embedding).
+- Any change to the Python chain (this is purely additive client code; the only
+  Python added is test-side generators/parity tests).
+
+## Decisions log
+
+- **Core signing parity first**, storage/UX deferred — smallest unblocking unit,
+  hardest correctness bar.
+- **In this repo** under `clients/wallet/` — co-located with `signing.py` so the
+  live cross-verify can feed JS output straight into the Python verifier. (The
+  separate-repo item is the gumption.com hub, EGU #5.)
+- **Vanilla ESM, zero-dep, zero-build, Web Crypto** — sidesteps npm supply-chain
+  risk; the browser is the target and Node runs the same code for tests.
+- **Parity strategy = golden vectors + live cross-verify (option A)**;
+  deterministic PKCS1v15 makes vectors exact. JS is CI-gated against the Python
+  verifier.
+- **Node 20 in CI, built-in runner, no npm deps** — the one surfaced new tool.
+
+## Definition of done
+
+- `gc-crypto.mjs` / `gc-wallet.mjs` / `gc-sig.mjs` under `clients/wallet/`,
+  vanilla ESM, zero deps, runnable in browser and Node.
+- A JS-produced `gc-sig-v1` signature verifies in the Python `signing.verify`,
+  and JS-derived addresses equal Python addresses — proven by the live
+  cross-verify test and the golden vectors.
+- `node --test clients/wallet/` green; the Python vector + parity tests green;
+  full `uv run pytest` green; ruff + mypy green (the new Python is test-side).
+- CI runs Node 20 (`node --test`) and the cross-verify, with no npm packages.
+- No change to the Python chain runtime; no schema/migration.

--- a/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2-core-signing-module-design.md
@@ -1,7 +1,7 @@
 # EGU #2.1 — headless gc-sig-v1 core signing module — design
 
 **Date:** 2026-06-06
-**Status:** Approved design, pre-implementation
+**Status:** Implemented in #171
 **Issue:** #170 (sub-project 1 of EGU #2 / #152)
 **Type:** New client module (vanilla JS / Web Crypto) — additive; no change to the Python chain.
 
@@ -93,7 +93,7 @@ sub-projects) handle UX. No silent fallback.
 
 1. **JS unit tests** — `clients/wallet/*.test.mjs`, run with Node's built-in
    runner (`node --test`), **zero npm dependencies**. Cover: keygen shape (2048,
-   e=65537), `millHash` against a known digest, base58check round-trip + against
+   e=65537), `millHash` against a known digest, base58 round-trip + against
    golden values, address derivation, `sign` against golden signature, canonical
    string bytes, and `signHeaders` shape/values.
 2. **Golden vectors** — `clients/wallet/testdata/gc-sig-vectors.json`, emitted by

--- a/tests/test_browser_wallet_parity.py
+++ b/tests/test_browser_wallet_parity.py
@@ -1,0 +1,50 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'sign-cli.mjs'
+)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signature_verifies_in_python() -> None:
+    req = {
+        'private_key_b58': VECTOR_WALLET_B58,
+        'method': 'POST',
+        'path': '/api/transactions',
+        'query': 'a=1',
+        'body': '{"x":1}',
+        'node_host': 'node.example',
+        'timestamp': '1700000002',
+    }
+    out = subprocess.run(  # noqa: S603
+        ['node', str(CLI), json.dumps(req)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result = json.loads(out.stdout)
+
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    assert result['address'] == w.address
+    canonical = _canonical(
+        method=req['method'],
+        path=req['path'],
+        query=req['query'],
+        body=req['body'].encode(),
+        node_host=req['node_host'],
+        timestamp=req['timestamp'],
+        address=w.address,
+    )
+    assert w.validate_signature(canonical, result['signature'])

--- a/tests/test_browser_wallet_vectors.py
+++ b/tests/test_browser_wallet_vectors.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 from gumptionchain.signing import _canonical
@@ -90,9 +91,15 @@ def _build_vectors() -> dict[str, object]:
 
 def test_vectors_committed_and_self_consistent() -> None:
     fresh = _build_vectors()
-    if not VECTORS_PATH.exists():
+    # Default run is READ-ONLY: fail loud if the committed oracle is missing,
+    # rather than silently regenerating (which would let an accidental deletion
+    # pass CI). Regenerate intentionally with GC_REGEN_VECTORS=1.
+    if os.environ.get('GC_REGEN_VECTORS'):
         VECTORS_PATH.parent.mkdir(parents=True, exist_ok=True)
         VECTORS_PATH.write_text(json.dumps(fresh, indent=2) + '\n')
+    assert VECTORS_PATH.exists(), (
+        'gc-sig-vectors.json missing; regenerate with GC_REGEN_VECTORS=1'
+    )
     committed = json.loads(VECTORS_PATH.read_text())
     assert committed == fresh, 'gc-sig-vectors.json drifted; regenerate'
 

--- a/tests/test_browser_wallet_vectors.py
+++ b/tests/test_browser_wallet_vectors.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+
+# A fixed, freshly-minted 2048-bit RSA wallet used solely to generate the
+# golden gc-sig vectors. Distinct from conftest's WALLET_PRIVATE_KEY_B58.
+VECTOR_WALLET_B58 = (
+    'riiewRJm2wpE3rWTs1ikUc83so8ZXMX8vp9dUTnRgMC8GyfLr99LtkqK8gDNAd1VyihbjW'
+    'opge9tGR3W9GCbpojrHtjpUqmmuEhHjpehtXGiMF1LqiZedaEE4V3X8X679uzitLTP3m8A'
+    'zcNGgqbPKWtVEd7VWmVWQdan68EpojZFwqrY3LFLiRnaKSLoNryxLUEFFrxcBNjyTpjL94'
+    '3Rs6YXFRgBs5UDSazh6GLPwu26oAPfLy8NNPqKjPuNHcCXoywopkMUug4bXJaKc93PxdtR'
+    '6kEWWxCaiNtsCe4JkukbRXNR6NpUrAtrgNgw8uM7Pg2tMP9ThbyaHxHLcaeYs8tfdPs2MX'
+    '3qfkw37cPX6P5wkFUVqcZhrL4PMzqHF2Hkf79hWYU1c3xwit8Rx2gM8HAQZgq5CGuNjj9Y'
+    'Ao3JcAbkVKtTqgFKJqmwY8jVLCtxKkzyBbxAAyuHtyioNQ5LFrxBs5qzoyRATTJwqVfhjo'
+    'WNEvHNpT3g97htCjtkgMssbfSBq6fmSa7mFpE3vA7dHPUhmjdiwhsdDhDVLnekVk8yxELP'
+    'EZzjCvKKZ1JW4oaXVcGvgkjFB2RquXCUFX272SYie7b2sEDbB61kC7rTxmrfanLX5Ah2X4'
+    'PKZK9xCaUKhEcbQsMBMve9uniasFMYecu829v9ELWRaRCjhMDKqnHhsPvvd7xMdLyUcTyC'
+    'Pcbwphc76GhyULAvpqumAoxvsQqXTcWmh4AtFzjjURneezkVa1sA1yfCEvfyEjPynpYv7X'
+    'WtymfciJ8NNS1SpuXBUrqdFSps2txaVD2F6JBwZE2VBA2SnVdd57cn5z7bcejheQB99mSC'
+    '69UFqR2vgPQek1VGHEQFsmtQXBWR3jrCeiSKsvW4SLESB3W7vDvhN1es5mjBnQ1rExmpDP'
+    'HQTAacJSVt1eiijvq8GccQcNsbLgHsJqXNBquvffYgWXTv3jY7kcZj7iCK1wjpLujhCzGX'
+    'J8mzTn7h6hu7ouAr3J54317eC4XeyZo7AQgiVSK7YrEyxw61fbsFdqMFMKi3ChmxfckTUk'
+    '3gNrTK8bXyhNrWpGN4masjADciLRYS7UD5M96nquMJop8hyftXEd2vmJVwqnzsorbePGu7'
+    'iAdFh26jKfYtDS1rNycLVCxKYR7nB9o6xDPVvEqnnTUUDrPNKf9wE8EbaHoysTeh5FqK7d'
+    'HupxRJCNp4h46dUnQpUCGtp5QzEZfRa6MLMoecPQ5icwfMMZuzraLpbLfSVdniZyuomZwd'
+    'W5rPDSqeZwaaWRTBizLaeeJKsfbb4gU27THHzCSxtd8S1pn4obmD5UHLXzBgi5nBCWuwmD'
+    'duz8mVm2ytQnTYGkAq6LJig8eGtYFtXMzhWuHUfEsj4o6k6rP1hLvVr7bhpp8r59a6m9Zi'
+    'tUCsCiEKxJC1b1TAy2EGLHoC6bwyUXUQe69dPTR981QsuW2CNmUrgtCduFfuGhqwvavxpP'
+    'NKPXuWVnuYYE2nzVNHZ7Bh2cicnQGF48iFnptWTWN7Nj6v8w6bHE4j9iosu13skYeN63y2'
+    'j4swwegX36KuEEfbutTBLJ7hq9GpSAqMgACbMKKEVhE7Zz3uzDTEFWHFGobWUYT8hzA9iy'
+    'fyhVv74B6CX4DS3biGzgPeBK81x6Yn83NSxXCh97wWTd1Q4ewdpwk'
+)
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'testdata'
+    / 'gc-sig-vectors.json'
+)
+
+_CASES = [
+    {
+        'method': 'GET',
+        'path': '/api/blocks',
+        'query': '',
+        'body': '',
+        'node_host': 'node.example',
+        'timestamp': '1700000000',
+    },
+    {
+        'method': 'POST',
+        'path': '/api/transactions',
+        'query': 'foo=bar',
+        'body': '{"hello":"world"}',
+        'node_host': 'node.example',
+        'timestamp': '1700000001',
+    },
+]
+
+
+def _build_vectors() -> dict[str, object]:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    cases = []
+    for c in _CASES:
+        canonical = _canonical(
+            method=c['method'],
+            path=c['path'],
+            query=c['query'],
+            body=c['body'].encode(),
+            node_host=c['node_host'],
+            timestamp=c['timestamp'],
+            address=w.address,
+        )
+        cases.append(
+            {
+                **c,
+                'canonical': canonical.decode(),
+                'signature': w.sign(canonical),
+            }
+        )
+    return {
+        'private_key_b58': VECTOR_WALLET_B58,
+        'public_key_b64': w.public_key_b64,
+        'address': w.address,
+        'cases': cases,
+    }
+
+
+def test_vectors_committed_and_self_consistent() -> None:
+    fresh = _build_vectors()
+    if not VECTORS_PATH.exists():
+        VECTORS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        VECTORS_PATH.write_text(json.dumps(fresh, indent=2) + '\n')
+    committed = json.loads(VECTORS_PATH.read_text())
+    assert committed == fresh, 'gc-sig-vectors.json drifted; regenerate'
+
+    w = Wallet(b58ks=committed['private_key_b58'])
+    for case in committed['cases']:
+        assert w.validate_signature(
+            case['canonical'].encode(), case['signature']
+        )


### PR DESCRIPTION
## Summary

Sub-project 1 of EGU #2 (#152): the **headless `gc-sig-v1` core signing module** — a vanilla-ESM, **zero-dependency, zero-build** JS module under `clients/wallet/` that produces `gc-sig-v1` signatures, `GC`-tagged addresses, and `GC-*` request headers **byte-for-byte compatible** with the Python node, using only Web Crypto. Browser-target; runs identically under Node for tests.

Closes #170. Depends on EGU 1b (#167, merged — RSA-2048). Storage / passkey / backup / message-signing UX / packaging are deferred to later #152 sub-projects.

## What's here

- **`gc-crypto.mjs`** — plain base58 (Bitcoin alphabet, no checksum), base64, `millHash` (sha256∘sha512), `sha256Hex`.
- **`gc-wallet.mjs`** — `Wallet`: RSA-2048 keygen (e=65537, PKCS1v15/SHA-384), PKCS8-b58 / SPKI-b64 import-export, `address()`, `sign(bytes)`.
- **`gc-sig.mjs`** — `canonical()` + `signHeaders()` mirroring `signing.py` and the `GC-*` headers.
- **`sign-cli.mjs`** — tiny node driver for the cross-verify.

## Parity — proven three independent ways

The module's reason to exist is byte-for-byte cross-language compatibility, so it's gated three ways:

1. **JS unit tests vs golden vectors** (`node --test`) — JS reproduces the committed address / canonical / signature byte-for-byte.
2. **Python drift-guard** (`test_browser_wallet_vectors.py`) — regenerates the vectors from a fixed wallet and asserts the committed file matches + Python verifies every signature.
3. **Live cross-verify** (`test_browser_wallet_parity.py`) — pytest shells to `node`, signs with the real JS module, and asserts the **real** `Wallet.validate_signature` accepts it and addresses match. No fixture drift.

Determinism makes this exact: `RSASSA-PKCS1-v1_5` has no randomness, so a fixed key + canonical yields identical signature bytes in JS and Python.

A notable correctness find during the build: the Python `base58check` lib's `b58encode` is actually **plain base58 (no checksum)** despite its name (verified: `b58encode(b'\x00')=='1'`). The JS implements plain base58 to match — a checksum would have silently broken parity.

## Supply chain

**Zero npm packages** — no `package.json`, no `node_modules`, no `npm install`. Only Node's built-in test runner + Web Crypto. The one new CI tool is the Node runtime itself, added via a **SHA-pinned** `actions/setup-node@4993…  # v4.4.0` (per the repo's actions-pinning policy). This is the supply-chain-safe path CLAUDE.md's npm-caution allows.

## Scope / safety

- **No Python chain change** — only client JS + test-side Python + one CI step. `src/gumptionchain/` untouched; no schema/migration; `db check` unaffected.
- Headless crypto only — storage/passkey/backup/UX/packaging explicitly out of scope.

## Test plan

- [x] `node --test clients/wallet/*.test.mjs` → 12 pass (golden-vector parity for base58/millHash/address/canonical/signature + keygen round-trip).
- [x] `test_browser_wallet_vectors.py` (drift guard + Python verifies sigs) and `test_browser_wallet_parity.py` (live node→Python) pass.
- [x] Full `uv run pytest` **352 passed / 1 skipped**; ruff + format + mypy green; CI adds Node 20 (SHA-pinned, no npm).

Reviewed via the local subagent pipeline (per-task spec + quality reviews, including an independent JS→Python signature-verification check and confirmation the pinned setup-node SHA is genuine, plus a holistic final pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
