### PR TITLE
feat(browser): subjects opposition/support leaderboard + detail (#196)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+import sqlalchemy as sa
 from flask import Blueprint, abort, current_app, jsonify, render_template
+from flask_sqlalchemy.pagination import SelectPagination
 from werkzeug.exceptions import HTTPException
 
 from gumptionchain.block import Block
@@ -10,8 +12,38 @@ from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import BlockDAO, ChainDAO, TransactionDAO
 from gumptionchain.node import Node
+from gumptionchain.payload import decode_subject
 from gumptionchain.provenance import lookup_provenance
 from gumptionchain.transaction import Transaction
+
+
+class _RowPagination(SelectPagination):
+    """Pagination over a compound/column select (not a single ORM entity).
+
+    ``db.paginate`` applies ``.scalars()``, which collapses a multi-column
+    leaderboard row down to its first column. This variant keeps whole
+    ``Row`` objects (so templates can read ``row.subject`` / ``.total``)
+    and counts without the ORM-only ``lazyload`` option.
+    """
+
+    def _query_items(self) -> list[Any]:
+        select = self._query_args['select']
+        select = select.limit(self.per_page).offset(self._query_offset)
+        session = self._query_args['session']
+        return list(session.execute(select).all())
+
+    def _query_count(self) -> int:
+        select = self._query_args['select']
+        sub = select.order_by(None).subquery()
+        session = self._query_args['session']
+        out = session.execute(
+            sa.select(sa.func.count()).select_from(sub)
+        ).scalar()
+        return out or 0
+
+
+def paginate_rows(select: sa.sql.Select[Any]) -> _RowPagination:
+    return _RowPagination(select=select, session=db.session())
 
 
 def longest_chain() -> Chain | None:
@@ -82,6 +114,67 @@ def blocks_view() -> Any:
         title='Blocks',
         blocks_page=blocks_page,
         tx_counts=tx_counts,
+    )
+
+
+@blueprint.route('/subjects')
+def subjects_view() -> Any:
+    try:
+        lc = longest_chain()
+        subjects_page = (
+            paginate_rows(lc.subject_leaderboard()) if lc is not None else None
+        )
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'subjects.html', title='Subjects', subjects_page=subjects_page
+    )
+
+
+@blueprint.route('/subject/<subject:subject>')
+def subject_view(subject: str) -> Any:
+    try:
+        lc = longest_chain()
+        if lc is None:
+            opposition = support = 0
+            opposition_flows: list[Any] = []
+            support_flows: list[Any] = []
+        else:
+            opposition = lc.opposition_balance(subject)
+            support = lc.support_balance(subject)
+            dao = lc.to_dao()
+            opposition_flows = list(
+                db.session.scalars(
+                    dao.unrescinded_outflows(subject, 'opposition')
+                )
+            )
+            support_flows = list(
+                db.session.scalars(dao.unrescinded_outflows(subject, 'support'))
+            )
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'subject.html',
+        title=f'Subject: {decode_subject(subject)}',
+        subject=subject,
+        opposition=opposition,
+        support=support,
+        opposition_flows=opposition_flows,
+        support_flows=support_flows,
     )
 
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import Any, Self, assert_never
 
+from sqlalchemy import Select
 from sqlalchemy.exc import SQLAlchemyError
 
 from gumptionchain.block import Block
@@ -514,6 +515,28 @@ class Chain:
 
     def support_balance(self, subject: str) -> int:
         return int(self.to_dao().support_balance(subject))
+
+    def subject_leaderboard(self, limit: int | None = None) -> Select[Any]:
+        return self.to_dao().subject_leaderboard(limit)
+
+    def recent_blocks(self, count: int = 10) -> list[Block]:
+        q = BlockDAO.longest_chain_blocks_q().limit(count)
+        return [Block.from_dao(b) for b in db.session.scalars(q)]
+
+    @property
+    def transaction_count(self) -> int:
+        q = BlockDAO.longest_chain_transactions_q().subquery()
+        return db.session.scalar(db.select(db.func.count()).select_from(q)) or 0
+
+    @property
+    def subject_count(self) -> int:
+        q = self.subject_leaderboard().subquery()
+        return db.session.scalar(db.select(db.func.count()).select_from(q)) or 0
+
+    @property
+    def total_staked(self) -> int:
+        q = self.subject_leaderboard().subquery()
+        return db.session.scalar(db.select(db.func.sum(q.c.total))) or 0
 
     def transaction_provenance(self, txid: str) -> dict[str, Any] | None:
         dao = self.to_dao()

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -824,6 +824,46 @@ class ChainDAO(Base):
             return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
         return stmt  # type: ignore[no-any-return]
 
