### PR TITLE
fix(browser): genesis block prev-link no longer 404s

### DIFF
--- a/src/gumptionchain/templates/block.html
+++ b/src/gumptionchain/templates/block.html
@@ -39,7 +39,7 @@
             </tr>
             <tr>
               <th class="col-3"><i class="bi-box-arrow-in-left"></i>&nbsp;Previous Block Hash</th>
-              <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.prev_hash) }}">{{ block.prev_hash }}</a></td>
+              <td>{% if block_dao.prev %}<a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.prev_hash) }}">{{ block.prev_hash }}</a>{% else %}<span class="text-muted">{{ block.prev_hash }} (genesis)</span>{% endif %}</td>
             </tr>
             <tr>
               <th class="col-3"><i class="bi-box-arrow-in-right"></i>&nbsp;Next Block Hash</th>

--- a/tests/test_block_view.py
+++ b/tests/test_block_view.py
@@ -1,0 +1,41 @@
+from gumptionchain.database import db
+from gumptionchain.models import BlockDAO
+
+
+def _block_at(idx):
+    return db.session.scalar(db.select(BlockDAO).where(BlockDAO.idx == idx))
+
+
+def test_genesis_prev_hash_is_not_a_dead_link(
+    app, host, mill_block, requests_proxy, wallet
+):
+    # The genesis block's prev_hash is the GENESIS_HASH sentinel, which has no
+    # block row — it must render unlinked (no dead /block/<sentinel> link).
+    with app.app_context():
+        mill_block(wallet)
+        mill_block(wallet)
+        genesis = _block_at(0)
+        page = (
+            app.test_client()
+            .get(f'/block/{genesis.block_hash}')
+            .get_data(as_text=True)
+        )
+        assert f'/block/{genesis.prev_hash}' not in page  # no dead link
+        assert '(genesis)' in page
+
+
+def test_non_genesis_prev_hash_links_to_parent(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        mill_block(wallet)
+        genesis = _block_at(0)
+        block1 = _block_at(1)
+        page = (
+            app.test_client()
+            .get(f'/block/{block1.block_hash}')
+            .get_data(as_text=True)
+        )
+        # block 1's previous-block link resolves to the genesis block
+        assert f'/block/{genesis.block_hash}' in page


### PR DESCRIPTION
The genesis block's detail page rendered its "Previous Block Hash" as a link to the `GENESIS_HASH` sentinel (`9a505967…`), which has no block row — so clicking it 404'd. Surfaced during local testing of the new explorer pages; it was logged as a polish nit in a #196 comment but #196 closed without addressing it.

## Fix
In `block.html`, guard the previous-block link on `block_dao.prev` (the FK relationship, which is `None` for the genesis block — and for any block whose parent isn't in our DB). Link only when the parent exists; otherwise render the hash unlinked with a `(genesis)` note. Mirrors how the "Next Block Hash" cell already handles the no-successor case ("None").

## Tests
`tests/test_block_view.py`: the genesis block renders its prev_hash without a `/block/<sentinel>` link (+ "(genesis)" note); a non-genesis block's prev link still resolves to its parent.

Gates green: ruff + format, mypy strict, pytest (441 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)