### PR TITLE
feat(wallet): generic message signing — gc-msg-v1 portable proofs (#177)

### DIFF
--- a/clients/wallet/MANUAL-VERIFICATION.md
+++ b/clients/wallet/MANUAL-VERIFICATION.md
@@ -60,6 +60,25 @@ demo page (file download/upload, passphrase prompt, clipboard) is manual:
 6. Click **Show raw key**, copy it; reload; paste into the import textarea and
    click **Import raw key** — confirm the address matches.
 
+## Message signing (#2.4)
+
+The `gc-msg-v1` crypto (`gc-message.mjs` — canonical, sign/verify, armored) is
+fully covered by `node --test` and by JS↔Python parity + golden-vector tests.
+Only the demo-page glue (textareas, copy buttons, JSON-vs-armored parsing) is
+manual:
+
+1. **Unlock a wallet.** In **Sign message**, enter some text and click **Sign
+   message**; confirm a proof JSON and an armored block appear, and that the
+   proof `address` matches the loaded wallet.
+2. Copy the **armored** block into **Verify message** and click **Verify
+   message**; confirm `valid: true` with the right `address`/`timestamp`.
+3. Edit one character of the armored cleartext (the human-readable line between
+   the headers) and verify again; confirm a `BadProofError` (cleartext
+   mismatch) is surfaced.
+4. Paste the **JSON** form instead and verify; confirm `valid: true`.
+5. Tamper a character inside the JSON `message` field and verify; confirm
+   `valid: false, reason: bad-signature`.
+
 ## Notes for the tester
 
 - The passkey credential is a **separate** WebAuthn credential (ES256/RS256,

--- a/clients/wallet/gc-errors.mjs
+++ b/clients/wallet/gc-errors.mjs
@@ -16,3 +16,7 @@ export class BadBackupError extends Error {}
 // importEncrypted decrypt failed (wrong passphrase or tampered backup) —
 // re-thrown from the GCM tag mismatch so callers never see garbage plaintext.
 export class BadPassphraseError extends Error {}
+
+// Input is not a structurally valid gc-msg-v1 proof (un-parseable / wrong
+// shape) — distinct from a proof that parses but fails verification.
+export class BadProofError extends Error {}

--- a/clients/wallet/gc-message.mjs
+++ b/clients/wallet/gc-message.mjs
@@ -77,7 +77,10 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   }
   if (maxAge !== undefined) {
     const current = now ?? Math.floor(Date.now() / 1000);
-    if (current - Number(timestamp) > maxAge) {
+    // Symmetric window: reject stale AND future timestamps (mirrors the
+    // server-side gc-sig-v1 freshness check) so maxAge can't be defeated by a
+    // far-future signed timestamp.
+    if (Math.abs(current - Number(timestamp)) > maxAge) {
       return { ...result, valid: false, reason: 'expired' };
     }
   }

--- a/clients/wallet/gc-message.mjs
+++ b/clients/wallet/gc-message.mjs
@@ -1,0 +1,76 @@
+// Generic gc-msg-v1 message signing: sign arbitrary text into a portable proof
+// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v1.
+// Pure Web Crypto + vanilla JS. No dependencies. Knows nothing about the chain.
+import { sha256Hex, base64encode, base64decode } from './gc-crypto.mjs';
+import { BadProofError } from './gc-errors.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const MSG_SCHEME = 'gc-msg-v1';
+const MSG_VERSION = '1';
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+export { BadProofError } from './gc-errors.mjs';
+
+export async function messageCanonical({ address, timestamp, message }) {
+  const digest = await sha256Hex(te.encode(message));
+  return te.encode(
+    [MSG_SCHEME, MSG_VERSION, address, String(timestamp), digest].join('\n'),
+  );
+}
+
+export async function signMessage(wallet, message, { timestamp } = {}) {
+  const ts = String(timestamp ?? Math.floor(Date.now() / 1000));
+  const address = await wallet.address();
+  const bytes = await messageCanonical({ address, timestamp: ts, message });
+  return {
+    scheme: MSG_SCHEME,
+    version: MSG_VERSION,
+    address,
+    public_key: await wallet.publicKeyB64(),
+    timestamp: ts,
+    message,
+    signature: await wallet.sign(bytes),
+  };
+}
+
+export async function verifyMessage(proof, { maxAge, now } = {}) {
+  if (!proof || typeof proof !== 'object') {
+    throw new BadProofError('not a proof object');
+  }
+  const {
+    scheme, version, address, public_key: publicKey, timestamp, message, signature,
+  } = proof;
+  if (
+    scheme !== MSG_SCHEME
+    || version !== MSG_VERSION
+    || typeof address !== 'string'
+    || typeof publicKey !== 'string'
+    || typeof timestamp !== 'string'
+    || typeof message !== 'string'
+    || typeof signature !== 'string'
+  ) {
+    throw new BadProofError('malformed gc-msg-v1 proof');
+  }
+  let verifier;
+  try {
+    verifier = await Wallet.fromPublicKeyB64(publicKey);
+  } catch {
+    throw new BadProofError('invalid public key');
+  }
+  const result = { address, timestamp, message };
+  if ((await verifier.address()) !== address) {
+    return { ...result, valid: false, reason: 'address-mismatch' };
+  }
+  const bytes = await messageCanonical({ address, timestamp, message });
+  if (!(await verifier.verify(bytes, signature))) {
+    return { ...result, valid: false, reason: 'bad-signature' };
+  }
+  if (maxAge !== undefined) {
+    const current = now ?? Math.floor(Date.now() / 1000);
+    if (current - Number(timestamp) > maxAge) {
+      return { ...result, valid: false, reason: 'expired' };
+    }
+  }
+  return { ...result, valid: true };
+}

--- a/clients/wallet/gc-message.mjs
+++ b/clients/wallet/gc-message.mjs
@@ -74,3 +74,34 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   }
   return { ...result, valid: true };
 }
+
+const ARMOR_HEADER = '-----BEGIN GUMPTION SIGNED MESSAGE-----';
+const ARMOR_SIG = '-----BEGIN GUMPTION SIGNATURE-----';
+const ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----';
+
+export function toArmored(proof) {
+  const blob = base64encode(te.encode(JSON.stringify(proof)));
+  return [ARMOR_HEADER, proof.message, ARMOR_SIG, blob, ARMOR_FOOTER].join('\n');
+}
+
+export function fromArmored(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const h = lines.indexOf(ARMOR_HEADER);
+  const s = lines.indexOf(ARMOR_SIG);
+  const f = lines.indexOf(ARMOR_FOOTER);
+  if (h < 0 || s < 0 || f < 0 || !(h < s && s < f)) {
+    throw new BadProofError('malformed armored message');
+  }
+  const cleartext = lines.slice(h + 1, s).join('\n');
+  const blob = lines.slice(s + 1, f).join('').trim();
+  let proof;
+  try {
+    proof = JSON.parse(td.decode(base64decode(blob)));
+  } catch {
+    throw new BadProofError('malformed armored signature block');
+  }
+  if (proof.message !== cleartext) {
+    throw new BadProofError('armored cleartext does not match signed message');
+  }
+  return proof;
+}

--- a/clients/wallet/gc-message.mjs
+++ b/clients/wallet/gc-message.mjs
@@ -47,6 +47,7 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
     || typeof address !== 'string'
     || typeof publicKey !== 'string'
     || typeof timestamp !== 'string'
+    || !/^[0-9]+$/.test(timestamp)
     || typeof message !== 'string'
     || typeof signature !== 'string'
   ) {
@@ -63,7 +64,15 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
     return { ...result, valid: false, reason: 'address-mismatch' };
   }
   const bytes = await messageCanonical({ address, timestamp, message });
-  if (!(await verifier.verify(bytes, signature))) {
+  let signatureOk;
+  try {
+    signatureOk = await verifier.verify(bytes, signature);
+  } catch {
+    // A non-base64 / malformed signature string fails verification; mirror
+    // Python (which catches binascii errors) rather than leaking an exception.
+    signatureOk = false;
+  }
+  if (!signatureOk) {
     return { ...result, valid: false, reason: 'bad-signature' };
   }
   if (maxAge !== undefined) {

--- a/clients/wallet/gc-message.test.mjs
+++ b/clients/wallet/gc-message.test.mjs
@@ -77,3 +77,21 @@ test('fromArmored rejects malformed armor and cleartext mismatch', async () => {
   const tampered = toArmored(proof).replace('hello', 'goodbye');
   assert.throws(() => fromArmored(tampered), BadProofError);
 });
+
+import { readFileSync } from 'node:fs';
+import { Wallet as W2 } from './gc-wallet.mjs';
+
+test('JS signatures match the committed golden vectors', async () => {
+  const VEC = JSON.parse(readFileSync(
+    new URL('./testdata/gc-msg-vectors.json', import.meta.url),
+  ));
+  // VECTOR_WALLET_B58 is the fixed key used by the Python generator.
+  const B58 = process.env.GC_VECTOR_KEY;
+  if (!B58) return; // key supplied by the parity runner; skip if absent
+  const w = await W2.fromPrivateKeyB58(B58);
+  for (const c of VEC) {
+    const proof = await signMessage(w, c.message, { timestamp: c.timestamp });
+    assert.equal(proof.signature, c.signature);
+    assert.equal(proof.address, c.address);
+  }
+});

--- a/clients/wallet/gc-message.test.mjs
+++ b/clients/wallet/gc-message.test.mjs
@@ -58,6 +58,15 @@ test('maxAge enforces freshness when supplied', async () => {
   assert.equal(fresh.valid, true);
 });
 
+test('maxAge rejects a far-future timestamp (symmetric window)', async () => {
+  const w = await Wallet.generate();
+  const future = String(Number(TS) + 10000);
+  const proof = await signMessage(w, 'hi', { timestamp: future });
+  const r = await verifyMessage(proof, { maxAge: 300, now: Number(TS) });
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'expired');
+});
+
 test('a non-base64 signature yields bad-signature, not an exception', async () => {
   const w = await Wallet.generate();
   const proof = await signMessage(w, 'hi', { timestamp: TS });

--- a/clients/wallet/gc-message.test.mjs
+++ b/clients/wallet/gc-message.test.mjs
@@ -58,6 +58,26 @@ test('maxAge enforces freshness when supplied', async () => {
   assert.equal(fresh.valid, true);
 });
 
+test('a non-base64 signature yields bad-signature, not an exception', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  proof.signature = '!!! not base64 !!!';
+  const r = await verifyMessage(proof);
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'bad-signature');
+});
+
+test('a non-numeric timestamp is rejected as a malformed proof', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  proof.timestamp = 'notanumber';
+  await assert.rejects(() => verifyMessage(proof), BadProofError);
+  await assert.rejects(
+    () => verifyMessage(proof, { maxAge: 300, now: 9999999999 }),
+    BadProofError,
+  );
+});
+
 import { toArmored, fromArmored } from './gc-message.mjs';
 
 test('toArmored/fromArmored round-trip preserves the proof', async () => {

--- a/clients/wallet/gc-message.test.mjs
+++ b/clients/wallet/gc-message.test.mjs
@@ -57,3 +57,23 @@ test('maxAge enforces freshness when supplied', async () => {
   const fresh = await verifyMessage(proof, { maxAge: 5000, now });
   assert.equal(fresh.valid, true);
 });
+
+import { toArmored, fromArmored } from './gc-message.mjs';
+
+test('toArmored/fromArmored round-trip preserves the proof', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'multi\nline\nmessage', { timestamp: TS });
+  const armored = toArmored(proof);
+  assert.ok(armored.startsWith('-----BEGIN GUMPTION SIGNED MESSAGE-----'));
+  const back = fromArmored(armored);
+  assert.deepEqual(back, proof);
+  assert.equal((await verifyMessage(back)).valid, true);
+});
+
+test('fromArmored rejects malformed armor and cleartext mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hello', { timestamp: TS });
+  assert.throws(() => fromArmored('not armored at all'), BadProofError);
+  const tampered = toArmored(proof).replace('hello', 'goodbye');
+  assert.throws(() => fromArmored(tampered), BadProofError);
+});

