### PR TITLE
feat(browser): mempool/pending view + home pending count (#203)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -83,6 +83,8 @@ def index_view() -> Any:
         subject_count = total_staked = 0
         if lc is not None:
             subject_count, total_staked = lc.stake_stats()
+        # Pending-pool size is independent of the chain (always available).
+        pending_count = PendingTxnDAO.count()
     except HTTPException as e:
         return e
     except Exception as e:
@@ -98,6 +100,7 @@ def index_view() -> Any:
         lc=lc,
         subject_count=subject_count,
         total_staked=total_staked,
+        pending_count=pending_count,
     )
 
 

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -14,14 +14,20 @@ from flask import (
 from flask_sqlalchemy.pagination import SelectPagination
 from werkzeug.exceptions import HTTPException
 
-from gumptionchain.block import Block
+from gumptionchain.block import Block, expiry_cutoff
 from gumptionchain.chain import Chain
 from gumptionchain.database import db
-from gumptionchain.models import BlockDAO, ChainDAO, TransactionDAO
+from gumptionchain.models import (
+    BlockDAO,
+    ChainDAO,
+    PendingTxnDAO,
+    TransactionDAO,
+)
 from gumptionchain.node import Node
 from gumptionchain.payload import decode_subject
 from gumptionchain.provenance import lookup_provenance
 from gumptionchain.transaction import Transaction
+from gumptionchain.util import now
 
 
 class _RowPagination(SelectPagination):
@@ -254,6 +260,44 @@ def address_view(address: str) -> Any:
         balance=balance,
         holdings_page=holdings_page,
         txns_page=txns_page,
+    )
+
+
+@blueprint.route('/mempool')
+def mempool_view() -> Any:
+    try:
+        # Read-only expiry filter (no prune): the API view prunes on GET,
+        # the browser read just excludes expired rows from the query.
+        pending_page = db.paginate(
+            PendingTxnDAO.pending_q(expired=expiry_cutoff(now())),
+            error_out=False,
+        )
+        entries = []
+        for row in pending_page.items:
+            txn = Transaction.from_json(row.json_data)
+            entries.append(
+                {
+                    'txid': txn.txid,
+                    'timestamp': txn.timestamp_dt,
+                    'inflows': len(txn.inflows),
+                    'outflows': len(txn.outflows),
+                    'total_out': sum(o.amount or 0 for o in txn.outflows),
+                }
+            )
+    except HTTPException as e:
+        return e
+    except Exception as e:
+        # Log the full traceback server-side, then return a controlled 500
+        # response. `return e` would hand Flask a raw Exception (not a valid
+        # response → make_response TypeError); abort(500) yields a proper
+        # error response with no internal detail in the body (audit WEB2).
+        current_app.logger.exception(e)
+        abort(500)
+    return render_template(
+        'mempool.html',
+        title='Mempool',
+        pending_page=pending_page,
+        entries=entries,
     )
 
 

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1184,6 +1184,20 @@ class PendingTxnDAO(Base):
             yield json_data
 
     @classmethod
