### PR TITLE
feat(egu-189): UI seam foundation — blueprint folders, block contract, wallet vendoring

### DIFF
--- a/docs/ui-extension-seam.md
+++ b/docs/ui-extension-seam.md
@@ -1,0 +1,46 @@
+# Base ↔ extension UI seam
+
+A vanilla `gumptionchain` node ships functional browser pages. An extension
+(e.g. gumption-hub) themes and extends them instead of reimplementing them.
+
+## Mechanism
+
+The `browser` blueprint carries its own `template_folder` and `static_folder`,
+so its pages and assets are available even when the blueprint is registered
+into a *consumer's* Flask app. Flask resolves **app-level templates before
+blueprint templates**, so a consumer overrides base templates by filename.
+
+## Block contract (`templates/base.html`)
+
+| Block     | Purpose                         |
+|-----------|---------------------------------|
+| `title`   | page `<title>`                  |
+| `head`    | extra `<head>` (CSS/meta)       |
+| `nav`     | navbar contents                 |
+| `content` | main page body                  |
+| `footer`  | footer contents                 |
+| `scripts` | end-of-body JS                  |
+
+A conformant consumer skin should define every block (even if empty); base
+page templates confine themselves to `content`/`title`/`scripts`.
+
+## Override rules
+
+1. **Re-skin everything** — drop your own `base.html` in app `templates/`.
+2. **Re-skin one page** — drop a same-named page template (e.g. `index.html`);
+   it renders on base's route with base's view data.
+3. **Inject into a page without replacing it** — provide the page's optional
+   include partial (e.g. `verify/extra.html`). Base pages use
+   `{% include "verify/extra.html" ignore missing %}`; base ships no such file.
+   (Jinja blocks can't be filled by a non-descendant, so injection uses
+   optional includes, not empty blocks.)
+4. **Add new pages** — register your own blueprint.
+5. **Link to shared pages** by base endpoint name, e.g.
+   `url_for('browser.verify_view')`.
+
+## Assets
+
+Reference base-bundled assets via `url_for('browser.static', filename=...)`
+(served from `/static/gumptionchain`), which resolves standalone or embedded.
+Wallet ESM is vendored into `static/wallet/` from `clients/wallet/` via
+`scripts/sync_wallet.py`.

--- a/docs/ui-extension-seam.md
+++ b/docs/ui-extension-seam.md
@@ -30,10 +30,10 @@ page templates confine themselves to `content`/`title`/`scripts`.
 2. **Re-skin one page** — drop a same-named page template (e.g. `index.html`);
    it renders on base's route with base's view data.
 3. **Inject into a page without replacing it** — provide the page's optional
-   include partial (e.g. `verify/extra.html`). Base pages use
-   `{% include "verify/extra.html" ignore missing %}`; base ships no such file.
-   (Jinja blocks can't be filled by a non-descendant, so injection uses
-   optional includes, not empty blocks.)
+   include partial (e.g. `verify/extra.html`). Base pages will use
+   `{% include "verify/extra.html" ignore missing %}` (added with the verify
+   page); base ships no such file. (Jinja blocks can't be filled by a
+   non-descendant, so injection uses optional includes, not empty blocks.)
 4. **Add new pages** — register your own blueprint.
 5. **Link to shared pages** by base endpoint name, e.g.
    `url_for('browser.verify_view')`.