+    def subject_leaderboard(
+        self,
+        limit: int | None = None,
+    ) -> Select[Any]:
+        inflows_alias = db.aliased(InflowDAO, self.inflows.subquery())
+
+        def _leg(column: Any, kind: StakeKind) -> Select[Any]:
+            stmt = self.outflows.where(column.is_not(None))
+            stmt = stmt.join(inflows_alias, OutflowDAO.inflows, isouter=True)
+            stmt = stmt.where(inflows_alias.id.is_(None))
+            stmt = stmt.with_only_columns(
+                column.label('subject'),
+                OutflowDAO.amount.label('amount'),
+                db.literal(kind).label('kind'),
+            )
+            # UNION legs must not carry their own ORDER BY (the
+            # chain-scoped self.outflows select adds one); SQLite rejects
+            # an ORDER BY inside a compound SELECT operand.
+            return stmt.order_by(None)
+
+        opp = _leg(OutflowDAO.opposition, 'opposition')
+        sup = _leg(OutflowDAO.support, 'support')
+        union = opp.union_all(sup).subquery()
+        stmt = db.select(
+            union.c.subject,
+            db.func.sum(
+                db.case((union.c.kind == 'opposition', union.c.amount), else_=0)
+            ).label('opposition'),
+            db.func.sum(
+                db.case((union.c.kind == 'support', union.c.amount), else_=0)
+            ).label('support'),
+            db.func.sum(union.c.amount).label('total'),
+        )
+        stmt = stmt.group_by(union.c.subject)
+        stmt = stmt.order_by(db.desc('total'), union.c.subject)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+            return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
+        return stmt  # type: ignore[no-any-return]
+
     def _is_longest(self) -> bool:
         """True iff this ChainDAO row is currently the longest chain.
 

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -18,6 +18,7 @@
     <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">Home</a>
     <a class="navbar-nav" href="{{ url_for('browser.chains_view') }}">Chains</a>
     <a class="navbar-nav" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
+    <a class="navbar-nav" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/subject.html
+++ b/src/gumptionchain/templates/subject.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <h3>{{ subject | human_subject }}</h3>
+  </div></div>
+
+  <div class="row my-3">
+    <div class="col">
+      <div class="card bg-light"><div class="card-body">
+        <div class="card-title h5">Opposition</div>
+        <p class="h4">{{ opposition }} <small class="text-muted">grains</small></p>
+        {%- if opposition_flows %}
+        <table class="table table-hover">
+          <thead><tr><th>Amount</th><th>Transaction</th></tr></thead>
+          <tbody class="font-monospace">
+          {%- for flow in opposition_flows %}
+            <tr>
+              <td>{{ flow.amount }}</td>
+              <td><a class="text-dark" href="{{ url_for('browser.transaction_view', txid=flow.txid) }}">{{ flow.txid }}</a></td>
+            </tr>
+          {%- endfor %}
+          </tbody>
+        </table>
+        {%- else %}
+        <p>none</p>
+        {%- endif %}
+      </div></div>
+    </div>
+
+    <div class="col">
+      <div class="card bg-light"><div class="card-body">
+        <div class="card-title h5">Support</div>
+        <p class="h4">{{ support }} <small class="text-muted">grains</small></p>
+        {%- if support_flows %}
+        <table class="table table-hover">
+          <thead><tr><th>Amount</th><th>Transaction</th></tr></thead>
+          <tbody class="font-monospace">
+          {%- for flow in support_flows %}
+            <tr>
+              <td>{{ flow.amount }}</td>
+              <td><a class="text-dark" href="{{ url_for('browser.transaction_view', txid=flow.txid) }}">{{ flow.txid }}</a></td>
+            </tr>
+          {%- endfor %}
+          </tbody>
+        </table>
+        {%- else %}
+        <p>none</p>
+        {%- endif %}
+      </div></div>
+    </div>
+  </div>
+</div>
+{%- endblock %}

--- a/src/gumptionchain/templates/subjects.html
+++ b/src/gumptionchain/templates/subjects.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Subjects</div>
+      {% include "subjects/extra.html" ignore missing %}
+      {%- if subjects_page and subjects_page.total %}
+      <table class="table table-hover subjects">
+        <thead><tr><th>#</th><th>Subject</th><th>Opposition</th><th>Support</th><th>Total</th></tr></thead>
+        <tbody>
+        {%- for row in subjects_page.items %}
+          <tr>
+            <td>{{ loop.index + (subjects_page.page - 1) * subjects_page.per_page }}</td>
+            <td><a class="text-dark" href="{{ url_for('browser.subject_view', subject=row.subject) }}">{{ row.subject | human_subject }}</a></td>
+            <td>{{ row.opposition }}</td>
+            <td>{{ row.support }}</td>
+            <td>{{ row.total }}</td>
+          </tr>
+        {%- endfor %}
+        </tbody>
+      </table>
+      {{ render_pagination(subjects_page, 'browser.subjects_view') }}
+      {%- else %}
+      <p>No subjects staked yet.</p>
+      {%- endif %}
+    </div></div>
+  </div></div>
+</div>
+{%- endblock %}

--- a/tests/test_subject_leaderboard.py
+++ b/tests/test_subject_leaderboard.py
@@ -1,0 +1,128 @@
+from gumptionchain.api_client import ApiClient
+from gumptionchain.database import db
+from gumptionchain.payload import encode_subject
+
+
+def _stake(host, chain, wallet, *, oppose=None, support=None):
+    """Create + post + return a staking txn for one subject/kind."""
+    if oppose is not None:
+        subject, amount = oppose
+        txn = chain.create_opposition(wallet, amount, subject)
+    else:
+        subject, amount = support
+        txn = chain.create_support(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+def test_subject_leaderboard_orders_by_total_and_splits_kinds(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    other = encode_subject('other')
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        # subject: 300 opposition + 150 support = 450
+        _stake(host, lc, wallet, oppose=(subject, 300))
+        mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, support=(subject, 150))
+        mill_block(wallet)
+        lc = m.longest_chain
+        # other: 100 opposition = 100
+        _stake(host, lc, wallet, oppose=(other, 100))
+        mill_block(wallet)
+
+        chain_dao = m.longest_chain.to_dao()
+        rows = db.session.execute(chain_dao.subject_leaderboard()).all()
+        by_subject = {r.subject: r for r in rows}
+
+        s = by_subject[subject]
+        assert s.opposition == 300
+        assert s.support == 150
+        assert s.total == 450
+
+        o = by_subject[other]
+        assert o.opposition == 100
+        assert o.support == 0
+        assert o.total == 100
+
+        totals = [r.total for r in rows]
+        assert totals == sorted(totals, reverse=True)
+        # subject (450) ranks before other (100)
+        assert rows[0].subject == subject
+
+
+def test_subject_leaderboard_excludes_rescinded(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, oppose=(subject, 300))
+        mill_block(wallet)
+
+        lc = m.longest_chain
+        rescind = lc.create_rescind(wallet, 200, subject, 'opposition')
+        rescind.sign()
+        ApiClient(host, wallet).post_transaction(rescind)
+        mill_block(wallet)
+
+        chain_dao = m.longest_chain.to_dao()
+        rows = db.session.execute(chain_dao.subject_leaderboard()).all()
+        by_subject = {r.subject: r for r in rows}
+        # 300 staked, 200 rescinded -> 100 live opposition remains
+        assert by_subject[subject].opposition == 100
+        assert by_subject[subject].total == 100
+
+
+def test_subject_leaderboard_limit(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    other = encode_subject('other')
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, oppose=(subject, 300))
+        mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, oppose=(other, 100))
+        mill_block(wallet)
+
+        chain_dao = m.longest_chain.to_dao()
+        rows = db.session.execute(chain_dao.subject_leaderboard(limit=1)).all()
+        assert len(rows) == 1
+        # the higher-total subject wins the single slot
+        assert rows[0].subject == subject
+
+
+def test_chain_delegates_and_stats(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    other = encode_subject('other')
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, oppose=(subject, 300))
+        mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, support=(other, 150))
+        mill_block(wallet)
+
+        lc = m.longest_chain
+        # delegate returns the same rows as the DAO
+        chain_rows = db.session.execute(lc.subject_leaderboard()).all()
+        dao_rows = db.session.execute(lc.to_dao().subject_leaderboard()).all()
+        assert {r.subject for r in chain_rows} == {r.subject for r in dao_rows}
+
+        assert lc.subject_count == 2
+        assert lc.total_staked == 450
+        # transaction_count counts every txn in the canonical chain
+        assert lc.transaction_count >= 4  # coinbases + 2 stakes
+
+        recent = lc.recent_blocks(2)
+        assert len(recent) == 2
+        # newest-first
+        assert recent[0].idx > recent[1].idx
+        assert recent[0].block_hash == lc.last_block.block_hash

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -1,0 +1,86 @@
+from gumptionchain.api_client import ApiClient
+from gumptionchain.payload import encode_subject
+
+
+def _stake_opposition(host, chain, wallet, amount, subject):
+    txn = chain.create_opposition(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+def _stake_support(host, chain, wallet, amount, subject):
+    txn = chain.create_support(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+# ---- subjects index ----------------------------------------------------
+
+
+def test_subjects_index_empty(test_client):
+    resp = test_client.get('/subjects')
+    assert resp.status_code == 200
+    assert b'No subjects staked yet' in resp.data
+
+
+def test_subjects_index_shows_stakes(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 300, subject)
+        mill_block(wallet)
+        _stake_support(host, m.longest_chain, wallet, 150, subject)
+        mill_block(wallet)
+
+        resp = app.test_client().get('/subjects')
+        assert resp.status_code == 200
+        # human-readable subject name rendered
+        assert b'failing tests' in resp.data
+        # opposition + support + total present
+        assert b'300' in resp.data
+        assert b'150' in resp.data
+        assert b'450' in resp.data
+        # links to the detail page using the encoded subject
+        assert f'/subject/{subject}'.encode() in resp.data
+
+
+# ---- subject detail ----------------------------------------------------
+
+
+def test_subject_detail_shows_totals_and_links(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        txn = _stake_opposition(host, m.longest_chain, wallet, 300, subject)
+        mill_block(wallet)
+        _stake_support(host, m.longest_chain, wallet, 150, subject)
+        mill_block(wallet)
+
+        resp = app.test_client().get(f'/subject/{subject}')
+        assert resp.status_code == 200
+        assert b'300' in resp.data  # opposition total
+        assert b'150' in resp.data  # support total
+        # link to the staking transaction
+        assert f'/transaction/{txn.txid}'.encode() in resp.data
+
+
+def test_subject_detail_unknown_valid_subject_is_200_zeros(
+    app, host, mill_block, requests_proxy, wallet
+):
+    unknown = encode_subject('never-staked')
+    with app.app_context():
+        mill_block(wallet)
+        resp = app.test_client().get(f'/subject/{unknown}')
+        assert resp.status_code == 200
+        # zero totals, no staking outflows
+        assert b'none' in resp.data
+
+
+def test_subject_detail_invalid_subject_is_404(test_client):
+    # '!!!' is not a valid base64url-encoded subject; converter rejects it.
+    resp = test_client.get('/subject/!!!')
+    assert resp.status_code == 404

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -47,6 +47,39 @@ def test_subjects_index_shows_stakes(
         assert f'/subject/{subject}'.encode() in resp.data
 
 
+def test_subjects_index_paginates_across_pages(
+    app, host, mill_block, requests_proxy, wallet
+):
+    # Stake three subjects with distinct totals so ranking is deterministic,
+    # then page with per_page=2 to exercise the _RowPagination offset/count
+    # path (the leaderboard is a multi-column Core select, not an ORM entity).
+    top = encode_subject('top-subject')
+    mid = encode_subject('mid-subject')
+    low = encode_subject('low-subject')
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 300, top)
+        mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 200, mid)
+        mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 100, low)
+        mill_block(wallet)
+
+        client = app.test_client()
+        page1 = client.get('/subjects?per_page=2&page=1')
+        assert page1.status_code == 200
+        assert f'/subject/{top}'.encode() in page1.data  # rank 1
+        assert f'/subject/{mid}'.encode() in page1.data  # rank 2
+        assert f'/subject/{low}'.encode() not in page1.data
+
+        page2 = client.get('/subjects?per_page=2&page=2')
+        assert page2.status_code == 200
+        # only the lowest-total subject spills onto page 2
+        assert f'/subject/{low}'.encode() in page2.data
+        assert f'/subject/{top}'.encode() not in page2.data
+        assert f'/subject/{mid}'.encode() not in page2.data
+
+
 # ---- subject detail ----------------------------------------------------
 
 

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -2,6 +2,37 @@ from flask import Flask
 
 from gumptionchain import create_app
 from gumptionchain.database import db
+from gumptionchain.payload import encode_subject
+
+_CONSUMER_BASE = (
+    '<!doctype html><html><head>'
+    '<title>{% block title %}{% endblock %}</title>'
+    '{% block head %}{% endblock %}</head><body>'
+    '<div id="custom-skin">SKINNED</div>'
+    '{% block nav %}{% endblock %}'
+    '<main>{% block content %}{% endblock %}</main>'
+    '{% block footer %}{% endblock %}'
+    '{% block scripts %}{% endblock %}'
+    '</body></html>'
+)
+
+
+def _consumer_app(tmp_path):
+    tdir = tmp_path / 'templates'
+    tdir.mkdir()
+    (tdir / 'base.html').write_text(_CONSUMER_BASE)
+    consumer = Flask('consumer_app', template_folder=str(tdir))
+    db_uri = f'sqlite:///{tmp_path / "seam.sqlite"}'
+    return create_app(
+        app=consumer,
+        config_map={
+            'TESTING': True,
+            'SECRET_KEY': 'x',
+            'SQLALCHEMY_DATABASE_URI': db_uri,
+            'NODE_HOST': 'http://localhost',
+            'READER_ADDRESSES': ['*'],
+        },
+    )
 
 
 def test_consumer_base_html_reskins_base_pages(tmp_path):
@@ -77,3 +108,28 @@ def test_consumer_base_html_reskins_blocks_page(tmp_path):
         assert resp.status_code == 200
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         assert b'No blocks' in resp.data  # base blocks content still rendered
+
+
+def test_consumer_base_html_reskins_subjects_page(tmp_path):
+    # Seam check for the subjects leaderboard index page.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/subjects')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base subjects content still rendered
+        assert b'No subjects staked yet' in resp.data
+
+
+def test_consumer_base_html_reskins_subject_detail_page(tmp_path):
+    # Seam check for the per-subject detail page (valid encoded subject).
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get(f'/subject/{encode_subject("goblins")}')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        assert b'goblins' in resp.data  # base subject content still rendered


### PR DESCRIPTION
PR 2 of **#196** (base default UI buildout). Adds the chain's whole point to the vanilla UI: a per-subject **opposition vs support** leaderboard and a per-subject detail page, on the existing seam.

## What
- **`/subjects`** — leaderboard ranked by total live stake: rank, subject (human-readable, links to detail), opposition / support / total grains. Paginated.
- **`/subject/<subject>`** — one subject: opposition & support totals + the unspent staking outflows for each kind (each linking to its staking transaction). Unknown-but-valid encoded subject renders 200 with zero totals (not 404); an invalid subject string 404s via the converter.
- **Nav link** added to `base.html`.

## Data layer
- **`ChainDAO.subject_leaderboard(limit=None)`** — mirrors `wallet_leaderboard`. UNION ALL of an opposition leg and a support leg, each built on the chain-scoped `self.outflows` with the unspent anti-join against consuming inflows (so rescinded stake is excluded), aggregated to `(subject, opposition, support, total)` ordered by total desc. `.order_by(None)` on each leg (SQLite rejects ORDER BY inside a compound-SELECT operand).
- **`Chain`**: `subject_leaderboard` delegate + `recent_blocks`, `transaction_count`, `subject_count`, `total_staked` stats helpers (scaffolding consumed by PR 3's home page).
- **`_RowPagination` / `paginate_rows`** (browser.py) — `db.paginate` applies `.scalars()`, which collapses a multi-column leaderboard row to its first column; this `SelectPagination` subclass keeps whole `Row` objects so templates can read `row.subject`/`.total`. Coupling to a flask-sqlalchemy internal is contained to one documented class.

## Seam conformance
`subjects.html`/`subject.html` `{% extends "base.html" %}`, fill only `content`; subjects index exposes a `{% include "subjects/extra.html" ignore missing %}` hook. Two new `test_ui_seam.py` tests prove app-`base.html` override re-skins both pages.

## Tests
- Leaderboard split correctness, ordering, **rescind exclusion** (300 staked − 200 rescinded = 100 live), limit, fork-scoped reads; `Chain` delegates + stats; index empty/stakes; **multi-page pagination** (per_page=2 across pages exercises `_RowPagination`); detail totals + txn links; unknown-valid → 200; invalid → 404.
- Gates green: ruff check + format, mypy strict, pytest (413 passed).

Independently reviewed (SQL compiled & verified: shared-alias union is correct, rescind exclusion holds, fork isolation real, pagination override sound) — verdict APPROVED.

Spec: `docs/superpowers/specs/2026-06-07-egu-196-base-ui-pages-design.md`
Refs #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)