### PR TITLE
feat(wallet): backup/recovery — passphrase-encrypted file + raw b58 (#174)

### DIFF
--- a/clients/wallet/MANUAL-VERIFICATION.md
+++ b/clients/wallet/MANUAL-VERIFICATION.md
@@ -55,7 +55,8 @@ demo page (file download/upload, passphrase prompt, clipboard) is manual:
    the file, and enter the passphrase — confirm the recovered address matches
    step 1.
 5. Enter a **wrong** passphrase — confirm a clear `BadPassphraseError` message
-   and that no wallet is loaded.
+   is shown and that any currently loaded wallet is left unchanged (a failed
+   restore does not replace it).
 6. Click **Show raw key**, copy it; reload; paste into the import textarea and
    click **Import raw key** — confirm the address matches.
 

--- a/clients/wallet/MANUAL-VERIFICATION.md
+++ b/clients/wallet/MANUAL-VERIFICATION.md
@@ -39,6 +39,26 @@ Real behavior is verified by hand using `passkey-wallet-demo.html`:
 
 6. **Clear.** Click **Clear** and confirm the record is removed from IndexedDB.
 
+## Backup / recovery (#2.3)
+
+The backup crypto (`gc-backup.mjs` — PBKDF2-SHA256 → AES-GCM-256, plus the
+raw-string path) is fully covered by `node --test`. Only the browser glue in the
+demo page (file download/upload, passphrase prompt, clipboard) is manual:
+
+1. **Enroll or unlock** a wallet; note its address.
+2. Click **Download backup**, enter a passphrase, and save
+   `gc-wallet-backup.json`.
+3. Open the file in a text editor — confirm it contains
+   `"kind": "gc-wallet-backup"`, base64 `salt`/`iv`/`ciphertext`, and **no**
+   recognizable private key.
+4. Reload the page (or use a fresh profile), click **Restore from file**, pick
+   the file, and enter the passphrase — confirm the recovered address matches
+   step 1.
+5. Enter a **wrong** passphrase — confirm a clear `BadPassphraseError` message
+   and that no wallet is loaded.
+6. Click **Show raw key**, copy it; reload; paste into the import textarea and
+   click **Import raw key** — confirm the address matches.
+
 ## Notes for the tester
 
 - The passkey credential is a **separate** WebAuthn credential (ES256/RS256,

--- a/clients/wallet/gc-backup.mjs
+++ b/clients/wallet/gc-backup.mjs
@@ -64,26 +64,43 @@ export async function importEncrypted(backup, passphrase) {
   if (
     !kdf
     || kdf.name !== 'PBKDF2'
-    || !kdf.salt
-    || typeof kdf.iterations !== 'number'
+    || kdf.hash !== 'SHA-256'
+    || typeof kdf.salt !== 'string'
+    || !Number.isSafeInteger(kdf.iterations)
     || kdf.iterations <= 0
-    || !iv
-    || !ciphertext
+    || typeof iv !== 'string'
+    || typeof ciphertext !== 'string'
   ) {
     throw new BadBackupError('malformed gc-wallet-backup artifact');
   }
-  const key = await deriveKey(passphrase, base64decode(kdf.salt), kdf.iterations);
+  // Decode the structural base64 fields up front: a decode failure here is a
+  // malformed artifact (BadBackupError), distinct from an authentic-but-wrong
+  // passphrase (BadPassphraseError) detected by the GCM tag below.
+  let salt;
+  let ivBytes;
+  let ctBytes;
+  try {
+    salt = base64decode(kdf.salt);
+    ivBytes = base64decode(iv);
+    ctBytes = base64decode(ciphertext);
+  } catch {
+    throw new BadBackupError('malformed gc-wallet-backup artifact');
+  }
+  const key = await deriveKey(passphrase, salt, kdf.iterations);
   let b58Bytes;
   try {
-    b58Bytes = await openWithKey(key, {
-      iv: base64decode(iv),
-      ciphertext: base64decode(ciphertext),
-    });
+    b58Bytes = await openWithKey(key, { iv: ivBytes, ciphertext: ctBytes });
   } catch {
     // GCM tag mismatch: wrong passphrase or tampered backup. Fail closed.
     throw new BadPassphraseError('wrong passphrase or corrupt backup');
   }
-  return Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+  try {
+    // GCM already authenticated the plaintext, so this should always succeed;
+    // map any residual decode/key failure to BadBackupError defensively.
+    return await Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+  } catch {
+    throw new BadBackupError('decrypted payload is not a valid wallet key');
+  }
 }
 
 // Raw-string backup: the b58 private key itself. At-rest protection is the

--- a/clients/wallet/gc-backup.mjs
+++ b/clients/wallet/gc-backup.mjs
@@ -77,3 +77,14 @@ export async function importEncrypted(backup, passphrase) {
   }
   return Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
 }
+
+// Raw-string backup: the b58 private key itself. At-rest protection is the
+// user's password manager. Thin, documented wrappers over the #2.1 key seam so
+// all backup surface lives in one module.
+export async function exportPlain(wallet) {
+  return wallet.exportPrivateKeyB58();
+}
+
+export async function importPlain(b58) {
+  return Wallet.fromPrivateKeyB58(b58);
+}

--- a/clients/wallet/gc-backup.mjs
+++ b/clients/wallet/gc-backup.mjs
@@ -1,0 +1,79 @@
+// Self-custody wallet backup/recovery. Converts a Wallet <-> a portable
+// artifact: a passphrase-encrypted JSON blob (PBKDF2-SHA256 -> AES-GCM-256,
+// via the shared gc-envelope primitive) and a raw b58 string. Storage-
+// decoupled and Node-testable: re-persist a recovered wallet by composing with
+// gc-store.enroll. No dependencies.
+import { base64encode, base64decode } from './gc-crypto.mjs';
+import { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const BACKUP_VERSION = 1;
+const BACKUP_KIND = 'gc-wallet-backup';
+const DEFAULT_ITERATIONS = 600000;
+const SALT_BYTES = 16;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so consumers can import the typed errors from here.
+export { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+
+async function deriveKey(passphrase, salt, iterations) {
+  const ikm = await crypto.subtle.importKey(
+    'raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: Uint8Array.from(salt), iterations },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+export async function exportEncrypted(wallet, passphrase, opts = {}) {
+  const iterations = opts.iterations ?? DEFAULT_ITERATIONS;
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const key = await deriveKey(passphrase, salt, iterations);
+  const { iv, ciphertext } = await sealWithKey(
+    key, te.encode(await wallet.exportPrivateKeyB58()),
+  );
+  return {
+    version: BACKUP_VERSION,
+    kind: BACKUP_KIND,
+    address: await wallet.address(),
+    kdf: {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations,
+      salt: base64encode(salt),
+    },
+    iv: base64encode(iv),
+    ciphertext: base64encode(ciphertext),
+  };
+}
+
+export async function importEncrypted(backup, passphrase) {
+  if (!backup || backup.kind !== BACKUP_KIND) {
+    throw new BadBackupError('not a gc-wallet-backup artifact');
+  }
+  if (backup.version !== BACKUP_VERSION) {
+    throw new BadBackupError(`unsupported backup version: ${backup.version}`);
+  }
+  const { kdf, iv, ciphertext } = backup;
+  if (!kdf || kdf.name !== 'PBKDF2' || !kdf.salt || !iv || !ciphertext) {
+    throw new BadBackupError('malformed gc-wallet-backup artifact');
+  }
+  const key = await deriveKey(passphrase, base64decode(kdf.salt), kdf.iterations);
+  let b58Bytes;
+  try {
+    b58Bytes = await openWithKey(key, {
+      iv: base64decode(iv),
+      ciphertext: base64decode(ciphertext),
+    });
+  } catch {
+    // GCM tag mismatch: wrong passphrase or tampered backup. Fail closed.
+    throw new BadPassphraseError('wrong passphrase or corrupt backup');
+  }
+  return Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+}

--- a/clients/wallet/gc-backup.mjs
+++ b/clients/wallet/gc-backup.mjs
@@ -61,7 +61,15 @@ export async function importEncrypted(backup, passphrase) {
     throw new BadBackupError(`unsupported backup version: ${backup.version}`);
   }
   const { kdf, iv, ciphertext } = backup;
-  if (!kdf || kdf.name !== 'PBKDF2' || !kdf.salt || !iv || !ciphertext) {
+  if (
+    !kdf
+    || kdf.name !== 'PBKDF2'
+    || !kdf.salt
+    || typeof kdf.iterations !== 'number'
+    || kdf.iterations <= 0
+    || !iv
+    || !ciphertext
+  ) {
     throw new BadBackupError('malformed gc-wallet-backup artifact');
   }
   const key = await deriveKey(passphrase, base64decode(kdf.salt), kdf.iterations);

--- a/clients/wallet/gc-backup.test.mjs
+++ b/clients/wallet/gc-backup.test.mjs
@@ -77,3 +77,19 @@ test('importEncrypted rejects a malformed artifact (missing fields)', async () =
     BadBackupError,
   );
 });
+
+import { exportPlain, importPlain } from './gc-backup.mjs';
+
+test('exportPlain equals the wallet b58 private key', async () => {
+  const wallet = await Wallet.generate();
+  assert.equal(await exportPlain(wallet), await wallet.exportPrivateKeyB58());
+});
+
+test('exportPlain -> importPlain recovers a wallet that signs identically', async () => {
+  const wallet = await Wallet.generate();
+  const b58 = await exportPlain(wallet);
+  const recovered = await importPlain(b58);
+  assert.equal(await recovered.address(), await wallet.address());
+  const msg = new TextEncoder().encode('prove-it');
+  assert.equal(await recovered.sign(msg), await wallet.sign(msg));
+});

--- a/clients/wallet/gc-backup.test.mjs
+++ b/clients/wallet/gc-backup.test.mjs
@@ -89,6 +89,20 @@ test('importEncrypted rejects a non-positive kdf.iterations', async () => {
   await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
 });
 
+test('importEncrypted rejects an unexpected kdf.hash', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  backup.kdf.hash = 'SHA-512';
+  await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
+});
+
+test('importEncrypted maps un-decodable base64 to BadBackupError', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  backup.ciphertext = '!!! not base64 !!!';
+  await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
+});
+
 import { exportPlain, importPlain } from './gc-backup.mjs';
 
 test('exportPlain equals the wallet b58 private key', async () => {

--- a/clients/wallet/gc-backup.test.mjs
+++ b/clients/wallet/gc-backup.test.mjs
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  exportEncrypted, importEncrypted, BadBackupError, BadPassphraseError,
+} from './gc-backup.mjs';
+
+// Keep PBKDF2 cheap in tests; production default (600k) is exercised by the
+// manual browser path. The override is the documented opts.iterations seam.
+const FAST = { iterations: 1000 };
+const PASS = 'correct horse battery staple';
+
+test('exportEncrypted -> importEncrypted recovers a wallet that signs identically', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  assert.equal(backup.kind, 'gc-wallet-backup');
+  assert.equal(backup.version, 1);
+  assert.equal(backup.address, await wallet.address());
+
+  const recovered = await importEncrypted(backup, PASS);
+  assert.equal(await recovered.address(), await wallet.address());
+  const msg = new TextEncoder().encode('prove-it');
+  assert.equal(await recovered.sign(msg), await wallet.sign(msg));
+});
+
+test('the backup artifact holds only ciphertext + non-secrets', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  assert.ok(backup.kdf.salt && backup.iv && backup.ciphertext);
+  assert.equal(backup.kdf.name, 'PBKDF2');
+  const blob = JSON.stringify(backup);
+  assert.ok(!blob.includes(await wallet.exportPrivateKeyB58()));
+});
+
+test('importEncrypted with a wrong passphrase throws BadPassphraseError', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  await assert.rejects(
+    () => importEncrypted(backup, 'wrong passphrase'),
+    BadPassphraseError,
+  );
+});
+
+test('importEncrypted on a tampered ciphertext throws BadPassphraseError', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  // flip a byte in the base64 ciphertext's decoded form via a known-bad value
+  backup.ciphertext = backup.ciphertext.slice(0, -2) + 'AA';
+  await assert.rejects(() => importEncrypted(backup, PASS), BadPassphraseError);
+});
+
+test('two exports of the same wallet use distinct salt and IV', async () => {
+  const wallet = await Wallet.generate();
+  const a = await exportEncrypted(wallet, PASS, FAST);
+  const b = await exportEncrypted(wallet, PASS, FAST);
+  assert.notEqual(a.kdf.salt, b.kdf.salt);
+  assert.notEqual(a.iv, b.iv);
+});
+
+test('importEncrypted rejects an unknown kind', async () => {
+  await assert.rejects(
+    () => importEncrypted({ kind: 'something-else', version: 1 }, PASS),
+    BadBackupError,
+  );
+});
+
+test('importEncrypted rejects an unknown version', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  backup.version = 999;
+  await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
+});
+
+test('importEncrypted rejects a malformed artifact (missing fields)', async () => {
+  await assert.rejects(
+    () => importEncrypted({ kind: 'gc-wallet-backup', version: 1 }, PASS),
+    BadBackupError,
+  );
+});

