### PR TITLE
feat(browser): identify and mark coinbase transactions

### DIFF
--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -5,7 +5,7 @@
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
       <div class="card bg-light"><div class="card-body">
-        <div class="h5">Transaction</div>
+        <div class="h5">Transaction{% if transaction.is_coinbase %} <span class="badge bg-info text-dark">Coinbase</span>{% endif %}</div>
         <table class="table table-hover" style="table-layout:fixed;">
           <tbody class="font-monospace">
             <tr>
@@ -61,7 +61,7 @@
             </tr>
             {%- else %}
             <tr>
-              <td>No Inflows</td>
+              <td>{% if transaction.is_coinbase %}Coinbase &mdash; newly minted (no inputs){% else %}No Inflows{% endif %}</td>
               <td></td>
               <td></td>
             </tr>

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -164,6 +164,14 @@ class Transaction:
         return iso_2_dt(self.timestamp) if self.timestamp else None
 
     @property
+    def is_coinbase(self) -> bool:
+        # A coinbase mints the block reward: it carries no inflows and binds
+        # its block's prev_hash into the txid. Regular txns must leave prev_hash
+        # unset (RegularTransactionModel), so a set prev_hash is the
+        # validation-enforced coinbase marker — and it survives to_dao/from_dao.
+        return self.prev_hash is not None
+
+    @property
     def data_csv(self) -> str:
         fields = [
             str(self.timestamp),

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -26,6 +26,11 @@ def test_txn_timestamp_dt(single_txn):
     assert dt_2_iso(single_txn.timestamp_dt) == single_txn.timestamp
 
 
+def test_is_coinbase(valid_coinbase_txn, single_txn):
+    assert valid_coinbase_txn.is_coinbase  # prev_hash bound
+    assert not single_txn.is_coinbase  # regular txn, no prev_hash
+
+
 def test_txn_valid(single_txn):
     with pytest.raises(UnsealedTransactionError):
         single_txn.sign()

--- a/tests/test_transaction_view.py
+++ b/tests/test_transaction_view.py
@@ -1,4 +1,6 @@
 from gumptionchain.api_client import ApiClient
+from gumptionchain.database import db
+from gumptionchain.models import TransactionDAO
 from gumptionchain.wallet import Wallet
 
 
@@ -6,6 +8,27 @@ def _post(host, txn, wallet):
     txn.sign()
     ApiClient(host, wallet).post_transaction(txn)
     return txn
+
+
+def test_transaction_view_marks_coinbase(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)  # every block carries a coinbase
+        cb = db.session.scalar(
+            db.select(TransactionDAO).where(
+                TransactionDAO.prev_hash.is_not(None)
+            )
+        )
+        page = (
+            app.test_client()
+            .get(f'/transaction/{cb.txid}')
+            .get_data(as_text=True)
+        )
+        assert 'Coinbase' in page  # the header badge
+        assert 'newly minted' in page  # the no-inputs message
+        # a coinbase's reward outputs are address transfers
+        assert 'transfer' in page
 
 
 def test_transaction_view_labels_stake_and_rescind_kinds(
@@ -56,3 +79,4 @@ def test_transaction_view_labels_transfer(
             .get_data(as_text=True)
         )
         assert 'transfer' in page
+        assert 'Coinbase' not in page  # a regular transfer is not a coinbase


### PR DESCRIPTION
A coinbase (block-reward) txn was visually indistinguishable from a regular transfer on `/transaction/<txid>` — its reward outputs render as `transfer` badges and its inflows section just said "No Inflows."

## What
- **`Transaction.is_coinbase`** property — `prev_hash is not None`. A coinbase binds its block's `prev_hash` into the txid and carries no inflows; `RegularTransactionModel` forbids `prev_hash`, so this is the validation-enforced marker, and it survives `to_dao`/`from_dao` (it's a persisted column).
- **Transaction view:** a `Coinbase` badge in the header, and the empty inflows row now reads "Coinbase — newly minted (no inputs)" instead of "No Inflows".

## Why prev_hash (not zero-inflows)
Both are coinbase-equivalent invariants; `prev_hash` is the explicit block-binding marker and is the single field that's always restored from the DB. Verified on a real local coinbase.

## Tests
- Domain: `is_coinbase` true for a coinbase fixture, false for a regular txn.
- Browser: a coinbase txn page shows the badge + minted message; a regular transfer does not.
Gates green: ruff + format, mypy strict, pytest (449 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)