### PR TITLE
fix(attestation): enforce txid as 64-char hex digest (#187)

### DIFF
--- a/clients/wallet/gc-attestation.mjs
+++ b/clients/wallet/gc-attestation.mjs
@@ -7,6 +7,13 @@ import { signMessage, verifyMessage } from './gc-message.mjs';
 
 const KINDS = new Set(['opposition', 'support', 'rescind', 'transfer']);
 
+// A txid is a transaction's mill hash: 64-char lowercase hex. Validating the
+// canonical shape here (not just "non-empty string") rejects a malformed txid
+// as a bad attestation up front, instead of letting it slip through to a
+// provenance fetch that 404s and gets mis-reported as 'txn-not-found'. Kept in
+// lockstep with the Python validator's _TXID_RE in attestation.py.
+const TXID_RE = /^[0-9a-f]{64}$/;
+
 export { BadAttestationError } from './gc-errors.mjs';
 
 function validateClaim(claim) {
@@ -14,8 +21,8 @@ function validateClaim(claim) {
     throw new BadAttestationError('claim must be an object');
   }
   const { txid, kind, subject, address, amount, handle } = claim;
-  if (typeof txid !== 'string' || !txid) {
-    throw new BadAttestationError('txid is required');
+  if (typeof txid !== 'string' || !TXID_RE.test(txid)) {
+    throw new BadAttestationError('txid must be a 64-char hex digest');
   }
   if (!KINDS.has(kind)) {
     throw new BadAttestationError(`invalid kind: ${kind}`);

--- a/clients/wallet/gc-attestation.test.mjs
+++ b/clients/wallet/gc-attestation.test.mjs
@@ -8,12 +8,14 @@ import {
 } from './gc-attestation.mjs';
 
 const TS = '1700002000';
-const CLAIM = { txid: 'tx1', kind: 'opposition', subject: 'goblins', amount: 300 };
+// A canonical txid is a 64-char lowercase-hex mill hash.
+const TX = '1'.repeat(64);
+const CLAIM = { txid: TX, kind: 'opposition', subject: 'goblins', amount: 300 };
 
 // A provenance object shaped like #176a's GET /transaction/<txid> response.
 function provenanceFor(address, { status = 'canonical', confirmations = 3 } = {}) {
   return {
-    txid: 'tx1', address, status, confirmations,
+    txid: TX, address, status, confirmations,
     outflows: [
       { kind: 'opposition', subject: 'goblins', amount: 300 },
       { kind: 'transfer', address: 'GCchangeGC', amount: 9700 },
@@ -24,25 +26,40 @@ function provenanceFor(address, { status = 'canonical', confirmations = 3 } = {}
 test('buildStakeMessage uses fixed key order, omits absent optionals', () => {
   assert.equal(
     buildStakeMessage(CLAIM),
-    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}',
+    `{"txid":"${TX}","kind":"opposition","subject":"goblins","amount":300}`,
   );
   assert.equal(
     buildStakeMessage({ ...CLAIM, handle: 'me.bsky.social' }),
-    '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+    `{"txid":"${TX}","kind":"opposition","subject":"goblins","amount":300,`
     + '"handle":"me.bsky.social"}',
   );
   assert.equal(
-    buildStakeMessage({ txid: 't', kind: 'transfer', address: 'GCxGC', amount: 5 }),
-    '{"txid":"t","kind":"transfer","address":"GCxGC","amount":5}',
+    buildStakeMessage({ txid: TX, kind: 'transfer', address: 'GCxGC', amount: 5 }),
+    `{"txid":"${TX}","kind":"transfer","address":"GCxGC","amount":5}`,
   );
 });
 
 test('buildStakeMessage rejects malformed claims', () => {
   assert.throws(() => buildStakeMessage({ kind: 'opposition', subject: 's', amount: 1 }), BadAttestationError);
-  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'nope', subject: 's', amount: 1 }), BadAttestationError);
-  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', subject: 's', amount: 0 }), BadAttestationError);
-  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'opposition', address: 'a', amount: 1 }), BadAttestationError);
-  assert.throws(() => buildStakeMessage({ txid: 't', kind: 'transfer', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: TX, kind: 'nope', subject: 's', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: TX, kind: 'opposition', subject: 's', amount: 0 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: TX, kind: 'opposition', address: 'a', amount: 1 }), BadAttestationError);
+  assert.throws(() => buildStakeMessage({ txid: TX, kind: 'transfer', subject: 's', amount: 1 }), BadAttestationError);
+});
+
+test('buildStakeMessage rejects a malformed txid', () => {
+  // Not 64-char lowercase hex -> rejected up front (see #187), so a malformed
+  // txid can't slip through to a provenance fetch and be mis-read as not-found.
+  for (const bad of [
+    'tx1', 'g'.repeat(64), '1'.repeat(63), '1'.repeat(65),
+    'A'.repeat(64), `${'1'.repeat(63)}/`,
+  ]) {
+    assert.throws(() => buildStakeMessage({ ...CLAIM, txid: bad }), BadAttestationError);
+  }
+  assert.ok(
+    buildStakeMessage({ ...CLAIM, txid: 'a'.repeat(64) })
+      .startsWith(`{"txid":"${'a'.repeat(64)}"`),
+  );
 });
 
 test('sign -> parse round-trips the claim', async () => {
@@ -63,21 +80,21 @@ test('parseStakeAttestation rejects non-canonical encodings', () => {
   // float amount (JSON.parse coerces 300.0 -> 300; rebuild differs)
   assert.throws(() => parseStakeAttestation({
     message:
-      '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300.0}',
+      `{"txid":"${TX}","kind":"opposition","subject":"goblins","amount":300.0}`,
   }), BadAttestationError);
   // reordered keys
   assert.throws(() => parseStakeAttestation({
     message:
-      '{"kind":"opposition","txid":"tx1","subject":"goblins","amount":300}',
+      `{"kind":"opposition","txid":"${TX}","subject":"goblins","amount":300}`,
   }), BadAttestationError);
 });
 
 test('buildStakeMessage rejects a present off-side key (even null)', () => {
   assert.throws(() => buildStakeMessage(
-    { txid: 't', kind: 'transfer', address: 'a', amount: 1, subject: null },
+    { txid: TX, kind: 'transfer', address: 'a', amount: 1, subject: null },
   ), BadAttestationError);
   assert.throws(() => buildStakeMessage(
-    { txid: 't', kind: 'opposition', subject: 's', amount: 1, address: null },
+    { txid: TX, kind: 'opposition', subject: 's', amount: 1, address: null },
   ), BadAttestationError);
 });
 
@@ -145,7 +162,7 @@ test('verifyStake reports signer-not-staker and claim-mismatch', async () => {
   const addr = await w.address();
   const mismatch = await verifyStake(proof, {
     fetchProvenance: async () => ({
-      txid: 'tx1', address: addr, status: 'canonical', confirmations: 3,
+      txid: TX, address: addr, status: 'canonical', confirmations: 3,
       outflows: [{ kind: 'opposition', subject: 'orcs', amount: 300 }],
     }),
   });

--- a/clients/wallet/testdata/gc-attestation-vectors.json
+++ b/clients/wallet/testdata/gc-attestation-vectors.json
@@ -1,39 +1,39 @@
 [
   {
     "claim": {
-      "txid": "tx1",
+      "txid": "1111111111111111111111111111111111111111111111111111111111111111",
       "kind": "opposition",
       "subject": "goblins",
       "amount": 300
     },
     "timestamp": "1700002000",
-    "message": "{\"txid\":\"tx1\",\"kind\":\"opposition\",\"subject\":\"goblins\",\"amount\":300}",
-    "signature": "Yxm3Af98619VHrRB9uLeuy9oCYeRYaF6XGM+bs2wbXjHbKCO7sLXDYIqgim9fVpLHPXIFBLxeJFIhB8eSFKyzMlurtuVDI4+IYBPP6xxORN1q7XdCEFAwW7par7c/F2MzXgkBdRZti++lX3CtfEqKY7fGpekstk6IrG4rDLuEWxbmM1CDHMSvko1+VlO71E+RhxvMhi3wOsaoMToDUv2JqmK2WrnRZ6ndLLjR6WEH7tFKP0U4NBcRh4kaWRur0MKG4wNzaI57QUeVnAtIRYFZxGZM9QjJKptLugnoWWjGAM2ECCBbTdeV6RqslUGY/1I6tzxkFq/Rup6pfJfHIyKVA==",
+    "message": "{\"txid\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"kind\":\"opposition\",\"subject\":\"goblins\",\"amount\":300}",
+    "signature": "U4VVMc7bdpGi9vpf04ZpJEcE1WFiHshk5BqSMX63vIcUSmfMn2/4lBDbZB3ehxG8ksaGRBSKxEAVpAVWceX/NlqVnSW3Va3HZcJ8fMakrrFI5Z5HuGBAP2+B7+Bb62i39u+/caCq0Q2r3um+v/sIvdfNSAEl+nt1VV0ezAEVNGLAn2AKXddUxM/4jngOZkotGAC3O9w5bH0L/KYaJsx3NNYeL2q+8/StoXPfo7fzCLlGH1z0Q8GYlDmEKBE6SLty8rhG1ke/he2Ue+mNDjhbw0tz9SvWNYY7dxYn81PpS7N2rNToXtQkVIPKTtVdPD+Y1s+m2YgFU3EKTsEhA6JhPw==",
     "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
   },
   {
     "claim": {
-      "txid": "tx2",
+      "txid": "2222222222222222222222222222222222222222222222222222222222222222",
       "kind": "support",
       "subject": "g\u00f6blins",
       "amount": 100,
       "handle": "me.bsky.social"
     },
     "timestamp": "1700002001",
-    "message": "{\"txid\":\"tx2\",\"kind\":\"support\",\"subject\":\"g\u00f6blins\",\"amount\":100,\"handle\":\"me.bsky.social\"}",
-    "signature": "APTIVloGspHqKMshTbS8uBq83VUL43EXutAGRCs7LaQWZtACFZ+C/lrH3mtLZ0HLbOs+1XMqVovG6UJBc5eHXeVP+BdC2uTlw6RNx+qw5btWW+SBiDJOUUi+8dDQ5AbzOgcK8heEA42bZc3CFxo5KklvaIz5Wrbmjtb9J21nHRk2c4GdLaIB0LCxy4vsk6zmvZkzFzz0wM+49sV1DHGf1ITUDp5QGEgz4VU4NY1En3/oEyIyvmbupbzCxiUUZcIyNd09NKfpN8wDBwsxQMkECULWj85VjxF+WDv4na7/Ke9O0vQ8xItdxA5rZ2R/IWc+mOGQRne4swXGSrd8fl22Kw==",
+    "message": "{\"txid\":\"2222222222222222222222222222222222222222222222222222222222222222\",\"kind\":\"support\",\"subject\":\"g\u00f6blins\",\"amount\":100,\"handle\":\"me.bsky.social\"}",
+    "signature": "V6Yot13eoFswSLLsKDpJuWvFZBXDqfgG4QO6qdzzpbFlh7yNEy2OUQU/xCJemabEYcDiUaBkaTGjbLd1QEhcKoIQbOCTmEa675S88qdeR2QdHFJd1u28SA4F0AJWEIMw2vU/cfJe6jUvDDZ7EkMDhL41qzbISlL/unxLahgvzkmBFMZBzFcen0D+LT30jXaQkIrqVcm7FNhGomqE0XPcR6qFwIusiW/GHrdX+9aW5g4rCf8OqsZIorkjLPnIVADQVWeyQ27h2Qu8h6SGm4saGaga2FFyN16bMPmqxTo82UoYnt6aXV69Wdge/XBoeJNlQJyK/dMRexWyrBwecOwFoQ==",
     "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
   },
   {
     "claim": {
-      "txid": "tx3",
+      "txid": "3333333333333333333333333333333333333333333333333333333333333333",
       "kind": "transfer",
       "address": "GCxGC",
       "amount": 5
     },
     "timestamp": "1700002002",
-    "message": "{\"txid\":\"tx3\",\"kind\":\"transfer\",\"address\":\"GCxGC\",\"amount\":5}",
-    "signature": "WA5+cwtQqBLzdpEVpBUod3x6zxuvp/MiI+QeTtbV2auZWqaUuwPEpWxjG5GCl9pt03ba9m6NSBpnXR+lt8iisb8zkIbnEuJ9YhpsQO7QdiVZLa9B+Exb3DrsqmOQwGVvAkDm7SaK8zepSOC3CnIgEj/BDYn+D0NnB3KI9BcIc/zpLN8vXw+48ZAJWnD2qCdPDgQBVETW27wtn3txzpHivf1dmCFKyu40bnGCFRZUJOC1649KJL5gxKjTI9/MGGHDPfTZ7oPBeT9lV8moCTY82linQoEo3k2T/ue4n++R00rBOtJajBPIh9Io7K7jtpd/K1JHqYzsxjnqKv0tAkb4gQ==",
+    "message": "{\"txid\":\"3333333333333333333333333333333333333333333333333333333333333333\",\"kind\":\"transfer\",\"address\":\"GCxGC\",\"amount\":5}",
+    "signature": "hoiwmjqVlPBqb2arHcpijHfQBWfao44VZmoZApAXTvsRmWqeSmkLiqfzU3pZ0KftXHLZCWXPb4l5itFJKrkKeMpi+lki8kC8+9b7R1ik1gzLpXh1OxQruhpt8Xk18awUk2+rSSWZCVmfM+YpEqEzCwE7dPvg+quZgns4ew2ifKidYiY468ToPh1a1E9mIzeTles8RjHEoC51zEKtZfxSfLlYB9Et/Av0xNAwaSpo/JwdkeQkb3eda/aDg3tNdlhvIwy0vt/lcJm5MjhYpZUs1H4DEw/shuG08yKq313W8Ml4YtMYS8eawELBPJxmvsvDcXN6yI6a3N3kJ8ReGh/egw==",
     "address": "GCFZ3Ce1Nt9nTppJBqUFqeqqKHepfJnbRY5qeCN9RNV6sCGC"
   }
 ]

--- a/src/gumptionchain/attestation.py
+++ b/src/gumptionchain/attestation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -12,6 +13,14 @@ from gumptionchain.message import (
 from gumptionchain.wallet import Wallet
 
 KINDS = frozenset({'opposition', 'support', 'rescind', 'transfer'})
+
+# A txid is a transaction's mill hash: 64-char lowercase hex (see
+# milling.mill_hash_str -> .hexdigest()). Validating the canonical shape here
+# (rather than only "non-empty string") means a malformed txid is rejected as a
+# bad attestation up front, instead of slipping through to a provenance fetch
+# that 404s and gets mis-reported as 'txn-not-found'. Kept in lockstep with the
+# JS validator's TXID_RE in clients/wallet/gc-attestation.mjs.
+_TXID_RE = re.compile(r'[0-9a-f]{64}')
 
 
 class AttestationError(Exception):
@@ -32,8 +41,8 @@ def _validate_claim(claim: Any) -> None:
     address = claim.get('address')
     amount = claim.get('amount')
     handle = claim.get('handle')
-    if not isinstance(txid, str) or not txid:
-        msg = 'txid is required'
+    if not isinstance(txid, str) or not _TXID_RE.fullmatch(txid):
+        msg = 'txid must be a 64-char hex digest'
         raise BadAttestationError(msg)
     if kind not in KINDS:
         msg = f'invalid kind: {kind}'

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -11,8 +11,10 @@ from gumptionchain.attestation import (
 from gumptionchain.wallet import Wallet
 
 TS = '1700002000'
+# A canonical txid is a 64-char lowercase-hex mill hash.
+TX = '1' * 64
 CLAIM = {
-    'txid': 'tx1',
+    'txid': TX,
     'kind': 'opposition',
     'subject': 'goblins',
     'amount': 300,
@@ -27,7 +29,7 @@ def _provenance(
     address: str, status: str = 'canonical', confirmations: int = 3
 ):
     return {
-        'txid': 'tx1',
+        'txid': TX,
         'address': address,
         'status': status,
         'confirmations': confirmations,
@@ -40,10 +42,10 @@ def _provenance(
 
 def test_build_stake_message_order_and_omission() -> None:
     assert build_stake_message(CLAIM) == (
-        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300}'
+        f'{{"txid":"{TX}","kind":"opposition","subject":"goblins","amount":300}}'
     )
     assert build_stake_message({**CLAIM, 'handle': 'me.bsky.social'}) == (
-        '{"txid":"tx1","kind":"opposition","subject":"goblins","amount":300,'
+        f'{{"txid":"{TX}","kind":"opposition","subject":"goblins","amount":300,'
         '"handle":"me.bsky.social"}'
     )
 
@@ -53,12 +55,31 @@ def test_build_stake_message_rejects_malformed() -> None:
         build_stake_message({'kind': 'opposition', 'subject': 's', 'amount': 1})
     with pytest.raises(BadAttestationError):
         build_stake_message(
-            {'txid': 't', 'kind': 'x', 'subject': 's', 'amount': 1}
+            {'txid': TX, 'kind': 'x', 'subject': 's', 'amount': 1}
         )
     with pytest.raises(BadAttestationError):
         build_stake_message(
-            {'txid': 't', 'kind': 'opposition', 'subject': 's', 'amount': 0}
+            {'txid': TX, 'kind': 'opposition', 'subject': 's', 'amount': 0}
         )
+
+
+def test_build_stake_message_rejects_malformed_txid() -> None:
+    # Not 64-char lowercase hex -> rejected up front as a bad attestation,
+    # rather than slipping through to a provenance fetch (see #187).
+    for bad in (
+        'tx1',  # too short + non-hex 'x'
+        'g' * 64,  # right length, non-hex char
+        '1' * 63,  # too short
+        '1' * 65,  # too long
+        'A' * 64,  # uppercase hex is not the canonical form
+        '1' * 63 + '/',  # path metacharacter
+    ):
+        with pytest.raises(BadAttestationError):
+            build_stake_message({**CLAIM, 'txid': bad})
+    # A valid 64-hex txid is accepted.
+    assert build_stake_message({**CLAIM, 'txid': 'a' * 64}).startswith(
+        f'{{"txid":"{"a" * 64}"'
+    )
 
 
 def test_sign_then_parse_round_trips() -> None:
@@ -113,7 +134,7 @@ def test_verify_stake_failure_reasons() -> None:
     )
 
     mismatch = {
-        'txid': 'tx1',
+        'txid': TX,
         'address': w.address,
         'status': 'canonical',
         'confirmations': 3,
@@ -134,7 +155,7 @@ def test_parse_rejects_non_canonical() -> None:
     with pytest.raises(BadAttestationError):
         parse_stake_attestation(
             {
-                'message': '{"txid":"tx1","kind":"opposition",'
+                'message': f'{{"txid":"{TX}","kind":"opposition",'
                 '"subject":"goblins","amount":300.0}'
             }
         )
@@ -142,7 +163,7 @@ def test_parse_rejects_non_canonical() -> None:
     with pytest.raises(BadAttestationError):
         parse_stake_attestation(
             {
-                'message': '{"kind":"opposition","txid":"tx1",'
+                'message': f'{{"kind":"opposition","txid":"{TX}",'
                 '"subject":"goblins","amount":300}'
             }
         )
@@ -153,7 +174,7 @@ def test_validate_rejects_present_offside_key() -> None:
     with pytest.raises(BadAttestationError):
         build_stake_message(
             {
-                'txid': 't',
+                'txid': TX,
                 'kind': 'transfer',
                 'address': 'a',
                 'amount': 1,
@@ -163,7 +184,7 @@ def test_validate_rejects_present_offside_key() -> None:
     with pytest.raises(BadAttestationError):
         build_stake_message(
             {
-                'txid': 't',
+                'txid': TX,
                 'kind': 'opposition',
                 'subject': 's',
                 'amount': 1,

--- a/tests/test_attestation_parity.py
+++ b/tests/test_attestation_parity.py
@@ -21,7 +21,7 @@ CLI = (
 )
 TS = '1700002000'
 CLAIM = {
-    'txid': 'tx1',
+    'txid': '1' * 64,
     'kind': 'opposition',
     'subject': 'göblins',
     'amount': 300,
@@ -58,7 +58,7 @@ def test_js_signed_attestation_verifies_in_python() -> None:
     )
     w = Wallet(b58ks=VECTOR_WALLET_B58)
     prov = {
-        'txid': 'tx1',
+        'txid': '1' * 64,
         'address': w.address,
         'status': 'canonical',
         'confirmations': 5,
@@ -74,7 +74,7 @@ def test_python_signed_attestation_verifies_in_js() -> None:
     w = Wallet(b58ks=VECTOR_WALLET_B58)
     proof = sign_stake_attestation(w, CLAIM, timestamp=int(TS))
     prov = {
-        'txid': 'tx1',
+        'txid': '1' * 64,
         'address': w.address,
         'status': 'canonical',
         'confirmations': 5,

--- a/tests/test_attestation_vectors.py
+++ b/tests/test_attestation_vectors.py
@@ -17,10 +17,11 @@ VECTORS_PATH = (
     / 'testdata'
     / 'gc-attestation-vectors.json'
 )
+# txids are canonical 64-char lowercase-hex mill hashes (see #187).
 _CASES = [
     {
         'claim': {
-            'txid': 'tx1',
+            'txid': '1' * 64,
             'kind': 'opposition',
             'subject': 'goblins',
             'amount': 300,
@@ -29,7 +30,7 @@ _CASES = [
     },
     {
         'claim': {
-            'txid': 'tx2',
+            'txid': '2' * 64,
             'kind': 'support',
             'subject': 'göblins',
             'amount': 100,
@@ -39,7 +40,7 @@ _CASES = [
     },
     {
         'claim': {
-            'txid': 'tx3',
+            'txid': '3' * 64,
             'kind': 'transfer',
             'address': 'GCxGC',
             'amount': 5,


### PR DESCRIPTION
Closes #187.

## Problem

Stake-attestation validators checked `txid` only as a *non-empty string*, not the 64-char lowercase-hex mill hash it must be — in **both** `clients/wallet/gc-attestation.mjs` and `src/gumptionchain/attestation.py`. A malformed `txid` (wrong length, non-hex, or containing `/` `?` `#`) passed attestation validation and surfaced *later* as a provenance fetch that 404s — which the verifier mis-reported as **`txn-not-found`** ("not on chain") instead of the truthful **"structurally invalid claim."**

## Fix

- Add a canonical `^[0-9a-f]{64}$` check in lockstep (`TXID_RE` in JS, `_TXID_RE` in Python) so a malformed txid is rejected as a `BadAttestationError` up front. Confirmed this matches the real format: `milling.mill_hash_str` → `.hexdigest()` = 64-char lowercase hex.
- Scoped to the attestation layer (did not retrofit the looser chain-wide `_check_mill_hash`/`MillHashConverter`, which validate `base64 + len 64` — separate concern).
- Updated fixtures to canonical 64-hex txids (JS + Python tests, vector `_CASES`, parity), **regenerated the golden vectors**, and added parity rejection tests (wrong length, non-hex, uppercase, path metacharacters; accept a valid 64-hex digest).

## Verification
- `uv run pytest` — 388 passed, 1 skipped; ruff + format + mypy clean.
- `node --test clients/wallet/*.test.mjs` — 73 passed.

## Follow-up (hub repo, not this PR)
`gc-attestation.mjs` is vendored into `gumption-hub` via `sync_wallet.py`. After this merges, re-run the hub's sync to pick up the canonical validation; the hub's `encodeURIComponent` band-aid can stay (harmless defense-in-depth) or be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)