### PR TITLE
feat(egu-189): /verify page + verify-glue.mjs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
-      - run: node --test clients/wallet/*.test.mjs
+      - run: node --test clients/wallet/*.test.mjs src/gumptionchain/static/js/*.test.mjs
       - run: uv run pytest
       - run: uv run mypy
       # Migration drift gate: upgrade a throwaway SQLite file, then compare

--- a/docs/ui-extension-seam.md
+++ b/docs/ui-extension-seam.md
@@ -44,3 +44,14 @@ Reference base-bundled assets via `url_for('browser.static', filename=...)`
 (served from `/static/gumptionchain`), which resolves standalone or embedded.
 Wallet ESM is vendored into `static/wallet/` from `clients/wallet/` via
 `scripts/sync_wallet.py`.
+
+## CSP considerations
+
+The verify page (and any base page that wires up client JS) uses an inline
+`<script type="module">`. Base's default Content-Security-Policy (in
+`application.py`) includes `'unsafe-inline'` in `script-src`, so this works out
+of the box. Per the CSP spec, `'unsafe-inline'` is **ignored** by the browser
+once a `nonce-*` or `hash-*` source is present in the same directive — so a
+consumer that hardens its own CSP with a nonce/hash must also cover base's
+inline scripts (add a matching nonce/hash, or `'strict-dynamic'`), or those
+pages' JS will be silently blocked.

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -147,3 +147,8 @@ def transaction_provenance_view(txid: str) -> Any:
     # Route param (mill_hash-validated) is authoritative for txid; unpack prov
     # first so a stray 'txid' key can't override the request path.
     return jsonify({**prov, 'txid': txid})
+
+
+@blueprint.route('/verify')
+def verify_view() -> Any:
+    return render_template('verify.html', title='Verify')

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -135,6 +135,10 @@ def transaction_view(txid: str) -> Any:
 
 @blueprint.route('/transaction/<mill_hash:txid>/provenance.json')
 def transaction_provenance_view(txid: str) -> Any:
+    # Deliberately simpler than the authed api.TransactionProvenanceView: this
+    # public read does no caching and omits `as_of_block`. The authed view's
+    # cache keys on the chain tip; replicating it here is unnecessary under the
+    # default NullCache and would couple this public read to the cache layer.
     try:
         prov = lookup_provenance(txid)
     except HTTPException as e:

--- a/src/gumptionchain/static/js/verify-glue.mjs
+++ b/src/gumptionchain/static/js/verify-glue.mjs
@@ -2,7 +2,15 @@
 // proof, fetching provenance from the node's public endpoint. Pure logic in
 // runVerify (fetchProvenance injectable for tests); renderVerdict lights the
 // DOM verdict.
-import { verifyStake } from '../wallet/gc-attestation.mjs';
+import {
+  BadAttestationError,
+  verifyStake,
+} from '../wallet/gc-attestation.mjs';
+
+// Re-exported so a page (base or an extension skin) can tell a user-input
+// error (bad/invalid attestation) apart from a system error (e.g. provenance
+// fetch failure) when rendering a message.
+export { BadAttestationError };
 
 // Adapter: node public provenance endpoint. 404 -> null (unknown txn); other
 // failures propagate so they are NOT misreported as 'txn-not-found'.
@@ -28,8 +36,12 @@ export async function runVerify(proof, { fetchProvenance, minConfirmations } = {
   });
 }
 
-// Light up the three checks + overall seal in the DOM. Expects elements with
-// data-check="signature|onchain|consistent" and id="verdict-seal".
+// Render a full verdict into the DOM: the three checks, the overall seal, and
+// the reasons line. Expects elements with data-check="signature|onchain|
+// consistent", id="verdict-seal", and (optionally) id="verdict-reasons". Each
+// element is optional, so a custom skin can omit any of them. This is the
+// single composable entry point a consumer calls — it owns the whole render,
+// not just the checks.
 export function renderVerdict(verdict, root = document) {
   for (const key of ['signature', 'onchain', 'consistent']) {
     const el = root.querySelector(`[data-check="${key}"]`);
@@ -40,4 +52,8 @@ export function renderVerdict(verdict, root = document) {
   }
   const seal = root.querySelector('#verdict-seal');
   if (seal) seal.classList.toggle('verified', verdict.valid);
+  const reasons = root.querySelector('#verdict-reasons');
+  if (reasons) {
+    reasons.textContent = verdict.reasons.join(', ') || 'all checks passed';
+  }
 }

--- a/src/gumptionchain/static/js/verify-glue.mjs
+++ b/src/gumptionchain/static/js/verify-glue.mjs
@@ -1,0 +1,43 @@
+// Base verify glue: run verifyStake (from the vendored wallet module) over a
+// proof, fetching provenance from the node's public endpoint. Pure logic in
+// runVerify (fetchProvenance injectable for tests); renderVerdict lights the
+// DOM verdict.
+import { verifyStake } from '../wallet/gc-attestation.mjs';
+
+// Adapter: node public provenance endpoint. 404 -> null (unknown txn); other
+// failures propagate so they are NOT misreported as 'txn-not-found'.
+export function nodeFetchProvenance(origin = '') {
+  return async (txid) => {
+    // Encode the path segment so a malformed txid (containing /, ?, #, …)
+    // can't reshape the request into an unintended path/query.
+    const resp = await fetch(
+      `${origin}/transaction/${encodeURIComponent(txid)}/provenance.json`,
+    );
+    if (resp.status === 404) return null;
+    if (!resp.ok) {
+      throw new Error(`provenance fetch failed: ${resp.status}`);
+    }
+    return resp.json();
+  };
+}
+
+export async function runVerify(proof, { fetchProvenance, minConfirmations } = {}) {
+  return verifyStake(proof, {
+    fetchProvenance: fetchProvenance ?? nodeFetchProvenance(),
+    minConfirmations,
+  });
+}
+
+// Light up the three checks + overall seal in the DOM. Expects elements with
+// data-check="signature|onchain|consistent" and id="verdict-seal".
+export function renderVerdict(verdict, root = document) {
+  for (const key of ['signature', 'onchain', 'consistent']) {
+    const el = root.querySelector(`[data-check="${key}"]`);
+    if (el) {
+      el.classList.toggle('check-pass', !!verdict.checks[key]);
+      el.classList.toggle('check-fail', !verdict.checks[key]);
+    }
+  }
+  const seal = root.querySelector('#verdict-seal');
+  if (seal) seal.classList.toggle('verified', verdict.valid);
+}

--- a/src/gumptionchain/static/js/verify-glue.test.mjs
+++ b/src/gumptionchain/static/js/verify-glue.test.mjs
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { nodeFetchProvenance } from './verify-glue.mjs';
+
+const TX = 'a'.repeat(64);
+
+test('nodeFetchProvenance returns null on 404', async () => {
+  globalThis.fetch = async () => ({ status: 404, ok: false });
+  assert.equal(await nodeFetchProvenance('')(TX), null);
+});
+
+test('nodeFetchProvenance throws on non-ok, non-404', async () => {
+  globalThis.fetch = async () => ({ status: 500, ok: false });
+  await assert.rejects(
+    () => nodeFetchProvenance('')(TX),
+    /provenance fetch failed: 500/,
+  );
+});
+
+test('nodeFetchProvenance encodes the txid path segment', async () => {
+  let captured;
+  globalThis.fetch = async (url) => {
+    captured = url;
+    return { status: 200, ok: true, json: async () => ({}) };
+  };
+  await nodeFetchProvenance('http://x')('a/b?c#d');
+  assert.equal(
+    captured,
+    'http://x/transaction/a%2Fb%3Fc%23d/provenance.json',
+  );
+});

--- a/src/gumptionchain/static/js/verify-glue.test.mjs
+++ b/src/gumptionchain/static/js/verify-glue.test.mjs
@@ -1,31 +1,117 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { nodeFetchProvenance } from './verify-glue.mjs';
+import { nodeFetchProvenance, renderVerdict } from './verify-glue.mjs';
 
 const TX = 'a'.repeat(64);
 
+// Swap in a stub fetch for the duration of fn, always restoring the original
+// afterward so tests don't bleed global state into each other.
+async function withFetch(stub, fn) {
+  const orig = globalThis.fetch;
+  globalThis.fetch = stub;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = orig;
+  }
+}
+
 test('nodeFetchProvenance returns null on 404', async () => {
-  globalThis.fetch = async () => ({ status: 404, ok: false });
-  assert.equal(await nodeFetchProvenance('')(TX), null);
+  await withFetch(
+    async () => ({ status: 404, ok: false }),
+    async () => assert.equal(await nodeFetchProvenance('')(TX), null),
+  );
 });
 
 test('nodeFetchProvenance throws on non-ok, non-404', async () => {
-  globalThis.fetch = async () => ({ status: 500, ok: false });
-  await assert.rejects(
-    () => nodeFetchProvenance('')(TX),
-    /provenance fetch failed: 500/,
+  await withFetch(
+    async () => ({ status: 500, ok: false }),
+    async () =>
+      assert.rejects(
+        () => nodeFetchProvenance('')(TX),
+        /provenance fetch failed: 500/,
+      ),
   );
 });
 
 test('nodeFetchProvenance encodes the txid path segment', async () => {
   let captured;
-  globalThis.fetch = async (url) => {
-    captured = url;
-    return { status: 200, ok: true, json: async () => ({}) };
+  await withFetch(
+    async (url) => {
+      captured = url;
+      return { status: 200, ok: true, json: async () => ({}) };
+    },
+    async () => {
+      await nodeFetchProvenance('http://x')('a/b?c#d');
+    },
+  );
+  assert.equal(captured, 'http://x/transaction/a%2Fb%3Fc%23d/provenance.json');
+});
+
+// Minimal DOM stand-in: querySelector returns a cached fake element per
+// selector, so renderVerdict and assertions see the same nodes.
+function fakeRoot() {
+  const nodes = {};
+  return {
+    querySelector(sel) {
+      nodes[sel] ??= {
+        textContent: '',
+        classList: {
+          flags: {},
+          toggle(name, on) {
+            this.flags[name] = on;
+          },
+        },
+      };
+      return nodes[sel];
+    },
   };
-  await nodeFetchProvenance('http://x')('a/b?c#d');
+}
+
+test('renderVerdict toggles checks/seal and writes reasons', () => {
+  const root = fakeRoot();
+  renderVerdict(
+    {
+      checks: { signature: true, onchain: true, consistent: false },
+      valid: false,
+      reasons: ['claim-mismatch'],
+    },
+    root,
+  );
   assert.equal(
-    captured,
-    'http://x/transaction/a%2Fb%3Fc%23d/provenance.json',
+    root.querySelector('[data-check="signature"]').classList.flags[
+      'check-pass'
+    ],
+    true,
+  );
+  assert.equal(
+    root.querySelector('[data-check="consistent"]').classList.flags[
+      'check-fail'
+    ],
+    true,
+  );
+  assert.equal(
+    root.querySelector('#verdict-seal').classList.flags.verified,
+    false,
+  );
+  assert.equal(
+    root.querySelector('#verdict-reasons').textContent,
+    'claim-mismatch',
+  );
+});
+
+test('renderVerdict reasons line defaults to all-checks-passed', () => {
+  const root = fakeRoot();
+  renderVerdict(
+    {
+      checks: { signature: true, onchain: true, consistent: true },
+      valid: true,
+      reasons: [],
+    },
+    root,
+  );
+  assert.equal(
+    root.querySelector('#verdict-reasons').textContent,
+    'all checks passed',
   );
 });

--- a/src/gumptionchain/templates/verify.html
+++ b/src/gumptionchain/templates/verify.html
@@ -29,19 +29,22 @@
 {% block scripts -%}
 {{ super() }}
 <script type="module">
-  import { runVerify, renderVerdict } from "{{ url_for('browser.static', filename='js/verify-glue.mjs') }}";
+  import { runVerify, renderVerdict, BadAttestationError } from "{{ url_for('browser.static', filename='js/verify-glue.mjs') }}";
   document.getElementById('verify-btn').addEventListener('click', async () => {
     const verdict = document.getElementById('verdict');
     try {
       const proof = JSON.parse(document.getElementById('proof-input').value);
-      const result = await runVerify(proof);
-      renderVerdict(result, document);
-      document.getElementById('verdict-reasons').textContent =
-        result.reasons.join(', ') || 'all checks passed';
+      renderVerdict(await runVerify(proof), document);
       verdict.hidden = false;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      document.getElementById('verdict-reasons').textContent = 'Invalid proof: ' + msg;
+      // A parse / attestation error is the user's input; anything else
+      // (e.g. a provenance fetch failure) is a system error — don't blame
+      // the proof for it.
+      const userError =
+        e instanceof SyntaxError || e instanceof BadAttestationError;
+      document.getElementById('verdict-reasons').textContent =
+        (userError ? 'Invalid proof: ' : 'Could not verify: ') + msg;
       verdict.hidden = false;
     }
   });

--- a/src/gumptionchain/templates/verify.html
+++ b/src/gumptionchain/templates/verify.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Verify a stake{% endblock %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Verify a stake</div>
+      <p>Paste a <code>gc-msg-v1</code> stake attestation to check it against the chain.</p>
+      <textarea id="proof-input" class="form-control" rows="8"
+                placeholder='{"scheme":"gc-msg-v1", ...}'></textarea>
+      <button id="verify-btn" class="btn btn-primary mt-2">Verify</button>
+      <div id="verdict" class="mt-3" hidden>
+        <div id="verdict-seal" class="seal-dot">&#10003;</div>
+        <ul class="list-unstyled mt-2">
+          <li data-check="signature">Signature</li>
+          <li data-check="onchain">On-chain</li>
+          <li data-check="consistent">Consistent</li>
+        </ul>
+        <pre id="verdict-reasons"></pre>
+      </div>
+    </div></div>
+  </div></div>
+  {% include "verify/extra.html" ignore missing %}
+</div>
+{%- endblock %}
+
+{% block scripts -%}
+{{ super() }}
+<script type="module">
+  import { runVerify, renderVerdict } from "{{ url_for('browser.static', filename='js/verify-glue.mjs') }}";
+  document.getElementById('verify-btn').addEventListener('click', async () => {
+    const verdict = document.getElementById('verdict');
+    try {
+      const proof = JSON.parse(document.getElementById('proof-input').value);
+      const result = await runVerify(proof);
+      renderVerdict(result, document);
+      document.getElementById('verdict-reasons').textContent =
+        result.reasons.join(', ') || 'all checks passed';
+      verdict.hidden = false;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      document.getElementById('verdict-reasons').textContent = 'Invalid proof: ' + msg;
+      verdict.hidden = false;
+    }
+  });
+</script>
+{%- endblock %}

--- a/tests/test_verify_page.py
+++ b/tests/test_verify_page.py
@@ -1,0 +1,11 @@
+import httpx
+
+
+def test_verify_page_renders(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/verify')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        assert 'proof-input' in body  # the textarea is present
+        assert 'verify-glue.mjs' in body  # glue module is wired in
+        assert '/static/gumptionchain/' in body  # served from blueprint static

--- a/tests/test_verify_page.py
+++ b/tests/test_verify_page.py
@@ -9,3 +9,9 @@ def test_verify_page_renders(app, test_client):
         assert 'proof-input' in body  # the textarea is present
         assert 'verify-glue.mjs' in body  # glue module is wired in
         assert '/static/gumptionchain/' in body  # served from blueprint static
+        # The verdict elements renderVerdict() drives must be in the markup.
+        assert 'data-check="signature"' in body
+        assert 'verdict-seal' in body
+        assert 'verdict-reasons' in body
+        # super() in the scripts block must keep base's bundled JS (Bootstrap).
+        assert 'bootstrap' in body


### PR DESCRIPTION
**PR 3 of 4** for EGU #189. Stacked on #193 (base: `feat/egu-189-public-provenance`).

- `static/js/verify-glue.mjs` — `nodeFetchProvenance` (provenance adapter; 404→null, other non-ok→throw, txid path-encoded), `runVerify` (wraps the vendored `verifyStake`), and `renderVerdict` (the single composable renderer: checks + seal + reasons). Re-exports `BadAttestationError`.
- `static/js/verify-glue.test.mjs` — 5 node tests (adapter behaviors + `renderVerdict`), each with `fetch` save/restore.
- `.github/workflows/tests.yml` — runs `src/gumptionchain/static/js/*.test.mjs`.
- `browser.py` — `GET /verify` (`verify_view`).
- `templates/verify.html` — verify-only page; uses only the `title`/`content`/`scripts` block contract; `scripts` uses `{{ super() }}` to keep base JS; ends with `{% include "verify/extra.html" ignore missing %}` (extension hook; base ships no such file); distinguishes user-input vs system errors.
- `tests/test_verify_page.py`.

Read-only — no proof-store/POST coupling.

Reviewed: two-stage subagent review (spec ✅, code-quality needs-changes → fixed: fetch teardown, composable renderVerdict, clearer error messaging, stronger page test). mypy strict clean; full suite 395 passed; 5 node tests pass.

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)