### PR TITLE
feat(wallet): stake attestation + verifier — Verified on GumptionChain (#184)

### DIFF
--- a/clients/wallet/MANUAL-VERIFICATION.md
+++ b/clients/wallet/MANUAL-VERIFICATION.md
@@ -87,6 +87,28 @@ manual:
 5. Tamper a character inside the JSON `message` field and verify; confirm
    `valid: false, reason: bad-signature`.
 
+## Stake attestation (#176b)
+
+Composes gc-msg-v1 signing with on-chain provenance. Verification fetches
+`GET /api/transaction/<txid>` from the node, so point the demo at a node where
+the relevant transaction is mined and reader access is granted (a public node
+sets `READER_ADDRESSES=["*"]`).
+
+1. With a wallet loaded, in **Stake attestation** enter a real mined `txid`,
+   pick the `kind`, fill `subject` (or, for `transfer`, the destination
+   `address`) and `amount` (grains) to match an outflow of that transaction,
+   then click **Build & sign attestation**. Confirm the proof JSON appears and
+   its `address` matches the loaded wallet.
+2. Copy the proof JSON into the verify box and click **Verify attestation**.
+   Confirm `valid: true` with all three checks green (`signature: true`,
+   `onchain: true`, `consistent: true`) and no `reasons`.
+3. Tamper one character inside the proof's `message` field and verify again;
+   confirm `valid: false` with `reasons: bad-signature`.
+4. Restore the proof but change the `txid` to one that is not mined (or that is
+   on an orphaned/pending branch) and verify; confirm `valid: false` with the
+   matching reason (`txn-not-found` for an unknown txn, `not-canonical` for a
+   non-canonical one).
+
 ## Notes for the tester
 
 - The passkey credential is a **separate** WebAuthn credential (ES256/RS256,

--- a/clients/wallet/attestation-cli.mjs
+++ b/clients/wallet/attestation-cli.mjs
@@ -1,0 +1,28 @@
+// Stake-attestation harness (test tool). Modes:
+//   build  '{claim}'                          -> canonical message string
+//   sign   '{"private_key_b58":..,"claim":{..},"timestamp":".."}' -> proof JSON
+//   verify '{"proof":{..},"provenance":{..}|null,"minConfirmations":..}' -> verdict
+import { Wallet } from './gc-wallet.mjs';
+import {
+  buildStakeMessage, signStakeAttestation, verifyStake,
+} from './gc-attestation.mjs';
+
+const mode = process.argv[2];
+const arg = JSON.parse(process.argv[3]);
+
+if (mode === 'build') {
+  process.stdout.write(buildStakeMessage(arg));
+} else if (mode === 'sign') {
+  const w = await Wallet.fromPrivateKeyB58(arg.private_key_b58);
+  const proof = await signStakeAttestation(w, arg.claim, { timestamp: arg.timestamp });
+  process.stdout.write(JSON.stringify(proof));
+} else if (mode === 'verify') {
+  const verdict = await verifyStake(arg.proof, {
+    fetchProvenance: async () => arg.provenance ?? null,
+    minConfirmations: arg.minConfirmations,
+  });
+  process.stdout.write(JSON.stringify(verdict));
+} else {
+  process.stderr.write(`unknown mode: ${mode}\n`);
+  process.exit(1);
+}

--- a/clients/wallet/gc-attestation.mjs
+++ b/clients/wallet/gc-attestation.mjs
@@ -73,6 +73,13 @@ export function parseStakeAttestation(proof) {
     throw new BadAttestationError('message is not a stake claim');
   }
   validateClaim(claim);
+  // Require canonical encoding: the signed message must be exactly what
+  // buildStakeMessage emits for this claim. Rejects non-canonical forms (a
+  // float amount like 300.0, reordered keys, extra fields, whitespace) so JS
+  // and Python agree on accept/reject for any signable input.
+  if (buildStakeMessage(claim) !== proof.message) {
+    throw new BadAttestationError('non-canonical stake claim encoding');
+  }
   return claim;
 }
 

--- a/clients/wallet/gc-attestation.mjs
+++ b/clients/wallet/gc-attestation.mjs
@@ -1,0 +1,140 @@
+// "Verified on GumptionChain" stake attestations: a gc-msg-v1 proof whose
+// message is the canonical JSON of a stake claim. verifyStake composes the
+// signature (gc-msg-v1), on-chain provenance (injected fetchProvenance), and a
+// consistency check. Pure — no I/O. No dependencies beyond sibling modules.
+import { BadAttestationError } from './gc-errors.mjs';
+import { signMessage, verifyMessage } from './gc-message.mjs';
+
+const KINDS = new Set(['opposition', 'support', 'rescind', 'transfer']);
+
+export { BadAttestationError } from './gc-errors.mjs';
+
+function validateClaim(claim) {
+  if (!claim || typeof claim !== 'object') {
+    throw new BadAttestationError('claim must be an object');
+  }
+  const { txid, kind, subject, address, amount, handle } = claim;
+  if (typeof txid !== 'string' || !txid) {
+    throw new BadAttestationError('txid is required');
+  }
+  if (!KINDS.has(kind)) {
+    throw new BadAttestationError(`invalid kind: ${kind}`);
+  }
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new BadAttestationError('amount must be a positive integer (grains)');
+  }
+  if (kind === 'transfer') {
+    if (typeof address !== 'string' || !address) {
+      throw new BadAttestationError('transfer requires address');
+    }
+    if (subject !== undefined) {
+      throw new BadAttestationError('transfer must not set subject');
+    }
+  } else {
+    if (typeof subject !== 'string' || !subject) {
+      throw new BadAttestationError('stake requires subject');
+    }
+    if (address !== undefined) {
+      throw new BadAttestationError('stake must not set address');
+    }
+  }
+  if (handle !== undefined && handle !== null && typeof handle !== 'string') {
+    throw new BadAttestationError('handle must be a string');
+  }
+}
+
+export function buildStakeMessage(claim) {
+  validateClaim(claim);
+  const ordered = { txid: claim.txid, kind: claim.kind };
+  if (claim.kind === 'transfer') {
+    ordered.address = claim.address;
+  } else {
+    ordered.subject = claim.subject;
+  }
+  ordered.amount = claim.amount;
+  if (claim.handle !== undefined && claim.handle !== null) {
+    ordered.handle = claim.handle;
+  }
+  return JSON.stringify(ordered);
+}
+
+export async function signStakeAttestation(wallet, claim, { timestamp } = {}) {
+  return signMessage(wallet, buildStakeMessage(claim), { timestamp });
+}
+
+export function parseStakeAttestation(proof) {
+  if (!proof || typeof proof.message !== 'string') {
+    throw new BadAttestationError('proof has no message');
+  }
+  let claim;
+  try {
+    claim = JSON.parse(proof.message);
+  } catch {
+    throw new BadAttestationError('message is not a stake claim');
+  }
+  validateClaim(claim);
+  return claim;
+}
+
+function outflowMatches(outflows, claim) {
+  return (outflows || []).some(
+    (o) => o.kind === claim.kind
+      && o.amount === claim.amount
+      && (claim.kind === 'transfer'
+        ? o.address === claim.address
+        : o.subject === claim.subject),
+  );
+}
+
+// fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
+// for an unknown txn. The verifier performs no transport itself.
+export async function verifyStake(
+  proof,
+  { fetchProvenance, maxAge, minConfirmations } = {},
+) {
+  const claim = parseStakeAttestation(proof);
+  const reasons = [];
+  const checks = { signature: false, onchain: false, consistent: false };
+  const signer = proof.address;
+
+  const sig = await verifyMessage(proof, { maxAge });
+  if (sig.valid && sig.address === signer) {
+    checks.signature = true;
+  } else {
+    reasons.push(sig.reason === 'expired' ? 'expired' : 'bad-signature');
+  }
+
+  const provenance = await fetchProvenance(claim.txid);
+  if (!provenance) {
+    reasons.push('txn-not-found');
+  } else if (provenance.status !== 'canonical') {
+    reasons.push('not-canonical');
+  } else if (
+    minConfirmations !== undefined
+    && (provenance.confirmations ?? 0) < minConfirmations
+  ) {
+    reasons.push('insufficient-confirmations');
+  } else {
+    checks.onchain = true;
+  }
+
+  if (checks.signature && checks.onchain && provenance) {
+    if (provenance.address !== signer) {
+      reasons.push('signer-not-staker');
+    } else if (!outflowMatches(provenance.outflows, claim)) {
+      reasons.push('claim-mismatch');
+    } else {
+      checks.consistent = true;
+    }
+  }
+
+  return {
+    valid: checks.signature && checks.onchain && checks.consistent,
+    checks,
+    signer,
+    claim,
+    provenance: provenance ?? null,
+    confirmations: provenance?.confirmations ?? 0,
+    reasons,
+  };
+}

--- a/clients/wallet/gc-attestation.mjs
+++ b/clients/wallet/gc-attestation.mjs
@@ -2,7 +2,7 @@
 // message is the canonical JSON of a stake claim. verifyStake composes the
 // signature (gc-msg-v1), on-chain provenance (injected fetchProvenance), and a
 // consistency check. Pure — no I/O. No dependencies beyond sibling modules.
-import { BadAttestationError } from './gc-errors.mjs';
+import { BadAttestationError, BadProofError } from './gc-errors.mjs';
 import { signMessage, verifyMessage } from './gc-message.mjs';
 
 const KINDS = new Set(['opposition', 'support', 'rescind', 'transfer']);
@@ -94,7 +94,10 @@ function outflowMatches(outflows, claim) {
 }
 
 // fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
