### PR TITLE
feat(egu-189): public GET /transaction/<txid>/provenance.json

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import Blueprint, abort, current_app, render_template
+from flask import Blueprint, abort, current_app, jsonify, render_template
 from werkzeug.exceptions import HTTPException
 
 from gumptionchain.block import Block
@@ -10,6 +10,7 @@ from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import BlockDAO, ChainDAO, TransactionDAO
 from gumptionchain.node import Node
+from gumptionchain.provenance import lookup_provenance
 from gumptionchain.transaction import Transaction
 
 
@@ -130,3 +131,19 @@ def transaction_view(txid: str) -> Any:
         outflows=outflows,
         outflow_total=outflow_total,
     )
+
+
+@blueprint.route('/transaction/<mill_hash:txid>/provenance.json')
+def transaction_provenance_view(txid: str) -> Any:
+    try:
+        prov = lookup_provenance(txid)
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        current_app.logger.exception(e)
+        abort(500)
+    if prov is None:
+        return jsonify({'error': 'transaction not found'}), 404
+    # Route param (mill_hash-validated) is authoritative for txid; unpack prov
+    # first so a stray 'txid' key can't override the request path.
+    return jsonify({**prov, 'txid': txid})

--- a/src/gumptionchain/provenance.py
+++ b/src/gumptionchain/provenance.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 from typing import Any
 
-from gumptionchain.api import node_lc_dao
+from flask import current_app
+
 from gumptionchain.models import ChainDAO
+from gumptionchain.node import Node
 
 
 def lookup_provenance(txid: str) -> dict[str, Any] | None:
-    """Public, in-process provenance lookup — the same code path the authed
-    /api/transaction/<txid> view uses, minus authentication. Returns the
+    """Public, in-process provenance lookup — the same data the authed
+    /api/transaction/<txid> view returns, minus authentication. Returns the
     #176a provenance dict, or None if the txn is unknown.