--- a/clients/wallet/gc-backup.test.mjs
+++ b/clients/wallet/gc-backup.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Wallet } from './gc-wallet.mjs';
+import { base64decode, base64encode } from './gc-crypto.mjs';
 import {
   exportEncrypted, importEncrypted, BadBackupError, BadPassphraseError,
 } from './gc-backup.mjs';
@@ -44,8 +45,11 @@ test('importEncrypted with a wrong passphrase throws BadPassphraseError', async 
 test('importEncrypted on a tampered ciphertext throws BadPassphraseError', async () => {
   const wallet = await Wallet.generate();
   const backup = await exportEncrypted(wallet, PASS, FAST);
-  // flip a byte in the base64 ciphertext's decoded form via a known-bad value
-  backup.ciphertext = backup.ciphertext.slice(0, -2) + 'AA';
+  // Flip a content byte so GCM's auth tag rejects it (a real bit-flip, not a
+  // length/padding change).
+  const ct = base64decode(backup.ciphertext);
+  ct[0] ^= 0xff;
+  backup.ciphertext = base64encode(ct);
   await assert.rejects(() => importEncrypted(backup, PASS), BadPassphraseError);
 });
 
@@ -76,6 +80,13 @@ test('importEncrypted rejects a malformed artifact (missing fields)', async () =
     () => importEncrypted({ kind: 'gc-wallet-backup', version: 1 }, PASS),
     BadBackupError,
   );
+});
+
+test('importEncrypted rejects a non-positive kdf.iterations', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  backup.kdf.iterations = 0;
+  await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
 });
 
 import { exportPlain, importPlain } from './gc-backup.mjs';

