### PR TITLE
feat(wallet): package the browser wallet — barrel, manifest, embedding guide (#180)

### DIFF
--- a/clients/wallet/README.md
+++ b/clients/wallet/README.md
@@ -29,9 +29,10 @@ This is a barrel-style ESM package; import from `index.mjs`.
 // Relative path (vendored / monorepo)
 import { Wallet, signMessage } from './clients/wallet/index.mjs';
 
-// Or pin a tag/commit via a CDN that serves the repo (no install):
+// Or pin a tag/commit via a CDN that serves the repo (no install). Include an
+// @<tag-or-sha> segment so you track a fixed version, not the default branch:
 // import { Wallet } from
-//   'https://cdn.jsdelivr.net/gh/gumptionthomas/gumptionchain/clients/wallet/index.mjs';
+//   'https://cdn.jsdelivr.net/gh/gumptionthomas/gumptionchain@<tag-or-sha>/clients/wallet/index.mjs';
 ```
 
 Only symbols re-exported from `index.mjs` are the supported public API. Other
@@ -143,7 +144,10 @@ the gumption.com hub (EGU #5):
 2. The only cross-repo coupling is the **JS↔Python parity tests** and the
    `sign-cli.mjs` / `message-cli.mjs` harnesses they invoke. Keep those here
    (pointing at a vendored/submoduled copy) or re-home them with the node.
-3. Serve over `https://`, or pin a tag via jsDelivr
-   (`https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/index.mjs`).
+3. Serve over `https://`, or pin a tag via jsDelivr. The path segment after
+   `@<tag>` is wherever `index.mjs` lives in the new repo — at the repo root if
+   you extracted `clients/wallet/`'s contents, e.g.
+   `https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/index.mjs` (or
+   `…@<tag>/clients/wallet/index.mjs` if you kept the subdirectory).
 
 No build step is required — the barrel is plain ESM.

--- a/clients/wallet/README.md
+++ b/clients/wallet/README.md
@@ -1,0 +1,149 @@
+# GumptionChain Browser Wallet
+
+A dependency-free, vanilla-JS ([Web Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API))
+wallet for [GumptionChain](../../README.md): RSA-2048 key management,
+`gc-sig-v1` authenticated API requests, passkey-anchored at-rest storage,
+self-custody backup/recovery, and generic `gc-msg-v1` message signing.
+
+Built across EGU #2.1–#2.5 (see `docs/superpowers/specs/`). The Python node
+verifies every signature this produces byte-for-byte.
+
+## Requirements
+
+- **A secure context** (`https://` or `http://localhost`) — WebAuthn and
+  IndexedDB require it. `file://` will not work.
+- **A PRF-capable authenticator** for passkey storage: a platform passkey
+  (Touch ID / iCloud Keychain / Google Password Manager), a phone passkey via
+  hybrid (QR), or a hardware key with `hmac-secret`. **The Bitwarden browser
+  extension does _not_ export PRF to external relying parties** (it uses PRF
+  only to unlock its own vault), so it cannot anchor wallet storage. Backup via
+  the raw b58 string (below) _can_ be stored in any password manager, Bitwarden
+  included.
+- A modern browser, or Node 20+ to run the test suite.
+
+## Importing
+
+This is a barrel-style ESM package; import from `index.mjs`.
+
+```js
+// Relative path (vendored / monorepo)
+import { Wallet, signMessage } from './clients/wallet/index.mjs';
+
+// Or pin a tag/commit via a CDN that serves the repo (no install):
+// import { Wallet } from
+//   'https://cdn.jsdelivr.net/gh/gumptionthomas/gumptionchain/clients/wallet/index.mjs';
+```
+
+Only symbols re-exported from `index.mjs` are the supported public API. Other
+files (`gc-crypto.mjs`, `gc-envelope.mjs`, …) are internal and may change.
+
+## Quickstart
+
+### 1. Sign an authenticated API request (`gc-sig-v1`)
+
+```js
+import { Wallet, signHeaders } from './index.mjs';
+
+const wallet = await Wallet.generate();
+const headers = await signHeaders(wallet, {
+  method: 'POST',
+  path: '/api/transactions',
+  query: '',
+  body: new TextEncoder().encode(JSON.stringify(txn)),
+  nodeHost: 'node.example',
+  timestamp: Math.floor(Date.now() / 1000),
+});
+await fetch('https://node.example/api/transactions', {
+  method: 'POST', headers, body: JSON.stringify(txn),
+});
+```
+
+### 2. Store under a passkey, then unlock after reload
+
+```js
+import { Wallet, enroll, unlock, hasWallet,
+         makeWebauthnPasskey, makeIdbStore } from './index.mjs';
+
+const passkey = makeWebauthnPasskey({ rpId: location.hostname, rpName: 'My App' });
+const store = makeIdbStore({ dbName: 'gc-wallet' });
+
+if (!(await hasWallet(store))) {
+  const wallet = await Wallet.generate();
+  await enroll(wallet, { passkey, store }, { userName: 'player' });
+}
+// ...later, after a reload:
+const wallet = await unlock({ passkey, store }); // one passkey ceremony
+```
+
+### 3. Back up & restore (self-custody)
+
+```js
+import { exportEncrypted, importEncrypted, exportPlain } from './index.mjs';
+
+// Passphrase-encrypted file (download backup.kind === 'gc-wallet-backup'):
+const backup = await exportEncrypted(wallet, passphrase);
+const restored = await importEncrypted(backup, passphrase);
+
+// Or the raw b58 string for a password manager:
+const b58 = await exportPlain(wallet);
+```
+
+### 4. Sign & verify a message (`gc-msg-v1`)
+
+```js
+import { signMessage, verifyMessage, toArmored, fromArmored } from './index.mjs';
+
+const proof = await signMessage(wallet, 'address X is me');
+const armored = toArmored(proof); // shareable PGP-style block
+
+const result = await verifyMessage(fromArmored(armored));
+// { valid: true, address, timestamp, message }
+```
+
+## Public API
+
+| Symbol | Purpose |
+| --- | --- |
+| `Wallet` | keygen, key import/export, address, sign, verify-only via `fromPublicKeyB64` |
+| `canonical`, `signHeaders` | `gc-sig-v1` request signing |
+| `enroll`, `unlock`, `hasWallet`, `clear` | passkey-anchored storage orchestration |
+| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters |
+| `exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain` | backup/recovery |
+| `signMessage`, `verifyMessage`, `toArmored`, `fromArmored` | `gc-msg-v1` message signing |
+| `UnsupportedError`, `NoWalletError`, `BadBackupError`, `BadPassphraseError`, `BadProofError` | typed errors |
+| `version` | package semver |
+
+Anything not listed is internal/unstable.
+
+## Versioning
+
+`version` is the **package** semver (currently `0.1.0`, pre-launch — the
+embedder API is not yet frozen). It is **independent** of the wire scheme ids
+`gc-sig-v1` and `gc-msg-v1`, which are protocol identifiers bound into
+signatures and change only on a protocol revision.
+
+## Testing
+
+```bash
+node --test clients/wallet/*.test.mjs   # JS unit + contract tests, zero npm
+```
+
+JS↔Python signature parity is enforced from the Python side
+(`tests/test_browser_wallet_parity.py`, `tests/test_message_parity.py`) via the
+`sign-cli.mjs` / `message-cli.mjs` harnesses. Browser-only flows (real passkey +
+IndexedDB) are covered by `MANUAL-VERIFICATION.md`.
+
+## Extracting to its own repo / hosting
+
+The wallet is packaged in place today. To move it to a dedicated repo or into
+the gumption.com hub (EGU #5):
+
+1. Copy `clients/wallet/` to the new location. It is self-contained — the
+   public surface has no imports outside this directory.
+2. The only cross-repo coupling is the **JS↔Python parity tests** and the
+   `sign-cli.mjs` / `message-cli.mjs` harnesses they invoke. Keep those here
+   (pointing at a vendored/submoduled copy) or re-home them with the node.
+3. Serve over `https://`, or pin a tag via jsDelivr
+   (`https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/index.mjs`).
+
+No build step is required — the barrel is plain ESM.

--- a/clients/wallet/index.mjs
+++ b/clients/wallet/index.mjs
@@ -1,0 +1,38 @@
+// GumptionChain browser wallet — public API barrel.
+// Import the supported surface from here. Anything not re-exported below
+// (e.g. gc-crypto low-level helpers, gc-envelope seal/open, messageCanonical)
+// is internal and may change without notice.
+//
+// The package `version` is the embedder-API semver; it is INDEPENDENT of the
+// wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
+export const version = '0.1.0';
+
+// Identity / keys
+export { Wallet } from './gc-wallet.mjs';
+
+// API request signing (gc-sig-v1)
+export { canonical, signHeaders } from './gc-sig.mjs';
+
+// Passkey-anchored storage
+export { enroll, unlock, hasWallet, clear } from './gc-store.mjs';
+export { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+export { makeIdbStore } from './gc-store-idb.mjs';
+
+// Backup / recovery
+export {
+  exportEncrypted, importEncrypted, exportPlain, importPlain,
+} from './gc-backup.mjs';
+
+// Message signing (gc-msg-v1)
+export {
+  signMessage, verifyMessage, toArmored, fromArmored,
+} from './gc-message.mjs';
+
+// Typed errors
+export {
+  UnsupportedError,
+  NoWalletError,
+  BadBackupError,
+  BadPassphraseError,
+  BadProofError,
+} from './gc-errors.mjs';

--- a/clients/wallet/index.test.mjs
+++ b/clients/wallet/index.test.mjs
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as api from './index.mjs';
+
+const FUNCTIONS = [
+  'canonical', 'signHeaders',
+  'enroll', 'unlock', 'hasWallet', 'clear',
+  'makeWebauthnPasskey', 'makeIdbStore',
+  'exportEncrypted', 'importEncrypted', 'exportPlain', 'importPlain',
+  'signMessage', 'verifyMessage', 'toArmored', 'fromArmored',
+];
+const ERRORS = [
+  'UnsupportedError', 'NoWalletError', 'BadBackupError',
+  'BadPassphraseError', 'BadProofError',
+];
+
+test('barrel exports every public function', () => {
+  for (const name of FUNCTIONS) {
+    assert.equal(typeof api[name], 'function', `missing function: ${name}`);
+  }
+});
+
+test('barrel exports Wallet as a class and the typed errors', () => {
+  assert.equal(typeof api.Wallet, 'function');
+  assert.equal(typeof api.Wallet.generate, 'function');
+  for (const name of ERRORS) {
+    assert.equal(typeof api[name], 'function', `missing error: ${name}`);
+    assert.ok(
+      new api[name]('x') instanceof Error,
+      `${name} is not an Error subclass`,
+    );
+  }
+});
+
+test('version is semver and agrees with package.json', () => {
+  assert.match(api.version, /^\d+\.\d+\.\d+$/);
+  const pkg = JSON.parse(
+    readFileSync(new URL('./package.json', import.meta.url)),
+  );
+  assert.equal(api.version, pkg.version);
+});
+
+test('end-to-end through the barrel: generate -> sign -> verify', async () => {
+  const w = await api.Wallet.generate();
+  const proof = await api.signMessage(w, 'packaged', { timestamp: '1700000000' });
+  const r = await api.verifyMessage(proof);
+  assert.equal(r.valid, true);
+  assert.equal(r.address, await w.address());
+});

--- a/clients/wallet/package.json
+++ b/clients/wallet/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gumptionchain/wallet",
+  "version": "0.1.0",
+  "description": "GumptionChain browser wallet — gc-sig-v1 signing, passkey storage, backup, message signing.",
+  "type": "module",
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "sideEffects": false,
+  "private": true,
+  "license": "SEE LICENSE IN ../../LICENSE"
+}

--- a/docs/superpowers/plans/2026-06-06-egu-2.5-wallet-packaging.md
+++ b/docs/superpowers/plans/2026-06-06-egu-2.5-wallet-packaging.md
@@ -10,7 +10,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-06-egu-2.5-wallet-packaging-design.md`
 
-**IMPORTANT (shell cwd):** run all commands from the repo root `/home/gumptionthomas/Development/gumptionchain`. Use repo-root-relative paths in `git add`.
+**IMPORTANT (shell cwd):** run all commands from the repository root (the top level of your clone). Use repo-root-relative paths in `git add`.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-06-egu-2.5-wallet-packaging.md
+++ b/docs/superpowers/plans/2026-06-06-egu-2.5-wallet-packaging.md
@@ -1,0 +1,393 @@
+# EGU #2.5 — wallet packaging — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `clients/wallet/` an embeddable, versioned package — a curated barrel entry, a private manifest, an embedding guide, and a contract-guarding smoke test — with no change to any module's behavior.
+
+**Architecture:** A barrel `index.mjs` re-exports the curated public API + a `version` constant; a private `package.json` records the entry/version for bundlers/CDNs (no npm publish); a `README.md` documents embedding; `index.test.mjs` guards the public contract and version/manifest agreement. Zero build step, zero npm tooling.
+
+**Tech Stack:** Vanilla ESM, Web Crypto, Node 20+ `node --test`, zero npm. No Python touched.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-egu-2.5-wallet-packaging-design.md`
+
+**IMPORTANT (shell cwd):** run all commands from the repo root `/home/gumptionthomas/Development/gumptionchain`. Use repo-root-relative paths in `git add`.
+
+---
+
+## File Structure
+
+- **Create** `clients/wallet/index.mjs` — curated re-exports + `version`.
+- **Create** `clients/wallet/package.json` — private manifest.
+- **Create** `clients/wallet/README.md` — embedding guide.
+- **Create** `clients/wallet/index.test.mjs` — contract + version-agreement + barrel round-trip.
+
+No existing module is modified. JS test command: `node --test clients/wallet/*.test.mjs`.
+
+---
+
+### Task 1: The barrel `index.mjs`
+
+**Files:**
+- Create: `clients/wallet/index.mjs`
+
+- [ ] **Step 1: Write the barrel** — create `clients/wallet/index.mjs`:
+
+```javascript
+// GumptionChain browser wallet — public API barrel.
+// Import the supported surface from here. Anything not re-exported below
+// (e.g. gc-crypto low-level helpers, gc-envelope seal/open, messageCanonical)
+// is internal and may change without notice.
+//
+// The package `version` is the embedder-API semver; it is INDEPENDENT of the
+// wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
+export const version = '0.1.0';
+
+// Identity / keys
+export { Wallet } from './gc-wallet.mjs';
+
+// API request signing (gc-sig-v1)
+export { canonical, signHeaders } from './gc-sig.mjs';
+
+// Passkey-anchored storage
+export { enroll, unlock, hasWallet, clear } from './gc-store.mjs';
+export { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+export { makeIdbStore } from './gc-store-idb.mjs';
+
+// Backup / recovery
+export {
+  exportEncrypted, importEncrypted, exportPlain, importPlain,
+} from './gc-backup.mjs';
+
+// Message signing (gc-msg-v1)
+export {
+  signMessage, verifyMessage, toArmored, fromArmored,
+} from './gc-message.mjs';
+
+// Typed errors
+export {
+  UnsupportedError,
+  NoWalletError,
+  BadBackupError,
+  BadPassphraseError,
+  BadProofError,
+} from './gc-errors.mjs';
+```
+
+- [ ] **Step 2: Verify it parses and re-exports resolve**
+
+Run: `node --input-type=module -e "import('./clients/wallet/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
+Expected: prints a comma-separated list including `BadBackupError,BadPassphraseError,BadProofError,NoWalletError,UnsupportedError,Wallet,canonical,clear,enroll,exportEncrypted,exportPlain,fromArmored,hasWallet,importEncrypted,importPlain,makeIdbStore,makeWebauthnPasskey,signHeaders,signMessage,toArmored,unlock,verifyMessage,version` (order may vary; all present).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/wallet/index.mjs
+git commit -m "feat(wallet): public API barrel (index.mjs) + version"
+```
+
+---
+
+### Task 2: Private `package.json` manifest
+
+**Files:**
+- Create: `clients/wallet/package.json`
+
+- [ ] **Step 1: Write the manifest** — create `clients/wallet/package.json`:
+
+```json
+{
+  "name": "@gumptionchain/wallet",
+  "version": "0.1.0",
+  "description": "GumptionChain browser wallet — gc-sig-v1 signing, passkey storage, backup, message signing.",
+  "type": "module",
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "sideEffects": false,
+  "private": true,
+  "license": "SEE LICENSE IN ../../LICENSE"
+}
+```
+
+- [ ] **Step 2: Verify it is valid JSON and version matches the barrel**
+
+Run: `node -e "const p=require('./clients/wallet/package.json'); if(p.version!=='0.1.0'||!p.private) throw new Error('bad manifest'); console.log('ok', p.name, p.version)"`
+Expected: `ok @gumptionchain/wallet 0.1.0`
+
+(Note: `require` of a JSON file works even though the package is `type: module`, because JSON is not an ES module. This is just a validity probe.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/wallet/package.json
+git commit -m "feat(wallet): private package.json manifest (no npm publish)"
+```
+
+---
+
+### Task 3: Contract smoke test `index.test.mjs`
+
+**Files:**
+- Create: `clients/wallet/index.test.mjs`
+
+- [ ] **Step 1: Write the test** — create `clients/wallet/index.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as api from './index.mjs';
+
+const FUNCTIONS = [
+  'canonical', 'signHeaders',
+  'enroll', 'unlock', 'hasWallet', 'clear',
+  'makeWebauthnPasskey', 'makeIdbStore',
+  'exportEncrypted', 'importEncrypted', 'exportPlain', 'importPlain',
+  'signMessage', 'verifyMessage', 'toArmored', 'fromArmored',
+];
+const ERRORS = [
+  'UnsupportedError', 'NoWalletError', 'BadBackupError',
+  'BadPassphraseError', 'BadProofError',
+];
+
+test('barrel exports every public function', () => {
+  for (const name of FUNCTIONS) {
+    assert.equal(typeof api[name], 'function', `missing function: ${name}`);
+  }
+});
+
+test('barrel exports Wallet as a class and the typed errors', () => {
+  assert.equal(typeof api.Wallet, 'function');
+  assert.equal(typeof api.Wallet.generate, 'function');
+  for (const name of ERRORS) {
+    assert.equal(typeof api[name], 'function', `missing error: ${name}`);
+    assert.ok(
+      new api[name]('x') instanceof Error,
+      `${name} is not an Error subclass`,
+    );
+  }
+});
+
+test('version is semver and agrees with package.json', () => {
+  assert.match(api.version, /^\d+\.\d+\.\d+$/);
+  const pkg = JSON.parse(
+    readFileSync(new URL('./package.json', import.meta.url)),
+  );
+  assert.equal(api.version, pkg.version);
+});
+
+test('end-to-end through the barrel: generate -> sign -> verify', async () => {
+  const w = await api.Wallet.generate();
+  const proof = await api.signMessage(w, 'packaged', { timestamp: '1700000000' });
+  const r = await api.verifyMessage(proof);
+  assert.equal(r.valid, true);
+  assert.equal(r.address, await w.address());
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `node --test clients/wallet/index.test.mjs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 3: Run the full wallet suite (nothing regressed)**
+
+Run: `node --test clients/wallet/*.test.mjs`
+Expected: PASS — all prior tests + the 4 new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clients/wallet/index.test.mjs
+git commit -m "test(wallet): barrel contract + version-agreement + round-trip"
+```
+
+---
+
+### Task 4: Embedding guide `README.md`
+
+**Files:**
+- Create: `clients/wallet/README.md`
+
+- [ ] **Step 1: Write the README** — create `clients/wallet/README.md` with exactly this content:
+
+````markdown
+# GumptionChain Browser Wallet
+
+A dependency-free, vanilla-JS ([Web Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API))
+wallet for [GumptionChain](../../README.md): RSA-2048 key management,
+`gc-sig-v1` authenticated API requests, passkey-anchored at-rest storage,
+self-custody backup/recovery, and generic `gc-msg-v1` message signing.
+
+Built across EGU #2.1–#2.5 (see `docs/superpowers/specs/`). The Python node
+verifies every signature this produces byte-for-byte.
+
+## Requirements
+
+- **A secure context** (`https://` or `http://localhost`) — WebAuthn and
+  IndexedDB require it. `file://` will not work.
+- **A PRF-capable authenticator** for passkey storage: a platform passkey
+  (Touch ID / iCloud Keychain / Google Password Manager), a phone passkey via
+  hybrid (QR), or a hardware key with `hmac-secret`. **The Bitwarden browser
+  extension does _not_ export PRF to external relying parties** (it uses PRF
+  only to unlock its own vault), so it cannot anchor wallet storage. Backup via
+  the raw b58 string (below) _can_ be stored in any password manager, Bitwarden
+  included.
+- A modern browser, or Node 20+ to run the test suite.
+
+## Importing
+
+This is a barrel-style ESM package; import from `index.mjs`.
+
+```js
+// Relative path (vendored / monorepo)
+import { Wallet, signMessage } from './clients/wallet/index.mjs';
+
+// Or pin a tag/commit via a CDN that serves the repo (no install):
+// import { Wallet } from
+//   'https://cdn.jsdelivr.net/gh/gumptionthomas/gumptionchain/clients/wallet/index.mjs';
+```
+
+Only symbols re-exported from `index.mjs` are the supported public API. Other
+files (`gc-crypto.mjs`, `gc-envelope.mjs`, …) are internal and may change.
+
+## Quickstart
+
+### 1. Sign an authenticated API request (`gc-sig-v1`)
+
+```js
+import { Wallet, signHeaders } from './index.mjs';
+
+const wallet = await Wallet.generate();
+const headers = await signHeaders(wallet, {
+  method: 'POST',
+  path: '/api/transactions',
+  query: '',
+  body: new TextEncoder().encode(JSON.stringify(txn)),
+  nodeHost: 'node.example',
+  timestamp: Math.floor(Date.now() / 1000),
+});
+await fetch('https://node.example/api/transactions', {
+  method: 'POST', headers, body: JSON.stringify(txn),
+});
+```
+
+### 2. Store under a passkey, then unlock after reload
+
+```js
+import { Wallet, enroll, unlock, hasWallet,
+         makeWebauthnPasskey, makeIdbStore } from './index.mjs';
+
+const passkey = makeWebauthnPasskey({ rpId: location.hostname, rpName: 'My App' });
+const store = makeIdbStore({ dbName: 'gc-wallet' });
+
+if (!(await hasWallet(store))) {
+  const wallet = await Wallet.generate();
+  await enroll(wallet, { passkey, store }, { userName: 'player' });
+}
+// ...later, after a reload:
+const wallet = await unlock({ passkey, store }); // one passkey ceremony
+```
+
+### 3. Back up & restore (self-custody)
+
+```js
+import { exportEncrypted, importEncrypted, exportPlain } from './index.mjs';
+
+// Passphrase-encrypted file (download backup.kind === 'gc-wallet-backup'):
+const backup = await exportEncrypted(wallet, passphrase);
+const restored = await importEncrypted(backup, passphrase);
+
+// Or the raw b58 string for a password manager:
+const b58 = await exportPlain(wallet);
+```
+
+### 4. Sign & verify a message (`gc-msg-v1`)
+
+```js
+import { signMessage, verifyMessage, toArmored, fromArmored } from './index.mjs';
+
+const proof = await signMessage(wallet, 'address X is me');
+const armored = toArmored(proof); // shareable PGP-style block
+
+const result = await verifyMessage(fromArmored(armored));
+// { valid: true, address, timestamp, message }
+```
+
+## Public API
+
+| Symbol | Purpose |
+| --- | --- |
+| `Wallet` | keygen, key import/export, address, sign, verify-only via `fromPublicKeyB64` |
+| `canonical`, `signHeaders` | `gc-sig-v1` request signing |
+| `enroll`, `unlock`, `hasWallet`, `clear` | passkey-anchored storage orchestration |
+| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters |
+| `exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain` | backup/recovery |
+| `signMessage`, `verifyMessage`, `toArmored`, `fromArmored` | `gc-msg-v1` message signing |
+| `UnsupportedError`, `NoWalletError`, `BadBackupError`, `BadPassphraseError`, `BadProofError` | typed errors |
+| `version` | package semver |
+
+Anything not listed is internal/unstable.
+
+## Versioning
+
+`version` is the **package** semver (currently `0.1.0`, pre-launch — the
+embedder API is not yet frozen). It is **independent** of the wire scheme ids
+`gc-sig-v1` and `gc-msg-v1`, which are protocol identifiers bound into
+signatures and change only on a protocol revision.
+
+## Testing
+
+```bash
+node --test clients/wallet/*.test.mjs   # JS unit + contract tests, zero npm
+```
+
+JS↔Python signature parity is enforced from the Python side
+(`tests/test_browser_wallet_parity.py`, `tests/test_message_parity.py`) via the
+`sign-cli.mjs` / `message-cli.mjs` harnesses. Browser-only flows (real passkey +
+IndexedDB) are covered by `MANUAL-VERIFICATION.md`.
+
+## Extracting to its own repo / hosting
+
+The wallet is packaged in place today. To move it to a dedicated repo or into
+the gumption.com hub (EGU #5):
+
+1. Copy `clients/wallet/` to the new location. It is self-contained — the
+   public surface has no imports outside this directory.
+2. The only cross-repo coupling is the **JS↔Python parity tests** and the
+   `sign-cli.mjs` / `message-cli.mjs` harnesses they invoke. Keep those here
+   (pointing at a vendored/submoduled copy) or re-home them with the node.
+3. Serve over `https://`, or pin a tag via jsDelivr
+   (`https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/index.mjs`).
+
+No build step is required — the barrel is plain ESM.
+````
+
+- [ ] **Step 2: Verify the fenced examples reference only real exports**
+
+Run: `grep -oE "from '\./(index|clients/wallet/index)\.mjs'" clients/wallet/README.md | head`
+Expected: matches present (sanity check the import lines exist). Manually confirm every imported name in the README appears in `index.mjs`'s exports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/wallet/README.md
+git commit -m "docs(wallet): embedding guide (README) — import, flows, hosting"
+```
+
+---
+
+## Final verification (before finishing the branch)
+
+- [ ] `node --test clients/wallet/*.test.mjs` — all green (incl. the 4 new contract tests).
+- [ ] `uv run pytest` — unaffected (no Python change; parity tests still pass).
+- [ ] `node -e "JSON.parse(require('fs').readFileSync('clients/wallet/package.json'))"` — manifest is valid JSON.
+- [ ] Every import name used in `README.md` examples exists in `index.mjs` exports.
+- [ ] Zero npm packages added; `index.mjs` imports only sibling `.mjs` files.
+
+## Self-review notes
+
+- **Spec coverage:** barrel + curated surface + `version` (Task 1); private manifest (Task 2); contract/version-agreement/round-trip test (Task 3); embedding guide incl. secure-context + Bitwarden-PRF caveat + extraction section (Task 4). All spec sections mapped.
+- **Type/name consistency:** the export list in `index.mjs`, the `FUNCTIONS`/`ERRORS` arrays in `index.test.mjs`, and the README's Public API table list the same symbols. `version` `0.1.0` matches across `index.mjs` and `package.json` (asserted by the test).
+- **No placeholders:** every file's full content is given.
+- **No behavior change:** only new files; no existing module edited.

--- a/docs/superpowers/specs/2026-06-06-egu-2.5-wallet-packaging-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-2.5-wallet-packaging-design.md
@@ -1,0 +1,160 @@
+# EGU #2.5 — wallet packaging — design
+
+**Date:** 2026-06-06
+**Status:** Approved — ready for implementation
+**Issue:** #180 (sub-project 5, final, of EGU #2 / #152)
+**Type:** Packaging of the existing client module (vanilla JS / ESM) — additive;
+no behavior change, no Python change.
+
+## Summary
+
+Turn the loose `clients/wallet/` module set (10 ESM modules, no entry point, no
+version, no consumer docs) into an **embeddable, versioned package** with a
+stable public API and an embedding guide — packaged **in place**, with a
+documented path to its own repo / CDN. No code behavior changes; this is entry
+point + manifest + docs + a contract-guarding smoke test.
+
+Distribution model (decided): a **barrel `index.mjs`, no build step** — zero npm
+tooling, consistent with the project's supply-chain stance. Modern browsers and
+import maps handle multi-file ESM directly.
+
+## Public API (the barrel `index.mjs`)
+
+`index.mjs` re-exports a **curated** public surface — the supported contract.
+Sub-modules remain individually importable for advanced use, but the barrel is
+what embedders should depend on.
+
+- **Identity / keys:** `Wallet` (from `gc-wallet.mjs`)
+- **API request signing (gc-sig-v1):** `canonical`, `signHeaders` (`gc-sig.mjs`)
+- **Passkey storage:** `enroll`, `unlock`, `hasWallet`, `clear` (`gc-store.mjs`);
+  `makeWebauthnPasskey` (`gc-passkey-webauthn.mjs`); `makeIdbStore`
+  (`gc-store-idb.mjs`)
+- **Backup / recovery:** `exportEncrypted`, `importEncrypted`, `exportPlain`,
+  `importPlain` (`gc-backup.mjs`)
+- **Message signing (gc-msg-v1):** `signMessage`, `verifyMessage`, `toArmored`,
+  `fromArmored` (`gc-message.mjs`)
+- **Typed errors:** `UnsupportedError`, `NoWalletError`, `BadBackupError`,
+  `BadPassphraseError`, `BadProofError` (`gc-errors.mjs`)
+- **`version`** — the package semver string (see below)
+
+**Kept internal** (NOT re-exported from the barrel; still directly importable
+from their files, but explicitly *unstable* and undocumented as public): the
+`gc-crypto` low-level helpers (`base58encode/decode`, `base64encode/decode`,
+`millHash`, `sha256Hex`), the `gc-envelope` primitives (`seal`, `open`,
+`sealWithKey`, `openWithKey`), and `messageCanonical`. Rationale: a small
+supported surface lets the low-level crypto evolve without breaking embedders.
+
+## Versioning
+
+- A single `version` string, exported from the barrel, starting **`0.1.0`**.
+  Pre-launch 0.x signals the embedder API is not yet frozen.
+- **Distinct from the wire scheme versions.** `gc-sig-v1` and `gc-msg-v1` are
+  independent protocol identifiers bound into signatures; they do not move with
+  the package version and are unchanged here. The README states this explicitly
+  so nobody conflates "package 0.1.0" with "scheme v1".
+- Source of truth: the `version` field in `package.json`, mirrored by the
+  `version` export. The smoke test asserts the two agree, so they can't drift.
+
+## `package.json` (private manifest)
+
+A manifest, **not an npm onboarding** — no dependencies, no install step:
+
+```json
+{
+  "name": "@gumptionchain/wallet",
+  "version": "0.1.0",
+  "description": "GumptionChain browser wallet — gc-sig-v1 signing, passkey storage, backup, message signing.",
+  "type": "module",
+  "exports": { ".": "./index.mjs" },
+  "sideEffects": false,
+  "private": true,
+  "license": "SEE LICENSE IN ../../LICENSE"
+}
+```
+
+- `exports` lets bundlers and CDNs (e.g. jsDelivr `/+esm`) resolve the entry.
+- `type: "module"` + explicit `.mjs` files keep ESM semantics unambiguous.
+- `sideEffects: false` enables tree-shaking by downstream bundlers.
+- **`private: true`** blocks accidental `npm publish`.
+- Lives in `clients/wallet/`; it does not affect the root `uv`/`uv_build`
+  Python project (separate directory) and adds no runtime dependency.
+
+## README.md (the embedding guide)
+
+`clients/wallet/README.md`, a concise quickstart:
+
+- **What it is** — one paragraph; links the design specs (#2.1–#2.5).
+- **Requirements** — a **secure context** (https / localhost) for WebAuthn +
+  IndexedDB; a **PRF-capable authenticator** for passkey storage, with the
+  caveat that the **Bitwarden extension does not export PRF to external RPs**
+  (link the finding); Web Crypto + ESM (any modern browser, Node 20+ for tests).
+- **Import options** — relative path; git submodule; CDN-from-repo
+  (`https://cdn.jsdelivr.net/gh/<owner>/<repo>/clients/wallet/index.mjs`).
+- **Worked examples** (copy-paste, importing from `./index.mjs`) for the four
+  flows:
+  1. Sign an authenticated API request (`signHeaders`).
+  2. Create → store under a passkey → reload → unlock (`Wallet.generate`,
+     `enroll`, `makeWebauthnPasskey`, `makeIdbStore`, `unlock`).
+  3. Back up & restore (`exportEncrypted`/`importEncrypted`, `exportPlain`).
+  4. Sign & verify a message (`signMessage`/`verifyMessage`, armored).
+- **Public API reference** — the curated export list above, one line each;
+  a note that anything not listed is internal/unstable.
+- **Versioning** — semver of the package vs. the independent wire schemes.
+- **Extracting to its own repo / hosting on gumption.com** — the documented
+  path: copy `clients/wallet/` into the #5 hub repo or a dedicated repo; the
+  only cross-repo coupling is the JS↔Python parity tests + `sign-cli.mjs` /
+  `message-cli.mjs` harnesses (which stay here, or get vendored/submoduled);
+  serve over https or via jsDelivr. Not executed in this sub-project.
+
+## Testing
+
+- **`index.test.mjs` (`node --test`, zero npm):**
+  - **Contract:** import the barrel and assert every public symbol above is
+    present with the expected type (functions are functions, `Wallet` is a
+    class, each error is a subclass of `Error`, `version` is a non-empty
+    string matching `^\d+\.\d+\.\d+$`).
+  - **Version agreement:** the exported `version` equals the `version` in
+    `package.json` (read + parsed in the test) — prevents drift.
+  - **End-to-end through the barrel:** `Wallet.generate()` → `signMessage` →
+    `verifyMessage` returns `{ valid: true }`, exercising the real export wiring
+    (not direct module imports).
+- **Manifest validity:** the version-agreement test parses `package.json`, which
+  also fails loudly if it is malformed JSON.
+- Existing suites unaffected (no module behavior changes); full `node --test`
+  and `uv run pytest` stay green.
+- The README's examples are illustrative; the browser flows remain covered by
+  the existing `MANUAL-VERIFICATION.md`.
+
+## Out of scope
+
+- **Actual repo extraction / npm publish / CDN deployment** — documented, not
+  executed.
+- **Single-file bundling** — deferred; the barrel is the chosen model. A
+  zero-dep concatenation could be added later without changing the public API.
+- The #5 gumption.com hub; the #176 verifiable stake card.
+- Any Python change; any change to module behavior.
+
+## Decisions log
+
+- **Barrel `index.mjs`, no build** (Q1) — zero npm tooling; browsers/import-maps
+  handle multi-file ESM; a bundle can be layered on later.
+- **Package in place, document extraction** (Q2) — keeps the JS↔Python parity
+  tests co-located; the actual split waits for the #5 hub.
+- **Private `package.json` manifest** (Q3) — metadata for bundlers/CDNs with
+  `private: true` guarding against publish; not an npm dependency story.
+- **Curated minimal public surface** — small supported contract; low-level
+  crypto stays internal-but-importable.
+- **version 0.1.0, independent of wire schemes** — pre-launch API; the smoke
+  test pins package-version/manifest agreement and keeps scheme versions
+  separate.
+
+## Definition of done
+
+- `clients/wallet/index.mjs` (curated re-exports + `version`),
+  `clients/wallet/package.json` (private manifest), `clients/wallet/README.md`
+  (embedding guide), `clients/wallet/index.test.mjs` (contract + version
+  agreement + barrel round-trip).
+- `node --test clients/wallet/*.test.mjs` green (incl. the new smoke test);
+  `uv run pytest` unaffected; zero npm packages added.
+- No change to any existing module's behavior; no Python change.
+- Closes EGU #2 (#152).


### PR DESCRIPTION
## Summary
EGU #2.5 (#180) — the final wallet sub-project. Turns the loose `clients/wallet/` module set into an **embeddable, versioned package** with a stable public API and an embedding guide, packaged **in place** with a documented path to its own repo / CDN. Additive only — no existing module's behavior changes.

- **`index.mjs` barrel** — re-exports the curated public API (Wallet; `canonical`/`signHeaders`; `enroll`/`unlock`/`hasWallet`/`clear` + `makeWebauthnPasskey`/`makeIdbStore`; the backup four; the message four; the five typed errors) + `version`. Low-level crypto/envelope stay internal-but-importable.
- **`version` 0.1.0** — package semver, explicitly independent of the `gc-sig-v1`/`gc-msg-v1` wire schemes. A test pins `version` ↔ `package.json` agreement so they can't drift.
- **`package.json`** — private manifest (`@gumptionchain/wallet`, `type: module`, `exports` map, `sideEffects: false`, **`private: true`**). Metadata for bundlers/CDNs; no deps, no npm publish.
- **`README.md`** — embedding guide: import options (relative / submodule / jsDelivr-from-repo), secure-context + **Bitwarden-PRF** caveats, worked copy-paste examples for all four flows, public API table, versioning note, and an extraction/hosting section.
- **`index.test.mjs`** — guards the public contract (every symbol + type), version/manifest agreement, and an end-to-end round-trip through the barrel.

**Distribution model:** barrel ESM, no build step (zero npm tooling). **Out of scope (documented, not executed):** repo extraction, npm publish, CDN deploy, single-file bundling.

## Test Plan
- [x] `node --test clients/wallet/*.test.mjs` — 60/60 (56 prior + 4 new contract tests).
- [x] `uv run pytest` — 366 passed, 1 skipped (unaffected; no Python touched).
- [x] `package.json` valid JSON; every README example imports only real exports with correct signatures.
- [x] Spec-compliance review (SPEC COMPLIANT) + code-quality review (APPROVED, no actionable issues).
- [x] Additions-only diff; zero existing modules modified; zero npm packages.

Spec: `docs/superpowers/specs/2026-06-06-egu-2.5-wallet-packaging-design.md`
Plan: `docs/superpowers/plans/2026-06-06-egu-2.5-wallet-packaging.md`

Closes #180. **Completes EGU #2 (#152).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)