### PR TITLE
feat(browser): net stance (opposed/supported) on subject views

### DIFF
--- a/src/gumptionchain/templates/_net.html
+++ b/src/gumptionchain/templates/_net.html
@@ -1,0 +1,9 @@
+{# Net stance for a subject: which side leads (support vs opposition) and by
+   how much. Magnitude + word so the meaning is unambiguous (no implicit sign
+   convention). Green = net supported, red = net opposed, muted = even. #}
+{% macro net_stance(opposition, support) -%}
+{%- set net = support - opposition -%}
+{%- if net > 0 %}<span class="text-success">{{ net }} supported</span>
+{%- elif net < 0 %}<span class="text-danger">{{ -net }} opposed</span>
+{%- else %}<span class="text-muted">even</span>{% endif -%}
+{%- endmacro %}

--- a/src/gumptionchain/templates/subject.html
+++ b/src/gumptionchain/templates/subject.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
+{% from "_net.html" import net_stance %}
 
 {% block content -%}
 <div class="container-fluid">
   <div class="row my-3"><div class="col">
     <h3>{{ subject | human_subject }}</h3>
+    <p class="h5">Net: {{ net_stance(opposition, support) }}</p>
   </div></div>
 
   <div class="row my-3">

--- a/src/gumptionchain/templates/subjects.html
+++ b/src/gumptionchain/templates/subjects.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_pagination.html" import render_pagination %}
+{% from "_net.html" import net_stance %}
 
 {% block content -%}
 <div class="container-fluid">
@@ -9,7 +10,7 @@
       {% include "subjects/extra.html" ignore missing %}
       {%- if subjects_page and subjects_page.total %}
       <table class="table table-hover subjects">
-        <thead><tr><th>#</th><th>Subject</th><th>Opposition</th><th>Support</th><th>Total</th></tr></thead>
+        <thead><tr><th>#</th><th>Subject</th><th>Opposition</th><th>Support</th><th>Net</th><th>Total</th></tr></thead>
         <tbody>
         {%- for row in subjects_page.items %}
           <tr>
@@ -17,6 +18,7 @@
             <td><a class="text-dark" href="{{ url_for('browser.subject_view', subject=row.subject) }}">{{ row.subject | human_subject }}</a></td>
             <td>{{ row.opposition }}</td>
             <td>{{ row.support }}</td>
+            <td>{{ net_stance(row.opposition, row.support) }}</td>
             <td>{{ row.total }}</td>
           </tr>
         {%- endfor %}

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -43,6 +43,8 @@ def test_subjects_index_shows_stakes(
         assert b'300' in resp.data
         assert b'150' in resp.data
         assert b'450' in resp.data
+        # net stance: opposition 300 leads support 150 by 150
+        assert b'150 opposed' in resp.data
         # links to the detail page using the encoded subject
         assert f'/subject/{subject}'.encode() in resp.data
 
@@ -97,6 +99,9 @@ def test_subject_detail_shows_totals_and_links(
         assert resp.status_code == 200
         assert b'300' in resp.data  # opposition total
         assert b'150' in resp.data  # support total
+        # net stance indicator: opposition leads support by 150
+        assert b'Net:' in resp.data
+        assert b'150 opposed' in resp.data
         # link to the staking transaction
         assert f'/transaction/{txn.txid}'.encode() in resp.data
 


### PR DESCRIPTION
Adds an overall **opposed-vs-supported** indicator to the subject views, so you can see a subject's net stance at a glance.

## What
- **`/subjects` leaderboard** — a new **Net** column (Opposition · Support · **Net** · Total).
- **`/subject/<x>` detail** — a **Net:** line under the subject header.
- Shared **`_net.html`** macro `net_stance(opposition, support)` renders magnitude + leading side, colored: `150 opposed` (red) / `150 supported` (green) / `even` (muted). Magnitude+word avoids any implicit +/- sign convention.

## Notes
- Pure presentation: net is derived from the existing `opposition`/`support` values already on each leaderboard row and the detail context — **no data-layer / query change**.
- Ordering unchanged (still by total desc).

## Tests
Extended `tests/test_subjects_page.py`: the leaderboard and detail both show `150 opposed` for an opp-300/sup-150 subject; detail shows the `Net:` label.
Gates green: ruff + format, mypy strict, pytest (441 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)