--- a/clients/wallet/gc-message.test.mjs
+++ b/clients/wallet/gc-message.test.mjs
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  signMessage, verifyMessage, BadProofError,
+} from './gc-message.mjs';
+
+const TS = '1700001000';
+
+test('signMessage -> verifyMessage round-trips valid', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'I made stake T1', { timestamp: TS });
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.version, '1');
+  assert.equal(proof.address, await w.address());
+  assert.equal(proof.timestamp, TS);
+  const r = await verifyMessage(proof);
+  assert.deepEqual(r, {
+    valid: true, address: await w.address(), timestamp: TS, message: 'I made stake T1',
+  });
+});
+
+test('a tampered message yields bad-signature', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'original', { timestamp: TS });
+  proof.message = 'forged';
+  const r = await verifyMessage(proof);
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'bad-signature');
+});
+
+test('an address not matching the public key yields address-mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  proof.address = `${proof.address}X`;
+  const r = await verifyMessage(proof);
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'address-mismatch');
+});
+
+test('wrong scheme/version/missing fields throw BadProofError', async () => {
+  const w = await Wallet.generate();
+  const good = await signMessage(w, 'hi', { timestamp: TS });
+  await assert.rejects(() => verifyMessage({ ...good, scheme: 'gc-sig-v1' }), BadProofError);
+  await assert.rejects(() => verifyMessage({ ...good, version: '2' }), BadProofError);
+  await assert.rejects(() => verifyMessage({ scheme: 'gc-msg-v1', version: '1' }), BadProofError);
+  await assert.rejects(() => verifyMessage(null), BadProofError);
+});
+
+test('maxAge enforces freshness when supplied', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  const now = Number(TS) + 1000;
+  const stale = await verifyMessage(proof, { maxAge: 300, now });
+  assert.equal(stale.valid, false);
+  assert.equal(stale.reason, 'expired');
+  const fresh = await verifyMessage(proof, { maxAge: 5000, now });
+  assert.equal(fresh.valid, true);
+});

--- a/clients/wallet/gc-wallet.mjs
+++ b/clients/wallet/gc-wallet.mjs
@@ -1,7 +1,7 @@
 // GumptionChain browser wallet: keygen, key import/export, address, sign.
 // Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
 import {
-  base58encode, base58decode, base64encode, millHash,
+  base58encode, base58decode, base64encode, base64decode, millHash,
 } from './gc-crypto.mjs';
 
 const ALG = { name: 'RSASSA-PKCS1-v1_5' };
@@ -74,6 +74,18 @@ export class Wallet {
     return new Wallet(priv, pub);
   }
 
