### PR TITLE
feat(browser): explorer home with stats + recent blocks (#196)

### DIFF
--- a/docs/ui-extension-seam.md
+++ b/docs/ui-extension-seam.md
@@ -24,6 +24,10 @@ blueprint templates**, so a consumer overrides base templates by filename.
 A conformant consumer skin should define every block (even if empty); base
 page templates confine themselves to `content`/`title`/`scripts`.
 
+Base also ships `_pagination.html`, a macro template providing
+`render_pagination(page, endpoint)` for Bootstrap pagination; the blocks and
+subjects lists import it via `{% from "_pagination.html" import render_pagination %}`.
+
 ## Override rules
 
 1. **Re-skin everything** — drop your own `base.html` in app `templates/`.
@@ -34,6 +38,8 @@ page templates confine themselves to `content`/`title`/`scripts`.
    `{% include "verify/extra.html" ignore missing %}` (added with the verify
    page); base ships no such file. (Jinja blocks can't be filled by a
    non-descendant, so injection uses optional includes, not empty blocks.)
+   The home page exposes `index/extra.html` and the subjects index exposes
+   `subjects/extra.html` for the same purpose.
 4. **Add new pages** — register your own blueprint.
 5. **Link to shared pages** by base endpoint name, e.g.
    `url_for('browser.verify_view')`.

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -63,6 +63,13 @@ blueprint = Blueprint(
 def index_view() -> Any:
     try:
         lc = longest_chain()
+        # Compute stats in the view (explicit + testable). stake_stats runs
+        # the leaderboard union-anti-join once, yielding both the distinct
+        # subject count and the total live stake; the template reads
+        # lc.length / lc.transaction_count / lc.recent_blocks(10) directly.
+        subject_count = total_staked = 0
+        if lc is not None:
+            subject_count, total_staked = lc.stake_stats()
     except HTTPException as e:
         return e
     except Exception as e:
@@ -72,7 +79,13 @@ def index_view() -> Any:
         # error response with no internal detail in the body (audit WEB2).
         current_app.logger.exception(e)
         abort(500)
-    return render_template('index.html', title='Home', lc=lc)
+    return render_template(
+        'index.html',
+        title='Home',
+        lc=lc,
+        subject_count=subject_count,
+        total_staked=total_staked,
+    )
 
 
 @blueprint.route('/chains')

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -538,6 +538,20 @@ class Chain:
         q = self.subject_leaderboard().subquery()
         return db.session.scalar(db.select(db.func.sum(q.c.total))) or 0
 
+    def stake_stats(self) -> tuple[int, int]:
+        # Single query for both the distinct-subject count and the total live
+        # stake — the leaderboard union-anti-join is heavy, so the home view
+        # uses this instead of reading subject_count and total_staked
+        # separately (which would run the leaderboard twice).
+        sub = self.subject_leaderboard().subquery()
+        row = db.session.execute(
+            db.select(
+                db.func.count().label('n'),
+                db.func.coalesce(db.func.sum(sub.c.total), 0).label('staked'),
+            ).select_from(sub)
+        ).one()
+        return int(row.n), int(row.staked)
+
     def transaction_provenance(self, txid: str) -> dict[str, Any] | None:
         dao = self.to_dao()
         if dao is not None:

--- a/src/gumptionchain/templates/index.html
+++ b/src/gumptionchain/templates/index.html
@@ -2,12 +2,39 @@
 
 {% block content -%}
 <div class="container-fluid">
+  {%- if lc %}
+  <div class="row my-3 g-3">
+    <div class="col-6 col-md-3">
+      <div class="card bg-light h-100"><div class="card-body">
+        <div class="text-muted small">Height</div>
+        <div class="h4 mb-0">{{ lc.length }}</div>
+      </div></div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card bg-light h-100"><div class="card-body">
+        <div class="text-muted small">Transactions</div>
+        <div class="h4 mb-0">{{ lc.transaction_count }}</div>
+      </div></div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card bg-light h-100"><div class="card-body">
+        <div class="text-muted small">Total staked</div>
+        <div class="h4 mb-0">{{ total_staked }} <span class="small text-muted">grains</span></div>
+      </div></div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card bg-light h-100"><div class="card-body">
+        <div class="text-muted small">Subjects</div>
+        <div class="h4 mb-0">{{ subject_count }}</div>
+      </div></div>
+    </div>
+  </div>
+
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">
-      <div class="card-title h5">Current Chain</div>
+      <div class="card-title h5">Chain Tip</div>
       <table class="table table-hover block" style="table-layout:fixed;">
         <tbody class="font-monospace">
-          {%- if lc -%}
           <tr>
             <th class="col-2"><i class="bi-info"></i>&nbsp;Last Block Index</th>
             <td>{{ lc.last_block.idx }}</td>
@@ -20,14 +47,44 @@
             <th class="col-2"><i class="bi-clock"></i>&nbsp;Timestamp</th>
             <td>{{ lc.last_block.timestamp_dt | utc_datetime }}</td>
           </tr>
-        {%- else %}
-          <tr>
-            No chain
-          </tr>
-        {%- endif %}
         </tbody>
       </table>
     </div></div>
   </div></div>
+
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="d-flex justify-content-between align-items-center">
+        <div class="card-title h5 mb-0">Recent Blocks</div>
+        <div>
+          <a href="{{ url_for('browser.blocks_view') }}">View all blocks</a>
+          &middot;
+          <a href="{{ url_for('browser.subjects_view') }}">Subjects</a>
+        </div>
+      </div>
+      <table class="table table-hover blocks mt-3">
+        <thead><tr><th>#</th><th>Hash</th><th>Timestamp</th></tr></thead>
+        <tbody class="font-monospace">
+        {%- for block in lc.recent_blocks(10) %}
+          <tr>
+            <td>{{ block.idx }}</td>
+            <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.block_hash) }}">{{ block.block_hash }}</a></td>
+            <td>{{ block.timestamp_dt | utc_datetime }}</td>
+          </tr>
+        {%- endfor %}
+        </tbody>
+      </table>
+    </div></div>
+  </div></div>
+
+  {% include "index/extra.html" ignore missing %}
+  {%- else %}
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Current Chain</div>
+      <p>No chain</p>
+    </div></div>
+  </div></div>
+  {%- endif %}
 </div>
 {%- endblock %}

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,0 +1,36 @@
+from gumptionchain.api_client import ApiClient
+
+
+def _stake_opposition(host, chain, wallet, amount, subject):
+    txn = chain.create_opposition(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+def test_home_empty_chain(test_client):
+    resp = test_client.get('/')
+    assert resp.status_code == 200
+    assert b'No chain' in resp.data
+
+
+def test_home_shows_stats_and_recent_blocks(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b1 = mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 300, subject)
+        _m, tip = mill_block(wallet)
+
+        resp = app.test_client().get('/')
+        assert resp.status_code == 200
+        body = resp.data
+        # stats strip labels
+        assert b'Height' in body or b'Blocks' in body
+        assert b'Transactions' in body
+        assert b'Subjects' in body
+        # links into the explorer
+        assert b'/blocks' in body
+        assert b'/subjects' in body
+        # the chain tip hash appears in the recent-blocks table
+        assert tip.block_hash.encode() in body

--- a/tests/test_subject_leaderboard.py
+++ b/tests/test_subject_leaderboard.py
@@ -126,3 +126,35 @@ def test_chain_delegates_and_stats(
         # newest-first
         assert recent[0].idx > recent[1].idx
         assert recent[0].block_hash == lc.last_block.block_hash
+
+
+def test_stake_stats_matches_individual_properties(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    other = encode_subject('other')
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, oppose=(subject, 300))
+        mill_block(wallet)
+        lc = m.longest_chain
+        _stake(host, lc, wallet, support=(other, 150))
+        mill_block(wallet)
+
+        lc = m.longest_chain
+        count, staked = lc.stake_stats()
+        # two distinct subjects, 450 grains live
+        assert count == 2
+        assert staked == 450
+        # single-query path agrees with the individual properties
+        assert count == lc.subject_count
+        assert staked == lc.total_staked
+
+
+def test_stake_stats_empty_chain(app, host, mill_block, requests_proxy, wallet):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        # a chain with only coinbase blocks has no live stake
+        count, staked = m.longest_chain.stake_stats()
+        assert count == 0
+        assert staked == 0


### PR DESCRIPTION
PR 3 (final) of **#196** (base default UI buildout). Rewrites the bare single-card home into a vanilla-node explorer landing.

## What
- **Stats strip** — Height (`lc.length`), Transactions (`lc.transaction_count`), Total staked (grains), Subjects (distinct staked).
- **Chain tip** card — last block idx + hash link + timestamp (preserves prior content).
- **Recent blocks** table — `lc.recent_blocks(10)` with "View all blocks" → `/blocks` and a "Subjects" → `/subjects` cross-link.
- `{% include "index/extra.html" ignore missing %}` injection hook; "No chain" fallback retained.

## Data layer
- **`Chain.stake_stats() -> (subject_count, total_staked)`** — one query over the leaderboard subquery, so the home page doesn't run the heavy union-anti-join twice (addresses a PR 2 review note). The individual `subject_count`/`total_staked` properties are kept for other consumers.
- `index_view` computes the stats in the view (explicit + testable) inside the existing error contract.

## Seam conformance
`index.html` `{% extends "base.html" %}`, fills only `content`. Home seam is already covered by the existing `test_ui_seam.py` case (`/` re-skin); confirmed still green against the rewrite.

## Docs
`docs/ui-extension-seam.md` now documents the `index/extra.html` + `subjects/extra.html` include hooks and the base-provided `_pagination.html` macro.

## Tests
`tests/test_home_page.py` (empty "No chain"; stats labels + cross-links + tip hash) and `stake_stats` agreement/empty tests. Gates green: ruff check + format, mypy strict, pytest (417 passed). Independently reviewed — APPROVED.

Closes #196 once merged (final PR of the three).
Spec: `docs/superpowers/specs/2026-06-07-egu-196-base-ui-pages-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)