### PR TITLE
fix(browser): chains pagination links to chains_view (#202)

### DIFF
--- a/src/gumptionchain/templates/chains.html
+++ b/src/gumptionchain/templates/chains.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
 
 {% block content -%}
 <div class="container-fluid">
@@ -26,33 +27,9 @@
     </div></div>
   </div></div>
   {% endfor -%}
-  <ul class="pagination">
-    <li class="page-item {{ '' if chains_page.has_prev else 'disabled' }}">
-      <a class="page-link" href="{{ url_for('browser.index_view', page=chains_page.prev_num) }}">Previous</a>
-    </li>
-    {%- for page in chains_page.iter_pages() %}
-    {%- if page -%}
-    {%- if page != chains_page.page %}
-    <li class="page-item">
-      <a class="page-link" href="{{ url_for('browser.index_view', page=page) }}">{{ page }}</a>
-    </li>
-    {%- else %}
-    <li class="page-item active">
-      <a class="page-link" tabindex="-1" href="{{ url_for('browser.index_view', page=page) }}">{{ page }}</a>
-    </li>
-    {%- endif %}
-    {%- else %}
-    <span class=ellipsis>…</span>
-    {%- endif %}
-    {%- endfor %}
-    <li class="page-item {{ '' if chains_page.has_next else 'disabled' }}">
-      <a class="page-link" href="{{ url_for('browser.index_view', page=chains_page.next_num) }}">Next</a>
-    </li>
-  </ul>
+  {{ render_pagination(chains_page, 'browser.chains_view') }}
   {%- else %}
-    <tr>
-      No chains
-    </tr>
+  <p>No chains</p>
   {%- endif %}
 </div>
 {%- endblock %}

--- a/tests/test_chains_page.py
+++ b/tests/test_chains_page.py
@@ -1,0 +1,31 @@
+from flask import render_template
+
+
+class _FakeChainsPage:
+    # Minimal stub: empty items (skip the chain-row loop) but >1 page so the
+    # pagination macro renders. Carries the attributes db.paginate provides.
+    pages = 2
+    page = 1
+    items = ()
+    has_prev = False
+    has_next = True
+    prev_num = 0
+    next_num = 2
+
+    def iter_pages(self):
+        return [1, 2]
+
+
+def test_chains_pagination_links_to_chains_view(app):
+    # Regression for #202: the pager must link to the chains list, not home.
+    with app.test_request_context():
+        html = render_template('chains.html', chains_page=_FakeChainsPage())
+    assert 'class="pagination"' in html
+    assert '/chains?page=2' in html  # Next / page-2 link targets chains_view
+    assert '/?page=' not in html  # the old bug pointed the pager at index_view
+
+
+def test_chains_index_empty(test_client):
+    resp = test_client.get('/chains')
+    assert resp.status_code == 200
+    assert b'No chains' in resp.data


### PR DESCRIPTION
Fixes **#202**. `chains.html`'s hand-rolled pagination linked every control (Previous / page numbers / Next) to `url_for('browser.index_view', ...)`, so paging the chains list bounced back to the home page instead of the next page of chains.

## Fix
- Migrate `chains.html` to the shared `_pagination.html` macro (shipped in #199): `{{ render_pagination(chains_page, 'browser.chains_view') }}`. Corrects the endpoint and drops ~20 lines of duplicated markup. The macro also renders nothing for a single page (the old markup always showed a pager).
- Fix the empty-state's stray `<tr>No chains</tr>` (invalid markup outside a table) → `<p>No chains</p>`, matching `blocks.html`. Same paginated list's other branch, not unrelated scope.

## Tests
`tests/test_chains_page.py`:
- regression: the rendered pager links to `/chains?page=…`, not `/?page=…`;
- empty `/chains` renders "No chains".

Gates green: ruff check + format, mypy strict, pytest (419 passed).

On the EGU launch checklist (#190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)