--- a/clients/wallet/gc-envelope.mjs
+++ b/clients/wallet/gc-envelope.mjs
@@ -1,6 +1,8 @@
-// Authenticated at-rest encryption for the wallet key. HKDF-SHA256 derives an
-// AES-GCM-256 key from a 32-byte WebAuthn PRF output; random 12-byte IV per
-// seal; GCM's auth tag makes tampering fail closed. Pure Web Crypto.
+// Authenticated at-rest encryption for the wallet key. Exposes a key-level
+// primitive (sealWithKey/openWithKey) over AES-GCM-256 plus the PRF-keyed
+// seal/open wrappers: HKDF-SHA256 derives an AES-GCM-256 key from a 32-byte
+// WebAuthn PRF output; random 12-byte IV per seal; GCM's auth tag makes
+// tampering fail closed. Pure Web Crypto.
 const HKDF_INFO = new TextEncoder().encode('gc-wallet-aesgcm-v1');
 const IV_BYTES = 12;
 
@@ -21,19 +23,25 @@ async function deriveAesKey(prfOutput) {
   );
 }
 
-export async function seal(prfOutput, bytes) {
-  const key = await deriveAesKey(prfOutput);
+export async function sealWithKey(key, bytes) {
   const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
   const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, bytes);
   return { iv, ciphertext: new Uint8Array(ct) };
 }
 
