### PR TITLE
feat(browser): address holdings pages — leaderboard + detail (#203)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 import sqlalchemy as sa
-from flask import Blueprint, abort, current_app, jsonify, render_template
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    jsonify,
+    render_template,
+    request,
+)
 from flask_sqlalchemy.pagination import SelectPagination
 from werkzeug.exceptions import HTTPException
 
@@ -151,6 +158,27 @@ def subjects_view() -> Any:
     )
 
 
+@blueprint.route('/addresses')
+def addresses_view() -> Any:
+    try:
+        lc = longest_chain()
+        addresses_page = (
+            paginate_rows(lc.wallet_leaderboard()) if lc is not None else None
+        )
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'addresses.html', title='Addresses', addresses_page=addresses_page
+    )
+
+
 @blueprint.route('/subject/<subject:subject>')
 def subject_view(subject: str) -> Any:
     try:
@@ -188,6 +216,44 @@ def subject_view(subject: str) -> Any:
         support=support,
         opposition_flows=opposition_flows,
         support_flows=support_flows,
+    )
+
+
+@blueprint.route('/address/<address:address>')
+def address_view(address: str) -> Any:
+    try:
+        lc = longest_chain()
+        if lc is None:
+            balance = 0
+            holdings_page = txns_page = None
+        else:
+            balance = lc.balance(address)
+            # error_out=False: an out-of-range page (e.g. an empty list's
+            # ?txn_page=2) returns an empty page, not a 404.
+            holdings_page = db.paginate(
+                lc.address_holdings(address), error_out=False
+            )
+            txns_page = db.paginate(
+                lc.address_transactions(address),
+                page=request.args.get('txn_page', 1, type=int),
+                error_out=False,
+            )
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'address.html',
+        title=f'Address: {address}',
+        address=address,
+        balance=balance,
+        holdings_page=holdings_page,
+        txns_page=txns_page,
     )
 
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -35,7 +35,12 @@ from gumptionchain.exceptions import (
     SpentTransactionError,
 )
 from gumptionchain.milling import mill_hash_str
-from gumptionchain.models import BlockDAO, ChainDAO
+from gumptionchain.models import (
+    BlockDAO,
+    ChainDAO,
+    OutflowDAO,
+    TransactionDAO,
+)
 from gumptionchain.payload import Inflow, Outflow, StakeKind
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import dt_2_iso, now
@@ -509,6 +514,24 @@ class Chain:
 
     def balance(self, address: str) -> int:
         return int(self.to_dao().wallet_balance(address))
+
+    def wallet_leaderboard(self, limit: int | None = None) -> Select[Any]:
+        return self.to_dao().wallet_leaderboard(limit=limit)
+
+    def address_holdings(self, address: str) -> Select[tuple[OutflowDAO]]:
+        # unspent_outflows has no inherent order; add a deterministic sort so
+        # paginated holdings are stable across requests.
+        return (
+            self.to_dao()
+            .unspent_outflows(address)
+            .order_by(OutflowDAO.amount.desc(), OutflowDAO.txid)
+        )
+
+    def address_transactions(
+        self, address: str
+    ) -> Select[tuple[TransactionDAO]]:
+        # Already ordered (timestamp desc, id) by ChainDAO.address_transactions.
+        return self.to_dao().address_transactions(address)
 
     def opposition_balance(self, subject: str) -> int:
         return int(self.to_dao().opposition_balance(subject))

--- a/src/gumptionchain/templates/_pagination.html
+++ b/src/gumptionchain/templates/_pagination.html
@@ -1,20 +1,26 @@
-{% macro render_pagination(page, endpoint) -%}
+{% macro render_pagination(page, endpoint, page_param='page') -%}
 {%- if page.pages > 1 %}
+{%- set args = request.args.to_dict() %}
+{%- set _ = args.pop(page_param, none) %}
+{%- set _ = args.update(request.view_args | default({}, true)) %}
 <ul class="pagination">
+  {%- set _ = args.update({page_param: page.prev_num}) %}
   <li class="page-item {{ '' if page.has_prev else 'disabled' }}">
-    <a class="page-link" href="{{ url_for(endpoint, page=page.prev_num) }}">Previous</a>
+    <a class="page-link" href="{{ url_for(endpoint, **args) }}">Previous</a>
   </li>
   {%- for p in page.iter_pages() %}
   {%- if p %}
+  {%- set _ = args.update({page_param: p}) %}
   <li class="page-item {{ 'active' if p == page.page else '' }}">
-    <a class="page-link" href="{{ url_for(endpoint, page=p) }}">{{ p }}</a>
+    <a class="page-link" href="{{ url_for(endpoint, **args) }}">{{ p }}</a>
   </li>
   {%- else %}
   <li class="page-item disabled"><span class="page-link">…</span></li>
   {%- endif %}
   {%- endfor %}