+    def pending_q(
+        cls,
+        expired: datetime.datetime | None = None,
+    ) -> Select[tuple[PendingTxnDAO]]:
+        stmt = db.select(cls)
+        if expired is not None:
+            # open-boundary expiry, read-only (no prune): keep
+            # timestamp >= cutoff (mirrors json_datas / txn_is_expired).
+            stmt = stmt.where(cls.timestamp >= expired)
+        return stmt.order_by(  # type: ignore[no-any-return]
+            cls.received.desc(), cls.txid
+        )
+
+    @classmethod
     def delete_expired(cls, cutoff: datetime.datetime) -> int:
         """Delete every pending txn strictly older than `cutoff`
         (timestamp < cutoff) in a single commit, returning the count

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -20,6 +20,7 @@
     <a class="navbar-nav" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
     <a class="navbar-nav" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
     <a class="navbar-nav" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
+    <a class="navbar-nav" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/index.html
+++ b/src/gumptionchain/templates/index.html
@@ -28,6 +28,12 @@
         <div class="h4 mb-0">{{ subject_count }}</div>
       </div></div>
     </div>
+    <div class="col-6 col-md-3">
+      <div class="card bg-light h-100"><div class="card-body">
+        <div class="text-muted small">Pending</div>
+        <div class="h4 mb-0">{{ pending_count }}</div>
+      </div></div>
+    </div>
   </div>
 
   <div class="row my-3"><div class="col">

--- a/src/gumptionchain/templates/mempool.html
+++ b/src/gumptionchain/templates/mempool.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block content -%}
+<div class="container-fluid">
+  <div class="row my-3"><div class="col">
+    <div class="card bg-light"><div class="card-body">
+      <div class="card-title h5">Mempool <span class="small text-muted">({{ pending_page.total }} pending)</span></div>
+      {% include "mempool/extra.html" ignore missing %}
+      {%- if pending_page.total %}
+      <table class="table table-hover mempool">
+        <thead><tr><th>Txid</th><th>Timestamp</th><th>Inflows</th><th>Outflows</th><th>Total out</th></tr></thead>
+        <tbody class="font-monospace">
+        {%- for entry in entries %}
+          <tr>
+            <td>{{ entry.txid }}</td>
+            <td>{{ entry.timestamp | utc_datetime }}</td>
+            <td>{{ entry.inflows }}</td>
+            <td>{{ entry.outflows }}</td>
+            <td>{{ entry.total_out }} <span class="small text-muted">grains</span></td>
+          </tr>
+        {%- endfor %}
+        </tbody>
+      </table>
+      {{ render_pagination(pending_page, 'browser.mempool_view') }}
+      {%- else %}
+      <p>Mempool is empty.</p>
+      {%- endif %}
+    </div></div>
+  </div></div>
+</div>
+{%- endblock %}

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -34,3 +34,18 @@ def test_home_shows_stats_and_recent_blocks(
         assert b'/subjects' in body
         # the chain tip hash appears in the recent-blocks table
         assert tip.block_hash.encode() in body
+
+
+def test_home_shows_pending_count(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        _stake_opposition(host, m.longest_chain, wallet, 300, subject)
+
+        resp = app.test_client().get('/')
+        assert resp.status_code == 200
+        body = resp.data
+        # a Pending stat card with the pool count (1 pending txn)
+        assert b'Pending' in body
+        assert b'>1<' in body

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -1,0 +1,54 @@
+import datetime
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.block import expiry_cutoff
+from gumptionchain.database import db
+from gumptionchain.models import PendingTxnDAO
+from gumptionchain.util import now
+
+
+def _post_pending(host, chain, wallet, amount, subject):
+    txn = chain.create_opposition(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+# ---- data-layer: pending_q ---------------------------------------------
+
+
+def test_pending_q_returns_all_ordered_received_desc(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        m, _b = mill_block(wallet)
+        lc = m.longest_chain
+        txn1 = _post_pending(host, lc, wallet, 300, subject)
+        txn2 = _post_pending(host, lc, wallet, 200, subject)
+
+        rows = db.session.scalars(PendingTxnDAO.pending_q()).all()
+        txids = [row.txid for row in rows]
+        assert set(txids) == {txn1.txid, txn2.txid}
+        # ordered by received desc, tie-break txid
+        receiveds = [row.received for row in rows]
+        assert receiveds == sorted(receiveds, reverse=True)
+
+
+def test_pending_q_expired_filter_is_read_only(app):
+    with app.app_context():
+        old_ts = now() - datetime.timedelta(hours=8)
+        dao = PendingTxnDAO(
+            txid='a' * 64,
+            timestamp=old_ts,
+            json_data='{}',
+        )
+        dao.commit()
+        assert PendingTxnDAO.count() == 1
+
+        cutoff = expiry_cutoff(now())
+        rows = db.session.scalars(PendingTxnDAO.pending_q(expired=cutoff)).all()
+        # the old txn is excluded by the expiry filter
+        assert rows == []
+        # ...but NOT deleted: the query is read-only
+        assert PendingTxnDAO.count() == 1

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -52,3 +52,32 @@ def test_pending_q_expired_filter_is_read_only(app):
         assert rows == []
         # ...but NOT deleted: the query is read-only
         assert PendingTxnDAO.count() == 1
+
+
+# ---- mempool view ------------------------------------------------------
+
+
+def test_mempool_empty(test_client):
+    resp = test_client.get('/mempool')
+    assert resp.status_code == 200
+    assert b'Mempool is empty' in resp.data
+
+
+def test_mempool_shows_pending_txn(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
+
+        total_out = sum(o.amount or 0 for o in txn.outflows)
+
+        resp = app.test_client().get('/mempool')
+        assert resp.status_code == 200
+        body = resp.data
+        # the pending txid is shown
+        assert txn.txid.encode() in body
+        # the numeric total-out is shown
+        assert str(total_out).encode() in body
+        # link-free: no /transaction/<txid> link rendered for it
+        assert f'/transaction/{txn.txid}'.encode() not in body

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -158,3 +158,16 @@ def test_consumer_base_html_reskins_address_detail_page(tmp_path):
         resp = client.get(f'/address/{Wallet().address}')
         assert resp.status_code == 200
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+
+
+def test_consumer_base_html_reskins_mempool_page(tmp_path):
+    # Seam check for the mempool/pending pool page.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/mempool')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base mempool content still rendered
+        assert b'Mempool is empty' in resp.data


### PR DESCRIPTION
PR 2 (final) of **#203** (base UI: deferred views from #196). Adds a read-only mempool view + a pending count on the home page.

## What
- **`/mempool`** — the unconfirmed-transaction pool: count header + a table of txid (link-free — pending txns aren't in TransactionDAO), age, #inflows, #outflows, total out (grains). Paginated, newest-first.
- **Home** — a "Pending" card added to the stats strip.
- **Nav link** added to `base.html`.

## Data layer
- **`PendingTxnDAO.pending_q(expired=None)`** — `db.select(PendingTxnDAO)` ordered by `received desc, txid`, with an optional **read-only** open-boundary expiry filter (`timestamp >= cutoff`). Unlike the API's `PendingTxnView` (which prunes expired on GET), the browser read never mutates the pool. Paginatable via plain `db.paginate` (single ORM entity).
- `mempool_view` parses each page row's `json_data` via `Transaction.from_json` (≤20/page) to derive the summary; `total_out` is total outflow incl. change. Pending count via `PendingTxnDAO.count()`.

## Seam conformance
`mempool.html` extends `base.html`, fills only `content`, exposes `{% include "mempool/extra.html" ignore missing %}`. Seam test proves app-`base.html` override.

## Tests
`pending_q` ordering + read-only expiry exclusion (excluded, not deleted); mempool empty/populated + link-free assertion; home pending count; seam. Gates green: ruff + format, mypy strict, pytest (439 passed). Independently reviewed — APPROVED.

Closes #203.
Spec: `docs/superpowers/specs/2026-06-08-egu-203-address-mempool-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)