### PR TITLE
feat(browser): paginated blocks list page (#196)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -61,6 +61,24 @@ def chains_view() -> Any:
     )
 
 
+@blueprint.route('/blocks')
+def blocks_view() -> Any:
+    try:
+        blocks_page = db.paginate(BlockDAO.longest_chain_blocks_q())
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'blocks.html', title='Blocks', blocks_page=blocks_page
+    )
+
+
 @blueprint.route('/block')
 @blueprint.route('/block/<mill_hash:block_hash>')
 def block_view(block_hash: str | None = None) -> Any:

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -65,6 +65,9 @@ def chains_view() -> Any:
 def blocks_view() -> Any:
     try:
         blocks_page = db.paginate(BlockDAO.longest_chain_blocks_q())
+        tx_counts = BlockDAO.transaction_counts(
+            [block.id for block in blocks_page.items]
+        )
     except HTTPException as e:
         return e
     except Exception as e:
@@ -75,7 +78,10 @@ def blocks_view() -> Any:
         current_app.logger.exception(e)
         abort(500)
     return render_template(
-        'blocks.html', title='Blocks', blocks_page=blocks_page
+        'blocks.html',
+        title='Blocks',
+        blocks_page=blocks_page,
+        tx_counts=tx_counts,
     )
 
 

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -531,6 +531,27 @@ class BlockDAO(Base):
         )
 
     @classmethod