+  {%- set _ = args.update({page_param: page.next_num}) %}
   <li class="page-item {{ '' if page.has_next else 'disabled' }}">
-    <a class="page-link" href="{{ url_for(endpoint, page=page.next_num) }}">Next</a>
+    <a class="page-link" href="{{ url_for(endpoint, **args) }}">Next</a>
   </li>
 </ul>
 {%- endif %}

--- a/src/gumptionchain/templates/address.html
+++ b/src/gumptionchain/templates/address.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <h3 class="font-monospace">{{ address }}</h3>
+    <p class="h4">{{ balance }} <small class="text-muted">grains</small></p>
+  </div></div>
+
+  {%- if holdings_page is not none %}
+  <div class="row my-3">
+    <div class="col">
+      <div class="card bg-light"><div class="card-body">
+        <div class="card-title h5">Holdings</div>
+        {%- if holdings_page.total %}
+        <table class="table table-hover">
+          <thead><tr><th>Amount</th><th>Transaction</th></tr></thead>
+          <tbody class="font-monospace">
+          {%- for flow in holdings_page.items %}
+            <tr>
+              <td>{{ flow.amount }}</td>
+              <td><a class="text-dark" href="{{ url_for('browser.transaction_view', txid=flow.txid) }}">{{ flow.txid }}</a></td>
+            </tr>
+          {%- endfor %}
+          </tbody>
+        </table>
+        {{ render_pagination(holdings_page, 'browser.address_view', 'page') }}
+        {%- else %}
+        <p>none</p>
+        {%- endif %}
+      </div></div>
+    </div>
+
+    <div class="col">
+      <div class="card bg-light"><div class="card-body">
+        <div class="card-title h5">Transactions</div>
+        {%- if txns_page.total %}
+        <table class="table table-hover">
+          <thead><tr><th>Transaction</th><th>Timestamp</th></tr></thead>
+          <tbody class="font-monospace">
+          {%- for txn in txns_page.items %}
+            <tr>
+              <td><a class="text-dark" href="{{ url_for('browser.transaction_view', txid=txn.txid) }}">{{ txn.txid }}</a></td>
+              <td>{{ txn.timestamp | utc_datetime }}</td>
+            </tr>
+          {%- endfor %}
+          </tbody>
+        </table>
+        {{ render_pagination(txns_page, 'browser.address_view', 'txn_page') }}
+        {%- else %}
+        <p>none</p>
+        {%- endif %}
+      </div></div>
+    </div>
+  </div>
+  {%- else %}
+  <div class="row my-3"><div class="col"><p>none</p></div></div>
+  {%- endif %}
+</div>
+{%- endblock %}

--- a/src/gumptionchain/templates/addresses.html
+++ b/src/gumptionchain/templates/addresses.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Addresses</div>
+      {% include "addresses/extra.html" ignore missing %}
+      {%- if addresses_page and addresses_page.total %}
+      <table class="table table-hover addresses">
+        <thead><tr><th>#</th><th>Address</th><th>Balance</th></tr></thead>
+        <tbody>
+        {%- for row in addresses_page.items %}
+          <tr>
+            <td>{{ loop.index + (addresses_page.page - 1) * addresses_page.per_page }}</td>
+            <td class="font-monospace"><a class="text-dark" href="{{ url_for('browser.address_view', address=row.address) }}">{{ row.address }}</a></td>
+            <td>{{ row.ct }} <small class="text-muted">grains</small></td>
+          </tr>
+        {%- endfor %}
+        </tbody>
+      </table>
+      {{ render_pagination(addresses_page, 'browser.addresses_view') }}
+      {%- else %}
+      <p>No addresses with a balance yet.</p>
+      {%- endif %}
+    </div></div>
+  </div></div>
+</div>
+{%- endblock %}

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -19,6 +19,7 @@
     <a class="navbar-nav" href="{{ url_for('browser.chains_view') }}">Chains</a>
     <a class="navbar-nav" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
     <a class="navbar-nav" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
