### PR TITLE
feat(browser): label outflow kinds on the transaction view

### DIFF
--- a/src/gumptionchain/templates/_outflow.html
+++ b/src/gumptionchain/templates/_outflow.html
@@ -1,0 +1,19 @@
+{# Outflow kind/target helpers. An outflow is exactly one of: an address
+   transfer, an opposition stake, a support stake, or a rescind (which carries
+   the kind it rescinds). These surface the kind as a scannable badge and the
+   target (address or human-readable subject). #}
+{% macro outflow_kind(o) -%}
+{%- if o.opposition %}<span class="badge bg-danger">opposition</span>
+{%- elif o.support %}<span class="badge bg-success">support</span>
+{%- elif o.rescind %}<span class="badge bg-warning text-dark">rescind {{ o.rescind_kind }}</span>
+{%- elif o.address %}<span class="badge bg-secondary">transfer</span>
+{%- else %}<span class="text-muted">&mdash;</span>{% endif -%}
+{%- endmacro %}
+
+{% macro outflow_target(o) -%}
+{%- if o.address %}{{ o.address }}
+{%- elif o.opposition %}{{ o.opposition }} <em class="text-muted">({{ o.opposition | human_subject }})</em>
+{%- elif o.support %}{{ o.support }} <em class="text-muted">({{ o.support | human_subject }})</em>
+{%- elif o.rescind %}{{ o.rescind }} <em class="text-muted">({{ o.rescind | human_subject }})</em>
+{%- else %}<span class="text-muted">&mdash;</span>{% endif -%}
+{%- endmacro %}

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_outflow.html" import outflow_kind, outflow_target %}
 
 {% block content -%}
   <div class="container-fluid">
@@ -86,10 +87,8 @@
           <thead>
             <tr>
               <th class="col-1">Index</th>
-              <th class="col-3">Address</th>
-              <th class="col-2">Opposition</th>
-              <th class="col-2">Rescind</th>
-              <th class="col-2">Support</th>
+              <th class="col-2">Kind</th>
+              <th class="col-7">Target</th>
               <th class="col-2">Amount</th>
             </tr>
           </thead>
@@ -97,10 +96,8 @@
             {%- for o in outflows %}
               <tr>
                 <td class="col-1">{{ loop.index0 }}</td>
-                <td class="col-3">{{ o.address or None }}</td>
-                <td class="col-2">{{ o.opposition }}{% if o.opposition %} <em>({{ o.opposition | human_subject }})</em>{% endif %}</td>
-                <td class="col-2">{{ o.rescind }}{% if o.rescind %} <em>({{ o.rescind | human_subject }})</em>{% endif %}{% if o.rescind_kind %} <em>({{ o.rescind_kind }})</em>{% endif %}</td>
-                <td class="col-2">{{ o.support }}{% if o.support %} <em>({{ o.support | human_subject }})</em>{% endif %}</td>
+                <td class="col-2">{{ outflow_kind(o) }}</td>
+                <td class="col-7">{{ outflow_target(o) }}</td>
                 <td class="col-2">{{ o.amount }}</td>
               </tr>
             {%- endfor %}
@@ -108,10 +105,8 @@
           <tfoot class="font-monospace">
             <tr>
               <td class="col-1"></td>
-              <td class="col-3"></td>
               <td class="col-2"></td>
-              <td class="col-2"></td>
-              <td class="col-2"></td>
+              <td class="col-7"></td>
               <td class="col-2">{{ outflow_total }}</td>
             </tr>
           </tfoot>

--- a/tests/test_transaction_view.py
+++ b/tests/test_transaction_view.py
@@ -1,0 +1,58 @@
+from gumptionchain.api_client import ApiClient
+from gumptionchain.wallet import Wallet
+
+
+def _post(host, txn, wallet):
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+def test_transaction_view_labels_stake_and_rescind_kinds(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        opp = _post(
+            host,
+            m.longest_chain.create_opposition(wallet, 300, subject),
+            wallet,
+        )
+        mill_block(wallet)
+        resc = _post(
+            host,
+            m.longest_chain.create_rescind(wallet, 100, subject, 'opposition'),
+            wallet,
+        )
+        mill_block(wallet)
+
+        c = app.test_client()
+        # the opposition stake txn labels its stake + change outflows
+        opp_page = c.get(f'/transaction/{opp.txid}').get_data(as_text=True)
+        assert 'Kind' in opp_page  # new column header
+        assert 'opposition' in opp_page
+        assert 'transfer' in opp_page  # the change output is a transfer
+
+        # the rescind txn labels the rescind (with its kind) + re-staked change
+        resc_page = c.get(f'/transaction/{resc.txid}').get_data(as_text=True)
+        assert 'rescind opposition' in resc_page
+        assert 'opposition' in resc_page  # the 200 re-staked as opposition
+
+
+def test_transaction_view_labels_transfer(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        xfer = _post(
+            host,
+            m.longest_chain.create_transfer(wallet, 100, Wallet().address),
+            wallet,
+        )
+        mill_block(wallet)
+        page = (
+            app.test_client()
+            .get(f'/transaction/{xfer.txid}')
+            .get_data(as_text=True)
+        )
+        assert 'transfer' in page


### PR DESCRIPTION
The `/transaction/<txid>` outflows table spread **Address / Opposition / Rescind / Support** across four sparse columns — each outflow fills only one — so you couldn't tell an outflow's *kind* at a glance (e.g. reading a rescind txn).

## What
- Replace the four sparse columns with a **Kind** badge + a single **Target** column:
  - `transfer` (grey), `opposition` (red), `support` (green), `rescind <kind>` (amber).
  - Target shows the address, or the encoded subject with its human-readable form.
- Logic lives in a shared `_outflow.html` macro (`outflow_kind` / `outflow_target`), reusable by other views later.
- No information lost — same data, organized so the kind is the headline.

## Example
A rescind txn now reads clearly: `rescind opposition` for the withdrawn portion + `opposition` for the re-staked change (verified against a real rescind txn on a local node).

## Tests
`tests/test_transaction_view.py`: an opposition stake txn shows `opposition` + `transfer` (change); a rescind shows `rescind opposition`; a plain transfer shows `transfer`.
Gates green: ruff + format, mypy strict, pytest (443 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)