-// for an unknown txn. The verifier performs no transport itself.
+// for an unknown txn. The verifier performs no transport itself; mapping a
+// 404 to null is the injected adapter's job. Genuine transport errors (e.g. a
+// network failure) propagate by design — they must NOT be misreported as
+// 'txn-not-found', which would mark a real canonical stake unverifiable.
 export async function verifyStake(
   proof,
   { fetchProvenance, maxAge, minConfirmations } = {},
@@ -104,7 +107,16 @@ export async function verifyStake(
   const checks = { signature: false, onchain: false, consistent: false };
   const signer = proof.address;
 
-  const sig = await verifyMessage(proof, { maxAge });
+  let sig;
+  try {
+    sig = await verifyMessage(proof, { maxAge });
+  } catch (e) {
+    // A structurally malformed gc-msg-v1 envelope is a malformed attestation.
+    if (e instanceof BadProofError) {
+      throw new BadAttestationError('attestation is not a valid gc-msg-v1 proof');
+    }
+    throw e;
+  }
   if (sig.valid && sig.address === signer) {
     checks.signature = true;
   } else {

--- a/clients/wallet/gc-attestation.test.mjs
+++ b/clients/wallet/gc-attestation.test.mjs
@@ -1,0 +1,120 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  buildStakeMessage, signStakeAttestation, parseStakeAttestation,
+  verifyStake, BadAttestationError,
+} from './gc-attestation.mjs';
+
+const TS = '1700002000';
+const CLAIM = { txid: 'tx1', kind: 'opposition', subject: 'goblins', amount: 300 };
+
+// A provenance object shaped like #176a's GET /transaction/<txid> response.
+function provenanceFor(address, { status = 'canonical', confirmations = 3 } = {}) {
+  return {
+    txid: 'tx1', address, status, confirmations,
+    outflows: [
+      { kind: 'opposition', subject: 'goblins', amount: 300 },
+      { kind: 'transfer', address: 'GCchangeGC', amount: 9700 },
+    ],
+  };
+}
+
+test('buildStakeMessage uses fixed key order, omits absent optionals', () => {
+  assert.equal(
+    buildStakeMessage(CLAIM),
+    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}',
+  );
+  assert.equal(
+    buildStakeMessage({ ...CLAIM, handle: 'me.bsky.social' }),
+    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+    + '"handle":"me.bsky.social"}',
+  );
+  assert.equal(
+    buildStakeMessage({ txid: 't', kind: 'transfer', address: 'GCxGC', amount: 5 }),
+    '{"txid":"t","kind":"transfer","address":"GCxGC","amount":5}',
+  );
+});
+
+test('buildStakeMessage rejects malformed claims', () => {
+  assert.throws(() => buildStakeMessage({ kind: 'opposition', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'nope', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', subject: 's', amount: 0 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', address: 'a', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'transfer', subject: 's', amount: 1 }), BadAttestationError);
+});
+
+test('sign -> parse round-trips the claim', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.deepEqual(parseStakeAttestation(proof), CLAIM);
+});
+
+test('parseStakeAttestation throws on a non-claim message', () => {
+  assert.throws(
+    () => parseStakeAttestation({ message: 'not json' }),
+    BadAttestationError,
+  );
+});
+
+test('verifyStake valid when signature + onchain + consistent all hold', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  const fetchProvenance = async () => provenanceFor(await w.address());
+  const v = await verifyStake(proof, { fetchProvenance });
+  assert.equal(v.valid, true);
+  assert.deepEqual(v.checks, { signature: true, onchain: true, consistent: true });
+  assert.equal(v.signer, await w.address());
+  assert.equal(v.confirmations, 3);
+  assert.deepEqual(v.reasons, []);
+});
+
+test('verifyStake reports bad-signature on a tampered claim', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  proof.message = buildStakeMessage({ ...CLAIM, amount: 999 });
+  const v = await verifyStake(proof, { fetchProvenance: async () => provenanceFor(await w.address()) });
+  assert.equal(v.valid, false);
+  assert.ok(v.reasons.includes('bad-signature'));
+});
+
+test('verifyStake reports txn-not-found, not-canonical, insufficient-confirmations', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  const addr = await w.address();
+
+  const missing = await verifyStake(proof, { fetchProvenance: async () => null });
+  assert.equal(missing.valid, false);
+  assert.ok(missing.reasons.includes('txn-not-found'));
+
+  const orphaned = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor(addr, { status: 'orphaned' }),
+  });
+  assert.ok(orphaned.reasons.includes('not-canonical'));
+
+  const shallow = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor(addr, { confirmations: 1 }),
+    minConfirmations: 6,
+  });
+  assert.ok(shallow.reasons.includes('insufficient-confirmations'));
+});
+
+test('verifyStake reports signer-not-staker and claim-mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+
+  const notStaker = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor('GCsomeoneelseGC'),
+  });
+  assert.ok(notStaker.reasons.includes('signer-not-staker'));
+
+  const addr = await w.address();
+  const mismatch = await verifyStake(proof, {
+    fetchProvenance: async () => ({
+      txid: 'tx1', address: addr, status: 'canonical', confirmations: 3,
+      outflows: [{ kind: 'opposition', subject: 'orcs', amount: 300 }],
+    }),
+  });
+  assert.ok(mismatch.reasons.includes('claim-mismatch'));
+});

--- a/clients/wallet/gc-attestation.test.mjs
+++ b/clients/wallet/gc-attestation.test.mjs
@@ -59,6 +59,19 @@ test('parseStakeAttestation throws on a non-claim message', () => {
   );
 });
 
+test('parseStakeAttestation rejects non-canonical encodings', () => {
+  // float amount (JSON.parse coerces 300.0 -> 300; rebuild differs)
+  assert.throws(() => parseStakeAttestation({
+    message:
+      '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300.0}',
+  }), BadAttestationError);
+  // reordered keys
+  assert.throws(() => parseStakeAttestation({
+    message:
+      '{"kind":"opposition","txid":"tx1","subject":"goblins","amount":300}',
+  }), BadAttestationError);
+});
+
 test('verifyStake valid when signature + onchain + consistent all hold', async () => {
   const w = await Wallet.generate();
   const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });

--- a/clients/wallet/gc-attestation.test.mjs
+++ b/clients/wallet/gc-attestation.test.mjs
@@ -72,6 +72,25 @@ test('parseStakeAttestation rejects non-canonical encodings', () => {
   }), BadAttestationError);
 });
 
+test('buildStakeMessage rejects a present off-side key (even null)', () => {
+  assert.throws(() => buildStakeMessage(
+    { txid: 't', kind: 'transfer', address: 'a', amount: 1, subject: null },
+  ), BadAttestationError);
+  assert.throws(() => buildStakeMessage(
+    { txid: 't', kind: 'opposition', subject: 's', amount: 1, address: null },
+  ), BadAttestationError);
+});
+
+test('verifyStake wraps a malformed proof envelope as BadAttestationError', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  proof.scheme = 'gc-sig-v1'; // malformed gc-msg-v1 envelope
+  await assert.rejects(
+    () => verifyStake(proof, { fetchProvenance: async () => provenanceFor(await w.address()) }),
+    BadAttestationError,
+  );
+});
+
 test('verifyStake valid when signature + onchain + consistent all hold', async () => {
   const w = await Wallet.generate();
   const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });

--- a/clients/wallet/gc-attestation.test.mjs
+++ b/clients/wallet/gc-attestation.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { Wallet } from './gc-wallet.mjs';
 import {
   buildStakeMessage, signStakeAttestation, parseStakeAttestation,
@@ -117,4 +118,13 @@ test('verifyStake reports signer-not-staker and claim-mismatch', async () => {
     }),
   });
   assert.ok(mismatch.reasons.includes('claim-mismatch'));
+});
+
+test('JS canonical messages match the committed golden vectors', () => {
+  const vec = JSON.parse(readFileSync(
+    new URL('./testdata/gc-attestation-vectors.json', import.meta.url),
+  ));
+  for (const c of vec) {
+    assert.equal(buildStakeMessage(c.claim), c.message);
+  }
 });

--- a/clients/wallet/gc-errors.mjs
+++ b/clients/wallet/gc-errors.mjs
@@ -20,3 +20,7 @@ export class BadPassphraseError extends Error {}
 // Input is not a structurally valid gc-msg-v1 proof (un-parseable / wrong
 // shape) — distinct from a proof that parses but fails verification.
 export class BadProofError extends Error {}
+
+// Input is not a structurally valid stake attestation (bad claim shape or a
+// proof whose message is not a parseable claim).
+export class BadAttestationError extends Error {}

--- a/clients/wallet/index.mjs
+++ b/clients/wallet/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.1.0';
+export const version = '0.2.0';
 
 // Identity / keys
 export { Wallet } from './gc-wallet.mjs';
@@ -28,6 +28,11 @@ export {
   signMessage, verifyMessage, toArmored, fromArmored,
 } from './gc-message.mjs';
 