+    <a class="navbar-nav" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/tests/test_address_pages.py
+++ b/tests/test_address_pages.py
@@ -40,3 +40,26 @@ def test_address_holdings_empty_for_unknown_address(
         unknown = Wallet().address
         flows = list(db.session.scalars(lc.address_holdings(unknown)))
         assert flows == []
+
+
+# ---- addresses index ---------------------------------------------------
+
+
+def test_addresses_index_empty(test_client):
+    resp = test_client.get('/addresses')
+    assert resp.status_code == 200
+    assert b'No addresses with a balance yet' in resp.data
+
+
+def test_addresses_index_shows_milled_address(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        balance = m.longest_chain.balance(wallet.address)
+
+        resp = app.test_client().get('/addresses')
+        assert resp.status_code == 200
+        assert wallet.address.encode() in resp.data
+        assert f'/address/{wallet.address}'.encode() in resp.data
+        assert str(balance).encode() in resp.data

--- a/tests/test_address_pages.py
+++ b/tests/test_address_pages.py
@@ -1,0 +1,42 @@
+from gumptionchain.database import db
+from gumptionchain.wallet import Wallet
+
+# ---- data-layer delegates ----------------------------------------------
+
+
+def test_wallet_leaderboard_includes_milled_address(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        rows = db.session.execute(lc.wallet_leaderboard()).all()
+        by_addr = {row.address: row.ct for row in rows}
+        assert wallet.address in by_addr
+        assert by_addr[wallet.address] == lc.balance(wallet.address)
+
+
+def test_address_holdings_ordered_amount_desc(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        flows = list(db.session.scalars(lc.address_holdings(wallet.address)))
+        assert len(flows) >= 1
+        amounts = [f.amount for f in flows]
+        assert amounts == sorted(amounts, reverse=True)
+        # all holdings belong to the queried address
+        assert all(f.address == wallet.address for f in flows)
+
+
+def test_address_holdings_empty_for_unknown_address(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        unknown = Wallet().address
+        flows = list(db.session.scalars(lc.address_holdings(unknown)))
+        assert flows == []

--- a/tests/test_address_pages.py
+++ b/tests/test_address_pages.py
@@ -63,3 +63,50 @@ def test_addresses_index_shows_milled_address(
         assert wallet.address.encode() in resp.data
         assert f'/address/{wallet.address}'.encode() in resp.data
         assert str(balance).encode() in resp.data
+
+
+# ---- address detail ----------------------------------------------------
+
+
+def test_address_detail_shows_balance_and_holdings(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        balance = lc.balance(wallet.address)
+        flows = list(db.session.scalars(lc.address_holdings(wallet.address)))
+        a_txid = flows[0].txid
+
+        resp = app.test_client().get(f'/address/{wallet.address}')
+        assert resp.status_code == 200
+        assert wallet.address.encode() in resp.data
+        assert str(balance).encode() in resp.data
+        # a holding links to its source transaction
+        assert f'/transaction/{a_txid}'.encode() in resp.data
+
+
+def test_address_detail_unknown_valid_address_is_200_zeros(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        unknown = Wallet().address
+        resp = app.test_client().get(f'/address/{unknown}')
+        assert resp.status_code == 200
+        assert b'0' in resp.data
+        assert b'none' in resp.data
+
+
+def test_address_detail_invalid_address_is_404(test_client):
+    resp = test_client.get('/address/notvalid')
+    assert resp.status_code == 404
+
+
+def test_address_detail_accepts_txn_page_arg(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        resp = app.test_client().get(f'/address/{wallet.address}?txn_page=2')
+        assert resp.status_code == 200

--- a/tests/test_pagination_macro.py
+++ b/tests/test_pagination_macro.py
@@ -54,8 +54,10 @@ def test_custom_page_param_preserves_other_query_and_path_args(app):
     )
     # txn_page is the param being driven by this list
     assert 'txn_page=2' in html
-    # the sibling list's current page is preserved
-    assert 'page=2' in html
+    # the sibling list's current page is preserved — asserted on the txn_page=3
+    # link so 'page=2' can't be a substring of a 'txn_page=2' match (& is
+    # HTML-escaped to &amp; in the rendered output)
+    assert 'page=2&amp;txn_page=3' in html
     # the path arg is preserved in the generated URLs
     assert f'/subject/{subj}' in html
     # no link carries the page_param twice (the original value must be popped,

--- a/tests/test_pagination_macro.py
+++ b/tests/test_pagination_macro.py
@@ -1,0 +1,76 @@
+from flask import render_template_string
+
+
+class _FakePage:
+    def __init__(self, *, pages, page=1, prev=False, nxt=False):
+        self.pages = pages
+        self.page = page
+        self.has_prev = prev
+        self.has_next = nxt
+        self.prev_num = page - 1
+        self.next_num = page + 1
+
+    def iter_pages(self):
+        return list(range(1, self.pages + 1))
+
+
+def _render(app, template, path, **ctx):
+    with app.test_request_context(path):
+        return render_template_string(template, **ctx)
+
+
+def test_default_page_param_renders_page_links(app):
+    template = (
+        "{% from '_pagination.html' import render_pagination %}"
+        "{{ render_pagination(page, 'browser.blocks_view') }}"
+    )
+    html = _render(
+        app,
+        template,
+        '/blocks',
+        page=_FakePage(pages=3, page=2, prev=True, nxt=True),
+    )
+    assert 'class="pagination"' in html
+    assert 'page=1' in html
+    assert 'page=3' in html
+    assert 'active' in html
+
+
+def test_custom_page_param_preserves_other_query_and_path_args(app):
+    # A page with a path arg (subject) and two paginated lists: the second list
+    # uses page_param='txn_page' and must preserve the first list's current
+    # `page` query arg plus the path arg across its links. (subject_view stands
+    # in for any path-arg route; address_view is added in a later task.)
+    template = (
+        "{% from '_pagination.html' import render_pagination %}"
+        "{{ render_pagination(page, 'browser.subject_view', 'txn_page') }}"
+    )
+    subj = 'Z29ibGlucw'  # encode_subject('goblins'), a valid encoded subject
+    html = _render(
+        app,
+        template,
+        f'/subject/{subj}?page=2&txn_page=1',
+        page=_FakePage(pages=3, page=1, prev=False, nxt=True),
+    )
+    # txn_page is the param being driven by this list
+    assert 'txn_page=2' in html
+    # the sibling list's current page is preserved
+    assert 'page=2' in html
+    # the path arg is preserved in the generated URLs
+    assert f'/subject/{subj}' in html
+    # no link carries the page_param twice (the original value must be popped,
+    # not appended alongside the override)
+    for link in html.split('href="')[1:]:
+        url = link.split('"')[0]
+        assert url.count('txn_page=') <= 1
+
+
+def test_single_page_renders_nothing(app):
+    template = (
+        "{% from '_pagination.html' import render_pagination %}"
+        "{{ render_pagination(page, 'browser.subject_view', 'txn_page') }}"
+    )
+    subj = 'Z29ibGlucw'
+    html = _render(app, template, f'/subject/{subj}', page=_FakePage(pages=1))
+    assert 'class="pagination"' not in html
+    assert html.strip() == ''

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -3,6 +3,7 @@ from flask import Flask
 from gumptionchain import create_app
 from gumptionchain.database import db
 from gumptionchain.payload import encode_subject
+from gumptionchain.wallet import Wallet
 
 _CONSUMER_BASE = (
     '<!doctype html><html><head>'
@@ -133,3 +134,27 @@ def test_consumer_base_html_reskins_subject_detail_page(tmp_path):
         assert resp.status_code == 200
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         assert b'goblins' in resp.data  # base subject content still rendered
+
+
+def test_consumer_base_html_reskins_addresses_page(tmp_path):
+    # Seam check for the addresses leaderboard index page.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/addresses')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base addresses content still rendered
+        assert b'No addresses with a balance yet' in resp.data
+
+
+def test_consumer_base_html_reskins_address_detail_page(tmp_path):
+    # Seam check for the per-address detail page (valid GC...GC address).
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get(f'/address/{Wallet().address}')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint


### PR DESCRIPTION
PR 1 of **#203** (base UI: deferred views from #196). Adds address/wallet holdings pages on the existing seam.

## What
- **`/addresses`** — addresses leaderboard ranked by live balance (rank, address → detail link, balance grains). Reuses `ChainDAO.wallet_leaderboard()` + `paginate_rows` (multi-column rows).
- **`/address/<address>`** — per-address detail: balance header + a **paginated holdings** card (unspent outflows → `/transaction/<txid>`) + a **paginated transactions** card (txns created by the address). Two independent pagers (`page` + `txn_page`).
- **Nav link** added to `base.html`.

## Data layer
- **`Chain.wallet_leaderboard`** delegate; **`Chain.address_holdings`** (orders `unspent_outflows` by amount desc, txid — stable pagination); **`Chain.address_transactions`** delegate (it existed only on `ChainDAO`/`BlockDAO` — the plan was wrong that `Chain` had it; the DAO already orders `timestamp desc, id`).
- **`_pagination.html` macro enhancement** (backward-compatible): `render_pagination(page, endpoint, page_param='page')` now preserves the route's path args + the sibling list's query args, overriding only its own page param — so the address detail can carry two independent pagers. Existing `blocks`/`subjects`/`chains` links unchanged (and now correctly preserve `?per_page=`).

## Notes
- `error_out=False` on both `db.paginate` calls so an out-of-range `?txn_page=N` renders empty, not 404.
- Jinja can't do multiple `**` splats or a variable-keyed dict literal, so the macro merges one `args` dict and mutates the page param per link (equivalent behavior).

## Tests
- Leaderboard rows + ordering via the `Chain` delegate; ordered holdings; addresses index (empty/populated); address detail (balance + holding link; unknown-valid → 200 zeros; invalid → 404; `?txn_page` accepted); macro unit tests (default + custom page_param + arg preservation + single-page); seam tests for both pages.
- Gates green: ruff + format, mypy strict, pytest (433 passed). Independently reviewed — APPROVED.

Spec: `docs/superpowers/specs/2026-06-08-egu-203-address-mempool-design.md`
Refs #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)