--- a/scripts/sync_wallet.py
+++ b/scripts/sync_wallet.py
@@ -1,0 +1,36 @@
+"""Copy the runtime wallet ESM modules from this gumptionchain checkout's
+clients/wallet into the served static dir. Excludes *.test.mjs and *-cli.mjs
+(dev-only).
+
+Usage: uv run python scripts/sync_wallet.py [--source .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+DEST = (
+    Path(__file__).resolve().parent.parent / 'src/gumptionchain/static/wallet'
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--source', default='.')
+    args = parser.parse_args()
+    src = Path(args.source).resolve() / 'clients/wallet'
+    if not src.is_dir():
+        msg = f'wallet source not found: {src}'
+        raise SystemExit(msg)
+    DEST.mkdir(parents=True, exist_ok=True)
+    for mjs in sorted(src.glob('*.mjs')):
+        if mjs.name.endswith('.test.mjs') or mjs.name.endswith('-cli.mjs'):
+            continue
+        shutil.copy2(mjs, DEST / mjs.name)
+        print(f'vendored {mjs.name}')  # noqa: T201
+
+
+if __name__ == '__main__':
+    main()

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -17,7 +17,13 @@ def longest_chain() -> Chain | None:
     return Node(logger=current_app.logger).longest_chain
 
 
-blueprint = Blueprint('browser', __name__)
+blueprint = Blueprint(
+    'browser',
+    __name__,
+    template_folder='templates',
+    static_folder='static',
+    static_url_path='/static/gumptionchain',
+)
 
 
 @blueprint.route('/')

--- a/src/gumptionchain/static/wallet/gc-attestation.mjs
+++ b/src/gumptionchain/static/wallet/gc-attestation.mjs
@@ -1,0 +1,166 @@
+// "Verified on GumptionChain" stake attestations: a gc-msg-v1 proof whose
+// message is the canonical JSON of a stake claim. verifyStake composes the
+// signature (gc-msg-v1), on-chain provenance (injected fetchProvenance), and a
+// consistency check. Pure — no I/O. No dependencies beyond sibling modules.
+import { BadAttestationError, BadProofError } from './gc-errors.mjs';
+import { signMessage, verifyMessage } from './gc-message.mjs';
+
+const KINDS = new Set(['opposition', 'support', 'rescind', 'transfer']);
+
+// A txid is a transaction's mill hash: 64-char lowercase hex. Validating the
+// canonical shape here (not just "non-empty string") rejects a malformed txid
+// as a bad attestation up front, instead of letting it slip through to a
+// provenance fetch that 404s and gets mis-reported as 'txn-not-found'. Kept in
+// lockstep with the Python validator's _TXID_RE in attestation.py.
+const TXID_RE = /^[0-9a-f]{64}$/;
+
+export { BadAttestationError } from './gc-errors.mjs';
+
+function validateClaim(claim) {
+  if (!claim || typeof claim !== 'object') {
+    throw new BadAttestationError('claim must be an object');
+  }
+  const { txid, kind, subject, address, amount, handle } = claim;
+  if (typeof txid !== 'string' || !TXID_RE.test(txid)) {
+    throw new BadAttestationError('txid must be a 64-char hex digest');
+  }
+  if (!KINDS.has(kind)) {
+    throw new BadAttestationError(`invalid kind: ${kind}`);
+  }
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new BadAttestationError('amount must be a positive integer (grains)');
+  }
+  if (kind === 'transfer') {
+    if (typeof address !== 'string' || !address) {
+      throw new BadAttestationError('transfer requires address');
+    }
+    if (subject !== undefined) {
+      throw new BadAttestationError('transfer must not set subject');
+    }
+  } else {
+    if (typeof subject !== 'string' || !subject) {
+      throw new BadAttestationError('stake requires subject');
+    }
+    if (address !== undefined) {
+      throw new BadAttestationError('stake must not set address');
+    }
+  }
+  if (handle !== undefined && handle !== null && typeof handle !== 'string') {
+    throw new BadAttestationError('handle must be a string');
+  }
+}
+
+export function buildStakeMessage(claim) {
+  validateClaim(claim);
+  const ordered = { txid: claim.txid, kind: claim.kind };
+  if (claim.kind === 'transfer') {
+    ordered.address = claim.address;
+  } else {
+    ordered.subject = claim.subject;
+  }
+  ordered.amount = claim.amount;
+  if (claim.handle !== undefined && claim.handle !== null) {
+    ordered.handle = claim.handle;
+  }
+  return JSON.stringify(ordered);
+}
+
+export async function signStakeAttestation(wallet, claim, { timestamp } = {}) {
+  return signMessage(wallet, buildStakeMessage(claim), { timestamp });
+}
+
+export function parseStakeAttestation(proof) {
+  if (!proof || typeof proof.message !== 'string') {
+    throw new BadAttestationError('proof has no message');
+  }
+  let claim;
+  try {
+    claim = JSON.parse(proof.message);
+  } catch {
+    throw new BadAttestationError('message is not a stake claim');
+  }
+  validateClaim(claim);
+  // Require canonical encoding: the signed message must be exactly what
+  // buildStakeMessage emits for this claim. Rejects non-canonical forms (a
+  // float amount like 300.0, reordered keys, extra fields, whitespace) so JS
+  // and Python agree on accept/reject for any signable input.
+  if (buildStakeMessage(claim) !== proof.message) {
+    throw new BadAttestationError('non-canonical stake claim encoding');
+  }
+  return claim;
+}
+
+function outflowMatches(outflows, claim) {
+  return (outflows || []).some(
+    (o) => o.kind === claim.kind
+      && o.amount === claim.amount
+      && (claim.kind === 'transfer'
+        ? o.address === claim.address
+        : o.subject === claim.subject),
+  );
+}
+
+// fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
+// for an unknown txn. The verifier performs no transport itself; mapping a
+// 404 to null is the injected adapter's job. Genuine transport errors (e.g. a
+// network failure) propagate by design — they must NOT be misreported as
+// 'txn-not-found', which would mark a real canonical stake unverifiable.
+export async function verifyStake(
+  proof,
+  { fetchProvenance, maxAge, minConfirmations } = {},
+) {
+  const claim = parseStakeAttestation(proof);
+  const reasons = [];
+  const checks = { signature: false, onchain: false, consistent: false };
+  const signer = proof.address;
+
+  let sig;
+  try {
+    sig = await verifyMessage(proof, { maxAge });
+  } catch (e) {
+    // A structurally malformed gc-msg-v1 envelope is a malformed attestation.
+    if (e instanceof BadProofError) {
+      throw new BadAttestationError('attestation is not a valid gc-msg-v1 proof');
+    }
+    throw e;
+  }
+  if (sig.valid && sig.address === signer) {
+    checks.signature = true;
+  } else {
+    reasons.push(sig.reason === 'expired' ? 'expired' : 'bad-signature');
+  }
+
+  const provenance = await fetchProvenance(claim.txid);
+  if (!provenance) {
+    reasons.push('txn-not-found');
+  } else if (provenance.status !== 'canonical') {
+    reasons.push('not-canonical');
+  } else if (
+    minConfirmations !== undefined
+    && (provenance.confirmations ?? 0) < minConfirmations
+  ) {
+    reasons.push('insufficient-confirmations');
+  } else {
+    checks.onchain = true;
+  }
+
+  if (checks.signature && checks.onchain && provenance) {
+    if (provenance.address !== signer) {
+      reasons.push('signer-not-staker');
+    } else if (!outflowMatches(provenance.outflows, claim)) {
+      reasons.push('claim-mismatch');
+    } else {
+      checks.consistent = true;
+    }
+  }
+
+  return {
+    valid: checks.signature && checks.onchain && checks.consistent,
+    checks,
+    signer,
+    claim,
+    provenance: provenance ?? null,
+    confirmations: provenance?.confirmations ?? 0,
+    reasons,
+  };
+}

--- a/src/gumptionchain/static/wallet/gc-backup.mjs
+++ b/src/gumptionchain/static/wallet/gc-backup.mjs
@@ -1,0 +1,115 @@
+// Self-custody wallet backup/recovery. Converts a Wallet <-> a portable
+// artifact: a passphrase-encrypted JSON blob (PBKDF2-SHA256 -> AES-GCM-256,
+// via the shared gc-envelope primitive) and a raw b58 string. Storage-
+// decoupled and Node-testable: re-persist a recovered wallet by composing with
+// gc-store.enroll. No dependencies.
+import { base64encode, base64decode } from './gc-crypto.mjs';
+import { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const BACKUP_VERSION = 1;
+const BACKUP_KIND = 'gc-wallet-backup';
+const DEFAULT_ITERATIONS = 600000;
+const SALT_BYTES = 16;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so consumers can import the typed errors from here.
+export { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
+
+async function deriveKey(passphrase, salt, iterations) {
+  const ikm = await crypto.subtle.importKey(
+    'raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: Uint8Array.from(salt), iterations },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+export async function exportEncrypted(wallet, passphrase, opts = {}) {
+  const iterations = opts.iterations ?? DEFAULT_ITERATIONS;
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const key = await deriveKey(passphrase, salt, iterations);
+  const { iv, ciphertext } = await sealWithKey(
+    key, te.encode(await wallet.exportPrivateKeyB58()),
+  );
+  return {
+    version: BACKUP_VERSION,
+    kind: BACKUP_KIND,
+    address: await wallet.address(),
+    kdf: {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations,
+      salt: base64encode(salt),
+    },
+    iv: base64encode(iv),
+    ciphertext: base64encode(ciphertext),
+  };
+}
+
+export async function importEncrypted(backup, passphrase) {
+  if (!backup || backup.kind !== BACKUP_KIND) {
+    throw new BadBackupError('not a gc-wallet-backup artifact');
+  }
+  if (backup.version !== BACKUP_VERSION) {
+    throw new BadBackupError(`unsupported backup version: ${backup.version}`);
+  }
+  const { kdf, iv, ciphertext } = backup;
+  if (
+    !kdf
+    || kdf.name !== 'PBKDF2'
+    || kdf.hash !== 'SHA-256'
+    || typeof kdf.salt !== 'string'
+    || !Number.isSafeInteger(kdf.iterations)
+    || kdf.iterations <= 0
+    || typeof iv !== 'string'
+    || typeof ciphertext !== 'string'
+  ) {
+    throw new BadBackupError('malformed gc-wallet-backup artifact');
+  }
+  // Decode the structural base64 fields up front: a decode failure here is a
+  // malformed artifact (BadBackupError), distinct from an authentic-but-wrong
+  // passphrase (BadPassphraseError) detected by the GCM tag below.
+  let salt;
+  let ivBytes;
+  let ctBytes;
+  try {
+    salt = base64decode(kdf.salt);
+    ivBytes = base64decode(iv);
+    ctBytes = base64decode(ciphertext);
+  } catch {
+    throw new BadBackupError('malformed gc-wallet-backup artifact');
+  }
+  const key = await deriveKey(passphrase, salt, kdf.iterations);
+  let b58Bytes;
+  try {
+    b58Bytes = await openWithKey(key, { iv: ivBytes, ciphertext: ctBytes });
+  } catch {
+    // GCM tag mismatch: wrong passphrase or tampered backup. Fail closed.
+    throw new BadPassphraseError('wrong passphrase or corrupt backup');
+  }
+  try {
+    // GCM already authenticated the plaintext, so this should always succeed;
+    // map any residual decode/key failure to BadBackupError defensively.
+    return await Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+  } catch {
+    throw new BadBackupError('decrypted payload is not a valid wallet key');
+  }
+}
+
+// Raw-string backup: the b58 private key itself. At-rest protection is the
+// user's password manager. Thin, documented wrappers over the #2.1 key seam so
+// all backup surface lives in one module.
+export async function exportPlain(wallet) {
+  return wallet.exportPrivateKeyB58();
+}
+
+export async function importPlain(b58) {
+  return Wallet.fromPrivateKeyB58(b58);
+}

--- a/src/gumptionchain/static/wallet/gc-crypto.mjs
+++ b/src/gumptionchain/static/wallet/gc-crypto.mjs
@@ -1,0 +1,70 @@
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export function base58encode(bytes) {
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  const digits = [];
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let out = '1'.repeat(zeros);
+  for (let k = digits.length - 1; k >= 0; k--) out += B58[digits[k]];
+  return out;
+}
+
+export function base58decode(str) {
+  let zeros = 0;
+  while (zeros < str.length && str[zeros] === '1') zeros++;
+  const bytes = [];
+  for (let i = zeros; i < str.length; i++) {
+    const val = B58.indexOf(str[i]);
+    if (val < 0) throw new Error(`invalid base58 char: ${str[i]}`);
+    let carry = val;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let k = 0; k < bytes.length; k++) out[zeros + k] = bytes[bytes.length - 1 - k];
+  return out;
+}
+
+export function base64encode(bytes) {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export function base64decode(str) {
+  const bin = atob(str);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function millHash(bytes) {
+  const inner = await crypto.subtle.digest('SHA-512', bytes);
+  const outer = await crypto.subtle.digest('SHA-256', inner);
+  return new Uint8Array(outer);
+}
+
+export async function sha256Hex(bytes) {
+  const d = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  return Array.from(d, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/src/gumptionchain/static/wallet/gc-envelope.mjs
+++ b/src/gumptionchain/static/wallet/gc-envelope.mjs
@@ -1,0 +1,47 @@
+// Authenticated at-rest encryption for the wallet key. Exposes a key-level
+// primitive (sealWithKey/openWithKey) over AES-GCM-256 plus the PRF-keyed
+// seal/open wrappers: HKDF-SHA256 derives an AES-GCM-256 key from a 32-byte
+// WebAuthn PRF output; random 12-byte IV per seal; GCM's auth tag makes
+// tampering fail closed. Pure Web Crypto.
+const HKDF_INFO = new TextEncoder().encode('gc-wallet-aesgcm-v1');
+const IV_BYTES = 12;
+
+async function deriveAesKey(prfOutput) {
+  const ikm = await crypto.subtle.importKey('raw', prfOutput, 'HKDF', false, [
+    'deriveKey',
+  ]);
+  return crypto.subtle.deriveKey(
+    // Empty HKDF salt is deliberate and sound (RFC 5869): the PRF output is
+    // already high-entropy keying material, and the versioned HKDF_INFO label
+    // provides domain separation. The PRF output is never used as the key
+    // directly — it is HKDF input keying material.
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: HKDF_INFO },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+export async function sealWithKey(key, bytes) {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, bytes);
+  return { iv, ciphertext: new Uint8Array(ct) };
+}
+
+export async function openWithKey(key, { iv, ciphertext }) {
+  const pt = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: Uint8Array.from(iv) },
+    key,
+    Uint8Array.from(ciphertext),
+  );
+  return new Uint8Array(pt);
+}
+
+export async function seal(prfOutput, bytes) {
+  return sealWithKey(await deriveAesKey(prfOutput), bytes);
+}
+
+export async function open(prfOutput, envelope) {
+  return openWithKey(await deriveAesKey(prfOutput), envelope);
+}

--- a/src/gumptionchain/static/wallet/gc-errors.mjs
+++ b/src/gumptionchain/static/wallet/gc-errors.mjs
@@ -1,0 +1,26 @@
+// Typed errors shared by the wallet storage orchestration (gc-store) and the
+// real adapters (gc-passkey-webauthn). Kept in their own module so an adapter
+// can throw the typed error without importing the whole orchestration graph.
+
+// PRF/WebAuthn unavailable, or an assertion returned no PRF result — distinct
+// from a user-cancel/abort DOMException, so callers can branch on it.
+export class UnsupportedError extends Error {}
+
+// unlock() called with nothing stored.
+export class NoWalletError extends Error {}
+
+// Backup artifact is not a recognizable gc-wallet-backup, has an unknown
+// version, or is missing required fields — thrown before any crypto.
+export class BadBackupError extends Error {}
+
+// importEncrypted decrypt failed (wrong passphrase or tampered backup) —
+// re-thrown from the GCM tag mismatch so callers never see garbage plaintext.
+export class BadPassphraseError extends Error {}
+
+// Input is not a structurally valid gc-msg-v1 proof (un-parseable / wrong
+// shape) — distinct from a proof that parses but fails verification.
+export class BadProofError extends Error {}
+
+// Input is not a structurally valid stake attestation (bad claim shape or a
+// proof whose message is not a parseable claim).
+export class BadAttestationError extends Error {}

--- a/src/gumptionchain/static/wallet/gc-message.mjs
+++ b/src/gumptionchain/static/wallet/gc-message.mjs
@@ -1,0 +1,119 @@
+// Generic gc-msg-v1 message signing: sign arbitrary text into a portable proof
+// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v1.
+// Pure Web Crypto + vanilla JS. No dependencies. Knows nothing about the chain.
+import { sha256Hex, base64encode, base64decode } from './gc-crypto.mjs';
+import { BadProofError } from './gc-errors.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const MSG_SCHEME = 'gc-msg-v1';
+const MSG_VERSION = '1';
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+export { BadProofError } from './gc-errors.mjs';
+
+export async function messageCanonical({ address, timestamp, message }) {
+  const digest = await sha256Hex(te.encode(message));
+  return te.encode(
+    [MSG_SCHEME, MSG_VERSION, address, String(timestamp), digest].join('\n'),
+  );
+}
+
+export async function signMessage(wallet, message, { timestamp } = {}) {
+  const ts = String(timestamp ?? Math.floor(Date.now() / 1000));
+  const address = await wallet.address();
+  const bytes = await messageCanonical({ address, timestamp: ts, message });
+  return {
+    scheme: MSG_SCHEME,
+    version: MSG_VERSION,
+    address,
+    public_key: await wallet.publicKeyB64(),
+    timestamp: ts,
+    message,
+    signature: await wallet.sign(bytes),
+  };
+}
+
+export async function verifyMessage(proof, { maxAge, now } = {}) {
+  if (!proof || typeof proof !== 'object') {
+    throw new BadProofError('not a proof object');
+  }
+  const {
+    scheme, version, address, public_key: publicKey, timestamp, message, signature,
+  } = proof;
+  if (
+    scheme !== MSG_SCHEME
+    || version !== MSG_VERSION
+    || typeof address !== 'string'
+    || typeof publicKey !== 'string'
+    || typeof timestamp !== 'string'
+    || !/^[0-9]+$/.test(timestamp)
+    || typeof message !== 'string'
+    || typeof signature !== 'string'
+  ) {
+    throw new BadProofError('malformed gc-msg-v1 proof');
+  }
+  let verifier;
+  try {
+    verifier = await Wallet.fromPublicKeyB64(publicKey);
+  } catch {
+    throw new BadProofError('invalid public key');
+  }
+  const result = { address, timestamp, message };
+  if ((await verifier.address()) !== address) {
+    return { ...result, valid: false, reason: 'address-mismatch' };
+  }
+  const bytes = await messageCanonical({ address, timestamp, message });
+  let signatureOk;
+  try {
+    signatureOk = await verifier.verify(bytes, signature);
+  } catch {
+    // A non-base64 / malformed signature string fails verification; mirror
+    // Python (which catches binascii errors) rather than leaking an exception.
+    signatureOk = false;
+  }
+  if (!signatureOk) {
+    return { ...result, valid: false, reason: 'bad-signature' };
+  }
+  if (maxAge !== undefined) {
+    const current = now ?? Math.floor(Date.now() / 1000);
+    // Symmetric window: reject stale AND future timestamps (mirrors the
+    // server-side gc-sig-v1 freshness check) so maxAge can't be defeated by a
+    // far-future signed timestamp.
+    if (Math.abs(current - Number(timestamp)) > maxAge) {
+      return { ...result, valid: false, reason: 'expired' };
+    }
+  }
+  return { ...result, valid: true };
+}
+
+const ARMOR_HEADER = '-----BEGIN GUMPTION SIGNED MESSAGE-----';
+const ARMOR_SIG = '-----BEGIN GUMPTION SIGNATURE-----';
+const ARMOR_FOOTER = '-----END GUMPTION SIGNED MESSAGE-----';
+
+export function toArmored(proof) {
+  const blob = base64encode(te.encode(JSON.stringify(proof)));
+  return [ARMOR_HEADER, proof.message, ARMOR_SIG, blob, ARMOR_FOOTER].join('\n');
+}
+
+export function fromArmored(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const h = lines.indexOf(ARMOR_HEADER);
+  const s = lines.indexOf(ARMOR_SIG);
+  const f = lines.indexOf(ARMOR_FOOTER);
+  if (h < 0 || s < 0 || f < 0 || !(h < s && s < f)) {
+    throw new BadProofError('malformed armored message');
+  }
+  const cleartext = lines.slice(h + 1, s).join('\n');
+  const blob = lines.slice(s + 1, f).join('').trim();
+  let proof;
+  try {
+    proof = JSON.parse(td.decode(base64decode(blob)));
+  } catch {
+    throw new BadProofError('malformed armored signature block');
+  }
+  if (proof.message !== cleartext) {
+    throw new BadProofError('armored cleartext does not match signed message');
+  }
+  return proof;
+}

--- a/src/gumptionchain/static/wallet/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/wallet/gc-passkey-webauthn.mjs
@@ -1,0 +1,83 @@
+// Real WebAuthn-PRF passkey adapter (browser-only). Implements the `passkey`
+// interface. The passkey is a normal credential (ES256/RS256) used ONLY for its
+// PRF output — it is NOT the wallet's RSA key.
+import { base64encode, base64decode } from './gc-crypto.mjs';
+import { UnsupportedError } from './gc-errors.mjs';
+
+const PRF_SALT = new TextEncoder().encode('gc-wallet-prf-v1');
+
+function b64urlEncode(bytes) {
+  return base64encode(bytes)
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function b64urlDecode(s) {
+  const pad = s.length % 4 ? '='.repeat(4 - (s.length % 4)) : '';
+  return base64decode(s.replace(/-/g, '+').replace(/_/g, '/') + pad);
+}
+function prfFirst(credential) {
+  const r = credential.getClientExtensionResults?.()?.prf?.results?.first;
+  return r ? new Uint8Array(r) : null;
+}
+
+export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferred' }) {
+  async function unlock(credentialId) {
+    const assertion = await navigator.credentials.get({
+      publicKey: {
+        rpId,
+        challenge: crypto.getRandomValues(new Uint8Array(32)),
+        allowCredentials: [
+          { type: 'public-key', id: b64urlDecode(credentialId) },
+        ],
+        userVerification,
+        extensions: { prf: { eval: { first: PRF_SALT } } },
+      },
+    });
+    if (!assertion) {
+      throw new Error('passkey assertion failed or was cancelled');
+    }
+    const out = prfFirst(assertion);
+    if (!out) {
+      throw new UnsupportedError('passkey PRF not available on assertion');
+    }
+    return out;
+  }
+
+  return {
+    async isSupported() {
+      return (
+        typeof window !== 'undefined' &&
+        typeof window.PublicKeyCredential === 'function'
+      );
+    },
+
+    async enroll({ userId, userName } = {}) {
+      const idBytes =
+        typeof userId === 'string'
+          ? new TextEncoder().encode(userId)
+          : userId || crypto.getRandomValues(new Uint8Array(16));
+      const cred = await navigator.credentials.create({
+        publicKey: {
+          rp: { id: rpId, name: rpName },
+          user: { id: idBytes, name: userName, displayName: userName },
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          pubKeyCredParams: [
+            { type: 'public-key', alg: -7 },
+            { type: 'public-key', alg: -257 },
+          ],
+          authenticatorSelection: { residentKey: 'required', userVerification },
+          extensions: { prf: { eval: { first: PRF_SALT } } },
+        },
+      });
+      if (!cred) {
+        throw new Error('passkey creation failed or was cancelled');
+      }
+      const credentialId = b64urlEncode(new Uint8Array(cred.rawId));
+      // Prefer the create-time PRF result; else one assertion gets it (which
+      // throws UnsupportedError if the authenticator doesn't support PRF).
+      const prfOutput = prfFirst(cred) ?? (await unlock(credentialId));
+      return { credentialId, prfOutput };
+    },
+
+    unlock,
+  };
+}

--- a/src/gumptionchain/static/wallet/gc-sig.mjs
+++ b/src/gumptionchain/static/wallet/gc-sig.mjs
@@ -1,0 +1,52 @@
+// GumptionChain gc-sig-v1 canonical string + GC-* signing headers.
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
+import { sha256Hex } from './gc-crypto.mjs';
+
+const SIG_SCHEME = 'gc-sig-v1';
+const SIG_VERSION = '1';
+
+export async function canonical({
+  method,
+  path,
+  query,
+  body,
+  nodeHost,
+  timestamp,
+  address,
+}) {
+  const bodyDigest = await sha256Hex(body ?? new Uint8Array());
+  const lines = [
+    SIG_SCHEME,
+    method.toUpperCase(),
+    path,
+    query,
+    bodyDigest,
+    nodeHost,
+    timestamp,
+    address,
+  ];
+  return new TextEncoder().encode(lines.join('\n'));
+}
+
+export async function signHeaders(
+  wallet,
+  { method, path, query, body, nodeHost, timestamp },
+) {
+  const address = await wallet.address();
+  const bytes = await canonical({
+    method,
+    path,
+    query,
+    body,
+    nodeHost,
+    timestamp,
+    address,
+  });
+  return {
+    'GC-Sig-Version': SIG_VERSION,
+    'GC-Address': address,
+    'GC-Public-Key': await wallet.publicKeyB64(),
+    'GC-Timestamp': String(timestamp),
+    'GC-Signature': await wallet.sign(bytes),
+  };
+}

--- a/src/gumptionchain/static/wallet/gc-store-idb.mjs
+++ b/src/gumptionchain/static/wallet/gc-store-idb.mjs
@@ -1,0 +1,58 @@
+// Real IndexedDB store adapter (browser-only). Implements the `store` interface:
+// one DB, one object store, a single fixed-key record. Touches `indexedDB` only
+// inside functions so it imports cleanly in Node.
+const STORE = 'wallet';
+const KEY = 'singleton';
+
+function openDb(dbName) {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx(db, mode, fn) {
+  return new Promise((resolve, reject) => {
+    const t = db.transaction(STORE, mode);
+    const req = fn(t.objectStore(STORE));
+    t.oncomplete = () => resolve(req ? req.result : undefined);
+    t.onerror = () => reject(t.error);
+    t.onabort = () => reject(t.error);
+  });
+}
+
+export function makeIdbStore({ dbName = 'gc-wallet' } = {}) {
+  return {
+    async get() {
+      const db = await openDb(dbName);
+      try {
+        const rec = await tx(db, 'readonly', (s) => s.get(KEY));
+        return rec ?? null;
+      } finally {
+        db.close();
+      }
+    },
+    async put(record) {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.put(record, KEY));
+      } finally {
+        db.close();
+      }
+    },
+    async delete() {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.delete(KEY));
+      } finally {
+        db.close();
+      }
+    },
+  };
+}

--- a/src/gumptionchain/static/wallet/gc-store.mjs
+++ b/src/gumptionchain/static/wallet/gc-store.mjs
@@ -1,0 +1,64 @@
+// Enroll/unlock orchestration for the browser wallet. Wires the pure
+// gc-envelope seal/open over two INJECTED interfaces (passkey, store) so the
+// whole lock/unlock flow is Node-testable with fakes. No dependencies.
+//
+// passkey: isSupported()->bool, enroll(opts)->{credentialId, prfOutput},
+//          unlock(credentialId)->prfOutput (Uint8Array).
+// store (single record): get()->record|null, put(record), delete().
+import { base64encode, base64decode } from './gc-crypto.mjs';
+import { NoWalletError, UnsupportedError } from './gc-errors.mjs';
+import { seal, open } from './gc-envelope.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const RECORD_VERSION = 1;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so existing consumers/tests can import the typed errors from here.
+export { NoWalletError, UnsupportedError } from './gc-errors.mjs';
+
+export async function hasWallet(store) {
+  return (await store.get()) !== null;
+}
+
+export async function enroll(wallet, { passkey, store }, opts) {
+  if (!(await passkey.isSupported())) {
+    throw new UnsupportedError('passkey PRF is not available on this device');
+  }
+  const { credentialId, prfOutput } = await passkey.enroll(opts);
+  const { iv, ciphertext } = await seal(
+    prfOutput,
+    te.encode(await wallet.exportPrivateKeyB58()),
+  );
+  const address = await wallet.address();
+  await store.put({
+    version: RECORD_VERSION,
+    address,
+    credentialId,
+    iv: base64encode(iv),
+    ciphertext: base64encode(ciphertext),
+  });
+  return address;
+}
+
+export async function unlock({ passkey, store }) {
+  const rec = await store.get();
+  if (rec === null) {
+    throw new NoWalletError('no stored wallet');
+  }
+  if (rec.version !== RECORD_VERSION) {
+    // Fail fast on an unknown/corrupt record rather than mis-decoding fields;
+    // a future schema bump handles migration here explicitly.
+    throw new Error(`unsupported wallet record version: ${rec.version}`);
+  }
+  const prfOutput = await passkey.unlock(rec.credentialId);
+  const b58Bytes = await open(prfOutput, {
+    iv: base64decode(rec.iv),
+    ciphertext: base64decode(rec.ciphertext),
+  });
+  return Wallet.fromPrivateKeyB58(td.decode(b58Bytes));
+}
+
+export async function clear(store) {
+  await store.delete();
+}

--- a/src/gumptionchain/static/wallet/gc-wallet.mjs
+++ b/src/gumptionchain/static/wallet/gc-wallet.mjs
@@ -1,0 +1,123 @@
+// GumptionChain browser wallet: keygen, key import/export, address, sign.
+// Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
+import {
+  base58encode, base58decode, base64encode, base64decode, millHash,
+} from './gc-crypto.mjs';
+
+const ALG = { name: 'RSASSA-PKCS1-v1_5' };
+const KEYGEN = {
+  name: 'RSASSA-PKCS1-v1_5',
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+  hash: 'SHA-384',
+};
+const IMPORT_PARAMS = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' };
+const ADDRESS_TAG = 'GC';
+const KEY_SIZE = 2048;
+const PUBLIC_EXPONENT = Uint8Array.of(0x01, 0x00, 0x01); // 65537
+
+// Mirror the node's Wallet key-profile guard: reject any imported key that is
+// not RSA-2048 with e=65537, so a client can't mint an identity/signature the
+// Python node will always reject. (Web Crypto exposes both on key.algorithm.)
+function assertKeyProfile(key) {
+  const { modulusLength, publicExponent } = key.algorithm;
+  if (modulusLength !== KEY_SIZE) {
+    throw new Error(
+      `unsupported RSA modulus length ${modulusLength} (want ${KEY_SIZE})`,
+    );
+  }
+  const e = new Uint8Array(publicExponent);
+  const ok =
+    e.length === PUBLIC_EXPONENT.length &&
+    e.every((b, i) => b === PUBLIC_EXPONENT[i]);
+  if (!ok) {
+    throw new Error('unsupported RSA public exponent (want 65537)');
+  }
+}
+
+export class Wallet {
+  #privateKey;
+  #publicKey;
+
+  constructor(privateKey, publicKey) {
+    this.#privateKey = privateKey;
+    this.#publicKey = publicKey;
+  }
+
+  static async generate() {
+    const pair = await crypto.subtle.generateKey(KEYGEN, true, [
+      'sign',
+      'verify',
+    ]);
+    return new Wallet(pair.privateKey, pair.publicKey);
+  }
+
+  static async fromPrivateKeyB58(b58) {
+    const pkcs8 = base58decode(b58);
+    const priv = await crypto.subtle.importKey(
+      'pkcs8',
+      pkcs8,
+      IMPORT_PARAMS,
+      true,
+      ['sign'],
+    );
+    assertKeyProfile(priv);
+    const jwk = await crypto.subtle.exportKey('jwk', priv);
+    const pubJwk = { kty: jwk.kty, n: jwk.n, e: jwk.e, ext: true };
+    const pub = await crypto.subtle.importKey(
+      'jwk',
+      pubJwk,
+      IMPORT_PARAMS,
+      true,
+      ['verify'],
+    );
+    return new Wallet(priv, pub);
+  }
+
+  static async fromPublicKeyB64(b64) {
+    const pub = await crypto.subtle.importKey(
+      'spki',
+      base64decode(b64),
+      IMPORT_PARAMS,
+      true,
+      ['verify'],
+    );
+    assertKeyProfile(pub);
+    return new Wallet(null, pub);
+  }
+
+  async exportPrivateKeyB58() {
+    if (!this.#privateKey) {
+      throw new Error('no private key');
+    }
+    const pkcs8 = new Uint8Array(
+      await crypto.subtle.exportKey('pkcs8', this.#privateKey),
+    );
+    return base58encode(pkcs8);
+  }
+
+  async #spki() {
+    return new Uint8Array(await crypto.subtle.exportKey('spki', this.#publicKey));
+  }
+
+  async publicKeyB64() {
+    return base64encode(await this.#spki());
+  }
+
+  async address() {
+    const digest = await millHash(await this.#spki());
+    return `${ADDRESS_TAG}${base58encode(digest)}${ADDRESS_TAG}`;
+  }
+
+  async sign(bytes) {
+    if (!this.#privateKey) {
+      throw new Error('no private key');
+    }
+    const sig = await crypto.subtle.sign(ALG, this.#privateKey, bytes);
+    return base64encode(new Uint8Array(sig));
+  }
+
+  async verify(bytes, signatureB64) {
+    return crypto.subtle.verify(ALG, this.#publicKey, base64decode(signatureB64), bytes);
+  }
+}

--- a/src/gumptionchain/static/wallet/index.mjs
+++ b/src/gumptionchain/static/wallet/index.mjs
@@ -1,0 +1,44 @@
+// GumptionChain browser wallet — public API barrel.
+// Import the supported surface from here. Anything not re-exported below
+// (e.g. gc-crypto low-level helpers, gc-envelope seal/open, messageCanonical)
+// is internal and may change without notice.
+//
+// The package `version` is the embedder-API semver; it is INDEPENDENT of the
+// wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
+export const version = '0.2.0';
+
+// Identity / keys
+export { Wallet } from './gc-wallet.mjs';
+
+// API request signing (gc-sig-v1)
+export { canonical, signHeaders } from './gc-sig.mjs';
+
+// Passkey-anchored storage
+export { enroll, unlock, hasWallet, clear } from './gc-store.mjs';
+export { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+export { makeIdbStore } from './gc-store-idb.mjs';
+
+// Backup / recovery
+export {
+  exportEncrypted, importEncrypted, exportPlain, importPlain,
+} from './gc-backup.mjs';
+
+// Message signing (gc-msg-v1)
+export {
+  signMessage, verifyMessage, toArmored, fromArmored,
+} from './gc-message.mjs';
+
+// Stake attestations (gc-msg-v1 + on-chain provenance composition)
+export {
+  signStakeAttestation, parseStakeAttestation, verifyStake,
+} from './gc-attestation.mjs';
+
+// Typed errors
+export {
+  UnsupportedError,
+  NoWalletError,
+  BadBackupError,
+  BadPassphraseError,
+  BadProofError,
+  BadAttestationError,
+} from './gc-errors.mjs';

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -21,7 +21,7 @@
     {%- endblock %}
   </nav>
 
-  {% block page_container -%}
+  {% block content -%}
   <div class="container-fluid">
     <div class="row"><div class="col">
       This space (un)intentionally left blank.

--- a/src/gumptionchain/templates/block.html
+++ b/src/gumptionchain/templates/block.html
@@ -2,7 +2,7 @@
 
 {% set coinbase = block.coinbase %}
 
-{% block page_container -%}
+{% block content -%}
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
       <div class="card bg-light"><div class="card-body">

--- a/src/gumptionchain/templates/chains.html
+++ b/src/gumptionchain/templates/chains.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page_container -%}
+{% block content -%}
 <div class="container-fluid">
   {%- if chains_page.pages > 0 %}
   {%- for chain in chains_page.items %}

--- a/src/gumptionchain/templates/index.html
+++ b/src/gumptionchain/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page_container -%}
+{% block content -%}
 <div class="container-fluid">
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page_container -%}
+{% block content -%}
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
       <div class="card bg-light"><div class="card-body">

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -1,0 +1,42 @@
+from flask import Flask
+
+from gumptionchain import create_app
+from gumptionchain.database import db
+
+
+def test_consumer_base_html_reskins_base_pages(tmp_path):
+    # A consumer app (like the hub) creates its own Flask with an app-level
+    # templates/ dir. Flask resolves app templates before blueprint templates,
+    # so the consumer's base.html must re-skin base's pages.
+    tdir = tmp_path / 'templates'
+    tdir.mkdir()
+    (tdir / 'base.html').write_text(
+        '<!doctype html><html><head>'
+        '<title>{% block title %}{% endblock %}</title>'
+        '{% block head %}{% endblock %}</head><body>'
+        '<div id="custom-skin">SKINNED</div>'
+        '{% block nav %}{% endblock %}'
+        '<main>{% block content %}{% endblock %}</main>'
+        '{% block footer %}{% endblock %}'
+        '{% block scripts %}{% endblock %}'
+        '</body></html>'
+    )
+    consumer = Flask('consumer_app', template_folder=str(tdir))
+    db_uri = f'sqlite:///{tmp_path / "seam.sqlite"}'
+    app = create_app(
+        app=consumer,
+        config_map={
+            'TESTING': True,
+            'SECRET_KEY': 'x',
+            'SQLALCHEMY_DATABASE_URI': db_uri,
+            'NODE_HOST': 'http://localhost',
+            'READER_ADDRESSES': ['*'],
+        },
+    )
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        assert b'No chain' in resp.data  # base index content still rendered

--- a/tests/test_wallet_vendored.py
+++ b/tests/test_wallet_vendored.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+WALLET_DIR = Path('src/gumptionchain/static/wallet')
+REQUIRED = [
+    'gc-attestation.mjs',
+    'gc-message.mjs',
+    'gc-errors.mjs',
+    'gc-wallet.mjs',
+    'gc-crypto.mjs',
+    'gc-sig.mjs',
+    'index.mjs',
+]
+
+
+def test_runtime_wallet_modules_are_vendored():
+    for name in REQUIRED:
+        assert (WALLET_DIR / name).is_file(), f'missing vendored {name}'
+
+
+def test_no_test_or_cli_modules_vendored():
+    for p in WALLET_DIR.glob('*.mjs'):
+        assert not p.name.endswith('.test.mjs')
+        assert not p.name.endswith('-cli.mjs')

--- a/tests/test_wallet_vendored.py
+++ b/tests/test_wallet_vendored.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-WALLET_DIR = Path('src/gumptionchain/static/wallet')
+WALLET_DIR = (
+    Path(__file__).resolve().parent.parent / 'src/gumptionchain/static/wallet'
+)
 REQUIRED = [
     'gc-attestation.mjs',
     'gc-message.mjs',


### PR DESCRIPTION
**PR 1 of 4** for EGU #189 (verify migration + base↔extension UI seam). Plan: `docs/superpowers/plans/2026-06-07-egu-189-verify-migration.md`.

Establishes the template-override seam (no new pages yet):
- `browser` blueprint carries its own `template_folder` + `static_folder` (`static_url_path=/static/gumptionchain`) so base is usable when embedded in a consumer Flask app.
- Normalize the Jinja block contract: `page_container` → `content` across the 4 existing page templates + `base.html`.
- `scripts/sync_wallet.py` vendors wallet ESM from `clients/wallet/` into `static/wallet/` (committed; reproducible wheel).
- `tests/test_wallet_vendored.py` (vendoring completeness) + `tests/test_ui_seam.py` (consumer `base.html` re-skins base pages — locks in app-overrides-blueprint resolution).
- `docs/ui-extension-seam.md` documents the seam.

Reviewed: two-stage subagent review (spec ✅, code-quality approve) + follow-up fixes (anchored vendored-wallet path; doc wording). Full suite: 391 passed.

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)