+    def transaction_counts(cls, block_ids: list[int]) -> dict[int, int]:
+        """Map block id → transaction count for the given blocks.
+
+        One grouped query over the block↔transaction association table,
+        so a list view can show per-block txn counts without firing a
+        COUNT per row against the `lazy='dynamic'` `transactions`
+        relationship (an N+1).
+        """
+        if not block_ids:
+            return {}
+        rows = db.session.execute(
+            db.select(
+                block_transactions.c.block_id,
+                db.func.count().label('ct'),
+            )
+            .where(block_transactions.c.block_id.in_(block_ids))
+            .group_by(block_transactions.c.block_id)
+        ).all()
+        return {row[0]: row[1] for row in rows}
+
+    @classmethod
     def longest_chain_transactions_q(cls) -> Select[tuple[TransactionDAO]]:
         """Transactions in the longest chain, ordered tip→genesis.
 

--- a/src/gumptionchain/templates/_pagination.html
+++ b/src/gumptionchain/templates/_pagination.html
@@ -1,0 +1,21 @@
+{% macro render_pagination(page, endpoint) -%}
+{%- if page.pages > 1 %}
+<ul class="pagination">
+  <li class="page-item {{ '' if page.has_prev else 'disabled' }}">
+    <a class="page-link" href="{{ url_for(endpoint, page=page.prev_num) }}">Previous</a>
+  </li>
+  {%- for p in page.iter_pages() %}
+  {%- if p %}
+  <li class="page-item {{ 'active' if p == page.page else '' }}">
+    <a class="page-link" href="{{ url_for(endpoint, page=p) }}">{{ p }}</a>
+  </li>
+  {%- else %}
+  <li class="page-item disabled"><span class="page-link">…</span></li>
+  {%- endif %}
+  {%- endfor %}
+  <li class="page-item {{ '' if page.has_next else 'disabled' }}">
+    <a class="page-link" href="{{ url_for(endpoint, page=page.next_num) }}">Next</a>
+  </li>
+</ul>
+{%- endif %}
+{%- endmacro %}

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -17,6 +17,7 @@
   <nav class="navbar mx-3" >
     <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">Home</a>
     <a class="navbar-nav" href="{{ url_for('browser.chains_view') }}">Chains</a>
+    <a class="navbar-nav" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/blocks.html
+++ b/src/gumptionchain/templates/blocks.html
@@ -15,7 +15,7 @@
             <td>{{ block.idx }}</td>
             <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.block_hash) }}">{{ block.block_hash }}</a></td>
             <td>{{ block.timestamp | utc_datetime }}</td>
-            <td>{{ block.transactions.count() }}</td>
+            <td>{{ tx_counts.get(block.id, 0) }}</td>
           </tr>
         {%- endfor %}
         </tbody>

--- a/src/gumptionchain/templates/blocks.html
+++ b/src/gumptionchain/templates/blocks.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Blocks</div>
+      {%- if blocks_page.total %}
+      <table class="table table-hover blocks">
+        <thead><tr><th>#</th><th>Hash</th><th>Timestamp</th><th>Txns</th></tr></thead>
+        <tbody class="font-monospace">
+        {%- for block in blocks_page.items %}
+          <tr>
+            <td>{{ block.idx }}</td>
+            <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.block_hash) }}">{{ block.block_hash }}</a></td>
+            <td>{{ block.timestamp | utc_datetime }}</td>
+            <td>{{ block.transactions.count() }}</td>
+          </tr>
+        {%- endfor %}
+        </tbody>
+      </table>
+      {{ render_pagination(blocks_page, 'browser.blocks_view') }}
+      {%- else %}
+      <p>No blocks.</p>
+      {%- endif %}
+    </div></div>
+  </div></div>
+</div>
+{%- endblock %}

--- a/tests/test_blocks_page.py
+++ b/tests/test_blocks_page.py
@@ -1,3 +1,26 @@
+from flask import render_template_string
+
+from gumptionchain.api_client import ApiClient
+
+_MACRO = (
+    "{% from '_pagination.html' import render_pagination %}"
+    "{{ render_pagination(page, 'browser.blocks_view') }}"
+)
+
+
+class _FakePage:
+    def __init__(self, *, pages, page=1, prev=False, nxt=False):
+        self.pages = pages
+        self.page = page
+        self.has_prev = prev
+        self.has_next = nxt
+        self.prev_num = page - 1
+        self.next_num = page + 1
+
+    def iter_pages(self):
+        return list(range(1, self.pages + 1))
+
+
 def test_blocks_list_empty(test_client):
     resp = test_client.get('/blocks')
     assert resp.status_code == 200
@@ -16,3 +39,38 @@ def test_blocks_list_shows_mined_blocks(
         assert resp.status_code == 200
         assert tip_hash.encode() in resp.data
         assert b'/block/' in resp.data
+
+
+def test_blocks_list_shows_transaction_count(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    # A block carrying a staking txn shows a non-zero Txns count (the coinbase
+    # plus the staked transaction), exercising the precomputed tx_counts map.
+    with app.app_context():
+        m, _b1 = mill_block(wallet)
+        txn = m.longest_chain.create_opposition(wallet, 300, subject)
+        txn.sign()
+        ApiClient(host, wallet).post_transaction(txn)
+        mill_block(wallet)
+
+        resp = app.test_client().get('/blocks')
+        assert resp.status_code == 200
+        # the confirming block has 2 txns (coinbase + the opposition stake)
+        assert b'<td>2</td>' in resp.data
+
+
+def test_pagination_macro_renders_when_multipage(app):
+    with app.test_request_context():
+        html = render_template_string(
+            _MACRO, page=_FakePage(pages=3, page=2, prev=True, nxt=True)
+        )
+    assert 'class="pagination"' in html
+    assert 'page=1' in html  # Previous / first page link
+    assert 'page=3' in html  # Next / last page link
+    assert 'active' in html  # the current page is marked active
+
+
+def test_pagination_macro_hidden_when_single_page(app):
+    with app.test_request_context():
+        html = render_template_string(_MACRO, page=_FakePage(pages=1))
+    assert 'class="pagination"' not in html

--- a/tests/test_blocks_page.py
+++ b/tests/test_blocks_page.py
@@ -1,0 +1,18 @@
+def test_blocks_list_empty(test_client):
+    resp = test_client.get('/blocks')
+    assert resp.status_code == 200
+    assert b'No blocks' in resp.data
+
+
+def test_blocks_list_shows_mined_blocks(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        _m, b2 = mill_block(wallet)
+        tip_hash = b2.block_hash
+
+        resp = app.test_client().get('/blocks')
+        assert resp.status_code == 200
+        assert tip_hash.encode() in resp.data
+        assert b'/block/' in resp.data

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -40,3 +40,40 @@ def test_consumer_base_html_reskins_base_pages(tmp_path):
         assert resp.status_code == 200
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         assert b'No chain' in resp.data  # base index content still rendered
+
+
+def test_consumer_base_html_reskins_blocks_page(tmp_path):
+    # Same seam check for the blocks list page: the consumer's base.html must
+    # re-skin it while the blueprint's blocks.html content still renders.
+    tdir = tmp_path / 'templates'
+    tdir.mkdir()
+    (tdir / 'base.html').write_text(
+        '<!doctype html><html><head>'
+        '<title>{% block title %}{% endblock %}</title>'
+        '{% block head %}{% endblock %}</head><body>'
+        '<div id="custom-skin">SKINNED</div>'
+        '{% block nav %}{% endblock %}'
+        '<main>{% block content %}{% endblock %}</main>'
+        '{% block footer %}{% endblock %}'
+        '{% block scripts %}{% endblock %}'
+        '</body></html>'
+    )
+    consumer = Flask('consumer_app', template_folder=str(tdir))
+    db_uri = f'sqlite:///{tmp_path / "seam.sqlite"}'
+    app = create_app(
+        app=consumer,
+        config_map={
+            'TESTING': True,
+            'SECRET_KEY': 'x',
+            'SQLALCHEMY_DATABASE_URI': db_uri,
+            'NODE_HOST': 'http://localhost',
+            'READER_ADDRESSES': ['*'],
+        },
+    )
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/blocks')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        assert b'No blocks' in resp.data  # base blocks content still rendered


### PR DESCRIPTION
PR 1 of **#196** (base default UI buildout). Adds a paginated blocks list explorer page on the existing base↔extension seam.

## What
- **`/blocks`** — paginated canonical-chain block list (newest first): idx, hash (links to `/block/<hash>`), timestamp, txn count.
- **`_pagination.html`** — shared Jinja macro `render_pagination(page, endpoint)` (renders nothing for a single page). PR 2's subjects page will reuse it.
- **Nav link** added to `base.html`.
- **`BlockDAO.transaction_counts(block_ids)`** — one grouped query over the block↔transaction association table, so the list shows per-block txn counts without an N+1 against the `lazy='dynamic'` relationship.

## Seam conformance
`blocks.html` `{% extends "base.html" %}` and fills only the `content` block, so a consumer (gumption-hub) re-skins it for free. Covered by a new `test_ui_seam.py` test proving app `base.html` overrides the blueprint's.

## Tests
- Empty state, mined-blocks render, per-block txn-count, and macro-level pagination (multi-page renders links + active; single page renders nothing).
- Gates green: ruff check + format, mypy strict, pytest (401 passed).

## Notes
- The existing `chains.html` pagination has a latent wrong-endpoint bug (links to `index_view`); **not** touched here to avoid scope creep — filed separately. The new macro does it correctly.

Spec: `docs/superpowers/specs/2026-06-07-egu-196-base-ui-pages-design.md`
Refs #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)