+
+    Resolves the longest chain via Node directly (mirroring
+    browser.longest_chain) rather than the API layer, to avoid an upward
+    dependency from this module into the api blueprint.
     """
-    _, lc, _ = node_lc_dao()
+    lc = Node(logger=current_app.logger).longest_chain
     if lc is not None:
         return lc.transaction_provenance(txid)
     return ChainDAO.pending_provenance(txid)

--- a/src/gumptionchain/provenance.py
+++ b/src/gumptionchain/provenance.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+from gumptionchain.api import node_lc_dao
+from gumptionchain.models import ChainDAO
+
+
+def lookup_provenance(txid: str) -> dict[str, Any] | None:
+    """Public, in-process provenance lookup — the same code path the authed
+    /api/transaction/<txid> view uses, minus authentication. Returns the
+    #176a provenance dict, or None if the txn is unknown.
+    """
+    _, lc, _ = node_lc_dao()
+    if lc is not None:
+        return lc.transaction_provenance(txid)
+    return ChainDAO.pending_provenance(txid)

--- a/tests/test_provenance_public.py
+++ b/tests/test_provenance_public.py
@@ -1,48 +1,47 @@
 import httpx
 
-from gumptionchain.block import Block
+from gumptionchain.api_client import ApiClient
 from gumptionchain.provenance import lookup_provenance
 
 
 def test_lookup_provenance_returns_dict_for_canonical_txn(
-    app, add_chain_block, subject, wallet
+    app, host, mill_block, requests_proxy, subject, wallet
 ):
     with app.app_context():
         assert lookup_provenance('a' * 64) is None
-        c, _ = add_chain_block()
-        c.to_db()
-        t = c.create_support(wallet, 1, subject)
-        t.seal()
-        t.sign()
-        b = Block()
-        b.add_txn(t)
-        add_chain_block(chain=c, block=b)
-        prov = lookup_provenance(t.txid)
+        m, _b1 = mill_block(wallet)
+        txn = m.longest_chain.create_opposition(wallet, 300, subject)
+        txn.sign()
+        ApiClient(host, wallet).post_transaction(txn)
+        mill_block(wallet)
+        prov = lookup_provenance(txn.txid)
         assert prov is not None
-        assert 'status' in prov
+        assert prov['status'] == 'canonical'
 
 
-def test_provenance_json_route(
-    app, add_chain_block, subject, test_client, wallet
-):
+def test_provenance_json_route_unknown_returns_404(app, test_client):
     with app.app_context():
         resp = test_client.get('/transaction/' + 'a' * 64 + '/provenance.json')
         assert resp.status_code == httpx.codes.NOT_FOUND
         assert resp.is_json
         assert resp.get_json()['error'] == 'transaction not found'
 
-        c, _ = add_chain_block()
-        c.to_db()
-        t = c.create_support(wallet, 1, subject)
-        t.seal()
-        t.sign()
-        b = Block()
-        b.add_txn(t)
-        add_chain_block(chain=c, block=b)
 
-        resp = test_client.get(f'/transaction/{t.txid}/provenance.json')
+def test_provenance_json_route_canonical(
+    app, host, mill_block, requests_proxy, subject, test_client, wallet
+):
+    with app.app_context():
+        m, _b1 = mill_block(wallet)
+        txn = m.longest_chain.create_opposition(wallet, 300, subject)
+        txn.sign()
+        ApiClient(host, wallet).post_transaction(txn)
+        _m, b2 = mill_block(wallet)
+
+        resp = test_client.get(f'/transaction/{txn.txid}/provenance.json')
         assert resp.status_code == httpx.codes.OK
         assert resp.is_json
         data = resp.get_json()
-        assert data['txid'] == t.txid
-        assert 'status' in data
+        assert data['txid'] == txn.txid
+        assert data['status'] == 'canonical'
+        assert data['confirmations'] == 1
+        assert data['block_hash'] == b2.block_hash

--- a/tests/test_provenance_public.py
+++ b/tests/test_provenance_public.py
@@ -1,3 +1,5 @@
+import httpx
+
 from gumptionchain.block import Block
 from gumptionchain.provenance import lookup_provenance
 
@@ -18,3 +20,29 @@ def test_lookup_provenance_returns_dict_for_canonical_txn(
         prov = lookup_provenance(t.txid)
         assert prov is not None
         assert 'status' in prov
+
+
+def test_provenance_json_route(
+    app, add_chain_block, subject, test_client, wallet
+):
+    with app.app_context():
+        resp = test_client.get('/transaction/' + 'a' * 64 + '/provenance.json')
+        assert resp.status_code == httpx.codes.NOT_FOUND
+        assert resp.is_json
+        assert resp.get_json()['error'] == 'transaction not found'
+
+        c, _ = add_chain_block()
+        c.to_db()
+        t = c.create_support(wallet, 1, subject)
+        t.seal()
+        t.sign()
+        b = Block()
+        b.add_txn(t)
+        add_chain_block(chain=c, block=b)
+
+        resp = test_client.get(f'/transaction/{t.txid}/provenance.json')
+        assert resp.status_code == httpx.codes.OK
+        assert resp.is_json
+        data = resp.get_json()
+        assert data['txid'] == t.txid
+        assert 'status' in data

--- a/tests/test_provenance_public.py
+++ b/tests/test_provenance_public.py
@@ -1,0 +1,20 @@
+from gumptionchain.block import Block
+from gumptionchain.provenance import lookup_provenance
+
+
+def test_lookup_provenance_returns_dict_for_canonical_txn(
+    app, add_chain_block, subject, wallet
+):
+    with app.app_context():
+        assert lookup_provenance('a' * 64) is None
+        c, _ = add_chain_block()
+        c.to_db()
+        t = c.create_support(wallet, 1, subject)
+        t.seal()
+        t.sign()
+        b = Block()
+        b.add_txn(t)
+        add_chain_block(chain=c, block=b)
+        prov = lookup_provenance(t.txid)
+        assert prov is not None
+        assert 'status' in prov


### PR DESCRIPTION
**PR 2 of 4** for EGU #189 (supersedes #193, which auto-closed when the stacked base branch was deleted on merge of #192). Rebased onto `main`.

- `src/gumptionchain/provenance.py` — `lookup_provenance(txid)`, an **unauthed** in-process provenance read via `Node(...).longest_chain` (no upward dependency into the api blueprint).
- `browser.py` — unauthed `GET /transaction/<mill_hash:txid>/provenance.json`; 404 JSON for unknown, else `{**prov, 'txid': txid}`. Same data the HTML `transaction_view` already exposes.
- `tests/test_provenance_public.py` — exercises a genuinely canonical txn (mill→post→mill).

Reviewed earlier as #193: two-stage subagent review (spec ✅, code-quality approve-with-change applied). mypy strict clean; full suite green.

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)