### PR TITLE
docs(transact): base browser txn creation (Tiers 0+1) — spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-06-08-base-transact.md
+++ b/docs/superpowers/plans/2026-06-08-base-transact.md
@@ -1,0 +1,166 @@
+# Base `/transact` (Tiers 0+1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A base-node `/transact` page that builds (via existing server endpoints), signs client-side with an ephemeral imported key, and submits transactions — plus a stake-attestation signer. Keys are in-memory only, never persisted.
+
+**Architecture:** The node's existing `GET /transaction/{transfer,opposition,support,rescind}` endpoints return an *unsigned, sealed* txn built from a public key. The browser recomputes/verifies the txid, signs `signing_data` with the imported key, and POSTs. The only new crypto code is a parity-exact `data_csv`/`txid`/sign module in JS.
+
+**Tech Stack:** Flask + Jinja + Bootstrap; client ESM (`clients/wallet/`, vendored to `static/wallet/` via `scripts/sync_wallet.py`); Web Crypto (RSA, SHA-256/512 already in `gc-crypto`); pytest + node `--test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-base-transact-design.md`
+
+**Canonical formats (from `payload.py` / `transaction.py`) — must match byte-for-byte:**
+- `Inflow.data_csv` = `f"{outflow_txid},{outflow_idx}"`
+- `Outflow.data_csv` = `f"{amount},{address or ''},{opposition or ''},{rescind or ''},{support or ''},{rescind_kind or ''}"`
+- `Transaction.data_csv` = `",".join([timestamp, address, public_key, ",".join(inflow.data_csv...), ",".join(outflow.data_csv...), version])` (+ `,prev_hash` only for coinbases — never here)
+- `txid = sha256(sha512(data_csv)).hexdigest()` (`gc-crypto.millHash` does the digests; hex it)
+- `signing_data = (data_csv + "," + txid).encode()`; `signature = wallet.sign(signing_data)`
+- Server JSON omits `None` fields (`asdict_sans_none`), so reconstruct with `?? ''`.
+
+**Existing JS to reuse (`clients/wallet/`):** `Wallet.fromPrivateKeyB58(b58)`, `Wallet.fromPublicKeyB64`, `wallet.sign(bytes)→sig`, `wallet.publicKeyB64`/address accessors; `gc-crypto` `millHash`, `base58decode`, `base64encode`; `gc-sig` `signHeaders` (request auth); `gc-attestation` `signStakeAttestation`; `gc-backup` `importPlain`. **Read these before writing `gc-transaction.mjs`.**
+
+---
+
+## PR 1 — `gc-transaction.mjs` + Python-locked parity tests
+
+Branch: `feat/base-transact-js-core` off fresh `main`.
+
+### Task 1: Python fixture emitter (locks parity)
+
+**Files:** Create `tests/fixtures/gen_txn_fixtures.py`, output `tests/fixtures/txn_signing_vectors.json`
+
+- [ ] **Step 1:** Write a script that builds one `Transaction` per shape using fixed inputs (construct `Transaction` directly with literal `Inflow`/`Outflow` lists — NOT via a chain, for determinism), for: transfer (1 inflow, 2 outflows addr+change), opposition (inflow + opposition outflow + change), support, rescind (rescind outflow + restake change). For each, emit `{name, txn_dict (to_dict, unsigned), data_csv, txid, signing_data_b64}` using the real `.data_csv` / `.calculate_txid()` / `.signing_data`. Use a fixed timestamp + a fixed wallet's address/public_key (load a test wallet, set on the txn).
+
+```python
+# sketch
+import base64, json
+from gumptionchain.transaction import Transaction
+from gumptionchain.payload import Inflow, Outflow
+from gumptionchain.wallet import Wallet
+w = Wallet(b58ks='<fixed test b58>')  # or generate + print the b58 for the JS test
+def vec(name, inflows, outflows):
+    t = Transaction(timestamp='1700000000', inflows=inflows, outflows=outflows)
+    t.set_wallet(w); t.seal()
+    return {'name': name, 'txn': t.to_dict(), 'data_csv': t.data_csv,
+            'txid': t.txid, 'signing_data_b64': base64.b64encode(t.signing_data).decode()}
+# ... build the four shapes, json.dump a list
+```
+
+- [ ] **Step 2:** Run it; commit the script + generated `txn_signing_vectors.json`. Commit: `test(wallet): python-generated txn signing parity vectors`.
+
+### Task 2: `gc-transaction.mjs` (TDD against the vectors)
+
+**Files:** Create `clients/wallet/gc-transaction.mjs`, `clients/wallet/gc-transaction.test.mjs`
+
+- [ ] **Step 1: Failing test** — `gc-transaction.test.mjs` (node:test) loads `../../tests/fixtures/txn_signing_vectors.json`; for each vector asserts `dataCsv(v.txn) === v.data_csv`, `await txid(v.txn) === v.txid`, and `base64(signingData(v.txn)) === v.signing_data_b64`. Run `node --test clients/wallet/gc-transaction.test.mjs` → FAIL (module missing).
+
+- [ ] **Step 2: Implement `gc-transaction.mjs`:**
+
+```js
+import { millHash } from './gc-crypto.mjs';
+
+const inflowCsv = (i) => [String(i.outflow_txid), String(i.outflow_idx)].join(',');
+const outflowCsv = (o) => [
+  String(o.amount), o.address ?? '', o.opposition ?? '',
+  o.rescind ?? '', o.support ?? '', o.rescind_kind ?? '',
+].join(',');
+
+export function dataCsv(txn) {
+  const fields = [
+    String(txn.timestamp), String(txn.address), String(txn.public_key),
+    (txn.inflows ?? []).map(inflowCsv).join(','),
+    (txn.outflows ?? []).map(outflowCsv).join(','),
+    String(txn.version),
+  ];
+  if (txn.prev_hash != null) fields.push(String(txn.prev_hash));
+  return fields.join(',');
+}
+
+const hex = (bytes) => [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+
+export async function txid(txn) {
+  return hex(await millHash(new TextEncoder().encode(dataCsv(txn))));
+}
+
+export function signingData(txn) {
+  return new TextEncoder().encode(dataCsv(txn) + ',' + txn.txid);
+}
+
+// Verify the node's txid, then sign. Returns a signed txn object ready to POST.
+export async function signUnsignedTxn(unsigned, wallet) {
+  const recomputed = await txid({ ...unsigned, txid: undefined });
+  if (recomputed !== unsigned.txid) {
+    throw new Error('txid mismatch: node-built txn does not match its fields');
+  }
+  const sig = await wallet.sign(signingData(unsigned));
+  return { ...unsigned, public_key: wallet.publicKeyB64, address: wallet.address, signature: sig };
+}
+```
+
+> Confirm the exact accessor names on the JS `Wallet` (`publicKeyB64`/`address`/`sign` return type) by reading `gc-wallet.mjs`; adjust. `millHash` returns a Uint8Array (SHA-512 then SHA-256) — hex it. The server JSON already carries `public_key`/`address` (built from your key), so `signUnsignedTxn` mostly confirms + signs.
+
+- [ ] **Step 3: Run** → PASS. Add a sign-then-verify vector if a public-key verify helper exists in `gc-wallet`/`gc-crypto`.
+
+- [ ] **Step 4: Sync + Python cross-check** — run `uv run python scripts/sync_wallet.py` to copy into `static/wallet/`. Add a pytest that loads a JS-signed fixture txn (emit one signed vector from JS, or sign in Python with the same wallet) and asserts `Transaction.from_json(...).validate()` + signature verify passes. Run `uv run pytest -k txn_parity`.
+
+- [ ] **Step 5: Extend the node test glob** if needed so CI runs `clients/wallet/*.test.mjs` (check `.github/workflows/tests.yml`; `static/gumptionchain/static/js/*.test.mjs` is already covered — add the wallet dir glob).
+
+- [ ] **Step 6: Gates** — `uv run ruff format src tests && uv run ruff check src tests && uv run mypy && uv run pytest` + `node --test clients/wallet/gc-transaction.test.mjs`. Commit: `feat(wallet): gc-transaction.mjs — parity-exact txn data_csv/txid/sign`. Open PR.
+
+---
+
+## PR 2 — `/transact` page (build & sign + broadcast)
+
+Branch: `feat/base-transact-page` off fresh `main` (after PR 1).
+
+### Task 3: route + view + nav (TDD)
+
+**Files:** Modify `src/gumptionchain/browser.py`, `templates/base.html`; create `templates/transact.html`; test `tests/test_transact_page.py`
+
+- [ ] **Step 1: Failing test** — `GET /transact` → 200, contains the type selector markup, the security framing string ("never leaves your browser"), the broadcast section, and imports `wallet/gc-transaction.mjs`. Run → FAIL.
+
+- [ ] **Step 2: Add view** (no chain/DB work — it's a static shell; the page's JS calls the API):
+
+```python
+@blueprint.route('/transact')
+def transact_view() -> Any:
+    return render_template('transact.html', title='Transact')
+```
+
+- [ ] **Step 3: Create `transact.html`** — extends base, `content` block only. Sections: (1) **Build & sign** — a `<select>` for type (transfer/opposition/support/rescind) that shows the type-specific fields (transfer: amount + dest address; opposition/support: amount + subject; rescind: amount + subject + kind), a key-import control (textarea for b58 / file input for `.pem`), a "Sign & submit" button, and a result/error area; (2) a collapsible **Broadcast** ("paste a pre-signed txn JSON" + submit); (3) **Sign attestation** placeholder (filled in PR 3). Prominent security banner. `{% include "transact/extra.html" ignore missing %}` hook. End-of-page inline `<script type="module">` wiring (Step 4).
+
+- [ ] **Step 4: Client glue** — create `clients/wallet/transact-glue.mjs` (synced to static) exporting the wire-up: import key → `Wallet.fromPrivateKeyB58`/PEM; on submit, build the query, `signHeaders`-authed `GET /transaction/<type>?...`, parse → `signUnsignedTxn` → render confirmation → `signHeaders`-authed `POST /transaction/<txid>`; surface 403 (closed node), 503 (mempool full), and txid-mismatch distinctly. The inline module in `transact.html` imports and calls it (mirror how `verify.html` imports `verify-glue.mjs`). Keep DOM logic testable: a small `node:test` for the pure helpers (query building, response→message mapping) with a fake fetch, like `verify-glue.test.mjs`.
+
+- [ ] **Step 5: Nav link** in `base.html` after Mempool: `<a class="navbar-nav" href="{{ url_for('browser.transact_view') }}">Transact</a>`.
+
+- [ ] **Step 6:** Run view test + glue test → PASS. Commit: `feat(browser): /transact build-sign + broadcast page`.
+
+### Task 4: seam test + gates
+
+- [ ] **Step 1:** Add a `/transact` seam test to `tests/test_ui_seam.py` (consumer `base.html` re-skins it; the page is static so no chain needed).
+- [ ] **Step 2: Gates** (incl. `node --test`) green. Commit + open PR.
+
+---
+
+## PR 3 — Attestation signing
+
+Branch: `feat/base-transact-attestation` off fresh `main` (after PR 2).
+
+### Task 5: sign-attestation section (TDD)
+
+**Files:** Modify `templates/transact.html`, `clients/wallet/transact-glue.mjs` (+ test), `templates/verify.html` (link)
+
+- [ ] **Step 1: Failing test** — `node:test` for the attestation helper: given a wallet + a claim `{txid, kind, subject, amount}`, `signStakeAttestation` produces a proof whose `parseStakeAttestation`/`verifyStake(signature check)` round-trips. Run → FAIL if helper not wired.
+
+- [ ] **Step 2: Implement** — wire the **Sign attestation** section: inputs for txid/kind/subject/amount, reuse the imported key, call `signStakeAttestation`, render the proof JSON + a "copy" affordance + a note "paste into /verify". Add a link from `verify.html` to `/transact#attestation`.
+
+- [ ] **Step 3:** Run → PASS. Browser test: `/transact` shows the attestation section; `/verify` links to it.
+
+- [ ] **Step 4: Gates** green. Commit: `feat(browser): stake-attestation signer on /transact`. Open PR.
+
+---
+
+## Final
+
+After all three merge: final reviewer over the combined diff; update the base/hub boundary note + the EGU checklist (#190) to record Tiers 0+1 shipped and Tier 1.5 deferred; file the Tier 1.5 (persistent wallet + passkey) follow-up issue.

--- a/docs/superpowers/specs/2026-06-08-base-transact-design.md
+++ b/docs/superpowers/specs/2026-06-08-base-transact-design.md
@@ -1,0 +1,174 @@
+# Base node `/transact` — browser transaction creation (Tiers 0+1)
+
+**Date:** 2026-06-08
+**Context:** EGU #1 / #5 boundary decision — wallet/txn creation in the base app
+**Status:** design approved
+
+## Goal
+
+Give the vanilla `gumptionchain` node a browser path to **create and submit
+transactions** (and sign stake attestations), so a standalone node is usable
+for *participating* in the chain, not just exploring it. Keys are
+**ephemeral, imported, in-memory only** — never persisted, never sent.
+
+This is **Tiers 0 + 1** of the wallet roadmap. Deferred:
+- **Tier 1.5** — persistent browser wallet (IndexedDB + passkey/passphrase +
+  backup). Carries an origin-trust risk; gets its own security-focused pass.
+- **Tier 2** — hosted/networked features (cross-device sync, the handle→address
+  identity directory, recovery-as-a-service). Stays in the hub.
+
+## Boundary (restated)
+
+Base = stateless, ephemeral, single-shot signing client. Hub = the *trusted
+origin* for persistence (1.5) plus the server-only features (2). Mirrors the
+verify(base)/proof-store(hub) split: base does the stateless single-shot, the
+moment you want it *remembered* you go to the hub.
+
+## Architecture: node builds the unsigned txn, browser signs it
+
+The node already exposes the right primitive — server-side construction
+endpoints that take a **public key** (no private key) and return an *unsigned,
+sealed* transaction (`src/gumptionchain/api.py`):
+
+| Endpoint (GET, `authorize_transactor`) | Builds via | Params |
+|---|---|---|
+| `/transaction/transfer` | `lc.create_transfer` | `public_key`, `amount`, `address` |
+| `/transaction/opposition` | `lc.create_opposition` | `public_key`, `amount`, `subject` |
+| `/transaction/support` | `lc.create_support` | `public_key`, `amount`, `subject` |
+| `/transaction/rescind` | `lc.create_rescind` | `public_key`, `amount`, `subject`, `kind` |
+
+Each does the UTXO selection, inflow/outflow + change assembly, and `seal()`
+(sets the txid) server-side; it can't sign (no private key). So the browser
+**never reimplements transaction construction**.
+
+Per-transaction flow:
+1. Browser → `GET /transaction/<type>?public_key=…&…` → unsigned, sealed txn JSON.
+2. Browser parses + **displays** the txn (type, amount, dest/subject, inputs,
+   change/fee) for explicit user confirmation.
+3. Browser independently recomputes `txid` from the returned fields and
+   **verifies it matches** the node's txid (catches a dishonest node), then
+   signs `signing_data` with the imported key.
+4. Browser → `POST /transaction/<txid>` with the signed txn, gc-sig-v1 authed.
+
+### Signing parity (the one genuinely new piece)
+
+From `transaction.py`:
+- `data_csv` = canonical CSV of `timestamp, address, public_key, <inflows csv>,
+  <outflows csv>, version[, prev_hash]` (the trailing `prev_hash` only for
+  coinbases — never produced here).
+- `txid = mill_hash_str(data_csv)` where `mill_hash = sha256(sha512(data))`,
+  hex.
+- `signing_data = (data_csv + "," + txid).encode()`.
+- `signature = wallet.sign(signing_data)`.
+
+The browser must reconstruct **`data_csv`** (incl. each `Inflow.data_csv` /
+`Outflow.data_csv` sub-serialization and field order) to build `signing_data`
+and to verify the txid. This is the only real port, and it is **parity-critical**
+— one byte off and the node rejects the txn. It ships with **test vectors
+generated from Python** so JS and Python agree exactly.
+
+Everything else already exists in the shipped wallet ESM
+(`src/gumptionchain/static/wallet/`, source `clients/wallet/`):
+- `gc-crypto.millHash` already computes `sha256(sha512(...))` (hex via a small
+  bytes→hex helper),
+- `Wallet.fromPrivateKeyB58` / `sign(bytes)` (RSA, Web Crypto),
+- `signHeaders` (gc-sig-v1 request auth) for the GET/POST calls,
+- `gc-attestation.signStakeAttestation` for the attestation feature,
+- `gc-backup.importPlain` (b58) for key import.
+
+*Rejected alternative:* having the endpoints return `signing_data` so the
+browser signs server-provided bytes — less JS, but it delegates trust and skips
+the txid-honesty check. The browser deriving what it signs is worth the port.
+
+## Page: one `/transact`, two modes + attestation
+
+A single `browser` blueprint route `/transact` → `transact.html`, extending
+`base.html`, content block only, with a nav link. Three sections:
+
+1. **Build & sign** (Tier 1) — choose type (transfer / opposition / support /
+   rescind), fill the type-specific fields, import key, confirm the parsed txn,
+   sign + submit. Import: paste a b58 private key or upload a `.pem`
+   (`wallet create` output) — parsed to a `Wallet` **in JS memory only**.
+2. **Broadcast** (Tier 0, secondary/"advanced") — paste a pre-signed txn JSON
+   and submit. *Note:* `POST /transaction/<txid>` is `authorize_transactor`, so
+   even broadcast needs a key to sign the **request envelope** — the page
+   reuses the imported key for that. No new unauthed submit endpoint (that is
+   the #151 submit-PoW territory, out of scope).
+3. **Sign attestation** — produce a `gc-msg-v1` stake proof (the producer side
+   of `/verify`) via `signStakeAttestation` + the imported key. `/verify` stays
+   verify-only and links here.
+
+All client JS is an inline `<script type="module">` importing from
+`url_for('browser.static', filename='wallet/…')` + a new
+`wallet/gc-transaction.mjs`, consistent with how `/verify` wires its module
+(base CSP already allows the inline module).
+
+## Auth / anti-spam reality
+
+- Works cleanly on an **open-transacting** node (`GC_TRANSACTOR_ADDRESSES=["*"]`).
+- On a **closed** node, the imported key's address must be in
+  `TRANSACTOR_ADDRESSES` or the build GET / submit POST returns 403 — the UX
+  surfaces this explicitly ("this node restricts transacting; your address
+  isn't authorized") rather than failing opaquely.
+- Existing anti-spam (`MAX_PENDING_TXNS` 503, reverse-proxy rate limit, specced
+  submit-PoW #151) is unchanged; this page is just a browser client of the
+  existing authed API.
+
+## Security model (this effort)
+
+- **Import-only, in-memory, never persisted, never transmitted.** Only the
+  signature + public key leave the browser. No IndexedDB, no passkey, no
+  storage (that's 1.5).
+- Loud, persistent framing on the page: "your private key never leaves your
+  browser; this node does not store it; reloading or closing the tab clears
+  it."
+- The key lives in a module-scoped variable for the session; provide an
+  explicit "forget key" control.
+- Confirmation step before every signature shows exactly what is being signed.
+
+## Data flow
+
+```
+/transact (browser)
+  import key (b58/PEM) -> Wallet (JS, in-memory)
+  GET /transaction/<type>?public_key=...   (signHeaders authed)
+      -> unsigned sealed txn JSON
+  recompute txid (gc-transaction) == server txid ?  (honesty check)
+  display parsed txn -> user confirms
+  signing_data = data_csv + "," + txid ; wallet.sign(...)
+  POST /transaction/<txid>  (signHeaders authed) -> 201/202/503/403
+attestation: signStakeAttestation(wallet, claim) -> proof JSON (paste into /verify)
+```
+
+## Testing
+
+- **JS parity (node:test):** `gc-transaction.test.mjs` — `data_csv` + `txid` +
+  `signing_data` for each txn type match **Python-generated fixtures**;
+  round-trip a server-built unsigned txn → signed txn that Python
+  `Transaction.from_json(...).validate()` + signature-verify accepts. (A small
+  Python helper/test emits the fixtures so the two stay locked.)
+- **Server:** the build endpoints already have coverage; add a cross-check test
+  that a JS-signed txn (fixture) validates server-side.
+- **Browser view:** `/transact` renders (200), has the three sections + the
+  security framing + nav link; seam test (consumer `base.html` re-skins it).
+- **Hard gates:** ruff + format, mypy strict, pytest, and the node `--test`
+  glob (already includes `src/gumptionchain/static/js/*.test.mjs`; extend to the
+  wallet dir if needed).
+
+## PR decomposition (sequential, off fresh main)
+
+0. **docs** — this spec + the plan.
+1. **`gc-transaction.mjs` + parity tests** — `data_csv`/`txid`/`signing_data`
+   reconstruction and txn signing, vetted against Python fixtures. Foundation,
+   no UI. Synced into `static/wallet/` via the existing `scripts/sync_wallet.py`
+   (source of truth is `clients/wallet/`).
+2. **`/transact` page** — build & sign (all four types) + broadcast mode +
+   confirmation UX + closed-node 403 handling + security framing + nav link +
+   view/seam tests.
+3. **Attestation signing** section + `/verify` link.
+
+## Out of scope / follow-ups
+
+- Tier 1.5 (persistent wallet + passkey) — separate spec, security-focused.
+- An unauthed public submit endpoint (needs #151 submit-PoW first).
+- PEM import edge cases beyond standard pkcs8 (b58 is the primary path).


### PR DESCRIPTION
Design doc + implementation plan for the **base-node `/transact`** capability — the outcome of the wallet/txn boundary brainstorm.

## Decisions captured
- **Scope:** Tiers 0 (broadcast pre-signed) + 1 (build + client-sign + submit) now; **Tier 1.5** (persistent IndexedDB + passkey) and **Tier 2** (sync / identity directory / recovery) deferred. Base = stateless ephemeral single-shot; hub = trusted-origin persistence + hosted features.
- **Architecture:** the node already exposes `GET /transaction/{transfer,opposition,support,rescind}` that build an *unsigned, sealed* txn from a public key — so the browser never reimplements UTXO selection/construction; it verifies the txid, signs `signing_data`, and POSTs.
- **Keys:** import-only (b58 / PEM), in-memory, never persisted, never transmitted.
- **One new crypto module:** `gc-transaction.mjs` (data_csv/txid/sign) locked to **Python-generated parity vectors** — the one real risk, contained and tested.
- **Page:** one `/transact` (build & sign + broadcast + attestation signer); `/verify` stays verify-only and links over.

Spec: `docs/superpowers/specs/2026-06-08-base-transact-design.md`
Plan: `docs/superpowers/plans/2026-06-08-base-transact.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)