+// Stake attestations (gc-msg-v1 + on-chain provenance composition)
+export {
+  signStakeAttestation, parseStakeAttestation, verifyStake,
+} from './gc-attestation.mjs';
+
 // Typed errors
 export {
   UnsupportedError,
@@ -35,4 +40,5 @@ export {
   BadBackupError,
   BadPassphraseError,
   BadProofError,
+  BadAttestationError,
 } from './gc-errors.mjs';

--- a/clients/wallet/index.test.mjs
+++ b/clients/wallet/index.test.mjs
@@ -9,10 +9,11 @@ const FUNCTIONS = [
   'makeWebauthnPasskey', 'makeIdbStore',
   'exportEncrypted', 'importEncrypted', 'exportPlain', 'importPlain',
   'signMessage', 'verifyMessage', 'toArmored', 'fromArmored',
+  'signStakeAttestation', 'parseStakeAttestation', 'verifyStake',
 ];
 const ERRORS = [
   'UnsupportedError', 'NoWalletError', 'BadBackupError',
-  'BadPassphraseError', 'BadProofError',
+  'BadPassphraseError', 'BadProofError', 'BadAttestationError',
 ];
 
 test('barrel exports every public function', () => {

--- a/clients/wallet/package.json
+++ b/clients/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/wallet",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GumptionChain browser wallet — gc-sig-v1 signing, passkey storage, backup, message signing.",
   "type": "module",
   "exports": {

--- a/clients/wallet/passkey-wallet-demo.html
+++ b/clients/wallet/passkey-wallet-demo.html
@@ -109,6 +109,47 @@
       <button id="verify-msg">Verify message</button>
     </p>
 
+    <h2>Stake attestation (#176b)</h2>
+    <p class="hint">
+      Builds a "Verified on GumptionChain" stake claim, signs it with
+      <code>currentWallet</code> into a <code>gc-msg-v1</code> proof, then
+      verifies it against on-chain provenance fetched from this node.
+      Verification needs reader access — a public node sets
+      <code>READER_ADDRESSES=["*"]</code>.
+    </p>
+    <p>
+      <input id="att-txid" type="text" placeholder="txid" style="width: 100%" />
+    </p>
+    <p>
+      <select id="att-kind">
+        <option value="opposition">opposition</option>
+        <option value="support">support</option>
+        <option value="rescind">rescind</option>
+        <option value="transfer">transfer</option>
+      </select>
+      <input id="att-subject" type="text" placeholder="subject" />
+      <input id="att-amount" type="number" placeholder="amount (grains)" />
+    </p>
+    <p>
+      <button id="att-sign">Build &amp; sign attestation</button>
+      <button id="copy-att-json">Copy JSON</button>
+    </p>
+    <p>
+      <textarea id="att-json" rows="4"
+                style="width: 100%; font-family: monospace"
+                readonly placeholder="attestation proof JSON appears here">
+      </textarea>
+    </p>
+    <p>
+      <textarea id="att-verify-text" rows="6"
+                style="width: 100%; font-family: monospace"
+                placeholder="paste an attestation proof JSON to verify">
+      </textarea>
+    </p>
+    <p>
+      <button id="att-verify">Verify attestation</button>
+    </p>
+
     <h2>Output</h2>
     <pre id="out">(idle)</pre>
 
@@ -128,6 +169,7 @@
         from './gc-backup.mjs';
       import { signMessage, verifyMessage, toArmored, fromArmored }
         from './gc-message.mjs';
+      import { signStakeAttestation, verifyStake } from './index.mjs';
 
       const rpId = location.hostname;
       const rpName = 'GumptionChain Wallet Demo';
@@ -360,6 +402,79 @@
             show(lines.join('\n'));
           } catch (err) {
             fail('Verify message', err);
+          }
+        });
+
+      const readClaim = () => {
+        const kind = document.getElementById('att-kind').value;
+        const txid = document.getElementById('att-txid').value.trim();
+        const subjectOrAddress =
+          document.getElementById('att-subject').value.trim();
+        const amount = Number(document.getElementById('att-amount').value);
+        const claim = { txid, kind, amount };
+        if (kind === 'transfer') {
+          claim.address = subjectOrAddress;
+        } else {
+          claim.subject = subjectOrAddress;
+        }
+        return claim;
+      };
+
+      document.getElementById('att-sign').addEventListener('click', async () => {
+        try {
+          const wallet = requireWallet();
+          const proof = await signStakeAttestation(wallet, readClaim());
+          document.getElementById('att-json').value =
+            JSON.stringify(proof, null, 2);
+          show(`Signed attestation.\naddress: ${proof.address}`);
+        } catch (err) {
+          fail('Build & sign attestation', err);
+        }
+      });
+
+      document
+        .getElementById('copy-att-json')
+        .addEventListener('click', () => copyField('att-json', 'JSON'));
+
+      // No transport in the verifier: fetchProvenance does the I/O. A 404
+      // (unknown txn) maps to null so verifyStake reports txn-not-found.
+      const fetchProvenance = async (txid) => {
+        const res = await fetch(`/api/transaction/${encodeURIComponent(txid)}`);
+        if (res.status === 404) {
+          return null;
+        }
+        if (!res.ok) {
+          throw new Error(`provenance fetch failed: HTTP ${res.status}`);
+        }
+        return res.json();
+      };
+
+      document
+        .getElementById('att-verify')
+        .addEventListener('click', async () => {
+          try {
+            const text =
+              document.getElementById('att-verify-text').value.trim();
+            if (!text) {
+              show('Nothing to verify — paste an attestation proof first.');
+              return;
+            }
+            const proof = JSON.parse(text);
+            const v = await verifyStake(proof, { fetchProvenance });
+            const lines = [
+              `valid: ${v.valid}`,
+              `signer: ${v.signer}`,
+              `signature: ${v.checks.signature}`,
+              `onchain: ${v.checks.onchain}`,
+              `consistent: ${v.checks.consistent}`,
+              `confirmations: ${v.confirmations}`,
+            ];
+            if (v.reasons.length) {
+              lines.push(`reasons: ${v.reasons.join(', ')}`);
+            }
+            show(lines.join('\n'));
+          } catch (err) {
+            fail('Verify attestation', err);
           }
         });
     </script>

--- a/clients/wallet/testdata/gc-attestation-vectors.json
+++ b/clients/wallet/testdata/gc-attestation-vectors.json
@@ -1,0 +1,39 @@
+[
+  {
+    "claim": {
+      "txid": "tx1",
+      "kind": "opposition",
+      "subject": "goblins",
+      "amount": 300
+    },
+    "timestamp": "1700002000",
+    "message": "{\"txid\":\"tx1\",\"kind\":\"opposition\",\"subject\":\"goblins\",\"amount\":300}",
+    "signature": "Yxm3Af98619VHrRB9uLeuy9oCYeRYaF6XGM+bs2wbXjHbKCO7sLXDYIqgim9fVpLHPXIFBLxeJFIhB8eSFKyzMlurtuVDI4+IYBPP6xxORN1q7XdCEFAwW7par7c/F2MzXgkBdRZti++lX3CtfEqKY7fGpekstk6IrG4rDLuEWxbmM1CDHMSvko1+VlO71E+RhxvMhi3wOsaoMToDUv2JqmK2WrnRZ6ndLLjR6WEH7tFKP0U4NBcRh4kaWRur0MKG4wNzaI57QUeVnAtIRYFZxGZM9QjJKptLugnoWWjGAM2ECCBbTdeV6RqslUGY/1I6tzxkFq/Rup6pfJfHIyKVA==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  },
+  {
+    "claim": {
+      "txid": "tx2",
+      "kind": "support",
+      "subject": "g\u00f6blins",
+      "amount": 100,
+      "handle": "me.bsky.social"
+    },
+    "timestamp": "1700002001",
+    "message": "{\"txid\":\"tx2\",\"kind\":\"support\",\"subject\":\"g\u00f6blins\",\"amount\":100,\"handle\":\"me.bsky.social\"}",
+    "signature": "APTIVloGspHqKMshTbS8uBq83VUL43EXutAGRCs7LaQWZtACFZ+C/lrH3mtLZ0HLbOs+1XMqVovG6UJBc5eHXeVP+BdC2uTlw6RNx+qw5btWW+SBiDJOUUi+8dDQ5AbzOgcK8heEA42bZc3CFxo5KklvaIz5Wrbmjtb9J21nHRk2c4GdLaIB0LCxy4vsk6zmvZkzFzz0wM+49sV1DHGf1ITUDp5QGEgz4VU4NY1En3/oEyIyvmbupbzCxiUUZcIyNd09NKfpN8wDBwsxQMkECULWj85VjxF+WDv4na7/Ke9O0vQ8xItdxA5rZ2R/IWc+mOGQRne4swXGSrd8fl22Kw==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  },
+  {
+    "claim": {
+      "txid": "tx3",
+      "kind": "transfer",
+      "address": "GCxGC",
+      "amount": 5
+    },
+    "timestamp": "1700002002",
+    "message": "{\"txid\":\"tx3\",\"kind\":\"transfer\",\"address\":\"GCxGC\",\"amount\":5}",
+    "signature": "WA5+cwtQqBLzdpEVpBUod3x6zxuvp/MiI+QeTtbV2auZWqaUuwPEpWxjG5GCl9pt03ba9m6NSBpnXR+lt8iisb8zkIbnEuJ9YhpsQO7QdiVZLa9B+Exb3DrsqmOQwGVvAkDm7SaK8zepSOC3CnIgEj/BDYn+D0NnB3KI9BcIc/zpLN8vXw+48ZAJWnD2qCdPDgQBVETW27wtn3txzpHivf1dmCFKyu40bnGCFRZUJOC1649KJL5gxKjTI9/MGGHDPfTZ7oPBeT9lV8moCTY82linQoEo3k2T/ue4n++R00rBOtJajBPIh9Io7K7jtpd/K1JHqYzsxjnqKv0tAkb4gQ==",
+    "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
+  }
+]

--- a/docs/superpowers/plans/2026-06-06-egu-3-stake-attestation.md
+++ b/docs/superpowers/plans/2026-06-06-egu-3-stake-attestation.md
@@ -1,0 +1,903 @@
+# EGU #3 / #176b — stake attestation + verifier — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce and verify a portable "Verified on GumptionChain" stake attestation that composes gc-msg-v1 signing (#2.4) + on-chain provenance (#176a) + a consistency check, in JS and Python, with a pure dependency-injected verifier.
+
+**Architecture:** A stake attestation is a gc-msg-v1 proof whose `message` is the canonical JSON of a claim `{txid, kind, subject|address, amount, handle?}`. New `gc-attestation.mjs` (JS) + `attestation.py` (Python) provide `buildStakeMessage`/`signStakeAttestation`/`parseStakeAttestation`/`verifyStake`. The verifier does no I/O: `fetchProvenance(txid)` is injected and MUST return the provenance object or `null` for not-found. Byte-identical canonical messages across languages are enforced by golden vectors.
+
+**Tech Stack:** Vanilla ESM + Web Crypto (Node 20+ `node --test`), Python 3.12 (pytest, ruff/mypy strict). Zero npm.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-egu-3-stake-attestation-design.md`
+
+**IMPORTANT (shell cwd):** run all commands from the repository root; use repo-root-relative paths in `git add`.
+
+---
+
+## File Structure
+
+- **Create** `clients/wallet/gc-attestation.mjs` — JS attestation API.
+- **Create** `clients/wallet/gc-attestation.test.mjs` — JS tests.
+- **Modify** `clients/wallet/gc-errors.mjs` — add `BadAttestationError`.
+- **Modify** `clients/wallet/index.mjs` — re-export new surface; bump `version` to `0.2.0`.
+- **Modify** `clients/wallet/package.json` — bump `version` to `0.2.0`.
+- **Modify** `clients/wallet/index.test.mjs` — add new symbols to the contract test.
+- **Create** `clients/wallet/attestation-cli.mjs` — build/sign/verify harness for parity.
+- **Create** `src/gumptionchain/attestation.py` — Python mirror.
+- **Create** `tests/test_attestation.py` — Python tests.
+- **Create** `tests/test_attestation_parity.py` — JS↔Python parity.
+- **Create** `tests/test_attestation_vectors.py` + `clients/wallet/testdata/gc-attestation-vectors.json` — golden vectors.
+- **Modify** `clients/wallet/passkey-wallet-demo.html` + `MANUAL-VERIFICATION.md`.
+
+JS tests: `node --test clients/wallet/*.test.mjs`. Python: `uv run pytest`.
+
+**Shared claim/kind rules** (used by both languages, keep identical):
+- `kind` ∈ {`opposition`, `support`, `rescind`, `transfer`}.
+- exactly one of `subject` (stake kinds) / `address` (transfer); the other absent.
+- `amount`: positive integer (grains).
+- `handle`: optional string.
+- Canonical message key order: `txid, kind, (subject|address), amount, handle?`; compact JSON; omit absent optionals; Python `ensure_ascii=False`.
+
+---
+
+### Task 1: JS attestation module
+
+**Files:**
+- Modify: `clients/wallet/gc-errors.mjs`
+- Create: `clients/wallet/gc-attestation.mjs`
+- Test: `clients/wallet/gc-attestation.test.mjs`
+
+- [ ] **Step 1: Add the typed error** — append to `clients/wallet/gc-errors.mjs`:
+
+```javascript
+// Input is not a structurally valid stake attestation (bad claim shape or a
+// proof whose message is not a parseable claim).
+export class BadAttestationError extends Error {}
+```
+
+- [ ] **Step 2: Write the failing tests** — create `clients/wallet/gc-attestation.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import {
+  buildStakeMessage, signStakeAttestation, parseStakeAttestation,
+  verifyStake, BadAttestationError,
+} from './gc-attestation.mjs';
+
+const TS = '1700002000';
+const CLAIM = { txid: 'tx1', kind: 'opposition', subject: 'goblins', amount: 300 };
+
+// A provenance object shaped like #176a's GET /transaction/<txid> response.
+function provenanceFor(address, { status = 'canonical', confirmations = 3 } = {}) {
+  return {
+    txid: 'tx1', address, status, confirmations,
+    outflows: [
+      { kind: 'opposition', subject: 'goblins', amount: 300 },
+      { kind: 'transfer', address: 'GCchangeGC', amount: 9700 },
+    ],
+  };
+}
+
+test('buildStakeMessage uses fixed key order, omits absent optionals', () => {
+  assert.equal(
+    buildStakeMessage(CLAIM),
+    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}',
+  );
+  assert.equal(
+    buildStakeMessage({ ...CLAIM, handle: 'me.bsky.social' }),
+    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+    + '"handle":"me.bsky.social"}',
+  );
+  assert.equal(
+    buildStakeMessage({ txid: 't', kind: 'transfer', address: 'GCxGC', amount: 5 }),
+    '{"txid":"t","kind":"transfer","address":"GCxGC","amount":5}',
+  );
+});
+
+test('buildStakeMessage rejects malformed claims', () => {
+  assert.throws(() => buildStakeMessage({ kind: 'opposition', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'nope', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', subject: 's', amount: 0 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', address: 'a', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'transfer', subject: 's', amount: 1 }), BadAttestationError);
+});
+
+test('sign -> parse round-trips the claim', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.deepEqual(parseStakeAttestation(proof), CLAIM);
+});
+
+test('parseStakeAttestation throws on a non-claim message', () => {
+  assert.throws(
+    () => parseStakeAttestation({ message: 'not json' }),
+    BadAttestationError,
+  );
+});
+
+test('verifyStake valid when signature + onchain + consistent all hold', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  const fetchProvenance = async () => provenanceFor(await w.address());
+  const v = await verifyStake(proof, { fetchProvenance });
+  assert.equal(v.valid, true);
+  assert.deepEqual(v.checks, { signature: true, onchain: true, consistent: true });
+  assert.equal(v.signer, await w.address());
+  assert.equal(v.confirmations, 3);
+  assert.deepEqual(v.reasons, []);
+});
+
+test('verifyStake reports bad-signature on a tampered claim', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  proof.message = buildStakeMessage({ ...CLAIM, amount: 999 });
+  const v = await verifyStake(proof, { fetchProvenance: async () => provenanceFor(await w.address()) });
+  assert.equal(v.valid, false);
+  assert.ok(v.reasons.includes('bad-signature'));
+});
+
+test('verifyStake reports txn-not-found, not-canonical, insufficient-confirmations', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+  const addr = await w.address();
+
+  const missing = await verifyStake(proof, { fetchProvenance: async () => null });
+  assert.equal(missing.valid, false);
+  assert.ok(missing.reasons.includes('txn-not-found'));
+
+  const orphaned = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor(addr, { status: 'orphaned' }),
+  });
+  assert.ok(orphaned.reasons.includes('not-canonical'));
+
+  const shallow = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor(addr, { confirmations: 1 }),
+    minConfirmations: 6,
+  });
+  assert.ok(shallow.reasons.includes('insufficient-confirmations'));
+});
+
+test('verifyStake reports signer-not-staker and claim-mismatch', async () => {
+  const w = await Wallet.generate();
+  const proof = await signStakeAttestation(w, CLAIM, { timestamp: TS });
+
+  const notStaker = await verifyStake(proof, {
+    fetchProvenance: async () => provenanceFor('GCsomeoneelseGC'),
+  });
+  assert.ok(notStaker.reasons.includes('signer-not-staker'));
+
+  const addr = await w.address();
+  const mismatch = await verifyStake(proof, {
+    fetchProvenance: async () => ({
+      txid: 'tx1', address: addr, status: 'canonical', confirmations: 3,
+      outflows: [{ kind: 'opposition', subject: 'orcs', amount: 300 }],
+    }),
+  });
+  assert.ok(mismatch.reasons.includes('claim-mismatch'));
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `node --test clients/wallet/gc-attestation.test.mjs`
+Expected: FAIL — module missing.
+
+- [ ] **Step 4: Implement** — create `clients/wallet/gc-attestation.mjs`:
+
+```javascript
+// "Verified on GumptionChain" stake attestations: a gc-msg-v1 proof whose
+// message is the canonical JSON of a stake claim. verifyStake composes the
+// signature (gc-msg-v1), on-chain provenance (injected fetchProvenance), and a
+// consistency check. Pure — no I/O. No dependencies beyond sibling modules.
+import { BadAttestationError } from './gc-errors.mjs';
+import { signMessage, verifyMessage } from './gc-message.mjs';
+
+const KINDS = new Set(['opposition', 'support', 'rescind', 'transfer']);
+
+export { BadAttestationError } from './gc-errors.mjs';
+
+function validateClaim(claim) {
+  if (!claim || typeof claim !== 'object') {
+    throw new BadAttestationError('claim must be an object');
+  }
+  const { txid, kind, subject, address, amount, handle } = claim;
+  if (typeof txid !== 'string' || !txid) {
+    throw new BadAttestationError('txid is required');
+  }
+  if (!KINDS.has(kind)) {
+    throw new BadAttestationError(`invalid kind: ${kind}`);
+  }
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new BadAttestationError('amount must be a positive integer (grains)');
+  }
+  if (kind === 'transfer') {
+    if (typeof address !== 'string' || !address) {
+      throw new BadAttestationError('transfer requires address');
+    }
+    if (subject !== undefined) {
+      throw new BadAttestationError('transfer must not set subject');
+    }
+  } else {
+    if (typeof subject !== 'string' || !subject) {
+      throw new BadAttestationError('stake requires subject');
+    }
+    if (address !== undefined) {
+      throw new BadAttestationError('stake must not set address');
+    }
+  }
+  if (handle !== undefined && handle !== null && typeof handle !== 'string') {
+    throw new BadAttestationError('handle must be a string');
+  }
+}
+
+export function buildStakeMessage(claim) {
+  validateClaim(claim);
+  const ordered = { txid: claim.txid, kind: claim.kind };
+  if (claim.kind === 'transfer') {
+    ordered.address = claim.address;
+  } else {
+    ordered.subject = claim.subject;
+  }
+  ordered.amount = claim.amount;
+  if (claim.handle !== undefined && claim.handle !== null) {
+    ordered.handle = claim.handle;
+  }
+  return JSON.stringify(ordered);
+}
+
+export async function signStakeAttestation(wallet, claim, { timestamp } = {}) {
+  return signMessage(wallet, buildStakeMessage(claim), { timestamp });
+}
+
+export function parseStakeAttestation(proof) {
+  if (!proof || typeof proof.message !== 'string') {
+    throw new BadAttestationError('proof has no message');
+  }
+  let claim;
+  try {
+    claim = JSON.parse(proof.message);
+  } catch {
+    throw new BadAttestationError('message is not a stake claim');
+  }
+  validateClaim(claim);
+  return claim;
+}
+
+function outflowMatches(outflows, claim) {
+  return (outflows || []).some(
+    (o) => o.kind === claim.kind
+      && o.amount === claim.amount
+      && (claim.kind === 'transfer'
+        ? o.address === claim.address
+        : o.subject === claim.subject),
+  );
+}
+
+// fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
+// for an unknown txn. The verifier performs no transport itself.
+export async function verifyStake(
+  proof,
+  { fetchProvenance, maxAge, minConfirmations } = {},
+) {
+  const claim = parseStakeAttestation(proof);
+  const reasons = [];
+  const checks = { signature: false, onchain: false, consistent: false };
+  const signer = proof.address;
+
+  const sig = await verifyMessage(proof, { maxAge });
+  if (sig.valid && sig.address === signer) {
+    checks.signature = true;
+  } else {
+    reasons.push(sig.reason === 'expired' ? 'expired' : 'bad-signature');
+  }
+
+  const provenance = await fetchProvenance(claim.txid);
+  if (!provenance) {
+    reasons.push('txn-not-found');
+  } else if (provenance.status !== 'canonical') {
+    reasons.push('not-canonical');
+  } else if (
+    minConfirmations !== undefined
+    && (provenance.confirmations ?? 0) < minConfirmations
+  ) {
+    reasons.push('insufficient-confirmations');
+  } else {
+    checks.onchain = true;
+  }
+
+  if (checks.signature && checks.onchain && provenance) {
+    if (provenance.address !== signer) {
+      reasons.push('signer-not-staker');
+    } else if (!outflowMatches(provenance.outflows, claim)) {
+      reasons.push('claim-mismatch');
+    } else {
+      checks.consistent = true;
+    }
+  }
+
+  return {
+    valid: checks.signature && checks.onchain && checks.consistent,
+    checks,
+    signer,
+    claim,
+    provenance: provenance ?? null,
+    confirmations: provenance?.confirmations ?? 0,
+    reasons,
+  };
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `node --test clients/wallet/gc-attestation.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/wallet/gc-errors.mjs clients/wallet/gc-attestation.mjs clients/wallet/gc-attestation.test.mjs
+git commit -m "feat(wallet): stake attestation + verifyStake (JS)"
+```
+
+---
+
+### Task 2: Barrel re-export + version bump
+
+**Files:**
+- Modify: `clients/wallet/index.mjs`, `clients/wallet/package.json`, `clients/wallet/index.test.mjs`
+
+- [ ] **Step 1: Update the contract test** — in `clients/wallet/index.test.mjs`, add the new functions to the `FUNCTIONS` array (`'signStakeAttestation', 'parseStakeAttestation', 'verifyStake'`) and `'BadAttestationError'` to the `ERRORS` array.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test clients/wallet/index.test.mjs`
+Expected: FAIL — barrel does not export them yet; version mismatch once bumped.
+
+- [ ] **Step 3: Re-export + bump** — in `clients/wallet/index.mjs`, change `export const version = '0.1.0';` to `export const version = '0.2.0';` and add:
+
+```javascript
+// Stake attestations (gc-msg-v1 + on-chain provenance composition)
+export {
+  signStakeAttestation, parseStakeAttestation, verifyStake,
+} from './gc-attestation.mjs';
+```
+
+and add `BadAttestationError` to the existing `gc-errors.mjs` re-export block. In `clients/wallet/package.json`, change `"version": "0.1.0"` to `"version": "0.2.0"`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test clients/wallet/index.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/wallet/index.mjs clients/wallet/package.json clients/wallet/index.test.mjs
+git commit -m "feat(wallet): export stake attestation API; bump wallet to 0.2.0"
+```
+
+---
+
+### Task 3: Python attestation module
+
+**Files:**
+- Create: `src/gumptionchain/attestation.py`
+- Test: `tests/test_attestation.py`
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_attestation.py`:
+
+```python
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import (
+    BadAttestationError,
+    build_stake_message,
+    parse_stake_attestation,
+    sign_stake_attestation,
+    verify_stake,
+)
+from gumptionchain.wallet import Wallet
+
+TS = '1700002000'
+CLAIM = {'txid': 'tx1', 'kind': 'opposition', 'subject': 'goblins', 'amount': 300}
+
+
+def _wallet() -> Wallet:
+    return Wallet(b58ks=VECTOR_WALLET_B58)
+
+
+def _provenance(address: str, status: str = 'canonical', confirmations: int = 3):
+    return {
+        'txid': 'tx1', 'address': address, 'status': status,
+        'confirmations': confirmations,
+        'outflows': [
+            {'kind': 'opposition', 'subject': 'goblins', 'amount': 300},
+            {'kind': 'transfer', 'address': 'GCchangeGC', 'amount': 9700},
+        ],
+    }
+
+
+def test_build_stake_message_order_and_omission() -> None:
+    assert build_stake_message(CLAIM) == (
+        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}'
+    )
+    assert build_stake_message({**CLAIM, 'handle': 'me.bsky.social'}) == (
+        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+        '"handle":"me.bsky.social"}'
+    )
+
+
+def test_build_stake_message_rejects_malformed() -> None:
+    with pytest.raises(BadAttestationError):
+        build_stake_message({'kind': 'opposition', 'subject': 's', 'amount': 1})
+    with pytest.raises(BadAttestationError):
+        build_stake_message({'txid': 't', 'kind': 'x', 'subject': 's', 'amount': 1})
+    with pytest.raises(BadAttestationError):
+        build_stake_message({'txid': 't', 'kind': 'opposition', 'subject': 's', 'amount': 0})
+
+
+def test_sign_then_parse_round_trips() -> None:
+    proof = sign_stake_attestation(_wallet(), CLAIM, timestamp=int(TS))
+    assert parse_stake_attestation(proof) == CLAIM
+
+
+def test_verify_stake_valid() -> None:
+    w = _wallet()
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+    v = verify_stake(proof, lambda _txid: _provenance(w.address))
+    assert v['valid'] is True
+    assert v['checks'] == {'signature': True, 'onchain': True, 'consistent': True}
+    assert v['signer'] == w.address
+    assert v['confirmations'] == 3
+    assert v['reasons'] == []
+
+
+def test_verify_stake_failure_reasons() -> None:
+    w = _wallet()
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+
+    assert 'txn-not-found' in verify_stake(proof, lambda _t: None)['reasons']
+    assert 'not-canonical' in verify_stake(
+        proof, lambda _t: _provenance(w.address, status='pending')
+    )['reasons']
+    assert 'insufficient-confirmations' in verify_stake(
+        proof, lambda _t: _provenance(w.address, confirmations=1),
+        min_confirmations=6,
+    )['reasons']
+    assert 'signer-not-staker' in verify_stake(
+        proof, lambda _t: _provenance('GCotherGC')
+    )['reasons']
+
+    bad = dict(proof)
+    bad['message'] = build_stake_message({**CLAIM, 'amount': 999})
+    assert 'bad-signature' in verify_stake(
+        proof if False else bad, lambda _t: _provenance(w.address)
+    )['reasons']
+
+    mismatch = {
+        'txid': 'tx1', 'address': w.address, 'status': 'canonical',
+        'confirmations': 3,
+        'outflows': [{'kind': 'opposition', 'subject': 'orcs', 'amount': 300}],
+    }
+    assert 'claim-mismatch' in verify_stake(
+        proof, lambda _t: mismatch
+    )['reasons']
+
+
+def test_parse_rejects_non_claim() -> None:
+    with pytest.raises(BadAttestationError):
+        parse_stake_attestation({'message': 'not json'})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_attestation.py -q`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement** — create `src/gumptionchain/attestation.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from gumptionchain.message import sign_message, verify_message
+from gumptionchain.wallet import Wallet
+
+KINDS = frozenset({'opposition', 'support', 'rescind', 'transfer'})
+
+
+class AttestationError(Exception):
+    """Base class for stake-attestation errors."""
+
+
+class BadAttestationError(AttestationError):
+    """Input is not a structurally valid stake attestation."""
+
+
+def _validate_claim(claim: Any) -> None:
+    if not isinstance(claim, dict):
+        msg = 'claim must be an object'
+        raise BadAttestationError(msg)
+    txid = claim.get('txid')
+    kind = claim.get('kind')
+    subject = claim.get('subject')
+    address = claim.get('address')
+    amount = claim.get('amount')
+    handle = claim.get('handle')
+    if not isinstance(txid, str) or not txid:
+        msg = 'txid is required'
+        raise BadAttestationError(msg)
+    if kind not in KINDS:
+        msg = f'invalid kind: {kind}'
+        raise BadAttestationError(msg)
+    if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
+        msg = 'amount must be a positive integer (grains)'
+        raise BadAttestationError(msg)
+    if kind == 'transfer':
+        if not isinstance(address, str) or not address:
+            msg = 'transfer requires address'
+            raise BadAttestationError(msg)
+        if subject is not None:
+            msg = 'transfer must not set subject'
+            raise BadAttestationError(msg)
+    else:
+        if not isinstance(subject, str) or not subject:
+            msg = 'stake requires subject'
+            raise BadAttestationError(msg)
+        if address is not None:
+            msg = 'stake must not set address'
+            raise BadAttestationError(msg)
+    if handle is not None and not isinstance(handle, str):
+        msg = 'handle must be a string'
+        raise BadAttestationError(msg)
+
+
+def build_stake_message(claim: dict[str, Any]) -> str:
+    _validate_claim(claim)
+    ordered: dict[str, Any] = {'txid': claim['txid'], 'kind': claim['kind']}
+    if claim['kind'] == 'transfer':
+        ordered['address'] = claim['address']
+    else:
+        ordered['subject'] = claim['subject']
+    ordered['amount'] = claim['amount']
+    if claim.get('handle') is not None:
+        ordered['handle'] = claim['handle']
+    return json.dumps(ordered, separators=(',', ':'), ensure_ascii=False)
+
+
+def sign_stake_attestation(
+    wallet: Wallet, claim: dict[str, Any], timestamp: int | None = None
+) -> dict[str, str]:
+    return sign_message(wallet, build_stake_message(claim), timestamp=timestamp)
+
+
+def parse_stake_attestation(proof: Any) -> dict[str, Any]:
+    if not isinstance(proof, dict) or not isinstance(proof.get('message'), str):
+        msg = 'proof has no message'
+        raise BadAttestationError(msg)
+    try:
+        claim = json.loads(proof['message'])
+    except ValueError as e:
+        msg = 'message is not a stake claim'
+        raise BadAttestationError(msg) from e
+    _validate_claim(claim)
+    return claim  # type: ignore[no-any-return]
+
+
+def _outflow_matches(outflows: list[dict[str, Any]], claim: dict[str, Any]) -> bool:
+    for o in outflows or []:
+        if o.get('kind') != claim['kind'] or o.get('amount') != claim['amount']:
+            continue
+        if claim['kind'] == 'transfer':
+            if o.get('address') == claim['address']:
+                return True
+        elif o.get('subject') == claim['subject']:
+            return True
+    return False
+
+
+def verify_stake(
+    proof: Any,
+    fetch_provenance: Callable[[str], dict[str, Any] | None],
+    max_age: int | None = None,
+    min_confirmations: int | None = None,
+) -> dict[str, Any]:
+    claim = parse_stake_attestation(proof)
+    reasons: list[str] = []
+    checks = {'signature': False, 'onchain': False, 'consistent': False}
+    signer = proof.get('address')
+
+    sig = verify_message(proof, max_age=max_age)
+    if sig.get('valid') and sig.get('address') == signer:
+        checks['signature'] = True
+    else:
+        reasons.append(
+            'expired' if sig.get('reason') == 'expired' else 'bad-signature'
+        )
+
+    provenance = fetch_provenance(claim['txid'])
+    if not provenance:
+        reasons.append('txn-not-found')
+    elif provenance.get('status') != 'canonical':
+        reasons.append('not-canonical')
+    elif (
+        min_confirmations is not None
+        and (provenance.get('confirmations') or 0) < min_confirmations
+    ):
+        reasons.append('insufficient-confirmations')
+    else:
+        checks['onchain'] = True
+
+    if checks['signature'] and checks['onchain'] and provenance:
+        if provenance.get('address') != signer:
+            reasons.append('signer-not-staker')
+        elif not _outflow_matches(provenance.get('outflows', []), claim):
+            reasons.append('claim-mismatch')
+        else:
+            checks['consistent'] = True
+
+    return {
+        'valid': all(checks.values()),
+        'checks': checks,
+        'signer': signer,
+        'claim': claim,
+        'provenance': provenance,
+        'confirmations': (provenance or {}).get('confirmations', 0),
+        'reasons': reasons,
+    }
+```
+
+- [ ] **Step 4: Run tests + lint/type**
+
+Run: `uv run pytest tests/test_attestation.py -q && uv run ruff check src/gumptionchain/attestation.py tests/test_attestation.py && uv run mypy`
+Expected: PASS; ruff/mypy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gumptionchain/attestation.py tests/test_attestation.py
+git commit -m "feat(attestation): stake attestation + verify_stake (Python)"
+```
+
+---
+
+### Task 4: Cross-language parity + golden vectors
+
+**Files:**
+- Create: `clients/wallet/attestation-cli.mjs`
+- Create: `tests/test_attestation_parity.py`
+- Create: `tests/test_attestation_vectors.py`
+- Create: `clients/wallet/testdata/gc-attestation-vectors.json`
+
+- [ ] **Step 1: Create the JS harness** — `clients/wallet/attestation-cli.mjs`:
+
+```javascript
+// Stake-attestation harness (test tool). Modes:
+//   build  '{claim}'                          -> canonical message string
+//   sign   '{"private_key_b58":..,"claim":{..},"timestamp":".."}' -> proof JSON
+//   verify '{"proof":{..},"provenance":{..}|null,"minConfirmations":..}' -> verdict
+import { Wallet } from './gc-wallet.mjs';
+import {
+  buildStakeMessage, signStakeAttestation, verifyStake,
+} from './gc-attestation.mjs';
+
+const mode = process.argv[2];
+const arg = JSON.parse(process.argv[3]);
+
+if (mode === 'build') {
+  process.stdout.write(buildStakeMessage(arg));
+} else if (mode === 'sign') {
+  const w = await Wallet.fromPrivateKeyB58(arg.private_key_b58);
+  const proof = await signStakeAttestation(w, arg.claim, { timestamp: arg.timestamp });
+  process.stdout.write(JSON.stringify(proof));
+} else if (mode === 'verify') {
+  const verdict = await verifyStake(arg.proof, {
+    fetchProvenance: async () => arg.provenance ?? null,
+    minConfirmations: arg.minConfirmations,
+  });
+  process.stdout.write(JSON.stringify(verdict));
+} else {
+  process.stderr.write(`unknown mode: ${mode}\n`);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Parity test** — `tests/test_attestation_parity.py`:
+
+```python
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import build_stake_message, sign_stake_attestation
+from gumptionchain.wallet import Wallet
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'attestation-cli.mjs'
+)
+TS = '1700002000'
+CLAIM = {'txid': 'tx1', 'kind': 'opposition', 'subject': 'göblins', 'amount': 300}
+
+
+def _node(mode: str, payload: dict) -> str:
+    out = subprocess.run(  # noqa: S603
+        ['node', str(CLI), mode, json.dumps(payload)],  # noqa: S607
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_canonical_message_is_byte_identical() -> None:
+    # Non-ASCII subject exercises ensure_ascii=False parity.
+    assert _node('build', CLAIM) == build_stake_message(CLAIM)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signed_attestation_verifies_in_python() -> None:
+    from gumptionchain.attestation import verify_stake
+
+    proof = json.loads(_node('sign', {
+        'private_key_b58': VECTOR_WALLET_B58, 'claim': CLAIM, 'timestamp': TS,
+    }))
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    prov = {
+        'txid': 'tx1', 'address': w.address, 'status': 'canonical',
+        'confirmations': 5,
+        'outflows': [{'kind': 'opposition', 'subject': 'göblins', 'amount': 300}],
+    }
+    assert verify_stake(proof, lambda _t: prov)['valid'] is True
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_python_signed_attestation_verifies_in_js() -> None:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+    prov = {
+        'txid': 'tx1', 'address': w.address, 'status': 'canonical',
+        'confirmations': 5,
+        'outflows': [{'kind': 'opposition', 'subject': 'göblins', 'amount': 300}],
+    }
+    verdict = json.loads(_node('verify', {'proof': proof, 'provenance': prov}))
+    assert verdict['valid'] is True
+```
+
+- [ ] **Step 3: Golden vectors** — `tests/test_attestation_vectors.py`:
+
+```python
+import json
+import os
+from pathlib import Path
+
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import build_stake_message, sign_stake_attestation
+from gumptionchain.wallet import Wallet
+
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients' / 'wallet' / 'testdata' / 'gc-attestation-vectors.json'
+)
+_CASES = [
+    {'claim': {'txid': 'tx1', 'kind': 'opposition', 'subject': 'goblins',
+               'amount': 300}, 'timestamp': '1700002000'},
+    {'claim': {'txid': 'tx2', 'kind': 'support', 'subject': 'göblins',
+               'amount': 100, 'handle': 'me.bsky.social'},
+     'timestamp': '1700002001'},
+    {'claim': {'txid': 'tx3', 'kind': 'transfer', 'address': 'GCxGC',
+               'amount': 5}, 'timestamp': '1700002002'},
+]
+
+
+def _expected() -> list[dict]:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    out = []
+    for c in _CASES:
+        proof = sign_stake_attestation(
+            w, c['claim'], timestamp=int(c['timestamp'])
+        )
+        out.append({
+            **c,
+            'message': build_stake_message(c['claim']),
+            'signature': proof['signature'],
+            'address': proof['address'],
+        })
+    return out
+
+
+def test_attestation_vectors_match() -> None:
+    expected = _expected()
+    if os.environ.get('GC_REGEN_VECTORS'):
+        VECTORS_PATH.write_text(json.dumps(expected, indent=2) + '\n')
+    assert json.loads(VECTORS_PATH.read_text()) == expected
+```
+
+Generate the file once: `GC_REGEN_VECTORS=1 uv run pytest tests/test_attestation_vectors.py -q`, then confirm a plain run passes.
+
+- [ ] **Step 4: JS golden-vector check** — append to `clients/wallet/gc-attestation.test.mjs`:
+
+```javascript
+import { readFileSync } from 'node:fs';
+
+test('JS canonical messages match the committed golden vectors', () => {
+  const vec = JSON.parse(readFileSync(
+    new URL('./testdata/gc-attestation-vectors.json', import.meta.url),
+  ));
+  for (const c of vec) {
+    assert.equal(buildStakeMessage(c.claim), c.message);
+  }
+});
+```
+
+(The signature columns are covered by the Python vector test + the live parity test; the JS check pins the byte-identical canonical message, which is the parity-critical part.)
+
+- [ ] **Step 5: Run everything**
+
+Run: `node --test clients/wallet/*.test.mjs && uv run pytest tests/test_attestation.py tests/test_attestation_parity.py tests/test_attestation_vectors.py -q`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/wallet/attestation-cli.mjs clients/wallet/testdata/gc-attestation-vectors.json clients/wallet/gc-attestation.test.mjs tests/test_attestation_parity.py tests/test_attestation_vectors.py
+git commit -m "test(attestation): JS<->Python parity + golden vectors"
+```
+
+---
+
+### Task 5: Demo + manual verification
+
+**Files:**
+- Modify: `clients/wallet/passkey-wallet-demo.html`, `clients/wallet/MANUAL-VERIFICATION.md`
+
+Browser-only glue; the logic is Node/pytest-covered.
+
+- [ ] **Step 1: Add stake-attestation UI** — import from `./index.mjs`:
+`import { signStakeAttestation, verifyStake } from './index.mjs';`
+Add a panel wired to the demo's `currentWallet`:
+- **Build & sign attestation:** inputs for `txid`, `kind`, `subject`, `amount` → `signStakeAttestation(currentWallet, claim)` → show the proof JSON (copyable).
+- **Verify attestation:** paste a proof → `verifyStake(proof, { fetchProvenance })` where `fetchProvenance(txid)` does `fetch('/api/transaction/' + txid)` (signed if the node requires reader auth; note in the page that a public node uses `READER_ADDRESSES=["*"]`), returning the JSON or `null` on 404 → render `valid` + the three checks + `reasons`/`confirmations`. Surface `BadAttestationError.message` via the existing `fail()` path.
+
+- [ ] **Step 2: Document** — add a "Stake attestation (#176b)" section to `MANUAL-VERIFICATION.md`: build+sign a claim for a real mined txid, verify it (expect `valid:true`, three checks green), then tamper the proof message and confirm `bad-signature`, and verify a non-canonical/unknown txid → the matching reason.
+
+- [ ] **Step 3: Verify modules parse**
+
+Run: `node --check clients/wallet/gc-attestation.mjs && node --check clients/wallet/attestation-cli.mjs`
+Expected: exit 0. Browser flow is the manual gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clients/wallet/passkey-wallet-demo.html clients/wallet/MANUAL-VERIFICATION.md
+git commit -m "docs(wallet): demo + manual steps for stake attestations"
+```
+
+---
+
+## Final verification (before finishing the branch)
+
+- [ ] `node --test clients/wallet/*.test.mjs` — all green.
+- [ ] `uv run pytest` — full suite green (attestation unit/parity/vectors included).
+- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
+- [ ] `uv run mypy` — no new errors.
+- [ ] Zero npm; `gc-attestation.mjs`/`attestation-cli.mjs` import only sibling `.mjs`.
+- [ ] `index.mjs` and `package.json` both at `0.2.0`; barrel contract test passes.
+
+## Self-review notes
+
+- **Spec coverage:** claim shape + grains + fixed-order canonical (Task 1/3); byte-exact parity via golden vectors + non-ASCII subject (Task 4); `signStakeAttestation`/`parseStakeAttestation`/`verifyStake` (1/3); DI `fetchProvenance`, no I/O; verdict `{valid, checks, signer, claim, provenance, confirmations, reasons}` with the six reason codes; `BadAttestationError` throw-vs-data split; barrel export + version bump (Task 2); demo/manual (Task 5). All mapped.
+- **Name/shape consistency:** JS `buildStakeMessage`/`signStakeAttestation`/`parseStakeAttestation`/`verifyStake` ↔ Python `build_stake_message`/`sign_stake_attestation`/`parse_stake_attestation`/`verify_stake`; identical claim keys, kind set, check names, and reason strings (`bad-signature`/`expired`/`txn-not-found`/`not-canonical`/`insufficient-confirmations`/`signer-not-staker`/`claim-mismatch`); canonical key order identical.
+- **No placeholders:** complete code for every module/test.
+- **Additive:** new modules + barrel re-export + version bump; no existing module behavior changed; no Python chain/endpoint change.

--- a/docs/superpowers/specs/2026-06-06-egu-3-stake-attestation-design.md
+++ b/docs/superpowers/specs/2026-06-06-egu-3-stake-attestation-design.md
@@ -1,0 +1,206 @@
+# EGU #3 / #176b — composed stake verifier + attestation convention — design
+
+**Date:** 2026-06-06
+**Status:** Approved — ready for implementation
+**Issue:** #184 (second slice of the verifiable stake card #176, EGU #3)
+**Type:** New client module (vanilla JS / ESM) + new Python library module —
+additive; no node endpoint, no schema/consensus change.
+
+## Summary
+
+Produce and verify a portable **stake attestation** — a "Verified on
+GumptionChain" claim that composes three independent guarantees:
+
+1. **Signature** (gc-msg-v1, #2.4) — the attestation is signed by address X.
+2. **On-chain** (#176a provenance, #183) — the referenced txn is canonical.
+3. **Consistency** — the signer is the on-chain staker, and an on-chain outflow
+   matches the claimed kind/subject/amount.
+
+Built in **both JS and Python** (parity, like #2.4). The verifier is
+**client-side** and does **no I/O**: the node-read transport is injected
+(`fetchProvenance`), so the verifier is pure and fully testable with a fake — the
+node stays a dumb data source and the module, not a central server, is the
+federation glue.
+
+Depends on #2.4 (#178, message signing) and #176a (#183, provenance lookup). The
+verify web page + Bluesky OG unfurl + handle-ownership proof are #176c (EGU #5),
+out of scope here.
+
+## The stake attestation
+
+A stake attestation **is** a gc-msg-v1 proof whose `message` is the canonical
+JSON of a **claim**:
+
+```json
+{ "txid": "…", "kind": "opposition", "subject": "goblins", "amount": 300, "handle": "me.bsky.social" }
+```
+
+- **`txid`** — the staking transaction's id.
+- **`kind`** — one of the provenance kinds: `opposition` | `support` | `rescind`
+  | `transfer`. (The verifiable-share use case centers on `opposition`/`support`,
+  but the convention accepts any.)
+- **`subject`** — for `opposition`/`support`/`rescind`. For `transfer`, use
+  **`address`** instead (exactly one of `subject`/`address`, matching the kind).
+- **`amount`** — in **grains** (integer; matches the on-chain/provenance unit
+  exactly — no float; GRIT formatting is the display layer's job).
+- **`handle`** — *optional* off-chain identity (e.g. a Bluesky handle). It is
+  inside the signed message, so it is tamper-evident; **ownership of the handle
+  is not verified here** (that bidirectional AT-Protocol check is #176c).
+
+Because the whole claim is the signed gc-msg-v1 message, every field is
+tamper-evident.
+
+### Canonical message — byte-exact cross-language (critical)
+
+`buildStakeMessage(claim)` MUST produce byte-identical output in JS and Python,
+or signatures will not cross-verify. Rules:
+
+- **Fixed key order:** `txid`, `kind`, then exactly one of `subject` / `address`
+  (per kind), then `amount`, then `handle` **only if present**. Absent optionals
+  are omitted entirely (not emitted as `null`).
+- **Compact separators, no whitespace.** JS: `JSON.stringify` over an object
+  literal built in that order. Python: `json.dumps(ordered_dict,
+  separators=(',', ':'), ensure_ascii=False)`.
+- **`ensure_ascii=False`** in Python is mandatory — JS `JSON.stringify` leaves
+  non-ASCII (UTF-8 subjects/handles) unescaped; Python's default would escape
+  them and break parity.
+- Golden vectors (a fixed key + fixed claims) are checked by both languages to
+  lock the bytes.
+
+## API (identical shape in both languages)
+
+- **`signStakeAttestation(wallet, claim, { timestamp? })` → proof** — validates
+  the claim shape, builds the canonical message, returns
+  `signMessage(wallet, buildStakeMessage(claim), { timestamp })`.
+- **`parseStakeAttestation(proof) → claim`** — `verifyMessage`-independent
+  structural parse: `JSON.parse(proof.message)`, validate required fields and the
+  kind/subject-or-address pairing; throw **`BadAttestationError`** on malformed
+  input.
+- **`verifyStake(proof, { fetchProvenance, maxAge?, minConfirmations? }) →
+  verdict`** — the composed check. `fetchProvenance(txid)` is an injected async
+  function returning the #176a provenance object (or `null`/throwing on 404).
+  The verifier performs no network/db I/O itself.
+
+`fetchProvenance` contract: `async (txid: string) => provenance | null`, where
+`provenance` is the #176a response `{ address, outflows:[{kind,
+subject|address, amount, …}], status, confirmations, … }`. Returning `null`
+(or a thrown not-found) means unknown txid.
+
+## Verdict
+
+```json
+{
+  "valid": true,
+  "checks": { "signature": true, "onchain": true, "consistent": true },
+  "signer": "GC…GC",
+  "claim": { "txid": "…", "kind": "opposition", "subject": "goblins", "amount": 300 },
+  "provenance": { "...#176a object..." },
+  "confirmations": 5,
+  "reasons": []
+}
+```
+
+Check semantics (evaluated in order; later checks still run so `reasons`
+accumulates a full picture):
+
+1. **signature** — `verifyMessage(proof)` returns `valid: true` **and** its
+   `address` equals `proof.address`. If `maxAge` is supplied it is passed through
+   to `verifyMessage`. Failure → `reasons += 'bad-signature'` (or `'expired'`).
+2. **onchain** — `prov = await fetchProvenance(claim.txid)`. `prov` exists and
+   `prov.status === 'canonical'`. If `minConfirmations` is supplied,
+   `prov.confirmations >= minConfirmations`. Failures →
+   `'txn-not-found'` / `'not-canonical'` / `'insufficient-confirmations'`.
+3. **consistent** — only meaningful when signature+onchain hold: `prov.address
+   === signer` (staker is the signer) **and** at least one outflow in
+   `prov.outflows` matches the claim — same `kind`, same `subject` (stake kinds)
+   or `address` (transfer), same `amount`. Failures → `'signer-not-staker'` /
+   `'claim-mismatch'`.
+
+`valid = signature && onchain && consistent`. `confirmations` mirrors
+`prov.confirmations` (or `0`/absent). The **verdict is data** — verification
+failures return `valid:false` with `reasons`; only structurally malformed input
+throws (`BadAttestationError`), mirroring `verifyMessage`'s split. The claim a
+caller sees in the verdict comes from the *signed* `proof.message` (not a
+caller-supplied claim), so it cannot be spoofed.
+
+## Components
+
+### JavaScript (`clients/wallet/`)
+
+- **`gc-attestation.mjs`** (new) — `buildStakeMessage`, `signStakeAttestation`,
+  `parseStakeAttestation`, `verifyStake`. Pure; reuses `gc-message`
+  (`signMessage`/`verifyMessage`).
+- **`gc-errors.mjs`** (modified) — add `BadAttestationError` (re-exported from
+  `gc-attestation`).
+- **`index.mjs`** (modified) — re-export the new public surface
+  (`signStakeAttestation`, `parseStakeAttestation`, `verifyStake`,
+  `BadAttestationError`); bump package `version`.
+
+### Python (`src/gumptionchain/`)
+
+- **`attestation.py`** (new) — `build_stake_message`, `sign_stake_attestation`,
+  `parse_stake_attestation`, `verify_stake`, `BadAttestationError` (subclass of
+  a module error). Reuses `message.py` (`sign_message`/`verify_message`).
+  `verify_stake(proof, fetch_provenance, max_age=None, min_confirmations=None)`
+  where `fetch_provenance` is a `Callable[[str], dict | None]`.
+
+## Testing
+
+- **JS (`node --test`, zero npm):**
+  - `buildStakeMessage` byte-exactness (fixed order, omitted optionals, UTF-8
+    subject/handle), and golden vectors.
+  - `signStakeAttestation` → `parseStakeAttestation` round-trip; malformed proof
+    / claim → `BadAttestationError`.
+  - `verifyStake` with a **fake `fetchProvenance`**: happy path (`valid:true`,
+    all checks); tampered claim → `bad-signature`; unknown txn → `txn-not-found`;
+    orphaned/pending provenance → `not-canonical`; `minConfirmations` not met →
+    `insufficient-confirmations`; provenance address ≠ signer →
+    `signer-not-staker`; amount/subject/kind mismatch → `claim-mismatch`;
+    matching against a txn with a **change-transfer** outflow present (the real
+    #176a shape).
+- **Python (`uv run pytest`):** the same matrix in `tests/test_attestation.py`
+  with a fake `fetch_provenance`.
+- **Cross-language parity (`tests/test_attestation_parity.py`, skipif no node):**
+  - byte-identical canonical messages (JS `message-cli`-style harness vs Python
+    `build_stake_message`) and golden vectors at
+    `clients/wallet/testdata/gc-attestation-vectors.json`.
+  - a JS-signed attestation verifies in Python and vice-versa, using a fake
+    provenance both sides agree on (no live node).
+- **Demo (manual):** extend `passkey-wallet-demo.html` — build+sign a stake
+  attestation, then verify it with a real `fetchProvenance` that GETs
+  `/api/transaction/<txid>`; documented in `MANUAL-VERIFICATION.md`.
+
+## Out of scope
+
+- **Handle ownership verification** (Bluesky/AT-Protocol bidirectional proof) —
+  #176c.
+- The **verify web page + OG unfurl / Bluesky delivery** — #176c (EGU #5 hub).
+- A node `/verify` endpoint (rejected: client-side composition by design).
+- Multi-chain / chain-id binding; GRIT formatting; encryption.
+
+## Decisions log
+
+- **Client-side verifier, injected `fetchProvenance`** (Q1) — pure, parity-
+  testable, decentralized; the node is a data source, the module is the glue.
+- **JS + Python parity** (Q2) — both can produce and verify attestations now;
+  symmetry with #2.4.
+- **Grains in the claim** — exact integer match with on-chain/provenance; GRIT is
+  display. Avoids a float units-mismatch bug class.
+- **Canonical JSON message, fixed key order + `ensure_ascii=False`** — guarantees
+  byte-identical cross-language signing; golden vectors enforce it.
+- **Claim is the signed message; verdict's claim comes from `proof.message`** —
+  no caller-supplied claim to spoof; everything is bound by the signature.
+- **`valid:false`+reasons vs. throw** — verification outcomes are data; only
+  malformed input is exceptional (mirrors `verifyMessage`).
+- **handle signed but ownership deferred** — tamper-evident now; bidirectional
+  proof is #176c.
+
+## Definition of done
+
+- `gc-attestation.mjs` (4-function API) + `BadAttestationError` + `index.mjs`
+  re-export/version bump; Python `attestation.py` mirror.
+- JS tests + Python tests + cross-language parity (canonical bytes, golden
+  vectors, JS↔Python verify with a fake provenance) pass; full `uv run pytest`
+  green; `ruff`/`mypy` clean; zero npm.
+- Demo + `MANUAL-VERIFICATION.md` updated for sign/verify of a stake attestation.
+- No node endpoint, no schema/consensus change. Part of #176.

--- a/src/gumptionchain/attestation.py
+++ b/src/gumptionchain/attestation.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from gumptionchain.message import sign_message, verify_message
+from gumptionchain.wallet import Wallet
+
+KINDS = frozenset({'opposition', 'support', 'rescind', 'transfer'})
+
+
+class AttestationError(Exception):
+    """Base class for stake-attestation errors."""
+
+
+class BadAttestationError(AttestationError):
+    """Input is not a structurally valid stake attestation."""
+
+
+def _validate_claim(claim: Any) -> None:
+    if not isinstance(claim, dict):
+        msg = 'claim must be an object'
+        raise BadAttestationError(msg)
+    txid = claim.get('txid')
+    kind = claim.get('kind')
+    subject = claim.get('subject')
+    address = claim.get('address')
+    amount = claim.get('amount')
+    handle = claim.get('handle')
+    if not isinstance(txid, str) or not txid:
+        msg = 'txid is required'
+        raise BadAttestationError(msg)
+    if kind not in KINDS:
+        msg = f'invalid kind: {kind}'
+        raise BadAttestationError(msg)
+    if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
+        msg = 'amount must be a positive integer (grains)'
+        raise BadAttestationError(msg)
+    if kind == 'transfer':
+        if not isinstance(address, str) or not address:
+            msg = 'transfer requires address'
+            raise BadAttestationError(msg)
+        if subject is not None:
+            msg = 'transfer must not set subject'
+            raise BadAttestationError(msg)
+    else:
+        if not isinstance(subject, str) or not subject:
+            msg = 'stake requires subject'
+            raise BadAttestationError(msg)
+        if address is not None:
+            msg = 'stake must not set address'
+            raise BadAttestationError(msg)
+    if handle is not None and not isinstance(handle, str):
+        msg = 'handle must be a string'
+        raise BadAttestationError(msg)
+
+
+def build_stake_message(claim: dict[str, Any]) -> str:
+    _validate_claim(claim)
+    ordered: dict[str, Any] = {'txid': claim['txid'], 'kind': claim['kind']}
+    if claim['kind'] == 'transfer':
+        ordered['address'] = claim['address']
+    else:
+        ordered['subject'] = claim['subject']
+    ordered['amount'] = claim['amount']
+    if claim.get('handle') is not None:
+        ordered['handle'] = claim['handle']
+    return json.dumps(ordered, separators=(',', ':'), ensure_ascii=False)
+
+
+def sign_stake_attestation(
+    wallet: Wallet, claim: dict[str, Any], timestamp: int | None = None
+) -> dict[str, str]:
+    return sign_message(wallet, build_stake_message(claim), timestamp=timestamp)
+
+
+def parse_stake_attestation(proof: Any) -> dict[str, Any]:
+    if not isinstance(proof, dict) or not isinstance(proof.get('message'), str):
+        msg = 'proof has no message'
+        raise BadAttestationError(msg)
+    try:
+        claim = json.loads(proof['message'])
+    except ValueError as e:
+        msg = 'message is not a stake claim'
+        raise BadAttestationError(msg) from e
+    _validate_claim(claim)
+    return claim  # type: ignore[no-any-return]
+
+
+def _outflow_matches(
+    outflows: list[dict[str, Any]], claim: dict[str, Any]
+) -> bool:
+    for o in outflows or []:
+        if o.get('kind') != claim['kind'] or o.get('amount') != claim['amount']:
+            continue
+        if claim['kind'] == 'transfer':
+            if o.get('address') == claim['address']:
+                return True
+        elif o.get('subject') == claim['subject']:
+            return True
+    return False
+
+
+def verify_stake(
+    proof: Any,
+    fetch_provenance: Callable[[str], dict[str, Any] | None],
+    max_age: int | None = None,
+    min_confirmations: int | None = None,
+) -> dict[str, Any]:
+    claim = parse_stake_attestation(proof)
+    reasons: list[str] = []
+    checks = {'signature': False, 'onchain': False, 'consistent': False}
+    signer = proof.get('address')
+
+    sig = verify_message(proof, max_age=max_age)
+    if sig.get('valid') and sig.get('address') == signer:
+        checks['signature'] = True
+    else:
+        reasons.append(
+            'expired' if sig.get('reason') == 'expired' else 'bad-signature'
+        )
+
+    provenance = fetch_provenance(claim['txid'])
+    if not provenance:
+        reasons.append('txn-not-found')
+    elif provenance.get('status') != 'canonical':
+        reasons.append('not-canonical')
+    elif (
+        min_confirmations is not None
+        and (provenance.get('confirmations') or 0) < min_confirmations
+    ):
+        reasons.append('insufficient-confirmations')
+    else:
+        checks['onchain'] = True
+
+    if checks['signature'] and checks['onchain'] and provenance:
+        if provenance.get('address') != signer:
+            reasons.append('signer-not-staker')
+        elif not _outflow_matches(provenance.get('outflows', []), claim):
+            reasons.append('claim-mismatch')
+        else:
+            checks['consistent'] = True
+
+    return {
+        'valid': all(checks.values()),
+        'checks': checks,
+        'signer': signer,
+        'claim': claim,
+        'provenance': provenance,
+        'confirmations': (provenance or {}).get('confirmations', 0),
+        'reasons': reasons,
+    }

--- a/src/gumptionchain/attestation.py
+++ b/src/gumptionchain/attestation.py
@@ -85,6 +85,13 @@ def parse_stake_attestation(proof: Any) -> dict[str, Any]:
         msg = 'message is not a stake claim'
         raise BadAttestationError(msg) from e
     _validate_claim(claim)
+    # Require canonical encoding: the signed message must be exactly what
+    # build_stake_message emits for this claim. Rejects non-canonical forms
+    # (a float amount like 300.0, reordered keys, extra fields, whitespace)
+    # so JS and Python agree on accept/reject for any signable input.
+    if build_stake_message(claim) != proof['message']:
+        msg = 'non-canonical stake claim encoding'
+        raise BadAttestationError(msg)
     return claim  # type: ignore[no-any-return]
 
 
@@ -122,7 +129,7 @@ def verify_stake(
         )
 
     provenance = fetch_provenance(claim['txid'])
-    if not provenance:
+    if provenance is None:
         reasons.append('txn-not-found')
     elif provenance.get('status') != 'canonical':
         reasons.append('not-canonical')

--- a/src/gumptionchain/attestation.py
+++ b/src/gumptionchain/attestation.py
@@ -4,7 +4,11 @@ import json
 from collections.abc import Callable
 from typing import Any
 
-from gumptionchain.message import sign_message, verify_message
+from gumptionchain.message import (
+    BadProofError,
+    sign_message,
+    verify_message,
+)
 from gumptionchain.wallet import Wallet
 
 KINDS = frozenset({'opposition', 'support', 'rescind', 'transfer'})
@@ -41,14 +45,16 @@ def _validate_claim(claim: Any) -> None:
         if not isinstance(address, str) or not address:
             msg = 'transfer requires address'
             raise BadAttestationError(msg)
-        if subject is not None:
+        # Reject the off-side key by presence (matching JS's !== undefined),
+        # so {'kind':'transfer', 'subject': None} is rejected, not ignored.
+        if 'subject' in claim:
             msg = 'transfer must not set subject'
             raise BadAttestationError(msg)
     else:
         if not isinstance(subject, str) or not subject:
             msg = 'stake requires subject'
             raise BadAttestationError(msg)
-        if address is not None:
+        if 'address' in claim:
             msg = 'stake must not set address'
             raise BadAttestationError(msg)
     if handle is not None and not isinstance(handle, str):
@@ -115,12 +121,22 @@ def verify_stake(
     max_age: int | None = None,
     min_confirmations: int | None = None,
 ) -> dict[str, Any]:
+    # fetch_provenance(txid) MUST return the #176a provenance dict, or None for
+    # an unknown txn; mapping a 404 to None is the injected adapter's job.
+    # Genuine transport errors propagate by design — they must NOT be
+    # misreported as 'txn-not-found' (which would mark a real canonical stake
+    # unverifiable).
     claim = parse_stake_attestation(proof)
     reasons: list[str] = []
     checks = {'signature': False, 'onchain': False, 'consistent': False}
     signer = proof.get('address')
 
-    sig = verify_message(proof, max_age=max_age)
+    try:
+        sig = verify_message(proof, max_age=max_age)
+    except BadProofError as e:
+        # A malformed gc-msg-v1 envelope is a malformed attestation.
+        msg = 'attestation is not a valid gc-msg-v1 proof'
+        raise BadAttestationError(msg) from e
     if sig.get('valid') and sig.get('address') == signer:
         checks['signature'] = True
     else:

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,129 @@
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import (
+    BadAttestationError,
+    build_stake_message,
+    parse_stake_attestation,
+    sign_stake_attestation,
+    verify_stake,
+)
+from gumptionchain.wallet import Wallet
+
+TS = '1700002000'
+CLAIM = {
+    'txid': 'tx1',
+    'kind': 'opposition',
+    'subject': 'goblins',
+    'amount': 300,
+}
+
+
+def _wallet() -> Wallet:
+    return Wallet(b58ks=VECTOR_WALLET_B58)
+
+
+def _provenance(
+    address: str, status: str = 'canonical', confirmations: int = 3
+):
+    return {
+        'txid': 'tx1',
+        'address': address,
+        'status': status,
+        'confirmations': confirmations,
+        'outflows': [
+            {'kind': 'opposition', 'subject': 'goblins', 'amount': 300},
+            {'kind': 'transfer', 'address': 'GCchangeGC', 'amount': 9700},
+        ],
+    }
+
+
+def test_build_stake_message_order_and_omission() -> None:
+    assert build_stake_message(CLAIM) == (
+        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}'
+    )
+    assert build_stake_message({**CLAIM, 'handle': 'me.bsky.social'}) == (
+        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+        '"handle":"me.bsky.social"}'
+    )
+
+
+def test_build_stake_message_rejects_malformed() -> None:
+    with pytest.raises(BadAttestationError):
+        build_stake_message({'kind': 'opposition', 'subject': 's', 'amount': 1})
+    with pytest.raises(BadAttestationError):
+        build_stake_message(
+            {'txid': 't', 'kind': 'x', 'subject': 's', 'amount': 1}
+        )
+    with pytest.raises(BadAttestationError):
+        build_stake_message(
+            {'txid': 't', 'kind': 'opposition', 'subject': 's', 'amount': 0}
+        )
+
+
+def test_sign_then_parse_round_trips() -> None:
+    proof = sign_stake_attestation(_wallet(), CLAIM, timestamp=int(TS))
+    assert parse_stake_attestation(proof) == CLAIM
+
+
+def test_verify_stake_valid() -> None:
+    w = _wallet()
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+    v = verify_stake(proof, lambda _txid: _provenance(w.address))
+    assert v['valid'] is True
+    assert v['checks'] == {
+        'signature': True,
+        'onchain': True,
+        'consistent': True,
+    }
+    assert v['signer'] == w.address
+    assert v['confirmations'] == 3
+    assert v['reasons'] == []
+
+
+def test_verify_stake_failure_reasons() -> None:
+    w = _wallet()
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+
+    assert 'txn-not-found' in verify_stake(proof, lambda _t: None)['reasons']
+    assert (
+        'not-canonical'
+        in verify_stake(
+            proof, lambda _t: _provenance(w.address, status='pending')
+        )['reasons']
+    )
+    assert (
+        'insufficient-confirmations'
+        in verify_stake(
+            proof,
+            lambda _t: _provenance(w.address, confirmations=1),
+            min_confirmations=6,
+        )['reasons']
+    )
+    assert (
+        'signer-not-staker'
+        in verify_stake(proof, lambda _t: _provenance('GCotherGC'))['reasons']
+    )
+
+    bad = dict(proof)
+    bad['message'] = build_stake_message({**CLAIM, 'amount': 999})
+    assert (
+        'bad-signature'
+        in verify_stake(bad, lambda _t: _provenance(w.address))['reasons']
+    )
+
+    mismatch = {
+        'txid': 'tx1',
+        'address': w.address,
+        'status': 'canonical',
+        'confirmations': 3,
+        'outflows': [{'kind': 'opposition', 'subject': 'orcs', 'amount': 300}],
+    }
+    assert (
+        'claim-mismatch' in verify_stake(proof, lambda _t: mismatch)['reasons']
+    )
+
+
+def test_parse_rejects_non_claim() -> None:
+    with pytest.raises(BadAttestationError):
+        parse_stake_attestation({'message': 'not json'})

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -127,3 +127,22 @@ def test_verify_stake_failure_reasons() -> None:
 def test_parse_rejects_non_claim() -> None:
     with pytest.raises(BadAttestationError):
         parse_stake_attestation({'message': 'not json'})
+
+
+def test_parse_rejects_non_canonical() -> None:
+    # float amount (json.loads -> 300.0): non-int / non-canonical
+    with pytest.raises(BadAttestationError):
+        parse_stake_attestation(
+            {
+                'message': '{"txid":"tx1","kind":"opposition",'
+                '"subject":"goblins","amount":300.0}'
+            }
+        )
+    # reordered keys -> non-canonical encoding
+    with pytest.raises(BadAttestationError):
+        parse_stake_attestation(
+            {
+                'message': '{"kind":"opposition","txid":"tx1",'
+                '"subject":"goblins","amount":300}'
+            }
+        )

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -146,3 +146,35 @@ def test_parse_rejects_non_canonical() -> None:
                 '"subject":"goblins","amount":300}'
             }
         )
+
+
+def test_validate_rejects_present_offside_key() -> None:
+    # off-side key present (even as None) is rejected, matching JS
+    with pytest.raises(BadAttestationError):
+        build_stake_message(
+            {
+                'txid': 't',
+                'kind': 'transfer',
+                'address': 'a',
+                'amount': 1,
+                'subject': None,
+            }
+        )
+    with pytest.raises(BadAttestationError):
+        build_stake_message(
+            {
+                'txid': 't',
+                'kind': 'opposition',
+                'subject': 's',
+                'amount': 1,
+                'address': None,
+            }
+        )
+
+
+def test_verify_stake_wraps_bad_proof_envelope() -> None:
+    w = _wallet()
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+    proof['scheme'] = 'gc-sig-v1'  # malformed gc-msg-v1 envelope
+    with pytest.raises(BadAttestationError):
+        verify_stake(proof, lambda _t: _provenance(w.address))

--- a/tests/test_attestation_parity.py
+++ b/tests/test_attestation_parity.py
@@ -1,0 +1,86 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import (
+    build_stake_message,
+    sign_stake_attestation,
+    verify_stake,
+)
+from gumptionchain.wallet import Wallet
+
+CLI = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'attestation-cli.mjs'
+)
+TS = '1700002000'
+CLAIM = {
+    'txid': 'tx1',
+    'kind': 'opposition',
+    'subject': 'göblins',
+    'amount': 300,
+}
+
+
+def _node(mode: str, payload: dict) -> str:
+    out = subprocess.run(  # noqa: S603
+        ['node', str(CLI), mode, json.dumps(payload)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_canonical_message_is_byte_identical() -> None:
+    # Non-ASCII subject exercises ensure_ascii=False parity.
+    assert _node('build', CLAIM) == build_stake_message(CLAIM)
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_js_signed_attestation_verifies_in_python() -> None:
+    proof = json.loads(
+        _node(
+            'sign',
+            {
+                'private_key_b58': VECTOR_WALLET_B58,
+                'claim': CLAIM,
+                'timestamp': TS,
+            },
+        )
+    )
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    prov = {
+        'txid': 'tx1',
+        'address': w.address,
+        'status': 'canonical',
+        'confirmations': 5,
+        'outflows': [
+            {'kind': 'opposition', 'subject': 'göblins', 'amount': 300}
+        ],
+    }
+    assert verify_stake(proof, lambda _t: prov)['valid'] is True
+
+
+@pytest.mark.skipif(shutil.which('node') is None, reason='node not installed')
+def test_python_signed_attestation_verifies_in_js() -> None:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
+    prov = {
+        'txid': 'tx1',
+        'address': w.address,
+        'status': 'canonical',
+        'confirmations': 5,
+        'outflows': [
+            {'kind': 'opposition', 'subject': 'göblins', 'amount': 300}
+        ],
+    }
+    verdict = json.loads(_node('verify', {'proof': proof, 'provenance': prov}))
+    assert verdict['valid'] is True

--- a/tests/test_attestation_vectors.py
+++ b/tests/test_attestation_vectors.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import Path
+
+from test_browser_wallet_vectors import VECTOR_WALLET_B58
+
+from gumptionchain.attestation import (
+    build_stake_message,
+    sign_stake_attestation,
+)
+from gumptionchain.wallet import Wallet
+
+VECTORS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'clients'
+    / 'wallet'
+    / 'testdata'
+    / 'gc-attestation-vectors.json'
+)
+_CASES = [
+    {
+        'claim': {
+            'txid': 'tx1',
+            'kind': 'opposition',
+            'subject': 'goblins',
+            'amount': 300,
+        },
+        'timestamp': '1700002000',
+    },
+    {
+        'claim': {
+            'txid': 'tx2',
+            'kind': 'support',
+            'subject': 'göblins',
+            'amount': 100,
+            'handle': 'me.bsky.social',
+        },
+        'timestamp': '1700002001',
+    },
+    {
+        'claim': {
+            'txid': 'tx3',
+            'kind': 'transfer',
+            'address': 'GCxGC',
+            'amount': 5,
+        },
+        'timestamp': '1700002002',
+    },
+]
+
+
+def _expected() -> list[dict]:
+    w = Wallet(b58ks=VECTOR_WALLET_B58)
+    out = []
+    for c in _CASES:
+        proof = sign_stake_attestation(
+            w, c['claim'], timestamp=int(c['timestamp'])
+        )
+        out.append(
+            {
+                **c,
+                'message': build_stake_message(c['claim']),
+                'signature': proof['signature'],
+                'address': proof['address'],
+            }
+        )
+    return out
+
+
+def test_attestation_vectors_match() -> None:
+    expected = _expected()
+    if os.environ.get('GC_REGEN_VECTORS'):
+        VECTORS_PATH.write_text(json.dumps(expected, indent=2) + '\n')
+    assert json.loads(VECTORS_PATH.read_text()) == expected


### PR DESCRIPTION
## Summary
EGU #3 / #176b (#184) — the "Verified on GumptionChain" engine. Composes gc-msg-v1 signing (#2.4) + on-chain provenance (#176a, #183) + a consistency check into a portable stake attestation, in **both JS and Python**, with a **pure dependency-injected** verifier (no I/O).

- **Attestation** = a gc-msg-v1 proof whose `message` is the canonical JSON of a claim `{txid, kind, subject|address, amount, handle?}` (amount in grains; handle signed but ownership not verified here).
- **API (both langs):** `buildStakeMessage`/`signStakeAttestation`/`parseStakeAttestation`/`verifyStake` (JS) ↔ `build_stake_message`/`sign_stake_attestation`/`parse_stake_attestation`/`verify_stake` (Python).
- **`verifyStake(proof, {fetchProvenance, maxAge?, minConfirmations?})`** → `{valid, checks:{signature, onchain, consistent}, signer, claim, provenance, confirmations, reasons[]}`. `fetchProvenance(txid)` is injected (caller supplies transport); the verifier does no network/db I/O.
- **Three checks:** signature (gc-msg-v1) · onchain (provenance is canonical, optional minConfirmations) · consistent (signer == on-chain staker **and** an outflow matches kind+subject/address+amount). The verdict's `claim` is read from the **signed** message, so it can't be spoofed.
- **Cross-language byte-exactness:** `buildStakeMessage` emits identical bytes in both langs (fixed key order, compact separators, omit absent optionals, Python `ensure_ascii=False`), enforced by golden vectors + a non-ASCII (`göblins`) parity test. `parse` additionally requires the signed message to be canonical, so JS and Python agree on accept/reject for any signable input (incl. float amounts).
- Barrel `index.mjs` re-exports the new surface; wallet package bumped to **0.2.0**.

## Test Plan
- [x] `node --test clients/wallet/*.test.mjs` — 70/70.
- [x] `uv run pytest` — 385 passed, 1 skipped (attestation unit + JS↔Python live parity + golden vectors).
- [x] `uv run ruff check/format`, `uv run mypy` — clean.
- [x] Spec-compliance review (SPEC COMPLIANT) + code-quality review (APPROVED). Two cross-language divergences found and fixed: float-amount accept/reject parity (canonical-encoding check on parse, both langs) and provenance falsiness alignment; parity tests added.
- [x] No node endpoint, no schema/consensus change; additive only.

Spec: `docs/superpowers/specs/2026-06-06-egu-3-stake-attestation-design.md`
Plan: `docs/superpowers/plans/2026-06-06-egu-3-stake-attestation.md`

Closes #184. Second slice of #176 (EGU #3) — only the verify page + OG unfurl (#176c, EGU #5) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)