-export async function open(prfOutput, { iv, ciphertext }) {
-  const key = await deriveAesKey(prfOutput);
+export async function openWithKey(key, { iv, ciphertext }) {
   const pt = await crypto.subtle.decrypt(
     { name: 'AES-GCM', iv: Uint8Array.from(iv) },
     key,
     Uint8Array.from(ciphertext),
   );
   return new Uint8Array(pt);
+}
+
+export async function seal(prfOutput, bytes) {
+  return sealWithKey(await deriveAesKey(prfOutput), bytes);
+}
+
+export async function open(prfOutput, envelope) {
+  return openWithKey(await deriveAesKey(prfOutput), envelope);
 }

--- a/clients/wallet/gc-envelope.test.mjs
+++ b/clients/wallet/gc-envelope.test.mjs
@@ -31,3 +31,27 @@ test('each seal uses a fresh IV', async () => {
   assert.notEqual(hex(a.iv), hex(b.iv));
   assert.notEqual(hex(a.ciphertext), hex(b.ciphertext));
 });
+
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+
+test('sealWithKey/openWithKey round-trip with a fixed CryptoKey', async () => {
+  const raw = new Uint8Array(32).fill(5);
+  const key = await crypto.subtle.importKey(
+    'raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+  const msg = new TextEncoder().encode('hello-primitive');
+  const env = await sealWithKey(key, msg);
+  assert.equal(env.iv.length, 12);
+  const out = await openWithKey(key, env);
+  assert.deepEqual(out, msg);
+});
+
+test('openWithKey fails closed on a tampered ciphertext', async () => {
+  const raw = new Uint8Array(32).fill(6);
+  const key = await crypto.subtle.importKey(
+    'raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+  const env = await sealWithKey(key, new TextEncoder().encode('x'));
+  env.ciphertext[0] ^= 0xff;
+  await assert.rejects(() => openWithKey(key, env));
+});

--- a/clients/wallet/gc-errors.mjs
+++ b/clients/wallet/gc-errors.mjs
@@ -8,3 +8,11 @@ export class UnsupportedError extends Error {}
 
 // unlock() called with nothing stored.
 export class NoWalletError extends Error {}
+
+// Backup artifact is not a recognizable gc-wallet-backup, has an unknown
+// version, or is missing required fields — thrown before any crypto.
+export class BadBackupError extends Error {}
+
+// importEncrypted decrypt failed (wrong passphrase or tampered backup) —
+// re-thrown from the GCM tag mismatch so callers never see garbage plaintext.
+export class BadPassphraseError extends Error {}

--- a/clients/wallet/passkey-wallet-demo.html
+++ b/clients/wallet/passkey-wallet-demo.html
@@ -175,7 +175,9 @@
             a.href = url;
             a.download = 'gc-wallet-backup.json';
             a.click();
-            URL.revokeObjectURL(url);
+            // Defer the revoke: revoking immediately can abort the download
+            // before it starts in some browsers.
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
             show(`Downloaded gc-wallet-backup.json\naddress: ${backup.address}`);
           } catch (err) {
             fail('Download backup', err);

--- a/clients/wallet/passkey-wallet-demo.html
+++ b/clients/wallet/passkey-wallet-demo.html
@@ -45,6 +45,34 @@
       <button id="clear">Clear</button>
     </p>
 
+    <h2>Backup / recovery</h2>
+    <p class="hint">
+      Acts on the wallet from the most recent Enroll or Unlock above
+      (<code>currentWallet</code>).
+    </p>
+    <p>
+      <button id="download-backup">Download backup</button>
+      <button id="restore-file">Restore from file</button>
+      <input id="restore-input" type="file" accept=".json,application/json"
+             hidden />
+    </p>
+    <p>
+      <button id="show-raw">Show raw key</button>
+      <button id="copy-raw">Copy raw key</button>
+    </p>
+    <p>
+      <input id="raw-key" type="text" readonly
+             style="width: 100%; font-family: monospace"
+             placeholder="raw b58 private key appears here" />
+    </p>
+    <p>
+      <textarea id="import-raw-text" rows="3" style="width: 100%"
+                placeholder="paste a raw b58 private key to import"></textarea>
+    </p>
+    <p>
+      <button id="import-raw">Import raw key</button>
+    </p>
+
     <h2>Output</h2>
     <pre id="out">(idle)</pre>
 
@@ -60,6 +88,8 @@
       import { enroll, unlock, clear } from './gc-store.mjs';
       import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
       import { makeIdbStore } from './gc-store-idb.mjs';
+      import { exportEncrypted, importEncrypted, exportPlain, importPlain }
+        from './gc-backup.mjs';
 
       const rpId = location.hostname;
       const rpName = 'GumptionChain Wallet Demo';
@@ -67,6 +97,10 @@
 
       const passkey = makeWebauthnPasskey({ rpId, rpName });
       const store = makeIdbStore({ dbName: 'gc-wallet' });
+
+      // The wallet from the most recent enroll/unlock, held in memory so the
+      // backup controls can act on it. Cleared by Clear.
+      let currentWallet = null;
 
       const out = document.getElementById('out');
       const show = (msg) => {
@@ -76,12 +110,19 @@
         console.error(label, err);
         show(`${label} failed:\n${err && err.message ? err.message : err}`);
       };
+      const requireWallet = () => {
+        if (!currentWallet) {
+          throw new Error('no wallet loaded — Enroll or Unlock first');
+        }
+        return currentWallet;
+      };
 
       document.getElementById('enroll').addEventListener('click', async () => {
         try {
           show('Enrolling — complete the passkey ceremony…');
           const wallet = await Wallet.generate();
           const address = await enroll(wallet, { passkey, store }, { userName });
+          currentWallet = wallet;
           show(`Enrolled.\naddress: ${address}`);
         } catch (err) {
           fail('Enroll', err);
@@ -92,6 +133,7 @@
         try {
           show('Unlocking — complete the passkey ceremony…');
           const wallet = await unlock({ passkey, store });
+          currentWallet = wallet;
           const address = await wallet.address();
           const msg = new TextEncoder().encode('hello gumptionchain');
           const sig = await wallet.sign(msg);
@@ -107,11 +149,113 @@
       document.getElementById('clear').addEventListener('click', async () => {
         try {
           await clear(store);
+          currentWallet = null;
           show('Cleared. The stored record has been removed.');
         } catch (err) {
           fail('Clear', err);
         }
       });
+
+      document
+        .getElementById('download-backup')
+        .addEventListener('click', async () => {
+          try {
+            const wallet = requireWallet();
+            const passphrase = prompt('Passphrase to encrypt the backup:');
+            if (!passphrase) {
+              show('Download backup cancelled — no passphrase entered.');
+              return;
+            }
+            const backup = await exportEncrypted(wallet, passphrase);
+            const blob = new Blob([JSON.stringify(backup, null, 2)], {
+              type: 'application/json',
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'gc-wallet-backup.json';
+            a.click();
+            URL.revokeObjectURL(url);
+            show(`Downloaded gc-wallet-backup.json\naddress: ${backup.address}`);
+          } catch (err) {
+            fail('Download backup', err);
+          }
+        });
+
+      const restoreInput = document.getElementById('restore-input');
+      document
+        .getElementById('restore-file')
+        .addEventListener('click', () => restoreInput.click());
+      restoreInput.addEventListener('change', async () => {
+        const file = restoreInput.files && restoreInput.files[0];
+        restoreInput.value = '';
+        if (!file) {
+          return;
+        }
+        try {
+          const obj = JSON.parse(await file.text());
+          const passphrase = prompt('Passphrase to decrypt the backup:');
+          if (!passphrase) {
+            show('Restore cancelled — no passphrase entered.');
+            return;
+          }
+          const prior = currentWallet ? await currentWallet.address() : null;
+          const recovered = await importEncrypted(obj, passphrase);
+          const address = await recovered.address();
+          currentWallet = recovered;
+          const note =
+            prior && prior !== address
+              ? '\n(warning: differs from the previously loaded wallet)'
+              : prior
+                ? '\n(matches the previously loaded wallet)'
+                : '';
+          show(`Restored from file.\naddress: ${address}${note}`);
+        } catch (err) {
+          fail('Restore from file', err);
+        }
+      });
+
+      document.getElementById('show-raw').addEventListener('click', async () => {
+        try {
+          const wallet = requireWallet();
+          document.getElementById('raw-key').value = await exportPlain(wallet);
+          show('Raw key revealed. Copy it into a password manager, then clear.');
+        } catch (err) {
+          fail('Show raw key', err);
+        }
+      });
+
+      document.getElementById('copy-raw').addEventListener('click', async () => {
+        try {
+          const value = document.getElementById('raw-key').value;
+          if (!value) {
+            show('Nothing to copy — click Show raw key first.');
+            return;
+          }
+          await navigator.clipboard.writeText(value);
+          show('Raw key copied to clipboard.');
+        } catch (err) {
+          fail('Copy raw key', err);
+        }
+      });
+
+      document
+        .getElementById('import-raw')
+        .addEventListener('click', async () => {
+          try {
+            const value = document.getElementById('import-raw-text').value.trim();
+            if (!value) {
+              show('Nothing to import — paste a raw b58 private key first.');
+              return;
+            }
+            const recovered = await importPlain(value);
+            const address = await recovered.address();
+            currentWallet = recovered;
+            show(`Imported raw key.\naddress: ${address}`);
+          } catch (err) {
+            fail('Import raw key', err);
+          }
+        });
     </script>
   </body>
 </html>

--- a/docs/superpowers/plans/2026-06-06-egu-2.3-wallet-backup.md
+++ b/docs/superpowers/plans/2026-06-06-egu-2.3-wallet-backup.md
@@ -1,0 +1,459 @@
+# EGU #2.3 — wallet backup/recovery — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the browser wallet recoverable — export a `Wallet` to a portable artifact (passphrase-encrypted JSON file + raw b58 string) and import it back on any device — so a lost device does not mean a lost identity.
+
+**Architecture:** A new storage-decoupled, Wallet-level module `clients/wallet/gc-backup.mjs` converts `Wallet` ↔ artifact. The passphrase path uses PBKDF2-SHA256 → AES-GCM-256 via the **same** authenticated-encryption primitive #2.2 already ships; that primitive is factored out of `gc-envelope.mjs` so there is one audited AES-GCM implementation fed by two key schedules (HKDF for PRF, PBKDF2 for passphrase). All crypto is Node-testable (zero npm); only the file download/upload glue in the demo page is browser-manual.
+
+**Tech Stack:** Vanilla ESM, Web Crypto (`crypto.subtle`), Node 20+ built-in test runner (`node --test`), zero npm. Reuses `gc-crypto` (base64), `gc-wallet` (key seam), `gc-errors` (typed errors).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-egu-2.3-wallet-backup-design.md`
+
+---
+
+## File Structure
+
+- **Create** `clients/wallet/gc-backup.mjs` — the four-function backup API (`exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain`); PBKDF2 key derivation; artifact assembly/validation.
+- **Create** `clients/wallet/gc-backup.test.mjs` — Node tests for both paths.
+- **Modify** `clients/wallet/gc-envelope.mjs` — extract `sealWithKey`/`openWithKey`; PRF `seal`/`open` become thin wrappers (behavior unchanged).
+- **Modify** `clients/wallet/gc-envelope.test.mjs` — add a `sealWithKey`/`openWithKey` round-trip test (existing PRF tests are the regression guard).
+- **Modify** `clients/wallet/gc-errors.mjs` — add `BadBackupError`, `BadPassphraseError`.
+- **Modify** `clients/wallet/passkey-wallet-demo.html` + `clients/wallet/MANUAL-VERIFICATION.md` — download/restore + raw-string export/import glue; manual steps.
+
+All `node --test` runs use the project pattern: `node --test clients/wallet/*.test.mjs` (or a single file via `node --test clients/wallet/<file>.test.mjs`).
+
+---
+
+### Task 1: Factor the shared AES-GCM primitive out of `gc-envelope`
+
+**Files:**
+- Modify: `clients/wallet/gc-envelope.mjs`
+- Test: `clients/wallet/gc-envelope.test.mjs`
+
+- [ ] **Step 1: Write the failing test** — append to `clients/wallet/gc-envelope.test.mjs`:
+
+```javascript
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+
+test('sealWithKey/openWithKey round-trip with a fixed CryptoKey', async () => {
+  const raw = new Uint8Array(32).fill(5);
+  const key = await crypto.subtle.importKey(
+    'raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+  const msg = new TextEncoder().encode('hello-primitive');
+  const env = await sealWithKey(key, msg);
+  assert.equal(env.iv.length, 12);
+  const out = await openWithKey(key, env);
+  assert.deepEqual(out, msg);
+});
+
+test('openWithKey fails closed on a tampered ciphertext', async () => {
+  const raw = new Uint8Array(32).fill(6);
+  const key = await crypto.subtle.importKey(
+    'raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+  const env = await sealWithKey(key, new TextEncoder().encode('x'));
+  env.ciphertext[0] ^= 0xff;
+  await assert.rejects(() => openWithKey(key, env));
+});
+```
+
+(If `gc-envelope.test.mjs` does not already import `test`/`assert`, keep its existing imports; the file already uses `node:test` + `node:assert/strict`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test clients/wallet/gc-envelope.test.mjs`
+Expected: FAIL — `sealWithKey`/`openWithKey` are not exported yet.
+
+- [ ] **Step 3: Refactor `gc-envelope.mjs`** — replace the `seal`/`open` exports (keep `HKDF_INFO`, `IV_BYTES`, `deriveAesKey` exactly as they are) with the key-level primitive plus thin PRF wrappers:
+
+```javascript
+export async function sealWithKey(key, bytes) {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, bytes);
+  return { iv, ciphertext: new Uint8Array(ct) };
+}
+
+export async function openWithKey(key, { iv, ciphertext }) {
+  const pt = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: Uint8Array.from(iv) },
+    key,
+    Uint8Array.from(ciphertext),
+  );
+  return new Uint8Array(pt);
+}
+
+export async function seal(prfOutput, bytes) {
+  return sealWithKey(await deriveAesKey(prfOutput), bytes);
+}
+
+export async function open(prfOutput, envelope) {
+  return openWithKey(await deriveAesKey(prfOutput), envelope);
+}
+```
+
+Also update the file's top comment to note it now exposes a key-level primitive (`sealWithKey`/`openWithKey`) plus the PRF-keyed `seal`/`open` wrappers.
+
+- [ ] **Step 4: Run the full wallet test suite to verify nothing regressed**
+
+Run: `node --test clients/wallet/*.test.mjs`
+Expected: PASS — the new primitive tests pass AND every existing `gc-envelope`/`gc-store` PRF test still passes (the wrappers preserve behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-envelope.mjs clients/wallet/gc-envelope.test.mjs
+git commit -m "refactor(wallet): extract sealWithKey/openWithKey AES-GCM primitive"
+```
+
+---
+
+### Task 2: Add typed backup errors
+
+**Files:**
+- Modify: `clients/wallet/gc-errors.mjs`
+
+- [ ] **Step 1: Add the two typed errors** — append to `clients/wallet/gc-errors.mjs`:
+
+```javascript
+// Backup artifact is not a recognizable gc-wallet-backup, has an unknown
+// version, or is missing required fields — thrown before any crypto.
+export class BadBackupError extends Error {}
+
+// importEncrypted decrypt failed (wrong passphrase or tampered backup) —
+// re-thrown from the GCM tag mismatch so callers never see garbage plaintext.
+export class BadPassphraseError extends Error {}
+```
+
+- [ ] **Step 2: Verify the module still parses**
+
+Run: `node --check clients/wallet/gc-errors.mjs`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/wallet/gc-errors.mjs
+git commit -m "feat(wallet): add BadBackupError/BadPassphraseError typed errors"
+```
+
+---
+
+### Task 3: Implement `gc-backup` encrypted path (export/import)
+
+**Files:**
+- Create: `clients/wallet/gc-backup.mjs`
+- Test: `clients/wallet/gc-backup.test.mjs`
+
+- [ ] **Step 1: Write the failing tests** — create `clients/wallet/gc-backup.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  exportEncrypted, importEncrypted, BadBackupError, BadPassphraseError,
+} from './gc-backup.mjs';
+
+// Keep PBKDF2 cheap in tests; production default (600k) is exercised by the
+// manual browser path. The override is the documented opts.iterations seam.
+const FAST = { iterations: 1000 };
+const PASS = 'correct horse battery staple';
+
+test('exportEncrypted -> importEncrypted recovers a wallet that signs identically', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  assert.equal(backup.kind, 'gc-wallet-backup');
+  assert.equal(backup.version, 1);
+  assert.equal(backup.address, await wallet.address());
+
+  const recovered = await importEncrypted(backup, PASS);
+  assert.equal(await recovered.address(), await wallet.address());
+  const msg = new TextEncoder().encode('prove-it');
+  assert.equal(await recovered.sign(msg), await wallet.sign(msg));
+});
+
+test('the backup artifact holds only ciphertext + non-secrets', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  assert.ok(backup.kdf.salt && backup.iv && backup.ciphertext);
+  assert.equal(backup.kdf.name, 'PBKDF2');
+  const blob = JSON.stringify(backup);
+  assert.ok(!blob.includes(await wallet.exportPrivateKeyB58()));
+});
+
+test('importEncrypted with a wrong passphrase throws BadPassphraseError', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  await assert.rejects(
+    () => importEncrypted(backup, 'wrong passphrase'),
+    BadPassphraseError,
+  );
+});
+
+test('importEncrypted on a tampered ciphertext throws BadPassphraseError', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  // flip a byte in the base64 ciphertext's decoded form via a known-bad value
+  backup.ciphertext = backup.ciphertext.slice(0, -2) + 'AA';
+  await assert.rejects(() => importEncrypted(backup, PASS), BadPassphraseError);
+});
+
+test('two exports of the same wallet use distinct salt and IV', async () => {
+  const wallet = await Wallet.generate();
+  const a = await exportEncrypted(wallet, PASS, FAST);
+  const b = await exportEncrypted(wallet, PASS, FAST);
+  assert.notEqual(a.kdf.salt, b.kdf.salt);
+  assert.notEqual(a.iv, b.iv);
+});
+
+test('importEncrypted rejects an unknown kind', async () => {
+  await assert.rejects(
+    () => importEncrypted({ kind: 'something-else', version: 1 }, PASS),
+    BadBackupError,
+  );
+});
+
+test('importEncrypted rejects an unknown version', async () => {
+  const wallet = await Wallet.generate();
+  const backup = await exportEncrypted(wallet, PASS, FAST);
+  backup.version = 999;
+  await assert.rejects(() => importEncrypted(backup, PASS), BadBackupError);
+});
+
+test('importEncrypted rejects a malformed artifact (missing fields)', async () => {
+  await assert.rejects(
+    () => importEncrypted({ kind: 'gc-wallet-backup', version: 1 }, PASS),
+    BadBackupError,
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test clients/wallet/gc-backup.test.mjs`
+Expected: FAIL — `gc-backup.mjs` does not exist / has no exports.
+
+- [ ] **Step 3: Implement the encrypted path** — create `clients/wallet/gc-backup.mjs`:
+
+```javascript
+// Self-custody wallet backup/recovery. Converts a Wallet <-> a portable
+// artifact: a passphrase-encrypted JSON blob (PBKDF2-SHA256 -> AES-GCM-256,
+// via the shared gc-envelope primitive) and a raw b58 string. Storage-
+// decoupled and Node-testable: re-persist a recovered wallet by composing with
+// gc-store.enroll. No dependencies.
+import { base64encode, base64decode } from './gc-crypto.mjs';
+import { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const BACKUP_VERSION = 1;
+const BACKUP_KIND = 'gc-wallet-backup';
+const DEFAULT_ITERATIONS = 600000;
+const SALT_BYTES = 16;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so consumers can import the typed errors from here.
+export { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+
+async function deriveKey(passphrase, salt, iterations) {
+  const ikm = await crypto.subtle.importKey(
+    'raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: Uint8Array.from(salt), iterations },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+export async function exportEncrypted(wallet, passphrase, opts = {}) {
+  const iterations = opts.iterations ?? DEFAULT_ITERATIONS;
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const key = await deriveKey(passphrase, salt, iterations);
+  const { iv, ciphertext } = await sealWithKey(
+    key, te.encode(await wallet.exportPrivateKeyB58()),
+  );
+  return {
+    version: BACKUP_VERSION,
+    kind: BACKUP_KIND,
+    address: await wallet.address(),
+    kdf: {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations,
+      salt: base64encode(salt),
+    },
+    iv: base64encode(iv),
+    ciphertext: base64encode(ciphertext),
+  };
+}
+
+export async function importEncrypted(backup, passphrase) {
+  if (!backup || backup.kind !== BACKUP_KIND) {
+    throw new BadBackupError('not a gc-wallet-backup artifact');
+  }
+  if (backup.version !== BACKUP_VERSION) {
+    throw new BadBackupError(`unsupported backup version: ${backup.version}`);
+  }
+  const { kdf, iv, ciphertext } = backup;
+  if (!kdf || kdf.name !== 'PBKDF2' || !kdf.salt || !iv || !ciphertext) {
+    throw new BadBackupError('malformed gc-wallet-backup artifact');
+  }
+  const key = await deriveKey(passphrase, base64decode(kdf.salt), kdf.iterations);
+  let b58Bytes;
+  try {
+    b58Bytes = await openWithKey(key, {
+      iv: base64decode(iv),
+      ciphertext: base64decode(ciphertext),
+    });
+  } catch {
+    // GCM tag mismatch: wrong passphrase or tampered backup. Fail closed.
+    throw new BadPassphraseError('wrong passphrase or corrupt backup');
+  }
+  return Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test clients/wallet/gc-backup.test.mjs`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-backup.mjs clients/wallet/gc-backup.test.mjs
+git commit -m "feat(wallet): passphrase-encrypted backup export/import (PBKDF2 + AES-GCM)"
+```
+
+---
+
+### Task 4: Implement `gc-backup` raw-string path (plain export/import)
+
+**Files:**
+- Modify: `clients/wallet/gc-backup.mjs`
+- Test: `clients/wallet/gc-backup.test.mjs`
+
+- [ ] **Step 1: Write the failing tests** — append to `clients/wallet/gc-backup.test.mjs`:
+
+```javascript
+import { exportPlain, importPlain } from './gc-backup.mjs';
+
+test('exportPlain equals the wallet b58 private key', async () => {
+  const wallet = await Wallet.generate();
+  assert.equal(await exportPlain(wallet), await wallet.exportPrivateKeyB58());
+});
+
+test('exportPlain -> importPlain recovers a wallet that signs identically', async () => {
+  const wallet = await Wallet.generate();
+  const b58 = await exportPlain(wallet);
+  const recovered = await importPlain(b58);
+  assert.equal(await recovered.address(), await wallet.address());
+  const msg = new TextEncoder().encode('prove-it');
+  assert.equal(await recovered.sign(msg), await wallet.sign(msg));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test clients/wallet/gc-backup.test.mjs`
+Expected: FAIL — `exportPlain`/`importPlain` not exported.
+
+- [ ] **Step 3: Add the plain path** — append to `clients/wallet/gc-backup.mjs`:
+
+```javascript
+// Raw-string backup: the b58 private key itself. At-rest protection is the
+// user's password manager. Thin, documented wrappers over the #2.1 key seam so
+// all backup surface lives in one module.
+export async function exportPlain(wallet) {
+  return wallet.exportPrivateKeyB58();
+}
+
+export async function importPlain(b58) {
+  return Wallet.fromPrivateKeyB58(b58);
+}
+```
+
+- [ ] **Step 4: Run the full wallet suite to verify all pass**
+
+Run: `node --test clients/wallet/*.test.mjs`
+Expected: PASS — all backup tests (encrypted + plain) and all prior wallet tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-backup.mjs clients/wallet/gc-backup.test.mjs
+git commit -m "feat(wallet): raw-string backup export/import wrappers"
+```
+
+---
+
+### Task 5: Demo page + manual verification glue
+
+**Files:**
+- Modify: `clients/wallet/passkey-wallet-demo.html`
+- Modify: `clients/wallet/MANUAL-VERIFICATION.md`
+
+This task is browser-only glue (file download/upload, passphrase prompt); the crypto is already Node-covered. Keep it thin — no branching logic that isn't exercised by `gc-backup` tests.
+
+- [ ] **Step 1: Add backup UI + handlers to the demo page**
+
+In `clients/wallet/passkey-wallet-demo.html`, import the new module alongside the existing ones:
+
+```javascript
+import { exportEncrypted, importEncrypted, exportPlain, importPlain }
+  from './gc-backup.mjs';
+```
+
+Add four controls wired to an in-memory `currentWallet` (the wallet produced by enroll/unlock in the existing demo):
+
+- **Download backup:** prompt for a passphrase → `exportEncrypted(currentWallet, passphrase)` → `JSON.stringify` → trigger a `Blob` download named `gc-wallet-backup.json`.
+- **Restore from file:** `<input type="file">` → read text → `JSON.parse` → prompt passphrase → `importEncrypted(obj, passphrase)` → show the recovered address (and assert it matches if a wallet is loaded).
+- **Show raw key:** `exportPlain(currentWallet)` into a readonly field with a copy button.
+- **Import raw key:** textarea → `importPlain(value.trim())` → show the recovered address.
+
+Use the existing demo's status/output element for messages; surface `BadBackupError`/`BadPassphraseError` messages verbatim so wrong-passphrase is visibly distinct from a malformed file.
+
+- [ ] **Step 2: Document the manual steps**
+
+In `clients/wallet/MANUAL-VERIFICATION.md`, add a "Backup / recovery (#2.3)" section:
+
+1. Enroll or unlock a wallet; note its address.
+2. Click **Download backup**, enter a passphrase, save `gc-wallet-backup.json`.
+3. Open the file in a text editor — confirm it contains `kind: "gc-wallet-backup"`, base64 `salt`/`iv`/`ciphertext`, and **no** recognizable private key.
+4. Reload the page (or use a fresh profile), click **Restore from file**, pick the file, enter the passphrase — confirm the recovered address matches step 1.
+5. Enter a **wrong** passphrase — confirm a clear `BadPassphraseError` message, no wallet loaded.
+6. Click **Show raw key**, copy it; reload; **Import raw key**, paste — confirm the address matches.
+
+- [ ] **Step 3: Verify the page parses (no Node test for HTML)**
+
+Run: `node --check clients/wallet/gc-backup.mjs`
+Expected: exit 0 (module the page imports is valid). Manual browser verification per the steps above is the acceptance gate for the page itself.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clients/wallet/passkey-wallet-demo.html clients/wallet/MANUAL-VERIFICATION.md
+git commit -m "docs(wallet): demo + manual steps for backup/recovery"
+```
+
+---
+
+## Final verification (before finishing the branch)
+
+- [ ] `node --test clients/wallet/*.test.mjs` — all green (envelope regression + primitive, backup encrypted + plain, plus all #2.1/#2.2 tests).
+- [ ] `uv run pytest` — unaffected (no Python change; the browser-wallet parity/vector tests still pass).
+- [ ] `uv run ruff format --check src tests` and `uv run ruff check src tests` — unaffected (no `src`/`tests` change).
+- [ ] Zero npm packages added; grep confirms `gc-backup.mjs` imports only sibling `.mjs` modules.
+- [ ] Manual browser verification of the demo backup/restore flow completed per `MANUAL-VERIFICATION.md`.
+
+## Self-review notes
+
+- **Spec coverage:** encrypted file (Task 3) + raw string (Task 4) = both artifacts; shared primitive (Task 1); typed fail-closed errors (Task 2 + used in Task 3); storage-decoupled (gc-backup imports no store/passkey); 600k default with test override; demo/manual (Task 5). All spec sections mapped.
+- **No placeholders:** every code step shows complete code.
+- **Type consistency:** `exportEncrypted`/`importEncrypted`/`exportPlain`/`importPlain`, `BadBackupError`/`BadPassphraseError`, `sealWithKey`/`openWithKey` named identically across tasks and the spec; artifact field names (`version`,`kind`,`address`,`kdf.{name,hash,iterations,salt}`,`iv`,`ciphertext`) match the spec's JSON exactly.

--- a/docs/superpowers/specs/2026-06-06-egu-2.3-wallet-backup-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2.3-wallet-backup-design.md
@@ -1,0 +1,227 @@
+# EGU #2.3 — wallet backup/recovery — design
+
+**Date:** 2026-06-06
+**Status:** Approved — ready for implementation
+**Issue:** sub-project 3 of EGU #2 / #152 (tracking issue to be filed)
+**Type:** New client module (vanilla JS / Web Crypto) — additive; no change to
+the Python chain.
+
+## Summary
+
+Make the browser wallet **recoverable**: a lost device must not mean a lost
+identity. Add self-custody **backup/restore** that converts a `Wallet` to and
+from a portable artifact, in two forms:
+
+1. **Passphrase-encrypted file** (primary backup) — PBKDF2-SHA256 derives an
+   AES-GCM-256 key from a user passphrase; the encrypted private key is written
+   to a small, human-inspectable JSON blob the user can download and re-import
+   on any device with the passphrase. No plaintext key ever leaves the module.
+2. **Raw b58 string** (power-user / password-manager) — the existing
+   `exportPrivateKeyB58()` / `Wallet.fromPrivateKeyB58()`, surfaced as
+   documented symmetric wrappers so all backup surface lives in one module.
+   At-rest protection is delegated to the user's password manager (e.g.
+   Bitwarden), matching the existing 2b2f habit.
+
+Builds on the merged signing core (#170/#171) and storage layer (#172/#173).
+`Wallet.exportPrivateKeyB58()` / `Wallet.fromPrivateKeyB58()` are the
+persistence seam — no change to `gc-wallet`.
+
+**Scope:** backup/restore **only**, operating at the `Wallet` level
+(artifact ↔ `Wallet`). On-device persistence stays PRF-passkey-anchored (#2.2).
+A **passphrase-anchored on-device storage route (the non-PRF alternative) is
+explicitly out of scope** and remains a possible future sub-project.
+
+## Architecture — Wallet-level, storage-decoupled
+
+`gc-backup.mjs` knows nothing about IndexedDB or WebAuthn. It converts between a
+`Wallet` and an artifact; nothing more. This keeps the security-critical crypto
+fully Node-testable (no browser-only dependencies) and composable:
+
+- **Backup:** `Wallet` → artifact (the app offers it as a file download or a
+  copyable string).
+- **Restore:** artifact → `Wallet`. **Re-persisting** that recovered wallet on
+  the new device is a separate, already-built step: compose with #2.2's
+  `enroll(wallet, { passkey, store }, opts)`. `gc-backup` does not call it and
+  has no storage coupling.
+
+## Components (`clients/wallet/`)
+
+- **`gc-backup.mjs`** — new. Pure crypto, Node-tested. The four-function API
+  below. Reuses the shared AES-GCM primitive from `gc-envelope` (see below) and
+  base64 helpers from `gc-crypto`.
+- **`gc-envelope.mjs`** — modified. Extract a key-level primitive
+  `sealWithKey(key, bytes)` / `openWithKey(key, { iv, ciphertext })`; keep the
+  existing PRF `seal(prfOutput, …)` / `open(prfOutput, …)` as thin wrappers
+  (HKDF → `CryptoKey` → primitive). `gc-backup` derives via PBKDF2 →
+  `CryptoKey` → the **same** primitive. One encryption implementation, two key
+  schedules.
+- **`gc-errors.mjs`** — modified. Add typed `BadBackupError` and
+  `BadPassphraseError` (re-exported from `gc-backup` for consumers).
+- **`passkey-wallet-demo.html`** + **`MANUAL-VERIFICATION.md`** — extended with a
+  download-file / upload-file-plus-passphrase → unlock flow (thin glue;
+  the crypto is Node-covered).
+
+Dependency order: `gc-backup` → `gc-envelope` (shared primitive) + `gc-crypto`
+(base64) + `gc-wallet` (key seam) + `gc-errors` (typed errors).
+
+## Module API (`gc-backup.mjs`)
+
+- `exportEncrypted(wallet, passphrase, opts?) -> Promise<backupObject>` —
+  PBKDF2(passphrase, fresh salt, iterations) → AES-GCM key; seal
+  `utf8(wallet.exportPrivateKeyB58())`; return the artifact object below.
+  `opts.iterations` overrides the default (for tests / future tuning).
+- `importEncrypted(backupObject, passphrase) -> Promise<Wallet>` — validate
+  `kind`/`version`; re-derive the key from the stored kdf params; `openWithKey`;
+  decode UTF-8 → `Wallet.fromPrivateKeyB58(...)`. Throws `BadBackupError` on a
+  malformed/unknown artifact, `BadPassphraseError` when the GCM tag fails.
+- `exportPlain(wallet) -> Promise<string>` — thin, documented wrapper over
+  `wallet.exportPrivateKeyB58()`.
+- `importPlain(b58) -> Promise<Wallet>` — thin, documented wrapper over
+  `Wallet.fromPrivateKeyB58(b58)`.
+
+## Cryptographic design (the security-critical core)
+
+All via Web Crypto (`crypto.subtle`); browser + Node identical.
+
+- **Key derivation (passphrase path):** `importKey('raw', utf8(passphrase),
+  'PBKDF2', false, ['deriveKey'])` → `deriveKey({ name: 'PBKDF2', hash:
+  'SHA-256', salt, iterations }, …, { name: 'AES-GCM', length: 256 }, false,
+  ['encrypt','decrypt'])`. The derived key is **non-extractable**.
+  - **Iterations:** default **600,000** (OWASP 2023 guidance for
+    PBKDF2-HMAC-SHA256). Stored in the artifact so the schedule can be raised
+    later without breaking old backups.
+  - **Salt:** fresh **16 random bytes** per export (`crypto.getRandomValues`),
+    stored in the artifact.
+- **Encryption:** AES-GCM-256, fresh random **12-byte IV per export**;
+  ciphertext includes GCM's 16-byte auth tag. `openWithKey` **fails closed** if
+  the tag does not verify (wrong passphrase / tampered file) — never returns
+  partial or garbage plaintext.
+- **Plaintext:** the wallet's private key in its b58 form
+  (`utf8(wallet.exportPrivateKeyB58())`). On restore, decode UTF-8 →
+  `Wallet.fromPrivateKeyB58()`. (Encrypting the b58 string reuses #2.1's seam;
+  no raw-PKCS8 accessor is added to `gc-wallet`.)
+- **Shared primitive:** the AES-GCM seal/open bytes are identical to #2.2's
+  envelope; factoring `sealWithKey`/`openWithKey` means one audited
+  implementation, with HKDF (PRF) and PBKDF2 (passphrase) as the two key
+  schedules feeding it.
+
+## Backup artifact (JSON)
+
+```json
+{
+  "version": 1,
+  "kind": "gc-wallet-backup",
+  "address": "GC…GC",
+  "kdf": { "name": "PBKDF2", "hash": "SHA-256", "iterations": 600000, "salt": "<b64>" },
+  "iv": "<b64>",
+  "ciphertext": "<b64>"
+}
+```
+
+- All binary fields base64-encoded for JSON-friendly storage/transport.
+- `address` is plaintext (it is public) so a backup is identifiable — and the
+  recovered wallet's address can be cross-checked — without decrypting.
+- `kind` distinguishes this artifact from the #2.2 IndexedDB record and any
+  future export format; `version` is the schema/migration seam.
+
+## Data flow
+
+- **exportEncrypted:** derive salt + IV → PBKDF2 → `sealWithKey(key,
+  utf8(b58))` → assemble artifact (with `address`, kdf params) → return.
+- **importEncrypted:** validate `kind === 'gc-wallet-backup'` and known
+  `version` (else `BadBackupError`) → PBKDF2 from stored kdf params →
+  `openWithKey` (GCM failure → `BadPassphraseError`) → UTF-8 decode →
+  `Wallet.fromPrivateKeyB58`.
+
+## Error handling (typed errors, fail closed)
+
+- `BadBackupError` — artifact is not a recognizable `gc-wallet-backup`, has an
+  unknown `version`, or is missing required fields. Thrown before any crypto so
+  a malformed file gives a clear message rather than an opaque decrypt failure.
+- `BadPassphraseError` — `importEncrypted` GCM tag mismatch (wrong passphrase or
+  tampered ciphertext/IV/salt). The underlying `OperationError` from Web Crypto
+  is caught and re-thrown as this typed error; **never** returns garbage.
+- Typed errors live in `gc-errors.mjs`, alongside `UnsupportedError` /
+  `NoWalletError`; `gc-backup` re-exports the two it owns.
+- No silent fallback anywhere.
+
+## Security properties (explicitly, so they're checkable)
+
+1. **No plaintext key in any artifact.** The encrypted file holds only
+   ciphertext + non-secrets (address, kdf params, IV); the raw-string form is
+   the key itself and is the user's responsibility to store in a password
+   manager — documented as such.
+2. **The AES key is ephemeral and passphrase-bound.** Derived at the moment of
+   use via PBKDF2 and discarded; never stored; non-extractable.
+3. **Tamper-evident.** AES-GCM authentication makes any modification of the
+   ciphertext, IV, or (via re-derivation) salt fail `importEncrypted` closed.
+4. **Domain/format-separated, versioned.** `kind` + `version` + stored kdf
+   params let the format and key schedule evolve unambiguously.
+5. **No key exfiltration path widened.** `importEncrypted` returns a `Wallet`
+   (whose private key remains a #2.1 concern); the module never exposes the raw
+   AES key or derived bytes.
+
+## Testing
+
+- **Node (`node --test`, zero npm):**
+  - **Shared primitive (`gc-envelope`):** existing PRF `seal`/`open` tests still
+    pass (regression); `sealWithKey`/`openWithKey` round-trip with a fixed
+    `CryptoKey`.
+  - **`gc-backup` encrypted path:** `exportEncrypted` → `importEncrypted`
+    round-trip recovers a wallet that **signs identically** to the original
+    (cross-check against #2.1); wrong passphrase → `BadPassphraseError` (and no
+    plaintext leak); tampered ciphertext → throws; distinct salt **and** IV
+    across two exports of the same wallet; unknown `version`/`kind` →
+    `BadBackupError`; a low `opts.iterations` keeps tests fast without changing
+    behavior.
+  - **`gc-backup` plain path:** `exportPlain` → `importPlain` round-trip; parity
+    that `exportPlain(w)` equals `w.exportPrivateKeyB58()`.
+  - **No-plaintext check:** `JSON.stringify(backupObject)` does **not** contain
+    `wallet.exportPrivateKeyB58()`.
+- **Browser (manual, documented):** `passkey-wallet-demo.html` gains
+  "Download backup" (passphrase → file) and "Restore from backup" (file +
+  passphrase → unlocked wallet, address cross-checked), plus a raw-string
+  export/import. `MANUAL-VERIFICATION.md` documents the steps and confirms the
+  downloaded file contains only ciphertext.
+
+## Out of scope (later sub-projects of #152)
+
+- **Passphrase-anchored on-device storage (the non-PRF route)** — deferred.
+- Message-signing UX (#2.4); packaging/hosting (#2.5).
+- Multi-wallet; cross-device key transfer beyond explicit backup/restore and
+  platform passkey sync.
+- Any Python chain change (purely additive client code).
+
+## Decisions log
+
+- **Both artifact forms (file + raw string)** — the encrypted file is the robust
+  self-custody backup; the raw string matches the existing password-manager
+  habit. Raw-string support is essentially the existing #2.1 seam re-surfaced.
+- **Backup/restore only; no non-PRF storage** — smallest clean scope; keeps
+  `gc-backup` storage-decoupled and fully Node-testable. The non-PRF storage
+  route, if built, is its own sub-project.
+- **PBKDF2-SHA256 @ 600,000 iterations** — strongest passphrase KDF available in
+  Web Crypto without a dependency (Argon2 would break zero-npm); iterations
+  stored in-artifact for forward tuning.
+- **Shared AES-GCM primitive in `gc-envelope`** — one audited authenticated-
+  encryption implementation; HKDF (PRF) and PBKDF2 (passphrase) are the two key
+  schedules. The one touch to existing tested code; justified as the exact
+  primitive this feature needs, not unrelated refactoring.
+- **Encrypt the b58 private key** — reuses #2.1's seam; no `gc-wallet` change.
+- **Storage-decoupled** — re-persist a recovered wallet by composing with #2.2
+  `enroll`; `gc-backup` owns no storage.
+- **Zero npm preserved** — Node tests for all crypto/orchestration; manual
+  browser verification for the file download/upload glue only.
+
+## Definition of done
+
+- `gc-backup.mjs` with the four-function API; `gc-envelope.mjs` refactored to a
+  shared `sealWithKey`/`openWithKey` primitive (PRF wrappers unchanged in
+  behavior); `BadBackupError`/`BadPassphraseError` in `gc-errors.mjs`.
+- Node tests (envelope regression + shared-primitive round-trip; backup
+  encrypted round-trip with sign-parity, wrong-passphrase, tamper, distinct
+  salt/IV, version/kind errors, no-plaintext; plain round-trip + parity) pass
+  via `node --test`; full `uv run pytest` unaffected; zero npm packages.
+- Demo page + `MANUAL-VERIFICATION.md` updated for download/restore; file
+  confirmed to hold only ciphertext.
+- No Python chain change; no schema/migration.


### PR DESCRIPTION
## Summary
EGU #2.3 (#174) — makes the browser wallet **recoverable** so a lost device doesn't mean a lost identity. Self-custody backup/restore at the `Wallet` level (storage-decoupled), in two forms:

- **Passphrase-encrypted file** — `exportEncrypted`/`importEncrypted`: PBKDF2-SHA256 (600k iters, OWASP 2023) → AES-GCM-256, human-inspectable JSON artifact `{version, kind, address, kdf, iv, ciphertext}`. Re-import on any device with the passphrase. Fail-closed (`BadPassphraseError`) on wrong passphrase/tamper; `BadBackupError` on a malformed/unknown artifact.
- **Raw b58 string** — `exportPlain`/`importPlain`: thin wrappers over the #2.1 key seam for password-manager storage.

The AES-GCM primitive is factored out of `gc-envelope` (`sealWithKey`/`openWithKey`); #2.2's PRF `seal`/`open` are now thin wrappers — one audited encryption impl, two key schedules (HKDF for PRF, PBKDF2 for passphrase). `gc-backup` imports no storage/passkey module; re-persist a recovered wallet by composing with #2.2 `enroll`.

**Out of scope:** passphrase on-device storage (non-PRF route), message-signing UX (#2.4), packaging (#2.5), any Python change.

## Test Plan
- [x] `node --test clients/wallet/*.test.mjs` — 40/40 (envelope regression + primitive round-trip/tamper; encrypted round-trip with sign-parity, wrong-passphrase, real bit-flip tamper, distinct salt+IV, version/kind/malformed/bad-iterations; plain round-trip + parity; no-plaintext-in-blob).
- [x] `uv run pytest` — unaffected (352 passed, 1 skipped; no Python touched).
- [x] Spec-compliance review (clean) + code-quality review (approved; two LOW findings fixed: real bit-flip tamper test, typed error on bad `kdf.iterations`).
- [ ] Manual browser verification of the demo download/restore flow per `clients/wallet/MANUAL-VERIFICATION.md` (browser-only glue).

Spec: `docs/superpowers/specs/2026-06-06-egu-2.3-wallet-backup-design.md`
Plan: `docs/superpowers/plans/2026-06-06-egu-2.3-wallet-backup.md`

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)