+  static async fromPublicKeyB64(b64) {
+    const pub = await crypto.subtle.importKey(
+      'spki',
+      base64decode(b64),
+      IMPORT_PARAMS,
+      true,
+      ['verify'],
+    );
+    assertKeyProfile(pub);
+    return new Wallet(null, pub);
+  }
+
   async exportPrivateKeyB58() {
     if (!this.#privateKey) {
       throw new Error('no private key');
@@ -103,5 +115,9 @@ export class Wallet {
     }
     const sig = await crypto.subtle.sign(ALG, this.#privateKey, bytes);
     return base64encode(new Uint8Array(sig));
+  }
+
+  async verify(bytes, signatureB64) {
+    return crypto.subtle.verify(ALG, this.#publicKey, base64decode(signatureB64), bytes);
   }
 }

--- a/clients/wallet/gc-wallet.test.mjs
+++ b/clients/wallet/gc-wallet.test.mjs
@@ -67,3 +67,25 @@ test('exportPrivateKeyB58 round-trips through fromPrivateKeyB58', async () => {
   const w = await Wallet.fromPrivateKeyB58(V.private_key_b58);
   assert.equal(await w.exportPrivateKeyB58(), V.private_key_b58);
 });
+
+test('fromPublicKeyB64 yields a verify-only wallet with the same address', async () => {
+  const w = await Wallet.generate();
+  const v = await Wallet.fromPublicKeyB64(await w.publicKeyB64());
+  assert.equal(await v.address(), await w.address());
+});
+
+test('verify-only wallet verifies a good signature and rejects a bad one', async () => {
+  const w = await Wallet.generate();
+  const v = await Wallet.fromPublicKeyB64(await w.publicKeyB64());
+  const bytes = new TextEncoder().encode('hello');
+  const sig = await w.sign(bytes);
+  assert.equal(await v.verify(bytes, sig), true);
+  const other = new TextEncoder().encode('tampered');
+  assert.equal(await v.verify(other, sig), false);
+});
+
+test('verify-only wallet cannot sign or export the private key', async () => {
+  const v = await Wallet.fromPublicKeyB64(await (await Wallet.generate()).publicKeyB64());
+  await assert.rejects(() => v.sign(new Uint8Array([1])));
+  await assert.rejects(() => v.exportPrivateKeyB58());
+});

--- a/clients/wallet/message-cli.mjs
+++ b/clients/wallet/message-cli.mjs
@@ -1,0 +1,20 @@
+// gc-msg-v1 sign/verify harness (test tool, not a unit test). Used by the
+// Python parity tests to prove JS<->Python message-signing interop.
+//   node message-cli.mjs sign   '{"private_key_b58":"...","message":"...","timestamp":"..."}'
+//   node message-cli.mjs verify '<proof JSON>'
+import { Wallet } from './gc-wallet.mjs';
+import { signMessage, verifyMessage } from './gc-message.mjs';
+
+const mode = process.argv[2];
+const arg = JSON.parse(process.argv[3]);
+
+if (mode === 'sign') {
+  const w = await Wallet.fromPrivateKeyB58(arg.private_key_b58);
+  const proof = await signMessage(w, arg.message, { timestamp: arg.timestamp });
+  process.stdout.write(JSON.stringify(proof));
+} else if (mode === 'verify') {
+  process.stdout.write(JSON.stringify(await verifyMessage(arg)));
+} else {
+  process.stderr.write(`unknown mode: ${mode}\n`);
+  process.exit(1);
+}

--- a/clients/wallet/passkey-wallet-demo.html
+++ b/clients/wallet/passkey-wallet-demo.html
@@ -73,6 +73,42 @@
       <button id="import-raw">Import raw key</button>
     </p>
 
+    <h2>Sign message (#2.4)</h2>
+    <p class="hint">
+      Signs arbitrary text into a portable <code>gc-msg-v1</code> proof using
+      <code>currentWallet</code>. Verifies off-chain in JS and Python.
+    </p>
+    <p>
+      <textarea id="sign-msg-text" rows="3" style="width: 100%"
+                placeholder="message to sign"></textarea>
+    </p>
+    <p>
+      <button id="sign-msg">Sign message</button>
+      <button id="copy-msg-json">Copy JSON</button>
+      <button id="copy-msg-armored">Copy armored</button>
+    </p>
+    <p>
+      <textarea id="sign-msg-json" rows="4" style="width: 100%; font-family: monospace"
+                readonly placeholder="proof JSON appears here"></textarea>
+    </p>
+    <p>
+      <textarea id="sign-msg-armored" rows="6" style="width: 100%; font-family: monospace"
+                readonly placeholder="armored proof appears here"></textarea>
+    </p>
+
+    <h2>Verify message (#2.4)</h2>
+    <p class="hint">
+      Paste either the JSON proof or the armored block; verification is
+      self-contained (no wallet required).
+    </p>
+    <p>
+      <textarea id="verify-msg-text" rows="6" style="width: 100%; font-family: monospace"
+                placeholder="paste JSON or armored gc-msg-v1 proof"></textarea>
+    </p>
+    <p>
+      <button id="verify-msg">Verify message</button>
+    </p>
+
     <h2>Output</h2>
     <pre id="out">(idle)</pre>
 
@@ -90,6 +126,8 @@
       import { makeIdbStore } from './gc-store-idb.mjs';
       import { exportEncrypted, importEncrypted, exportPlain, importPlain }
         from './gc-backup.mjs';
+      import { signMessage, verifyMessage, toArmored, fromArmored }
+        from './gc-message.mjs';
 
       const rpId = location.hostname;
       const rpName = 'GumptionChain Wallet Demo';
@@ -256,6 +294,72 @@
             show(`Imported raw key.\naddress: ${address}`);
           } catch (err) {
             fail('Import raw key', err);
+          }
+        });
+
+      document.getElementById('sign-msg').addEventListener('click', async () => {
+        try {
+          const wallet = requireWallet();
+          const text = document.getElementById('sign-msg-text').value;
+          const proof = await signMessage(wallet, text);
+          document.getElementById('sign-msg-json').value =
+            JSON.stringify(proof, null, 2);
+          document.getElementById('sign-msg-armored').value = toArmored(proof);
+          show(`Signed message.\naddress: ${proof.address}`);
+        } catch (err) {
+          fail('Sign message', err);
+        }
+      });
+
+      const copyField = async (id, label) => {
+        try {
+          const value = document.getElementById(id).value;
+          if (!value) {
+            show('Nothing to copy — sign a message first.');
+            return;
+          }
+          await navigator.clipboard.writeText(value);
+          show(`${label} copied to clipboard.`);
+        } catch (err) {
+          fail(`Copy ${label}`, err);
+        }
+      };
+      document
+        .getElementById('copy-msg-json')
+        .addEventListener('click', () => copyField('sign-msg-json', 'JSON'));
+      document
+        .getElementById('copy-msg-armored')
+        .addEventListener('click', () =>
+          copyField('sign-msg-armored', 'Armored'),
+        );
+
+      document
+        .getElementById('verify-msg')
+        .addEventListener('click', async () => {
+          try {
+            const text = document.getElementById('verify-msg-text').value.trim();
+            if (!text) {
+              show('Nothing to verify — paste a JSON or armored proof first.');
+              return;
+            }
+            let proof;
+            try {
+              proof = JSON.parse(text);
+            } catch {
+              proof = fromArmored(text);
+            }
+            const r = await verifyMessage(proof);
+            const lines = [
+              `valid: ${r.valid}`,
+              `address: ${r.address}`,
+              `timestamp: ${r.timestamp}`,
+            ];
+            if (!r.valid) {
+              lines.push(`reason: ${r.reason}`);
+            }
+            show(lines.join('\n'));
+          } catch (err) {
+            fail('Verify message', err);
           }
         });
     </script>

--- a/clients/wallet/testdata/gc-msg-vectors.json
+++ b/clients/wallet/testdata/gc-msg-vectors.json
@@ -1,0 +1,20 @@
+[
+  {
+    "message": "hello world",
+    "timestamp": "1700001000",
+    "signature": "fWV3dWJquOJYYzNIJYgBwz5WRhfaC3VNDu88ZB0/L4ShH/rYSmdHSNkViNiUt6nyuD3csX4l72IDFc6ePtpeeB02L3HKpid3WUZjNQJAdXEkznv8n7gjTEdk7BAqIC0ODvvFN4T47zztVRjx6UkDSQi2yOa8FvJi0WtbXLb+Sd665rGwRR/9Ztp20SmuNomvQjQoqlbV4EevZVXlKX//Ibe1lNkvoNb/Hrtcm06psoswB6sd9yhkYAJw19tJ7y6QDqrlJxUMo8kGMYWKpIkX8vocJlanTYw9LOutjJkpXfQ6C6wQ8otpGOYNrVdsoLyaGg6Bq/6603HvZLkhXII8Sg==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  },
+  {
+    "message": "I made stake T1 \u2014 3 GRIT opposition on goblins",
+    "timestamp": "1700001001",
+    "signature": "WadwNjKhA0shH6kDCp9me5Myw0EGVGUS10MjqIMjw2PqXY39tnbCaiSSXQpiKkNS4sMzBAiYiTtabg9s+FbxSFitqp68YlgyIb0lruIs+blNRhnA8oLW7or4wpRBkS3zCHF97F4Ayh9FyRjIoEpd03QA3o/ngF3t3dTX9vMzRIcA9nddAkvpSgVI1vN/8OPmqYFuAh7BL/aKSlLdkbsMrwMumxBu2LdrM0Xh13Q2YCkQ3plX2Yphyqxt9TgavdG/S488I9ua7phlTiE5XjzZMq99jy5oTdmjW72lCPliI8XWTn/sl2YQEquX3bPYQPjetU+UxF3IAgQJ42wmZ79xcQ==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  },
+  {
+    "message": "multi\nline\nmessage",
+    "timestamp": "1700001002",
+    "signature": "Gw2GNcfydkwfh/XY8/chdouHaAb0BYKDy/FoUvT7pm3HkoD+kfnnyZFVvj1ko/8LKFZ3nvBFubUZyLmMqbJmTfOHrME9X9IG4y5Er5J/E9K/YSZmMHjy3fAnWt9OgsXFtyrr7KqaYhvehtKmsuROFzp15B7DqOtLHL7HS4mbEurb1Qwi++Rk+92cicdFc77TeXdgKJn2adsUYr7nYjWIJFqDnuuVidqNqTdzP2mGjS4xGClOIPajCHDmbPKXnCBdDvlta08aNibt3ZZ2ki+6+PYxTbBf/2fD8p1meDsF67dFD4EC+lJanZ9us2CLULDDXGABNO2giuMAmlOu5unGgg==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  }
+]

--- a/docs/superpowers/plans/2026-06-06-egu-2.4-message-signing.md
+++ b/docs/superpowers/plans/2026-06-06-egu-2.4-message-signing.md
@@ -1,0 +1,881 @@
+# EGU #2.4 — generic message signing (gc-msg-v1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sign arbitrary messages into portable `gc-msg-v1` proofs that verify off-chain in both JS and Python, so a holder can prove "address X said this."
+
+**Architecture:** A domain-separated scheme (`gc-msg-v1`) distinct from the `gc-sig-v1` HTTP-auth scheme. New JS module `clients/wallet/gc-message.mjs` and new Python module `src/gumptionchain/message.py` with mirrored APIs; a verify-only `Wallet.fromPublicKeyB64` added to JS `gc-wallet.mjs` (mirrors Python `Wallet(b64ks=…)`). Cross-language parity via a `message-cli.mjs` harness + golden vectors. No node HTTP endpoint, no schema change.
+
+**Tech Stack:** Vanilla ESM + Web Crypto (`crypto.subtle`), Node 20+ `node --test`, zero npm; Python 3.12 + cryptography lib (via existing `Wallet`), pytest, ruff/mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-egu-2.4-message-signing-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `clients/wallet/gc-wallet.mjs` — add `static fromPublicKeyB64(b64)` (verify-only Wallet) + instance `verify(bytes, sigB64)`; import `base64decode`.
+- **Modify** `clients/wallet/gc-errors.mjs` — add `BadProofError`.
+- **Create** `clients/wallet/gc-message.mjs` — canonical + sign/verify + armored.
+- **Create** `clients/wallet/gc-message.test.mjs` — JS unit tests.
+- **Modify** `clients/wallet/gc-wallet.test.mjs` — verify-only tests.
+- **Create** `clients/wallet/message-cli.mjs` — sign/verify harness for parity.
+- **Create** `src/gumptionchain/message.py` — mirrored Python API.
+- **Create** `tests/test_message.py` — Python unit tests + domain separation.
+- **Create** `tests/test_message_parity.py` — JS↔Python live cross-verify.
+- **Create** `tests/test_message_vectors.py` + `clients/wallet/testdata/gc-msg-vectors.json` — golden vectors checked by both languages.
+- **Modify** `clients/wallet/passkey-wallet-demo.html` + `MANUAL-VERIFICATION.md`.
+
+JS test command: `node --test clients/wallet/*.test.mjs`. Python: `uv run pytest`.
+
+---
+
+### Task 1: Verify-only `Wallet.fromPublicKeyB64` + `verify`
+
+**Files:**
+- Modify: `clients/wallet/gc-wallet.mjs`
+- Test: `clients/wallet/gc-wallet.test.mjs`
+
+- [ ] **Step 1: Write failing tests** — append to `clients/wallet/gc-wallet.test.mjs`:
+
+```javascript
+test('fromPublicKeyB64 yields a verify-only wallet with the same address', async () => {
+  const w = await Wallet.generate();
+  const v = await Wallet.fromPublicKeyB64(await w.publicKeyB64());
+  assert.equal(await v.address(), await w.address());
+});
+
+test('verify-only wallet verifies a good signature and rejects a bad one', async () => {
+  const w = await Wallet.generate();
+  const v = await Wallet.fromPublicKeyB64(await w.publicKeyB64());
+  const bytes = new TextEncoder().encode('hello');
+  const sig = await w.sign(bytes);
+  assert.equal(await v.verify(bytes, sig), true);
+  const other = new TextEncoder().encode('tampered');
+  assert.equal(await v.verify(other, sig), false);
+});
+
+test('verify-only wallet cannot sign or export the private key', async () => {
+  const v = await Wallet.fromPublicKeyB64(await (await Wallet.generate()).publicKeyB64());
+  await assert.rejects(() => v.sign(new Uint8Array([1])));
+  await assert.rejects(() => v.exportPrivateKeyB58());
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test clients/wallet/gc-wallet.test.mjs`
+Expected: FAIL — `fromPublicKeyB64`/`verify` not defined.
+
+- [ ] **Step 3: Implement** — in `clients/wallet/gc-wallet.mjs`:
+
+(a) extend the import to include `base64decode`:
+```javascript
+import {
+  base58encode, base58decode, base64encode, base64decode, millHash,
+} from './gc-crypto.mjs';
+```
+
+(b) add the static after `fromPrivateKeyB58` (note `new Wallet(null, pub)`):
+```javascript
+  static async fromPublicKeyB64(b64) {
+    const pub = await crypto.subtle.importKey(
+      'spki',
+      base64decode(b64),
+      IMPORT_PARAMS,
+      true,
+      ['verify'],
+    );
+    assertKeyProfile(pub);
+    return new Wallet(null, pub);
+  }
+```
+
+(c) add the instance method after `sign`:
+```javascript
+  async verify(bytes, signatureB64) {
+    return crypto.subtle.verify(ALG, this.#publicKey, base64decode(signatureB64), bytes);
+  }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test clients/wallet/gc-wallet.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-wallet.mjs clients/wallet/gc-wallet.test.mjs
+git commit -m "feat(wallet): verify-only Wallet.fromPublicKeyB64 + verify()"
+```
+
+---
+
+### Task 2: `BadProofError` + `gc-message` canonical/sign/verify (JS)
+
+**Files:**
+- Modify: `clients/wallet/gc-errors.mjs`
+- Create: `clients/wallet/gc-message.mjs`
+- Test: `clients/wallet/gc-message.test.mjs`
+
+- [ ] **Step 1: Add the typed error** — append to `clients/wallet/gc-errors.mjs`:
+
+```javascript
+// Input is not a structurally valid gc-msg-v1 proof (un-parseable / wrong
+// shape) — distinct from a proof that parses but fails verification.
+export class BadProofError extends Error {}
+```
+
+- [ ] **Step 2: Write failing tests** — create `clients/wallet/gc-message.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  signMessage, verifyMessage, BadProofError,
+} from './gc-message.mjs';
+
+const TS = '1700001000';
+
+test('signMessage -> verifyMessage round-trips valid', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'I made stake T1', { timestamp: TS });
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.version, '1');
+  assert.equal(proof.address, await w.address());
+  assert.equal(proof.timestamp, TS);
+  const r = await verifyMessage(proof);
+  assert.deepEqual(r, {
+    valid: true, address: await w.address(), timestamp: TS, message: 'I made stake T1',
+  });
+});
+
+test('a tampered message yields bad-signature', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'original', { timestamp: TS });
+  proof.message = 'forged';
+  const r = await verifyMessage(proof);
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'bad-signature');
+});
+
+test('an address not matching the public key yields address-mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  proof.address = `${proof.address}X`;
+  const r = await verifyMessage(proof);
+  assert.equal(r.valid, false);
+  assert.equal(r.reason, 'address-mismatch');
+});
+
+test('wrong scheme/version/missing fields throw BadProofError', async () => {
+  const w = await Wallet.generate();
+  const good = await signMessage(w, 'hi', { timestamp: TS });
+  await assert.rejects(() => verifyMessage({ ...good, scheme: 'gc-sig-v1' }), BadProofError);
+  await assert.rejects(() => verifyMessage({ ...good, version: '2' }), BadProofError);
+  await assert.rejects(() => verifyMessage({ scheme: 'gc-msg-v1', version: '1' }), BadProofError);
+  await assert.rejects(() => verifyMessage(null), BadProofError);
+});
+
+test('maxAge enforces freshness when supplied', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  const now = Number(TS) + 1000;
+  const stale = await verifyMessage(proof, { maxAge: 300, now });
+  assert.equal(stale.valid, false);
+  assert.equal(stale.reason, 'expired');
+  const fresh = await verifyMessage(proof, { maxAge: 5000, now });
+  assert.equal(fresh.valid, true);
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `node --test clients/wallet/gc-message.test.mjs`
+Expected: FAIL — module missing.
+
+- [ ] **Step 4: Implement** — create `clients/wallet/gc-message.mjs`:
+
+```javascript
+// Generic gc-msg-v1 message signing: sign arbitrary text into a portable proof
+// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v1.
+// Pure Web Crypto + vanilla JS. No dependencies. Knows nothing about the chain.
+import { sha256Hex, base64encode, base64decode } from './gc-crypto.mjs';
+import { BadProofError } from './gc-errors.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const MSG_SCHEME = 'gc-msg-v1';
+const MSG_VERSION = '1';
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+export { BadProofError } from './gc-errors.mjs';
+
+export async function messageCanonical({ address, timestamp, message }) {
+  const digest = await sha256Hex(te.encode(message));
+  return te.encode(
+    [MSG_SCHEME, MSG_VERSION, address, String(timestamp), digest].join('\n'),
+  );
+}
+
+export async function signMessage(wallet, message, { timestamp } = {}) {
+  const ts = String(timestamp ?? Math.floor(Date.now() / 1000));
+  const address = await wallet.address();
+  const bytes = await messageCanonical({ address, timestamp: ts, message });
+  return {
+    scheme: MSG_SCHEME,
+    version: MSG_VERSION,
+    address,
+    public_key: await wallet.publicKeyB64(),
+    timestamp: ts,
+    message,
+    signature: await wallet.sign(bytes),
+  };
+}
+
+export async function verifyMessage(proof, { maxAge, now } = {}) {
+  if (!proof || typeof proof !== 'object') {
+    throw new BadProofError('not a proof object');
+  }
+  const {
+    scheme, version, address, public_key: publicKey, timestamp, message, signature,
+  } = proof;
+  if (
+    scheme !== MSG_SCHEME
+    || version !== MSG_VERSION
+    || typeof address !== 'string'
+    || typeof publicKey !== 'string'
+    || typeof timestamp !== 'string'
+    || typeof message !== 'string'
+    || typeof signature !== 'string'
+  ) {
+    throw new BadProofError('malformed gc-msg-v1 proof');
+  }
+  let verifier;
+  try {
+    verifier = await Wallet.fromPublicKeyB64(publicKey);
+  } catch {
+    throw new BadProofError('invalid public key');
+  }
+  const result = { address, timestamp, message };
+  if ((await verifier.address()) !== address) {
+    return { ...result, valid: false, reason: 'address-mismatch' };
+  }
+  const bytes = await messageCanonical({ address, timestamp, message });
+  if (!(await verifier.verify(bytes, signature))) {
+    return { ...result, valid: false, reason: 'bad-signature' };
+  }
+  if (maxAge !== undefined) {
+    const current = now ?? Math.floor(Date.now() / 1000);
+    if (current - Number(timestamp) > maxAge) {
+      return { ...result, valid: false, reason: 'expired' };
+    }
+  }
+  return { ...result, valid: true };
+}
+```
+
+(`td`/`base64decode`/`base64encode` are used by the armored functions in Task 3; if a linter flags them as unused here, add Task 3 in the same change set — but per TDD keep tasks separate and accept the transient unused import only if your tooling errors. Node does not error on unused imports.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `node --test clients/wallet/gc-message.test.mjs`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/wallet/gc-errors.mjs clients/wallet/gc-message.mjs clients/wallet/gc-message.test.mjs
+git commit -m "feat(wallet): gc-msg-v1 message sign/verify (JS)"
+```
+
+---
+
+### Task 3: Armored text form (JS)
+
+**Files:**
+- Modify: `clients/wallet/gc-message.mjs`
+- Test: `clients/wallet/gc-message.test.mjs`
+
+- [ ] **Step 1: Write failing tests** — append to `clients/wallet/gc-message.test.mjs`:
+
+```javascript
+import { toArmored, fromArmored } from './gc-message.mjs';
+
+test('toArmored/fromArmored round-trip preserves the proof', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'multi\nline\nmessage', { timestamp: TS });
+  const armored = toArmored(proof);
+  assert.ok(armored.startsWith('-----BEGIN GUMPTION SIGNED MESSAGE-----'));
+  const back = fromArmored(armored);
+  assert.deepEqual(back, proof);
+  assert.equal((await verifyMessage(back)).valid, true);
+});
+
+test('fromArmored rejects malformed armor and cleartext mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signMessage(w, 'hello', { timestamp: TS });
+  assert.throws(() => fromArmored('not armored at all'), BadProofError);
+  const tampered = toArmored(proof).replace('hello', 'goodbye');
+  assert.throws(() => fromArmored(tampered), BadProofError);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test clients/wallet/gc-message.test.mjs`
+Expected: FAIL — `toArmored`/`fromArmored` not exported.
+
+- [ ] **Step 3: Implement** — append to `clients/wallet/gc-message.mjs`:
+
+```javascript
+const ARMOR_HEADER = '-----BEGIN GUMPTION SIGNED MESSAGE-----';
+const ARMOR_SIG = '-----BEGIN GUMPTION SIGNATURE-----';
+const ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----';
+
+export function toArmored(proof) {
+  const blob = base64encode(te.encode(JSON.stringify(proof)));
+  return [ARMOR_HEADER, proof.message, ARMOR_SIG, blob, ARMOR_FOOTER].join('\n');
+}
+
+export function fromArmored(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const h = lines.indexOf(ARMOR_HEADER);
+  const s = lines.indexOf(ARMOR_SIG);
+  const f = lines.indexOf(ARMOR_FOOTER);
+  if (h < 0 || s < 0 || f < 0 || !(h < s && s < f)) {
+    throw new BadProofError('malformed armored message');
+  }
+  const cleartext = lines.slice(h + 1, s).join('\n');
+  const blob = lines.slice(s + 1, f).join('').trim();
+  let proof;
+  try {
+    proof = JSON.parse(td.decode(base64decode(blob)));
+  } catch {
+    throw new BadProofError('malformed armored signature block');
+  }
+  if (proof.message !== cleartext) {
+    throw new BadProofError('armored cleartext does not match signed message');
+  }
+  return proof;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test clients/wallet/*.test.mjs`
+Expected: PASS — all wallet tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/gc-message.mjs clients/wallet/gc-message.test.mjs
+git commit -m "feat(wallet): armored text form for gc-msg-v1 proofs"
+```
+
+---
+
+### Task 4: Python `message.py` — sign/verify
+
+**Files:**
+- Create: `src/gumptionchain/message.py`
+- Test: `tests/test_message.py`
+
+- [ ] **Step 1: Write failing tests** — create `tests/test_message.py`:
+
+```python
+import pytest
+
+from gumptionchain.message import (
+    BadProofError,
+    sign_message,
+    verify_message,
+)
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+TS = '1700001000'
+
+
+def _wallet() -> Wallet:
+    return Wallet(b58ks=VECTOR_WALLET_B58)
+
+
+def test_sign_then_verify_is_valid() -> None:
+    w = _wallet()
+    proof = sign_message(w, 'I made stake T1', timestamp=int(TS))
+    assert proof['scheme'] == 'gc-msg-v1'
+    assert proof['address'] == w.address
+    r = verify_message(proof)
+    assert r == {
+        'valid': True, 'address': w.address, 'timestamp': TS,
+        'message': 'I made stake T1',
+    }
+
+
+def test_tampered_message_is_bad_signature() -> None:
+    proof = sign_message(_wallet(), 'original', timestamp=int(TS))
+    proof['message'] = 'forged'
+    r = verify_message(proof)
+    assert r['valid'] is False
+    assert r['reason'] == 'bad-signature'
+
+
+def test_address_mismatch() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    proof['address'] = proof['address'] + 'X'
+    r = verify_message(proof)
+    assert r['valid'] is False
+    assert r['reason'] == 'address-mismatch'
+
+
+def test_malformed_proof_raises() -> None:
+    good = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    with pytest.raises(BadProofError):
+        verify_message({**good, 'scheme': 'gc-sig-v1'})
+    with pytest.raises(BadProofError):
+        verify_message({'scheme': 'gc-msg-v1', 'version': '1'})
+    with pytest.raises(BadProofError):
+        verify_message(None)
+
+
+def test_max_age_enforces_freshness() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    now = int(TS) + 1000
+    stale = verify_message(proof, max_age=300, now=now)
+    assert stale['valid'] is False
+    assert stale['reason'] == 'expired'
+    assert verify_message(proof, max_age=5000, now=now)['valid'] is True
+
+
+def test_domain_separation_from_gc_sig() -> None:
+    # A gc-msg-v1 signature must not validate as a gc-sig-v1 canonical.
+    w = _wallet()
+    proof = sign_message(w, 'hi', timestamp=int(TS))
+    sig_canonical = _canonical(
+        method='GET', path='/', query='', body=b'',
+        node_host='n', timestamp=TS, address=w.address,
+    )
+    assert not w.validate_signature(sig_canonical, proof['signature'])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_message.py -q`
+Expected: FAIL — `gumptionchain.message` does not exist.
+
+- [ ] **Step 3: Implement** — create `src/gumptionchain/message.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+
+from gumptionchain.exceptions import InvalidKeyError
+from gumptionchain.wallet import Wallet
+
+MSG_SCHEME = 'gc-msg-v1'
+MSG_VERSION = '1'
+
+
+class MessageError(Exception):
+    """Base class for message-signing errors."""
+
+
+class BadProofError(MessageError):
+    """Input is not a structurally valid gc-msg-v1 proof."""
+
+
+def _message_canonical(*, address: str, timestamp: str, message: str) -> bytes:
+    digest = hashlib.sha256(message.encode()).hexdigest()
+    return '\n'.join(
+        [MSG_SCHEME, MSG_VERSION, address, timestamp, digest]
+    ).encode()
+
+
+def sign_message(
+    wallet: Wallet, message: str, timestamp: int | None = None
+) -> dict[str, str]:
+    ts = str(int(timestamp if timestamp is not None else time.time()))
+    canonical = _message_canonical(
+        address=wallet.address, timestamp=ts, message=message
+    )
+    return {
+        'scheme': MSG_SCHEME,
+        'version': MSG_VERSION,
+        'address': wallet.address,
+        'public_key': wallet.public_key_b64,
+        'timestamp': ts,
+        'message': message,
+        'signature': wallet.sign(canonical),
+    }
+
+
+def verify_message(
+    proof: Any, max_age: int | None = None, now: int | None = None
+) -> dict[str, Any]:
+    if not isinstance(proof, dict):
+        msg = 'not a proof object'
+        raise BadProofError(msg)
+    scheme = proof.get('scheme')
+    version = proof.get('version')
+    address = proof.get('address')
+    pubkey = proof.get('public_key')
+    ts = proof.get('timestamp')
+    message = proof.get('message')
+    sig = proof.get('signature')
+    if (
+        scheme != MSG_SCHEME
+        or version != MSG_VERSION
+        or not all(
+            isinstance(v, str) for v in (address, pubkey, ts, message, sig)
+        )
+    ):
+        msg = 'malformed gc-msg-v1 proof'
+        raise BadProofError(msg)
+    try:
+        wallet = Wallet(b64ks=pubkey)
+    except InvalidKeyError as e:
+        msg = 'invalid public key'
+        raise BadProofError(msg) from e
+    result: dict[str, Any] = {
+        'address': address, 'timestamp': ts, 'message': message,
+    }
+    if wallet.address != address:
+        return {**result, 'valid': False, 'reason': 'address-mismatch'}
+    canonical = _message_canonical(
+        address=address, timestamp=ts, message=message
+    )
+    if not wallet.validate_signature(canonical, sig):
+        return {**result, 'valid': False, 'reason': 'bad-signature'}
+    if max_age is not None:
+        current = int(now if now is not None else time.time())
+        if current - int(ts) > max_age:
+            return {**result, 'valid': False, 'reason': 'expired'}
+    return {**result, 'valid': True}
+```
+
+- [ ] **Step 4: Run to verify pass + lint/type**
+
+Run: `uv run pytest tests/test_message.py -q && uv run ruff check src/gumptionchain/message.py && uv run mypy`
+Expected: tests PASS; ruff clean; mypy clean (no new errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gumptionchain/message.py tests/test_message.py
+git commit -m "feat(message): gc-msg-v1 sign/verify (Python) + domain-separation test"
+```
+
+---
+
+### Task 5: Python armored form
+
+**Files:**
+- Modify: `src/gumptionchain/message.py`
+- Test: `tests/test_message.py`
+
+- [ ] **Step 1: Write failing tests** — append to `tests/test_message.py`:
+
+```python
+from gumptionchain.message import from_armored, to_armored
+
+
+def test_armored_round_trip() -> None:
+    w = _wallet()
+    proof = sign_message(w, 'multi\nline\nmessage', timestamp=int(TS))
+    armored = to_armored(proof)
+    assert armored.startswith('-----BEGIN GUMPTION SIGNED MESSAGE-----')
+    back = from_armored(armored)
+    assert back == proof
+    assert verify_message(back)['valid'] is True
+
+
+def test_from_armored_rejects_malformed_and_mismatch() -> None:
+    proof = sign_message(_wallet(), 'hello', timestamp=int(TS))
+    with pytest.raises(BadProofError):
+        from_armored('not armored at all')
+    tampered = to_armored(proof).replace('hello', 'goodbye')
+    with pytest.raises(BadProofError):
+        from_armored(tampered)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_message.py -q`
+Expected: FAIL — `to_armored`/`from_armored` missing.
+
+- [ ] **Step 3: Implement** — append to `src/gumptionchain/message.py` (add `import binascii`, `import json`, and `from base64 import standard_b64decode, standard_b64encode` to the imports at the top):
+
+```python
+ARMOR_HEADER = '-----BEGIN GUMPTION SIGNED MESSAGE-----'
+ARMOR_SIG = '-----BEGIN GUMPTION SIGNATURE-----'
+ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----'
+
+
+def to_armored(proof: dict[str, str]) -> str:
+    blob = standard_b64encode(json.dumps(proof).encode()).decode()
+    return '\n'.join(
+        [ARMOR_HEADER, proof['message'], ARMOR_SIG, blob, ARMOR_FOOTER]
+    )
+
+
+def from_armored(text: str) -> dict[str, Any]:
+    lines = text.replace('\r\n', '\n').split('\n')
+    try:
+        h = lines.index(ARMOR_HEADER)
+        s = lines.index(ARMOR_SIG)
+        f = lines.index(ARMOR_FOOTER)
+    except ValueError as e:
+        msg = 'malformed armored message'
+        raise BadProofError(msg) from e
+    if not h < s < f:
+        msg = 'malformed armored message'
+        raise BadProofError(msg)
+    cleartext = '\n'.join(lines[h + 1 : s])
+    blob = ''.join(lines[s + 1 : f]).strip()
+    try:
+        proof = json.loads(standard_b64decode(blob.encode()).decode())
+    except (ValueError, binascii.Error) as e:
+        msg = 'malformed armored signature block'
+        raise BadProofError(msg) from e
+    if proof.get('message') != cleartext:
+        msg = 'armored cleartext does not match signed message'
+        raise BadProofError(msg)
+    return proof
+```
+
+- [ ] **Step 4: Run to verify pass + lint/type**
+
+Run: `uv run pytest tests/test_message.py -q && uv run ruff check src/gumptionchain/message.py && uv run mypy`
+Expected: PASS; ruff/mypy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gumptionchain/message.py tests/test_message.py
+git commit -m "feat(message): armored text form (Python)"
+```
+
+---
+
+### Task 6: Cross-language parity + golden vectors
+
+**Files:**
+- Create: `clients/wallet/message-cli.mjs`
+- Create: `tests/test_message_parity.py`
+- Create: `tests/test_message_vectors.py`
+- Create: `clients/wallet/testdata/gc-msg-vectors.json`
+
+- [ ] **Step 1: Create the JS harness** — `clients/wallet/message-cli.mjs`:
+
+```javascript
+// gc-msg-v1 sign/verify harness (test tool, not a unit test). Used by the
+// Python parity tests to prove JS<->Python message-signing interop.
+//   node message-cli.mjs sign   '{"private_key_b58":"...","message":"...","timestamp":"..."}'
+//   node message-cli.mjs verify '<proof JSON>'
+import { Wallet } from './gc-wallet.mjs';
+import { signMessage, verifyMessage } from './gc-message.mjs';
+
+const mode = process.argv[2];
+const arg = JSON.parse(process.argv[3]);
+
+if (mode === 'sign') {
+  const w = await Wallet.fromPrivateKeyB58(arg.private_key_b58);
+  const proof = await signMessage(w, arg.message, { timestamp: arg.timestamp });
+  process.stdout.write(JSON.stringify(proof));
+} else if (mode === 'verify') {
+  process.stdout.write(JSON.stringify(await verifyMessage(arg)));
+} else {
+  process.stderr.write(`unknown mode: ${mode}\n`);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Write the parity test** — `tests/test_message_parity.py`:
+
+```python
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.message import sign_message, verify_message
+from gumptionchain.wallet import Wallet
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'message-cli.mjs'
+)
+TS = '1700001000'
+MESSAGE = 'I made stake T1 — 3 GRIT opposition on goblins'
+
+
+def _node(mode: str, payload: dict) -> dict:
+    out = subprocess.run(  # noqa: S603
+        ['node', str(CLI), mode, json.dumps(payload)],  # noqa: S607
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signed_message_verifies_in_python() -> None:
+    proof = _node('sign', {
+        'private_key_b58': VECTOR_WALLET_B58, 'message': MESSAGE, 'timestamp': TS,
+    })
+    assert verify_message(proof)['valid'] is True
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_python_signed_message_verifies_in_js() -> None:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    proof = sign_message(w, MESSAGE, timestamp=int(TS))
+    result = _node('verify', proof)
+    assert result['valid'] is True
+    assert result['address'] == w.address
+```
+
+- [ ] **Step 3: Write the golden-vector test + generate the file** — `tests/test_message_vectors.py`:
+
+```python
+import json
+import os
+from pathlib import Path
+
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.message import sign_message
+from gumptionchain.wallet import Wallet
+
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'testdata' / 'gc-msg-vectors.json'
+)
+_CASES = [
+    {'message': 'hello world', 'timestamp': '1700001000'},
+    {'message': 'I made stake T1 — 3 GRIT opposition on goblins',
+     'timestamp': '1700001001'},
+    {'message': 'multi\nline\nmessage', 'timestamp': '1700001002'},
+]
+
+
+def _expected() -> list[dict]:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    out = []
+    for c in _CASES:
+        proof = sign_message(w, c['message'], timestamp=int(c['timestamp']))
+        out.append({**c, 'signature': proof['signature'], 'address': proof['address']})
+    return out
+
+
+def test_message_vectors_match() -> None:
+    expected = _expected()
+    if os.environ.get('GC_REGEN_VECTORS'):
+        VECTORS_PATH.write_text(json.dumps(expected, indent=2) + '\n')
+    stored = json.loads(VECTORS_PATH.read_text())
+    assert stored == expected
+```
+
+Generate the committed vectors once:
+Run: `GC_REGEN_VECTORS=1 uv run pytest tests/test_message_vectors.py -q`
+(Then a second run without the env var must pass against the written file.)
+
+- [ ] **Step 4: Add the JS side of the golden-vector check** — append to `clients/wallet/gc-message.test.mjs`:
+
+```javascript
+import { readFileSync } from 'node:fs';
+import { Wallet as W2 } from './gc-wallet.mjs';
+
+test('JS signatures match the committed golden vectors', async () => {
+  const VEC = JSON.parse(readFileSync(
+    new URL('./testdata/gc-msg-vectors.json', import.meta.url),
+  ));
+  // VECTOR_WALLET_B58 is the fixed key used by the Python generator.
+  const B58 = process.env.GC_VECTOR_KEY;
+  if (!B58) return; // key supplied by the parity runner; skip if absent
+  const w = await W2.fromPrivateKeyB58(B58);
+  for (const c of VEC) {
+    const proof = await signMessage(w, c.message, { timestamp: c.timestamp });
+    assert.equal(proof.signature, c.signature);
+    assert.equal(proof.address, c.address);
+  }
+});
+```
+
+NOTE: the deterministic-PKCS1v15 signature equality across JS and Python is the real parity guarantee. Because the JS golden check needs the fixed private key, it reads it from `GC_VECTOR_KEY` and self-skips when absent (keeping the key out of the JS tree — Python owns it via `VECTOR_WALLET_B58`). The authoritative cross-language proof remains `tests/test_message_parity.py` (live) plus the Python vector file. If you prefer, drop this JS sub-test and rely solely on the live parity test — both satisfy the spec's "golden vectors + live cross-verify."
+
+- [ ] **Step 5: Run everything**
+
+Run: `node --test clients/wallet/*.test.mjs && uv run pytest tests/test_message.py tests/test_message_parity.py tests/test_message_vectors.py -q`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/wallet/message-cli.mjs clients/wallet/testdata/gc-msg-vectors.json clients/wallet/gc-message.test.mjs tests/test_message_parity.py tests/test_message_vectors.py
+git commit -m "test(message): JS<->Python parity + golden vectors for gc-msg-v1"
+```
+
+---
+
+### Task 7: Demo page + manual verification
+
+**Files:**
+- Modify: `clients/wallet/passkey-wallet-demo.html`
+- Modify: `clients/wallet/MANUAL-VERIFICATION.md`
+
+Browser-only glue; crypto is fully Node/pytest-covered. Read the existing demo first to match its structure.
+
+- [ ] **Step 1: Add sign/verify-message UI**
+
+Import: `import { signMessage, verifyMessage, toArmored, fromArmored } from './gc-message.mjs';`
+
+Add two panels wired to the demo's in-memory `currentWallet`:
+- **Sign message:** a textarea → on click, `signMessage(currentWallet, text)` → show the JSON proof and `toArmored(proof)` in readonly fields with copy buttons.
+- **Verify message:** a textarea accepting either JSON or armored text → on click, parse (try `JSON.parse`; if that throws, `fromArmored`) → `verifyMessage(proof)` → show `valid`, `address`, `timestamp`, and `reason` if invalid. Surface `BadProofError.message` verbatim via the existing `fail()` path.
+
+- [ ] **Step 2: Document** — add a "Message signing (#2.4)" section to `MANUAL-VERIFICATION.md`:
+
+1. Unlock a wallet. In **Sign message**, enter text; confirm a proof JSON + armored block appear and the proof `address` matches the wallet.
+2. Copy the armored block into **Verify message**; confirm `valid: true` with the right address/timestamp.
+3. Edit one character of the armored cleartext; confirm a `BadProofError` (cleartext mismatch).
+4. Paste the JSON form instead; confirm `valid: true`.
+5. Tamper a character inside the JSON `message`; confirm `valid: false, reason: bad-signature`.
+
+- [ ] **Step 3: Verify modules parse**
+
+Run: `node --check clients/wallet/gc-message.mjs && node --check clients/wallet/message-cli.mjs`
+Expected: exit 0. Browser flow is the manual acceptance gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clients/wallet/passkey-wallet-demo.html clients/wallet/MANUAL-VERIFICATION.md
+git commit -m "docs(wallet): demo + manual steps for gc-msg-v1 message signing"
+```
+
+---
+
+## Final verification (before finishing the branch)
+
+- [ ] `node --test clients/wallet/*.test.mjs` — all green.
+- [ ] `uv run pytest` — full suite green (new message unit/parity/vector tests included).
+- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
+- [ ] `uv run mypy` — no new errors.
+- [ ] Zero npm; `gc-message.mjs`/`message-cli.mjs` import only sibling `.mjs`.
+- [ ] Manual browser verification of sign/verify per `MANUAL-VERIFICATION.md`.
+
+## Self-review notes
+
+- **Spec coverage:** domain-separated canonical (Tasks 2/4); proof object snake_case (2/4); armored + cleartext binding (3/5); verify contract valid/reason vs throw (2/4); maxAge optional, durable default (2/4); `fromPublicKeyB64` verify-only (1); JS+Python parity + golden vectors + domain-separation assertion (6); demo/manual (7). All mapped.
+- **Type/name consistency:** `signMessage`/`verifyMessage`/`toArmored`/`fromArmored`/`messageCanonical` (JS) ↔ `sign_message`/`verify_message`/`to_armored`/`from_armored`/`_message_canonical` (Python); `BadProofError` both sides; proof keys `scheme/version/address/public_key/timestamp/message/signature` identical across languages and the CLI; reasons `address-mismatch`/`bad-signature`/`expired` identical.
+- **No placeholders:** every code step is complete.

--- a/docs/superpowers/specs/2026-06-06-egu-2.4-message-signing-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2.4-message-signing-design.md
@@ -1,0 +1,213 @@
+# EGU #2.4 — generic message signing (gc-msg-v1) — design
+
+**Date:** 2026-06-06
+**Status:** Approved — ready for implementation
+**Issue:** #177 (sub-project 4 of EGU #2 / #152); enables the verifiable stake
+share #176 (EGU #3).
+**Type:** New client module (vanilla JS / Web Crypto) **and** a new Python
+library module — additive; no node HTTP endpoint, no schema change.
+
+## Summary
+
+A generic message signer so a wallet holder can produce a **portable,
+self-contained proof** that "address X said this," verifiable off-chain in
+**both JS and Python**. This is the cryptographic primitive beneath the
+verifiable stake share (#176); it signs arbitrary text and is deliberately
+ignorant of stakes, transactions, and HTTP.
+
+Builds on the merged signing core (#170/#171): reuses `Wallet.sign` /
+`validate_signature` and address derivation. No change to the on-chain
+`gc-sig-v1` HTTP-auth scheme.
+
+## Domain separation (security-critical)
+
+A new **`gc-msg-v1`** scheme, distinct from the `gc-sig-v1` HTTP-auth scheme.
+The signed canonical is the `\n`-join of:
+
+```
+gc-msg-v1
+<version>            # "1"
+<address>            # GC…GC of the signer
+<timestamp>          # unix seconds, as a string
+<sha256hex(message)> # lowercase hex of SHA-256 over the UTF-8 message bytes
+```
+
+Because line 1 is `gc-msg-v1` (never `gc-sig-v1`) and the field layout differs,
+a message signature can **never** verify as an API request or transaction
+signature, and vice-versa. The message is bound by its SHA-256 (so arbitrarily
+large messages sign cheaply); the plaintext travels in the proof so a verifier
+recomputes the digest.
+
+## Proof object (machine form)
+
+```json
+{
+  "scheme": "gc-msg-v1",
+  "version": "1",
+  "address": "GC…GC",
+  "public_key": "<base64 SPKI DER>",
+  "timestamp": "<unix seconds>",
+  "message": "<utf8 text>",
+  "signature": "<base64>"
+}
+```
+
+- `public_key` is carried because RSA cannot recover the key from a signature;
+  the verifier checks the **address derives from this key** before trusting it.
+- `message` is UTF-8 text, human-readable in the proof.
+- `timestamp` is signed (tamper-evident) but **not** expiry-enforced by default.
+
+## Armored text form (for share/post)
+
+```
+-----BEGIN GUMPTION SIGNED MESSAGE-----
+<the message, cleartext>
+-----BEGIN GUMPTION SIGNATURE-----
+<base64(JSON proof)>
+-----END GUMPTION SIGNED MESSAGE-----
+```
+
+`toArmored(proof)` emits this; `fromArmored(text)` parses it back to the proof
+object. The cleartext message is human-readable; the signature block carries the
+full base64-encoded JSON proof (the authoritative bytes). On parse, the proof's
+`message` is the source of truth for verification (the cleartext section is
+display only); `fromArmored` MUST confirm the cleartext section equals
+`proof.message` and raise `BadProofError` on mismatch, so the visible text can
+never disagree with what was signed. Verifiers accept either form.
+
+## Verify contract (identical semantics in JS and Python)
+
+`verifyMessage(proof, { maxAge? }) -> { valid, address, timestamp, message, reason? }`
+
+Checks, in order:
+1. **Structure** — `scheme === 'gc-msg-v1'`, known `version`, required string
+   fields present and well-typed. Structurally malformed input throws
+   `BadProofError` (it is not a verifiable proof at all).
+2. **Address binding** — the address derived from `public_key` equals
+   `proof.address`. Mismatch → `{ valid: false, reason: 'address-mismatch' }`.
+3. **Signature** — recompute the `gc-msg-v1` canonical from
+   `address/timestamp/message` and verify `signature` against `public_key`.
+   Failure → `{ valid: false, reason: 'bad-signature' }`.
+4. **Optional freshness** — if `maxAge` (seconds) is supplied and
+   `now - timestamp > maxAge`, → `{ valid: false, reason: 'expired' }`. Omitted
+   by default: durable proofs never expire.
+
+On success: `{ valid: true, address, timestamp, message }`. The split — return
+`valid:false`+`reason` for verification failures, **throw** `BadProofError` only
+for un-parseable/structurally-invalid input — is identical in both languages.
+
+## Components
+
+### JavaScript (`clients/wallet/`)
+
+- **`gc-message.mjs`** (new) — `signMessage(wallet, message, { timestamp? })`,
+  `verifyMessage(proof, { maxAge? })`, `toArmored(proof)`, `fromArmored(text)`,
+  and the internal `messageCanonical({ address, timestamp, message })`. Pure;
+  Node-testable. Reuses `gc-crypto` (sha256Hex, base64) and `gc-wallet`.
+- **`gc-wallet.mjs`** (modified) — add `static fromPublicKeyB64(b64)` returning a
+  **verify-only** `Wallet` (public key imported extractable so `address()`
+  works) plus an instance method `verify(bytes, signatureB64) -> Promise<bool>`.
+  On a verify-only instance, `sign`/`exportPrivateKeyB58` throw a clear error.
+  This mirrors Python's `Wallet(b64ks=…)` (key-or-pubkey flexible). `signMessage`
+  uses the holder's full `Wallet`; `verifyMessage` uses `fromPublicKeyB64`.
+- **`gc-errors.mjs`** (modified) — add `BadProofError` (re-exported from
+  `gc-message`).
+- **`message-cli.mjs`** (new) — a test harness (like `sign-cli.mjs`): a `sign`
+  mode (b58 key + message + timestamp → proof JSON on stdout) and a `verify`
+  mode (proof JSON on argv → `{ valid, … }` JSON on stdout), used by the live
+  cross-language parity tests.
+
+### Python (`src/gumptionchain/`)
+
+- **`message.py`** (new) — `sign_message(wallet, message, timestamp=None)`,
+  `verify_message(proof, max_age=None)`, `to_armored(proof)`,
+  `from_armored(text)`, internal `_message_canonical(...)`, and a typed
+  `BadProofError` (subclass of a module `MessageError`). Reuses
+  `gumptionchain.wallet.Wallet` (`Wallet(b64ks=…)` for verify-only,
+  `validate_signature`, `address`, `public_key_b64`). `MSG_SCHEME = 'gc-msg-v1'`.
+  Mirrors `signing.py`'s structure but is a separate module (signing.py stays
+  HTTP-auth-only).
+
+## Testing
+
+- **JS (`node --test`, zero npm):**
+  - `gc-wallet`: `fromPublicKeyB64` → `address()` matches the origin wallet;
+    `verify()` true for a good signature, false for a tampered one; verify-only
+    `sign`/`exportPrivateKeyB58` throw.
+  - `gc-message`: sign → verify round-trip `{ valid: true }`; tampered message →
+    `bad-signature`; swapped address (address ≠ pubkey) → `address-mismatch`;
+    wrong scheme/version/malformed → `BadProofError`; `maxAge` past → `expired`,
+    within → valid; `toArmored`/`fromArmored` round-trip; armored cleartext-vs-
+    `message` mismatch → `BadProofError`.
+- **Python (`uv run pytest`):**
+  - `tests/test_message.py`: the same matrix as the JS `gc-message` tests, plus a
+    domain-separation assertion (a `gc-msg-v1` proof's signature does **not**
+    validate as a `gc-sig-v1` canonical and vice-versa).
+- **Cross-language parity (`tests/test_message_parity.py`, skipif no node):**
+  - JS signs (`message-cli.mjs sign`) → Python `verify_message` returns valid.
+  - Python signs → JS verifies (`message-cli.mjs verify`) returns valid.
+  - Golden vectors `clients/wallet/testdata/gc-msg-vectors.json` (fixed key +
+    fixed timestamp, deterministic PKCS1v15) checked by both sides; regenerate
+    only via an explicit env flag (mirrors `GC_REGEN_VECTORS` from #171).
+- **Browser (manual):** `passkey-wallet-demo.html` gains a "Sign message" box
+  (message → proof JSON + armored, copyable) and a "Verify message" box (paste
+  JSON or armored → `valid` + address + timestamp). `MANUAL-VERIFICATION.md`
+  documents the steps.
+
+## Security properties
+
+1. **Domain-separated.** `gc-msg-v1` ≠ `gc-sig-v1`; a message signature is not a
+   valid request/transaction signature (asserted by a parity test).
+2. **Address-bound.** A proof is only trusted if its `address` derives from its
+   carried `public_key`; an attacker can't claim someone else's address by
+   swapping the key.
+3. **Tamper-evident.** Message and timestamp are inside the signed canonical;
+   altering either invalidates the signature. Armored cleartext is checked
+   against the signed `message`.
+4. **Durable by default, optionally fresh.** No forced expiry (identity/
+   provenance statements verify forever); `maxAge` opts into freshness for
+   challenge-response.
+5. **No key exposure / no chain coupling.** Verify needs only the public key;
+   the module never touches the private key beyond the holder's own
+   `wallet.sign`, and knows nothing about stakes/transactions.
+
+## Out of scope (later)
+
+- The verifiable stake card / on-chain cross-check / `/verify` page (#176, EGU
+  #3) and any OG-unfurl share page (EGU #5).
+- Any node HTTP endpoint — verification is off-chain by design.
+- Message **encryption**, multi-sig, structured stake-attestation conventions
+  (the share layer's concern, #176).
+- #2.5 packaging.
+
+## Decisions log
+
+- **Separate `gc-msg-v1` scheme + separate Python module** — clean domain
+  separation from HTTP-auth; signing.py stays focused.
+- **JS + Python parity** — anyone (browser, node operator, third party) can
+  verify a proof byte-for-byte; same golden-vector + live cross-verify rigor as
+  #2.1.
+- **JSON proof + armored text** — machine form plus a paste-friendly block for
+  social/forum sharing; armored cleartext is bound to the signed message.
+- **Signed, non-expiring timestamp; optional `maxAge`** — durable provenance by
+  default, freshness available for challenge-response.
+- **Verify-only `Wallet.fromPublicKeyB64`** — mirrors Python's pubkey-flexible
+  `Wallet`; the one touch to the tested `gc-wallet` module, justified as the
+  verify capability the feature needs.
+- **`valid:false`+reason vs. throw `BadProofError`** — verification outcomes are
+  data; only un-parseable input is exceptional. Identical in both languages.
+- **Bind message by SHA-256** — arbitrary message size, cheap signing, mirrors
+  the API's body-digest approach.
+- **Zero npm preserved; no chain change** — Node + pytest cover all crypto;
+  manual browser verification only for the demo glue.
+
+## Definition of done
+
+- `gc-message.mjs` (4-function API + canonical); `gc-wallet.fromPublicKeyB64` +
+  `verify`; `BadProofError`; Python `message.py` with the mirrored API.
+- JS tests (`node --test`) + Python unit tests + cross-language parity
+  (JS↔Python, both directions) + golden vectors + a domain-separation assertion
+  all pass; full `uv run pytest` green; `ruff`/`mypy` clean on the new Python;
+  zero npm.
+- Demo page + `MANUAL-VERIFICATION.md` updated for sign/verify message.
+- No node HTTP endpoint, no schema/migration, no change to `gc-sig-v1`.

--- a/src/gumptionchain/message.py
+++ b/src/gumptionchain/message.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import base64
 import binascii
 import hashlib
 import json
 import re
 import time
-from base64 import standard_b64decode, standard_b64encode
 from typing import Any
 
 from gumptionchain.exceptions import InvalidKeyError
@@ -99,7 +99,9 @@ def verify_message(
         return {**result, 'valid': False, 'reason': 'bad-signature'}
     if max_age is not None:
         current = int(now if now is not None else time.time())
-        if current - int(ts) > max_age:
+        # Symmetric window: reject stale AND future timestamps (mirrors
+        # signing.verify) so max_age can't be defeated by a far-future stamp.
+        if abs(current - int(ts)) > max_age:
             return {**result, 'valid': False, 'reason': 'expired'}
     return {**result, 'valid': True}
 
@@ -110,7 +112,7 @@ ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----'
 
 
 def to_armored(proof: dict[str, str]) -> str:
-    blob = standard_b64encode(json.dumps(proof).encode()).decode()
+    blob = base64.standard_b64encode(json.dumps(proof).encode()).decode()
     return '\n'.join(
         [ARMOR_HEADER, proof['message'], ARMOR_SIG, blob, ARMOR_FOOTER]
     )
@@ -131,7 +133,10 @@ def from_armored(text: str) -> dict[str, Any]:
     cleartext = '\n'.join(lines[h + 1 : s])
     blob = ''.join(lines[s + 1 : f]).strip()
     try:
-        proof = json.loads(standard_b64decode(blob.encode()).decode())
+        # validate=True rejects non-canonical base64 (non-alphabet chars),
+        # keeping parsing strictness aligned with JS atob in fromArmored.
+        decoded = base64.b64decode(blob.encode(), validate=True)
+        proof = json.loads(decoded.decode())
     except (ValueError, binascii.Error) as e:
         msg = 'malformed armored signature block'
         raise BadProofError(msg) from e

--- a/src/gumptionchain/message.py
+++ b/src/gumptionchain/message.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import binascii
 import hashlib
+import json
 import time
+from base64 import standard_b64decode, standard_b64encode
 from typing import Any
 
 from gumptionchain.exceptions import InvalidKeyError
@@ -93,3 +96,44 @@ def verify_message(
         if current - int(ts) > max_age:
             return {**result, 'valid': False, 'reason': 'expired'}
     return {**result, 'valid': True}
+
+
+ARMOR_HEADER = '-----BEGIN GUMPTION SIGNED MESSAGE-----'
+ARMOR_SIG = '-----BEGIN GUMPTION SIGNATURE-----'
+ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----'
+
+
+def to_armored(proof: dict[str, str]) -> str:
+    blob = standard_b64encode(json.dumps(proof).encode()).decode()
+    return '\n'.join(
+        [ARMOR_HEADER, proof['message'], ARMOR_SIG, blob, ARMOR_FOOTER]
+    )
+
+
+def from_armored(text: str) -> dict[str, Any]:
+    lines = text.replace('\r\n', '\n').split('\n')
+    try:
+        h = lines.index(ARMOR_HEADER)
+        s = lines.index(ARMOR_SIG)
+        f = lines.index(ARMOR_FOOTER)
+    except ValueError as e:
+        msg = 'malformed armored message'
+        raise BadProofError(msg) from e
+    if not h < s < f:
+        msg = 'malformed armored message'
+        raise BadProofError(msg)
+    cleartext = '\n'.join(lines[h + 1 : s])
+    blob = ''.join(lines[s + 1 : f]).strip()
+    try:
+        proof = json.loads(standard_b64decode(blob.encode()).decode())
+    except (ValueError, binascii.Error) as e:
+        msg = 'malformed armored signature block'
+        raise BadProofError(msg) from e
+    if not isinstance(proof, dict):
+        msg = 'malformed armored signature block'
+        raise BadProofError(msg)
+    proof_dict: dict[str, Any] = proof
+    if proof_dict.get('message') != cleartext:
+        msg = 'armored cleartext does not match signed message'
+        raise BadProofError(msg)
+    return proof_dict

--- a/src/gumptionchain/message.py
+++ b/src/gumptionchain/message.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+
+from gumptionchain.exceptions import InvalidKeyError
+from gumptionchain.wallet import Wallet
+
+MSG_SCHEME = 'gc-msg-v1'
+MSG_VERSION = '1'
+
+
+class MessageError(Exception):
+    """Base class for message-signing errors."""
+
+
+class BadProofError(MessageError):
+    """Input is not a structurally valid gc-msg-v1 proof."""
+
+
+def _message_canonical(*, address: str, timestamp: str, message: str) -> bytes:
+    digest = hashlib.sha256(message.encode()).hexdigest()
+    return '\n'.join(
+        [MSG_SCHEME, MSG_VERSION, address, timestamp, digest]
+    ).encode()
+
+
+def sign_message(
+    wallet: Wallet, message: str, timestamp: int | None = None
+) -> dict[str, str]:
+    ts = str(int(timestamp if timestamp is not None else time.time()))
+    canonical = _message_canonical(
+        address=wallet.address, timestamp=ts, message=message
+    )
+    return {
+        'scheme': MSG_SCHEME,
+        'version': MSG_VERSION,
+        'address': wallet.address,
+        'public_key': wallet.public_key_b64,
+        'timestamp': ts,
+        'message': message,
+        'signature': wallet.sign(canonical),
+    }
+
+
+def verify_message(
+    proof: Any, max_age: int | None = None, now: int | None = None
+) -> dict[str, Any]:
+    if not isinstance(proof, dict):
+        msg = 'not a proof object'
+        raise BadProofError(msg)
+    scheme = proof.get('scheme')
+    version = proof.get('version')
+    address = proof.get('address')
+    pubkey = proof.get('public_key')
+    ts = proof.get('timestamp')
+    message = proof.get('message')
+    sig = proof.get('signature')
+    if (
+        scheme != MSG_SCHEME
+        or version != MSG_VERSION
+        or not all(
+            isinstance(v, str) for v in (address, pubkey, ts, message, sig)
+        )
+    ):
+        msg = 'malformed gc-msg-v1 proof'
+        raise BadProofError(msg)
+    assert isinstance(address, str)
+    assert isinstance(pubkey, str)
+    assert isinstance(ts, str)
+    assert isinstance(message, str)
+    assert isinstance(sig, str)
+    try:
+        wallet = Wallet(b64ks=pubkey)
+    except InvalidKeyError as e:
+        msg = 'invalid public key'
+        raise BadProofError(msg) from e
+    result: dict[str, Any] = {
+        'address': address,
+        'timestamp': ts,
+        'message': message,
+    }
+    if wallet.address != address:
+        return {**result, 'valid': False, 'reason': 'address-mismatch'}
+    canonical = _message_canonical(
+        address=address, timestamp=ts, message=message
+    )
+    if not wallet.validate_signature(canonical, sig):
+        return {**result, 'valid': False, 'reason': 'bad-signature'}
+    if max_age is not None:
+        current = int(now if now is not None else time.time())
+        if current - int(ts) > max_age:
+            return {**result, 'valid': False, 'reason': 'expired'}
+    return {**result, 'valid': True}

--- a/src/gumptionchain/message.py
+++ b/src/gumptionchain/message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import binascii
 import hashlib
 import json
+import re
 import time
 from base64 import standard_b64decode, standard_b64encode
 from typing import Any
@@ -74,6 +75,11 @@ def verify_message(
     assert isinstance(ts, str)
     assert isinstance(message, str)
     assert isinstance(sig, str)
+    if not re.fullmatch(r'[0-9]+', ts):
+        # Guarantee a numeric timestamp before any freshness math, so JS and
+        # Python agree (JS Number('x')->NaN would otherwise silently pass).
+        msg = 'malformed gc-msg-v1 proof'
+        raise BadProofError(msg)
     try:
         wallet = Wallet(b64ks=pubkey)
     except InvalidKeyError as e:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -67,6 +67,14 @@ def test_max_age_enforces_freshness() -> None:
     assert verify_message(proof, max_age=5000, now=now)['valid'] is True
 
 
+def test_max_age_rejects_future_timestamp() -> None:
+    future = int(TS) + 10000
+    proof = sign_message(_wallet(), 'hi', timestamp=future)
+    r = verify_message(proof, max_age=300, now=int(TS))
+    assert r['valid'] is False
+    assert r['reason'] == 'expired'
+
+
 def test_non_base64_signature_is_bad_signature() -> None:
     proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
     proof['signature'] = '!!! not base64 !!!'

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -3,7 +3,9 @@ from test_browser_wallet_vectors import VECTOR_WALLET_B58
 
 from gumptionchain.message import (
     BadProofError,
+    from_armored,
     sign_message,
+    to_armored,
     verify_message,
 )
 from gumptionchain.signing import _canonical
@@ -79,3 +81,22 @@ def test_domain_separation_from_gc_sig() -> None:
         address=w.address,
     )
     assert not w.validate_signature(sig_canonical, proof['signature'])
+
+
+def test_armored_round_trip() -> None:
+    w = _wallet()
+    proof = sign_message(w, 'multi\nline\nmessage', timestamp=int(TS))
+    armored = to_armored(proof)
+    assert armored.startswith('-----BEGIN GUMPTION SIGNED MESSAGE-----')
+    back = from_armored(armored)
+    assert back == proof
+    assert verify_message(back)['valid'] is True
+
+
+def test_from_armored_rejects_malformed_and_mismatch() -> None:
+    proof = sign_message(_wallet(), 'hello', timestamp=int(TS))
+    with pytest.raises(BadProofError):
+        from_armored('not armored at all')
+    tampered = to_armored(proof).replace('hello', 'goodbye')
+    with pytest.raises(BadProofError):
+        from_armored(tampered)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,81 @@
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.message import (
+    BadProofError,
+    sign_message,
+    verify_message,
+)
+from gumptionchain.signing import _canonical
+from gumptionchain.wallet import Wallet
+
+TS = '1700001000'
+
+
+def _wallet() -> Wallet:
+    return Wallet(b58ks=VECTOR_WALLET_B58)
+
+
+def test_sign_then_verify_is_valid() -> None:
+    w = _wallet()
+    proof = sign_message(w, 'I made stake T1', timestamp=int(TS))
+    assert proof['scheme'] == 'gc-msg-v1'
+    assert proof['address'] == w.address
+    r = verify_message(proof)
+    assert r == {
+        'valid': True,
+        'address': w.address,
+        'timestamp': TS,
+        'message': 'I made stake T1',
+    }
+
+
+def test_tampered_message_is_bad_signature() -> None:
+    proof = sign_message(_wallet(), 'original', timestamp=int(TS))
+    proof['message'] = 'forged'
+    r = verify_message(proof)
+    assert r['valid'] is False
+    assert r['reason'] == 'bad-signature'
+
+
+def test_address_mismatch() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    proof['address'] = proof['address'] + 'X'
+    r = verify_message(proof)
+    assert r['valid'] is False
+    assert r['reason'] == 'address-mismatch'
+
+
+def test_malformed_proof_raises() -> None:
+    good = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    with pytest.raises(BadProofError):
+        verify_message({**good, 'scheme': 'gc-sig-v1'})
+    with pytest.raises(BadProofError):
+        verify_message({'scheme': 'gc-msg-v1', 'version': '1'})
+    with pytest.raises(BadProofError):
+        verify_message(None)
+
+
+def test_max_age_enforces_freshness() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    now = int(TS) + 1000
+    stale = verify_message(proof, max_age=300, now=now)
+    assert stale['valid'] is False
+    assert stale['reason'] == 'expired'
+    assert verify_message(proof, max_age=5000, now=now)['valid'] is True
+
+
+def test_domain_separation_from_gc_sig() -> None:
+    # A gc-msg-v1 signature must not validate as a gc-sig-v1 canonical.
+    w = _wallet()
+    proof = sign_message(w, 'hi', timestamp=int(TS))
+    sig_canonical = _canonical(
+        method='GET',
+        path='/',
+        query='',
+        body=b'',
+        node_host='n',
+        timestamp=TS,
+        address=w.address,
+    )
+    assert not w.validate_signature(sig_canonical, proof['signature'])

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -67,6 +67,23 @@ def test_max_age_enforces_freshness() -> None:
     assert verify_message(proof, max_age=5000, now=now)['valid'] is True
 
 
+def test_non_base64_signature_is_bad_signature() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    proof['signature'] = '!!! not base64 !!!'
+    r = verify_message(proof)
+    assert r['valid'] is False
+    assert r['reason'] == 'bad-signature'
+
+
+def test_non_numeric_timestamp_is_malformed() -> None:
+    proof = sign_message(_wallet(), 'hi', timestamp=int(TS))
+    proof['timestamp'] = 'notanumber'
+    with pytest.raises(BadProofError):
+        verify_message(proof)
+    with pytest.raises(BadProofError):
+        verify_message(proof, max_age=300, now=9999999999)
+
+
 def test_domain_separation_from_gc_sig() -> None:
     # A gc-msg-v1 signature must not validate as a gc-sig-v1 canonical.
     w = _wallet()

--- a/tests/test_message_parity.py
+++ b/tests/test_message_parity.py
@@ -1,0 +1,51 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.message import sign_message, verify_message
+from gumptionchain.wallet import Wallet
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'message-cli.mjs'
+)
+TS = '1700001000'
+MESSAGE = 'I made stake T1 — 3 GRIT opposition on goblins'
+
+
+def _node(mode: str, payload: dict) -> dict:
+    out = subprocess.run(  # noqa: S603
+        ['node', str(CLI), mode, json.dumps(payload)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(out.stdout)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signed_message_verifies_in_python() -> None:
+    proof = _node(
+        'sign',
+        {
+            'private_key_b58': VECTOR_WALLET_B58,
+            'message': MESSAGE,
+            'timestamp': TS,
+        },
+    )
+    assert verify_message(proof)['valid'] is True
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_python_signed_message_verifies_in_js() -> None:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    proof = sign_message(w, MESSAGE, timestamp=int(TS))
+    result = _node('verify', proof)
+    assert result['valid'] is True
+    assert result['address'] == w.address

--- a/tests/test_message_vectors.py
+++ b/tests/test_message_vectors.py
@@ -1,0 +1,47 @@
+import json
+import os
+from pathlib import Path
+
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.message import sign_message
+from gumptionchain.wallet import Wallet
+
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'testdata'
+    / 'gc-msg-vectors.json'
+)
+_CASES = [
+    {'message': 'hello world', 'timestamp': '1700001000'},
+    {
+        'message': 'I made stake T1 — 3 GRIT opposition on goblins',
+        'timestamp': '1700001001',
+    },
+    {'message': 'multi\nline\nmessage', 'timestamp': '1700001002'},
+]
+
+
+def _expected() -> list[dict]:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    out = []
+    for c in _CASES:
+        proof = sign_message(w, c['message'], timestamp=int(c['timestamp']))
+        out.append(
+            {
+                **c,
+                'signature': proof['signature'],
+                'address': proof['address'],
+            }
+        )
+    return out
+
+
+def test_message_vectors_match() -> None:
+    expected = _expected()
+    if os.environ.get('GC_REGEN_VECTORS'):
+        VECTORS_PATH.write_text(json.dumps(expected, indent=2) + '\n')
+    stored = json.loads(VECTORS_PATH.read_text())
+    assert stored == expected


### PR DESCRIPTION
## Summary
EGU #2.4 (#177) — a **generic message signer** so a wallet holder can prove *"address X said this"* off-chain (share/post). The cryptographic primitive beneath the verifiable stake share (#176).

- **Domain-separated `gc-msg-v1`** scheme. Canonical = `\n`-join `['gc-msg-v1', '1', address, timestamp, sha256hex(message)]`. The distinct line-1 tag means a message signature can **never** validate as a `gc-sig-v1` API/transaction signature (asserted by `test_domain_separation_from_gc_sig`).
- **Portable proof** `{scheme, version, address, public_key, timestamp, message, signature}` (snake_case → JSON round-trips JS↔Python) + a PGP-style **armored** block whose cleartext is bound to the signed message.
- **Verify in JS and Python** with identical semantics: `verifyMessage(proof, {maxAge?, now?})` → `{valid, address, timestamp, message, reason?}` (reasons `address-mismatch` / `bad-signature` / `expired`); throws `BadProofError` only on structurally malformed input. Timestamp is signed/tamper-evident but **not** expiry-enforced by default (durable proofs); optional `maxAge` for challenge-response.
- Verify-only `Wallet.fromPublicKeyB64` (JS) mirroring Python's `Wallet(b64ks=…)`.
- **Cross-language parity:** `message-cli.mjs` harness, JS-signs→Python-verifies and Python-signs→JS-verifies live tests, plus committed golden vectors (`gc-msg-vectors.json`).

**Out of scope:** node HTTP endpoint (off-chain by design), message encryption, multi-sig, the verifiable stake card itself (#176), #2.5 packaging.

## Test Plan
- [x] `node --test clients/wallet/*.test.mjs` — 55/55.
- [x] `uv run pytest` — 365 passed, 1 skipped (message unit + JS↔Python live parity + golden vectors).
- [x] `uv run ruff check/format`, `uv run mypy` — clean.
- [x] Spec-compliance review (clean) + code-quality review (two cross-language verify-contract gaps fixed with parity tests: non-base64 signature → `bad-signature` both sides; non-numeric timestamp → `BadProofError` both sides).
- [ ] Manual browser verification of the demo sign/verify flow per `clients/wallet/MANUAL-VERIFICATION.md`.

Spec: `docs/superpowers/specs/2026-06-06-egu-2.4-message-signing-design.md`
Plan: `docs/superpowers/plans/2026-06-06-egu-2.4-message-signing.md`

Closes #177. Enables #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)