### PR TITLE
feat(browser): /transact build-sign-submit + broadcast page (#transact PR2)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -399,3 +399,17 @@ def transaction_provenance_view(txid: str) -> Any:
 @blueprint.route('/verify')
 def verify_view() -> Any:
     return render_template('verify.html', title='Verify')
+
+
+@blueprint.route('/transact')
+def transact_view() -> Any:
+    # Static shell — no chain/DB work. The page's client JS calls the authed
+    # build/submit API itself, signing each request with the imported key.
+    # NODE_HOST must reach the page because gc-sig-v1 is node-bound: the
+    # signature canonical includes the node's host, so the glue has to sign for
+    # *this* node.
+    return render_template(
+        'transact.html',
+        title='Transact',
+        node_host=current_app.config['NODE_HOST'],
+    )

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -1,0 +1,379 @@
+// Base /transact glue: build (via the node's authed server-side endpoints),
+// sign client-side with an ephemeral imported key, and submit. Plus a
+// "broadcast a pre-signed txn" mode. The imported Wallet lives ONLY in a
+// module-scoped variable here — never persisted (no IndexedDB/localStorage),
+// never sent (only the signature + public key leave the browser).
+//
+// The pure helpers (buildQuery / submitPath / responseMessage / buildSignSubmit)
+// are exported and DOM-free so they can be unit-tested with a fake fetch. The
+// DOM wiring is in init().
+import { Wallet } from '../wallet/gc-wallet.mjs';
+import { signHeaders } from '../wallet/gc-sig.mjs';
+import { signUnsignedTxn } from '../wallet/gc-transaction.mjs';
+
+const API_PREFIX = '/api';
+
+// The fields each transaction type sends. public_key is always added from the
+// imported wallet; the rest come from the form. (subject is the RAW UTF-8
+// subject — the server encodes it itself, so it must NOT be pre-encoded.)
+const TYPE_FIELDS = {
+  transfer: ['amount', 'address'],
+  opposition: ['amount', 'subject'],
+  support: ['amount', 'subject'],
+  rescind: ['amount', 'subject', 'kind'],
+};
+
+// Build the EXACT query string sent for a build GET. The same string is used
+// for the fetch URL and the gc-sig canonical, so consistency is what matters.
+export function buildQuery(type, fields) {
+  const names = TYPE_FIELDS[type];
+  if (!names) {
+    throw new Error(`unknown transaction type: ${type}`);
+  }
+  const params = new URLSearchParams();
+  // public_key first by convention; order is irrelevant to the server (it
+  // reconstructs the canonical from the actual request), but stable for tests.
+  if (fields.publicKey != null) {
+    params.set('public_key', fields.publicKey);
+  }
+  for (const name of names) {
+    const value = fields[name];
+    if (value != null && value !== '') {
+      params.set(name, String(value));
+    }
+  }
+  return params.toString();
+}
+
+// /api/transaction/<txid>, with the txid path segment encoded so a malformed
+// txid can't reshape the request into an unintended path/query.
+export function submitPath(txid) {
+  return `${API_PREFIX}/transaction/${encodeURIComponent(txid)}`;
+}
+
+// Map a submit/build response to a single user-facing string. Each documented
+// status is surfaced distinctly (closed node, mempool full, validation).
+export function responseMessage(status, body) {
+  const detail = body && typeof body.error === 'string' ? body.error : '';
+  if (status === 200 || status === 201 || status === 202) {
+    return 'Transaction submitted and received by the node.';
+  }
+  if (status === 403) {
+    return (
+      'This node restricts transacting: your address is not authorized ' +
+      '(not in TRANSACTOR_ADDRESSES on this node).'
+    );
+  }
+  if (status === 503) {
+    return 'The node is busy: its mempool is full. Try again shortly.';
+  }
+  if (status === 400) {
+    return `The node rejected the transaction: ${detail || 'validation error'}.`;
+  }
+  return `Unexpected response from the node (HTTP ${status})${
+    detail ? `: ${detail}` : ''
+  }.`;
+}
+
+// Read a fetch Response's JSON, tolerating an empty/non-JSON body.
+async function readBody(resp) {
+  try {
+    const text = await resp.text();
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return {};
+  }
+}
+
+// nowSeconds: gc-sig timestamps are epoch SECONDS (server allows +/-300s).
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+// Send a gc-sig-v1 authed request. path/query are signed separately so the
+// canonical matches what the server reconstructs from the actual request.
+async function authedFetch(
+  fetchImpl,
+  { method, path, query, body, wallet, nodeHost, timestamp },
+) {
+  const bodyBytes =
+    body != null ? new TextEncoder().encode(body) : new Uint8Array();
+  const headers = await signHeaders(wallet, {
+    method,
+    path,
+    query,
+    body: bodyBytes,
+    nodeHost,
+    timestamp,
+  });
+  const url = query ? `${path}?${query}` : path;
+  const opts = { method, headers };
+  if (body != null) {
+    opts.body = body;
+    opts.headers = { ...headers, 'Content-Type': 'application/json' };
+  }
+  return fetchImpl(url, opts);
+}
+
+// Full build -> verify-txid -> sign -> submit flow for one transaction. Returns
+// { unsigned, signed, status, message } so the caller can show the parsed txn
+// in a confirmation area and the final result. Throws (with a user-facing
+// message) if the build GET fails — no signature/POST happens after that.
+export async function buildSignSubmit({
+  type,
+  fields,
+  wallet,
+  nodeHost,
+  fetchImpl = globalThis.fetch,
+  timestamp = nowSeconds(),
+}) {
+  const publicKey = await wallet.publicKeyB64();
+  const query = buildQuery(type, { ...fields, publicKey });
+  const buildPath = `${API_PREFIX}/transaction/${type}`;
+  const buildResp = await authedFetch(fetchImpl, {
+    method: 'GET',
+    path: buildPath,
+    query,
+    wallet,
+    nodeHost,
+    timestamp,
+  });
+  if (!buildResp.ok) {
+    const body = await readBody(buildResp);
+    throw new Error(responseMessage(buildResp.status, body));
+  }
+  const unsigned = await buildResp.json();
+  // signUnsignedTxn recomputes + verifies the txid (catches a dishonest node)
+  // before signing.
+  const signed = await signUnsignedTxn(unsigned, wallet);
+  return submitSigned({
+    signed,
+    unsigned,
+    wallet,
+    nodeHost,
+    fetchImpl,
+  });
+}
+
+// Submit an already-signed txn (shared by build-sign and broadcast modes). The
+// POST itself is gc-sig authed with the imported key (the submit endpoint is
+// authorize_transactor), so broadcast also needs a key for the request
+// envelope even though the txn is already signed.
+export async function submitSigned({
+  signed,
+  unsigned = null,
+  wallet,
+  nodeHost,
+  fetchImpl = globalThis.fetch,
+  timestamp = nowSeconds(),
+}) {
+  const body = JSON.stringify(signed);
+  const resp = await authedFetch(fetchImpl, {
+    method: 'POST',
+    path: submitPath(signed.txid),
+    query: '',
+    body,
+    wallet,
+    nodeHost,
+    timestamp,
+  });
+  const respBody = await readBody(resp);
+  return {
+    unsigned: unsigned ?? signed,
+    signed,
+    status: resp.status,
+    message: responseMessage(resp.status, respBody),
+  };
+}
+
+// --- DOM wiring ------------------------------------------------------------
+
+// Module-scoped, in-memory only. Cleared by forgetKey() / page reload.
+let importedWallet = null;
+
+function setStatus(el, text, kind = 'info') {
+  if (!el) return;
+  el.textContent = text;
+  el.dataset.kind = kind;
+}
+
+// Import from a pasted b58 private key (primary path). PEM is a follow-up.
+async function importB58(b58) {
+  return Wallet.fromPrivateKeyB58(b58.trim());
+}
+
+// Render the parsed unsigned txn for explicit confirmation before submit.
+function describeUnsigned(unsigned) {
+  const lines = [`txid: ${unsigned.txid}`];
+  const out = (unsigned.outflows ?? [])
+    .map((o) => {
+      if (o.address) return `  -> ${o.amount} grains to ${o.address}`;
+      if (o.opposition) return `  -> ${o.amount} grains OPPOSE ${o.opposition}`;
+      if (o.support) return `  -> ${o.amount} grains SUPPORT ${o.support}`;
+      if (o.rescind) {
+        return `  -> ${o.amount} grains RESCIND ${o.rescind} (${o.rescind_kind ?? ''})`;
+      }
+      return `  -> ${o.amount} grains (change)`;
+    })
+    .join('\n');
+  lines.push(`inputs: ${(unsigned.inflows ?? []).length}`);
+  lines.push('outputs:');
+  lines.push(out);
+  return lines.join('\n');
+}
+
+// init attaches the handlers. root defaults to document; nodeHost is the
+// node's configured host (gc-sig is node-bound).
+export function init(root = document, { nodeHost } = {}) {
+  const $ = (sel) => root.querySelector(sel);
+
+  // Reveal type-specific fields when the type changes.
+  const typeSelect = $('#txn-type');
+  const updateFields = () => {
+    const names = TYPE_FIELDS[typeSelect.value] ?? [];
+    for (const group of root.querySelectorAll('[data-field-group]')) {
+      const field = group.dataset.fieldGroup;
+      group.hidden = !names.includes(field);
+    }
+  };
+  if (typeSelect) {
+    typeSelect.addEventListener('change', updateFields);
+    updateFields();
+  }
+
+  // Key import (b58 textarea / .pem file) + forget.
+  const keyStatus = $('#key-status');
+  const b58Input = $('#key-b58');
+  const pemInput = $('#key-pem');
+  const importBtn = $('#import-key-btn');
+  const forgetBtn = $('#forget-key-btn');
+
+  const onImported = async () => {
+    setStatus(
+      keyStatus,
+      `Key imported (in memory only): ${await importedWallet.address()}`,
+      'ok',
+    );
+  };
+
+  if (importBtn) {
+    importBtn.addEventListener('click', async () => {
+      try {
+        const b58 = b58Input ? b58Input.value : '';
+        if (!b58.trim()) {
+          setStatus(keyStatus, 'Paste a base58 private key first.', 'error');
+          return;
+        }
+        importedWallet = await importB58(b58);
+        await onImported();
+      } catch (e) {
+        importedWallet = null;
+        setStatus(keyStatus, `Could not import key: ${msgOf(e)}`, 'error');
+      }
+    });
+  }
+  if (pemInput) {
+    pemInput.addEventListener('change', async () => {
+      // PEM (.pem upload) import is a documented follow-up; b58 is the
+      // primary path this PR ships. Surface clearly rather than half-working.
+      setStatus(
+        keyStatus,
+        'PEM upload is not supported yet — paste the base58 private key ' +
+          'instead (a follow-up will add .pem import).',
+        'error',
+      );
+      pemInput.value = '';
+    });
+  }
+  if (forgetBtn) {
+    forgetBtn.addEventListener('click', () => {
+      importedWallet = null;
+      if (b58Input) b58Input.value = '';
+      setStatus(keyStatus, 'Key forgotten — cleared from memory.', 'info');
+    });
+  }
+
+  // Build & sign & submit.
+  const buildResult = $('#build-result');
+  const confirmArea = $('#confirm-area');
+  const signBtn = $('#sign-submit-btn');
+  if (signBtn) {
+    signBtn.addEventListener('click', async () => {
+      if (!importedWallet) {
+        setStatus(buildResult, 'Import a key first.', 'error');
+        return;
+      }
+      const type = typeSelect.value;
+      const fields = collectFields(root, type);
+      try {
+        setStatus(buildResult, 'Building & signing…', 'info');
+        const result = await buildSignSubmit({
+          type,
+          fields,
+          wallet: importedWallet,
+          nodeHost,
+        });
+        if (confirmArea) confirmArea.textContent = describeUnsigned(result.unsigned);
+        setStatus(
+          buildResult,
+          result.message,
+          result.status < 400 ? 'ok' : 'error',
+        );
+      } catch (e) {
+        setStatus(buildResult, msgOf(e), 'error');
+      }
+    });
+  }
+
+  // Broadcast a pre-signed txn (reuses the imported key for the request
+  // envelope).
+  const broadcastInput = $('#broadcast-input');
+  const broadcastResult = $('#broadcast-result');
+  const broadcastBtn = $('#broadcast-btn');
+  if (broadcastBtn) {
+    broadcastBtn.addEventListener('click', async () => {
+      if (!importedWallet) {
+        setStatus(broadcastResult, 'Import a key first.', 'error');
+        return;
+      }
+      try {
+        const signed = JSON.parse(broadcastInput.value);
+        setStatus(broadcastResult, 'Submitting…', 'info');
+        const result = await submitSigned({
+          signed,
+          wallet: importedWallet,
+          nodeHost,
+        });
+        setStatus(
+          broadcastResult,
+          result.message,
+          result.status < 400 ? 'ok' : 'error',
+        );
+      } catch (e) {
+        const m = e instanceof SyntaxError ? `Invalid JSON: ${e.message}` : msgOf(e);
+        setStatus(broadcastResult, m, 'error');
+      }
+    });
+  }
+}
+
+function msgOf(e) {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// Read the type-specific fields out of the form into the shape buildQuery
+// expects. amount is sent as an integer string (grains).
+function collectFields(root, type) {
+  const val = (sel) => {
+    const el = root.querySelector(sel);
+    return el ? el.value : '';
+  };
+  const fields = { amount: val('#field-amount') };
+  if (type === 'transfer') {
+    fields.address = val('#field-address');
+  } else {
+    fields.subject = val('#field-subject');
+    if (type === 'rescind') {
+      fields.kind = val('#field-kind');
+    }
+  }
+  return fields;
+}

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -9,7 +9,10 @@
 // DOM wiring is in init().
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import { signHeaders } from '../wallet/gc-sig.mjs';
-import { signUnsignedTxn } from '../wallet/gc-transaction.mjs';
+import {
+  signUnsignedTxn,
+  txid as computeTxid,
+} from '../wallet/gc-transaction.mjs';
 
 const API_PREFIX = '/api';
 
@@ -113,11 +116,11 @@ async function authedFetch(
   return fetchImpl(url, opts);
 }
 
-// Full build -> verify-txid -> sign -> submit flow for one transaction. Returns
-// { unsigned, signed, status, message } so the caller can show the parsed txn
-// in a confirmation area and the final result. Throws (with a user-facing
-// message) if the build GET fails — no signature/POST happens after that.
-export async function buildSignSubmit({
+// Build (GET) an unsigned txn and independently verify its txid — WITHOUT
+// signing — so the caller can show the parsed txn for explicit human
+// confirmation before any signature. Returns { unsigned }. Throws (with a
+// user-facing message) if the build GET fails: no signature/POST happens.
+export async function buildUnsigned({
   type,
   fields,
   wallet,
@@ -141,16 +144,28 @@ export async function buildSignSubmit({
     throw new Error(responseMessage(buildResp.status, body));
   }
   const unsigned = await buildResp.json();
-  // signUnsignedTxn recomputes + verifies the txid (catches a dishonest node)
-  // before signing.
+  // Honesty check: the node-built txid must match a fresh recompute from its
+  // own fields. This is INTEGRITY only — the human confirmation step (showing
+  // the parsed txn before this is signed) is what checks intent.
+  const recomputed = await computeTxid({ ...unsigned, txid: undefined });
+  if (recomputed !== unsigned.txid) {
+    throw new Error(
+      'txid mismatch: node-built txn does not match its fields',
+    );
+  }
+  return { unsigned };
+}
+
+// Sign a previously-built, txid-verified unsigned txn and submit it. Call ONLY
+// after the user has confirmed the parsed txn returned by buildUnsigned.
+export async function signAndSubmit({
+  unsigned,
+  wallet,
+  nodeHost,
+  fetchImpl = globalThis.fetch,
+}) {
   const signed = await signUnsignedTxn(unsigned, wallet);
-  return submitSigned({
-    signed,
-    unsigned,
-    wallet,
-    nodeHost,
-    fetchImpl,
-  });
+  return submitSigned({ signed, unsigned, wallet, nodeHost, fetchImpl });
 }
 
 // Submit an already-signed txn (shared by build-sign and broadcast modes). The
@@ -165,6 +180,12 @@ export async function submitSigned({
   fetchImpl = globalThis.fetch,
   timestamp = nowSeconds(),
 }) {
+  if (!signed || !signed.txid || !signed.signature) {
+    throw new Error(
+      'This does not look like a signed transaction ' +
+        '(missing txid or signature).',
+    );
+  }
   const body = JSON.stringify(signed);
   const resp = await authedFetch(fetchImpl, {
     method: 'POST',
@@ -291,12 +312,32 @@ export function init(root = document, { nodeHost } = {}) {
     });
   }
 
-  // Build & sign & submit.
+  // Build & review -> (human confirms) -> sign & submit. Two steps so the
+  // user sees the parsed txn BEFORE their key signs it.
   const buildResult = $('#build-result');
   const confirmArea = $('#confirm-area');
-  const signBtn = $('#sign-submit-btn');
-  if (signBtn) {
-    signBtn.addEventListener('click', async () => {
+  const buildBtn = $('#build-review-btn');
+  const confirmBtn = $('#confirm-submit-btn');
+
+  // The verified-but-unsigned txn held between the build and confirm clicks.
+  let pendingUnsigned = null;
+  const resetPending = () => {
+    pendingUnsigned = null;
+    if (confirmBtn) confirmBtn.hidden = true;
+    if (confirmArea) confirmArea.textContent = '';
+  };
+  // Any edit to type/fields invalidates a pending build (so you can't confirm
+  // a txn built from different inputs than what's now on screen).
+  for (const el of root.querySelectorAll(
+    '#txn-type, [data-field-group] input, [data-field-group] select',
+  )) {
+    el.addEventListener('input', resetPending);
+    el.addEventListener('change', resetPending);
+  }
+
+  if (buildBtn) {
+    buildBtn.addEventListener('click', async () => {
+      resetPending();
       if (!importedWallet) {
         setStatus(buildResult, 'Import a key first.', 'error');
         return;
@@ -304,19 +345,53 @@ export function init(root = document, { nodeHost } = {}) {
       const type = typeSelect.value;
       const fields = collectFields(root, type);
       try {
-        setStatus(buildResult, 'Building & signing…', 'info');
-        const result = await buildSignSubmit({
+        setStatus(buildResult, 'Building…', 'info');
+        const { unsigned } = await buildUnsigned({
           type,
           fields,
           wallet: importedWallet,
           nodeHost,
         });
-        if (confirmArea) confirmArea.textContent = describeUnsigned(result.unsigned);
+        pendingUnsigned = unsigned;
+        if (confirmArea) {
+          confirmArea.textContent = describeUnsigned(unsigned);
+        }
+        if (confirmBtn) confirmBtn.hidden = false;
+        setStatus(
+          buildResult,
+          'Review the transaction below, then Confirm & submit. ' +
+            'Nothing is signed until you confirm.',
+          'info',
+        );
+      } catch (e) {
+        setStatus(buildResult, msgOf(e), 'error');
+      }
+    });
+  }
+
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', async () => {
+      if (!pendingUnsigned) {
+        setStatus(buildResult, 'Build a transaction first.', 'error');
+        return;
+      }
+      if (!importedWallet) {
+        setStatus(buildResult, 'Import a key first.', 'error');
+        return;
+      }
+      try {
+        setStatus(buildResult, 'Signing & submitting…', 'info');
+        const result = await signAndSubmit({
+          unsigned: pendingUnsigned,
+          wallet: importedWallet,
+          nodeHost,
+        });
         setStatus(
           buildResult,
           result.message,
           result.status < 400 ? 'ok' : 'error',
         );
+        resetPending();
       } catch (e) {
         setStatus(buildResult, msgOf(e), 'error');
       }

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -1,0 +1,215 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildQuery,
+  submitPath,
+  responseMessage,
+  buildSignSubmit,
+} from './transact-glue.mjs';
+
+// --- buildQuery: one query string, used for BOTH the fetch URL and the
+// gc-sig canonical, so it must round-trip exactly the fields the type needs.
+
+test('buildQuery transfer carries public_key, amount, address', () => {
+  const q = buildQuery('transfer', {
+    publicKey: 'PUB',
+    amount: '42',
+    address: 'GCdestGC',
+  });
+  const p = new URLSearchParams(q);
+  assert.equal(p.get('public_key'), 'PUB');
+  assert.equal(p.get('amount'), '42');
+  assert.equal(p.get('address'), 'GCdestGC');
+  assert.equal(p.has('subject'), false);
+  assert.equal(p.has('kind'), false);
+});
+
+test('buildQuery opposition carries public_key, amount, subject (raw)', () => {
+  const q = buildQuery('opposition', {
+    publicKey: 'PUB',
+    amount: '7',
+    subject: 'goblins & orcs',
+  });
+  const p = new URLSearchParams(q);
+  assert.equal(p.get('public_key'), 'PUB');
+  assert.equal(p.get('amount'), '7');
+  // The server takes the RAW subject and encodes it itself — do NOT pre-encode.
+  assert.equal(p.get('subject'), 'goblins & orcs');
+  assert.equal(p.has('address'), false);
+  assert.equal(p.has('kind'), false);
+});
+
+test('buildQuery support behaves like opposition', () => {
+  const q = buildQuery('support', {
+    publicKey: 'PUB',
+    amount: '3',
+    subject: 'dragons',
+  });
+  const p = new URLSearchParams(q);
+  assert.equal(p.get('subject'), 'dragons');
+  assert.equal(p.has('kind'), false);
+});
+
+test('buildQuery rescind carries subject AND kind', () => {
+  const q = buildQuery('rescind', {
+    publicKey: 'PUB',
+    amount: '5',
+    subject: 'goblins',
+    kind: 'support',
+  });
+  const p = new URLSearchParams(q);
+  assert.equal(p.get('subject'), 'goblins');
+  assert.equal(p.get('kind'), 'support');
+});
+
+test('buildQuery rejects an unknown type', () => {
+  assert.throws(() => buildQuery('bogus', {}), /unknown transaction type/);
+});
+
+// --- submitPath
+
+test('submitPath builds the /api submit path, encoding the txid segment', () => {
+  assert.equal(submitPath('abc123'), '/api/transaction/abc123');
+  // A txid with path-significant chars can't reshape the request.
+  assert.equal(submitPath('a/b?c'), '/api/transaction/a%2Fb%3Fc');
+});
+
+// --- responseMessage: each documented status surfaces distinctly.
+
+test('responseMessage maps success codes', () => {
+  for (const s of [200, 201, 202]) {
+    const m = responseMessage(s, { received: 'now' });
+    assert.match(m, /submitted|accepted|received/i);
+  }
+});
+
+test('responseMessage 403 is the closed-node message', () => {
+  const m = responseMessage(403, {});
+  assert.match(m, /not authorized|restricts/i);
+});
+
+test('responseMessage 503 is the mempool-full message', () => {
+  const m = responseMessage(503, { error: 'mempool full' });
+  assert.match(m, /mempool/i);
+});
+
+test('responseMessage 400 surfaces the validation error', () => {
+  const m = responseMessage(400, { error: 'bad amount' });
+  assert.match(m, /bad amount/);
+});
+
+test('responseMessage falls back for an unmapped status', () => {
+  const m = responseMessage(418, {});
+  assert.match(m, /418/);
+});
+
+// --- buildSignSubmit happy path: a fake wallet + fake fetch verify that the
+// GET is gc-sig authed, the returned unsigned txn is signed, and the POST body
+// is the signed txn carrying a signature + GC-* headers.
+
+function fakeWallet() {
+  return {
+    address: async () => 'GCsignerGC',
+    publicKeyB64: async () => 'SIGNER_PUB',
+    sign: async () => 'SIGNATURE_B64',
+  };
+}
+
+// Minimal unsigned txn whose self-reported txid actually matches its fields,
+// so signUnsignedTxn's honesty check passes. We compute it the same way the
+// module does (via the shared gc-transaction txid()).
+import { txid as computeTxid } from '../wallet/gc-transaction.mjs';
+
+test('buildSignSubmit: GET authed -> sign -> POST signed txn', async () => {
+  const unsigned = {
+    timestamp: '1700000000',
+    address: 'GCsignerGC',
+    public_key: 'SIGNER_PUB',
+    inflows: [{ outflow_txid: 'a'.repeat(64), outflow_idx: 0 }],
+    outflows: [{ amount: 42, address: 'GCdestGC' }],
+    version: '1',
+  };
+  unsigned.txid = await computeTxid({ ...unsigned, txid: undefined });
+
+  const calls = [];
+  const fakeFetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    if (opts.method === undefined || opts.method === 'GET') {
+      return {
+        status: 200,
+        ok: true,
+        json: async () => unsigned,
+        text: async () => JSON.stringify(unsigned),
+      };
+    }
+    return {
+      status: 201,
+      ok: true,
+      json: async () => ({ received: 'now' }),
+      text: async () => '{"received":"now"}',
+    };
+  };
+
+  const result = await buildSignSubmit({
+    type: 'transfer',
+    fields: { amount: '42', address: 'GCdestGC' },
+    wallet: fakeWallet(),
+    nodeHost: 'http://node.example',
+    fetchImpl: fakeFetch,
+    timestamp: 1700000000,
+  });
+
+  // Two calls: the build GET then the submit POST.
+  assert.equal(calls.length, 2);
+  const get = calls[0];
+  const post = calls[1];
+
+  // GET went to the build endpoint with the public_key in the query and was
+  // gc-sig authed.
+  assert.match(get.url, /\/api\/transaction\/transfer\?/);
+  assert.match(get.url, /public_key=SIGNER_PUB/);
+  assert.equal(get.opts.headers['GC-Address'], 'GCsignerGC');
+  assert.equal(get.opts.headers['GC-Signature'], 'SIGNATURE_B64');
+  assert.equal(get.opts.headers['GC-Sig-Version'], '1');
+
+  // POST went to the submit path, body is the signed txn, gc-sig authed.
+  assert.equal(post.url, submitPath(unsigned.txid));
+  assert.equal(post.opts.method, 'POST');
+  const body = JSON.parse(post.opts.body);
+  assert.equal(body.signature, 'SIGNATURE_B64');
+  assert.equal(body.txid, unsigned.txid);
+  assert.equal(post.opts.headers['GC-Signature'], 'SIGNATURE_B64');
+
+  // The result surfaces the success status + parsed unsigned txn (for the
+  // confirmation UX) + a user-facing message.
+  assert.equal(result.status, 201);
+  assert.equal(result.unsigned.txid, unsigned.txid);
+  assert.match(result.message, /submitted|accepted|received/i);
+});
+
+test('buildSignSubmit surfaces a build-GET error without POSTing', async () => {
+  const calls = [];
+  const fakeFetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    return {
+      status: 403,
+      ok: false,
+      json: async () => ({ error: 'forbidden' }),
+      text: async () => '{"error":"forbidden"}',
+    };
+  };
+  await assert.rejects(
+    () =>
+      buildSignSubmit({
+        type: 'transfer',
+        fields: { amount: '1', address: 'GCdestGC' },
+        wallet: fakeWallet(),
+        nodeHost: 'http://node.example',
+        fetchImpl: fakeFetch,
+        timestamp: 1700000000,
+      }),
+    /not authorized|restricts/i,
+  );
+  // Only the GET happened — no signed POST after an auth failure.
+  assert.equal(calls.length, 1);
+});

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -4,7 +4,9 @@ import {
   buildQuery,
   submitPath,
   responseMessage,
-  buildSignSubmit,
+  buildUnsigned,
+  signAndSubmit,
+  submitSigned,
 } from './transact-glue.mjs';
 
 // --- buildQuery: one query string, used for BOTH the fetch URL and the
@@ -103,10 +105,15 @@ test('responseMessage falls back for an unmapped status', () => {
   assert.match(m, /418/);
 });
 
-// --- buildSignSubmit happy path: a fake wallet + fake fetch verify that the
-// GET is gc-sig authed, the returned unsigned txn is signed, and the POST body
-// is the signed txn carrying a signature + GC-* headers.
+// --- two-step flow: buildUnsigned (GET, verify txid, NO sign) then
+// signAndSubmit (sign + POST). A fake wallet tracks sign calls so we can prove
+// nothing is signed before the confirm step.
 
+// Note: wallet.sign is used for BOTH the gc-sig request-envelope (on every
+// authed request, incl. the build GET) AND the transaction itself. So "not
+// signed before confirm" is asserted via: no POST happened, and the built txn
+// carries no `signature` — NOT via a sign-call count (which the request auth
+// would trip).
 function fakeWallet() {
   return {
     address: async () => 'GCsignerGC',
@@ -115,13 +122,15 @@ function fakeWallet() {
   };
 }
 
+const posts = (calls) => calls.filter((c) => (c.opts.method ?? 'GET') === 'POST');
+
 // Minimal unsigned txn whose self-reported txid actually matches its fields,
 // so signUnsignedTxn's honesty check passes. We compute it the same way the
 // module does (via the shared gc-transaction txid()).
 import { txid as computeTxid } from '../wallet/gc-transaction.mjs';
 
-test('buildSignSubmit: GET authed -> sign -> POST signed txn', async () => {
-  const unsigned = {
+function unsignedTransfer() {
+  return {
     timestamp: '1700000000',
     address: 'GCsignerGC',
     public_key: 'SIGNER_PUB',
@@ -129,28 +138,23 @@ test('buildSignSubmit: GET authed -> sign -> POST signed txn', async () => {
     outflows: [{ amount: 42, address: 'GCdestGC' }],
     version: '1',
   };
+}
+
+test('buildUnsigned: GET authed, verifies txid, does NOT sign or POST', async () => {
+  const unsigned = unsignedTransfer();
   unsigned.txid = await computeTxid({ ...unsigned, txid: undefined });
 
   const calls = [];
   const fakeFetch = async (url, opts = {}) => {
     calls.push({ url, opts });
-    if (opts.method === undefined || opts.method === 'GET') {
-      return {
-        status: 200,
-        ok: true,
-        json: async () => unsigned,
-        text: async () => JSON.stringify(unsigned),
-      };
-    }
     return {
-      status: 201,
+      status: 200,
       ok: true,
-      json: async () => ({ received: 'now' }),
-      text: async () => '{"received":"now"}',
+      json: async () => unsigned,
+      text: async () => JSON.stringify(unsigned),
     };
   };
-
-  const result = await buildSignSubmit({
+  const { unsigned: got } = await buildUnsigned({
     type: 'transfer',
     fields: { amount: '42', address: 'GCdestGC' },
     wallet: fakeWallet(),
@@ -159,35 +163,47 @@ test('buildSignSubmit: GET authed -> sign -> POST signed txn', async () => {
     timestamp: 1700000000,
   });
 
-  // Two calls: the build GET then the submit POST.
-  assert.equal(calls.length, 2);
+  // Nothing submitted before confirmation, and the returned txn is UNSIGNED.
+  assert.equal(posts(calls).length, 0);
+  assert.equal(got.signature, undefined);
+  // The one call was the authed build GET.
+  assert.equal(calls.length, 1);
   const get = calls[0];
-  const post = calls[1];
-
-  // GET went to the build endpoint with the public_key in the query and was
-  // gc-sig authed.
   assert.match(get.url, /\/api\/transaction\/transfer\?/);
   assert.match(get.url, /public_key=SIGNER_PUB/);
-  assert.equal(get.opts.headers['GC-Address'], 'GCsignerGC');
   assert.equal(get.opts.headers['GC-Signature'], 'SIGNATURE_B64');
-  assert.equal(get.opts.headers['GC-Sig-Version'], '1');
-
-  // POST went to the submit path, body is the signed txn, gc-sig authed.
-  assert.equal(post.url, submitPath(unsigned.txid));
-  assert.equal(post.opts.method, 'POST');
-  const body = JSON.parse(post.opts.body);
-  assert.equal(body.signature, 'SIGNATURE_B64');
-  assert.equal(body.txid, unsigned.txid);
-  assert.equal(post.opts.headers['GC-Signature'], 'SIGNATURE_B64');
-
-  // The result surfaces the success status + parsed unsigned txn (for the
-  // confirmation UX) + a user-facing message.
-  assert.equal(result.status, 201);
-  assert.equal(result.unsigned.txid, unsigned.txid);
-  assert.match(result.message, /submitted|accepted|received/i);
+  assert.equal(got.txid, unsigned.txid);
 });
 
-test('buildSignSubmit surfaces a build-GET error without POSTing', async () => {
+test('buildUnsigned rejects a node whose txid does not match its fields', async () => {
+  const unsigned = unsignedTransfer();
+  unsigned.txid = 'f'.repeat(64); // lie
+  const calls = [];
+  const fakeFetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    return {
+      status: 200,
+      ok: true,
+      json: async () => unsigned,
+      text: async () => JSON.stringify(unsigned),
+    };
+  };
+  await assert.rejects(
+    () =>
+      buildUnsigned({
+        type: 'transfer',
+        fields: { amount: '42', address: 'GCdestGC' },
+        wallet: fakeWallet(),
+        nodeHost: 'http://node.example',
+        fetchImpl: fakeFetch,
+        timestamp: 1700000000,
+      }),
+    /txid mismatch/,
+  );
+  assert.equal(posts(calls).length, 0); // a dishonest txn is never submitted
+});
+
+test('buildUnsigned surfaces a build-GET error without signing/POSTing', async () => {
   const calls = [];
   const fakeFetch = async (url, opts = {}) => {
     calls.push({ url, opts });
@@ -200,7 +216,7 @@ test('buildSignSubmit surfaces a build-GET error without POSTing', async () => {
   };
   await assert.rejects(
     () =>
-      buildSignSubmit({
+      buildUnsigned({
         type: 'transfer',
         fields: { amount: '1', address: 'GCdestGC' },
         wallet: fakeWallet(),
@@ -210,6 +226,59 @@ test('buildSignSubmit surfaces a build-GET error without POSTing', async () => {
       }),
     /not authorized|restricts/i,
   );
-  // Only the GET happened — no signed POST after an auth failure.
+  assert.equal(calls.length, 1); // only the GET
+  assert.equal(posts(calls).length, 0); // nothing submitted
+});
+
+test('signAndSubmit: signs the confirmed txn and POSTs it', async () => {
+  const unsigned = unsignedTransfer();
+  unsigned.txid = await computeTxid({ ...unsigned, txid: undefined });
+
+  const calls = [];
+  const fakeFetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    return {
+      status: 201,
+      ok: true,
+      json: async () => ({ received: 'now' }),
+      text: async () => '{"received":"now"}',
+    };
+  };
+  const result = await signAndSubmit({
+    unsigned,
+    wallet: fakeWallet(),
+    nodeHost: 'http://node.example',
+    fetchImpl: fakeFetch,
+  });
+
+  // Exactly one call — the submit POST carrying the now-signed txn.
   assert.equal(calls.length, 1);
+  const post = calls[0];
+  assert.equal(post.url, submitPath(unsigned.txid));
+  assert.equal(post.opts.method, 'POST');
+  const body = JSON.parse(post.opts.body);
+  assert.equal(body.signature, 'SIGNATURE_B64');
+  assert.equal(body.txid, unsigned.txid);
+  assert.equal(post.opts.headers['GC-Signature'], 'SIGNATURE_B64');
+  assert.equal(result.status, 201);
+  assert.match(result.message, /submitted|accepted|received/i);
+});
+
+test('submitSigned rejects a pasted object missing txid/signature', async () => {
+  let fetched = false;
+  const fakeFetch = async () => {
+    fetched = true;
+    return { status: 201, ok: true, text: async () => '{}' };
+  };
+  await assert.rejects(
+    () =>
+      submitSigned({
+        signed: { outflows: [] }, // valid JSON, but not a signed txn
+        wallet: fakeWallet(),
+        nodeHost: 'http://node.example',
+        fetchImpl: fakeFetch,
+      }),
+    /signed transaction|txid or signature/i,
+  );
+  assert.equal(fetched, false); // never POSTed to /api/transaction/undefined
 });

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -21,6 +21,7 @@
     <a class="navbar-nav" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
     <a class="navbar-nav" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
     <a class="navbar-nav" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
+    <a class="navbar-nav" href="{{ url_for('browser.transact_view') }}">Transact</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}Transact{% endblock %}
+
+{% block content -%}
+<div class="container-fluid" data-node-host="{{ node_host }}">
+
+  <div class="row my-3"><div class="col">
+    <div class="alert alert-warning" role="alert">
+      <strong>Your private key never leaves your browser.</strong>
+      This node does not store it, and reloading or closing this tab clears it.
+      Only your signature and public key are ever sent. Keys are imported into
+      memory for this session only &mdash; nothing is saved.
+    </div>
+  </div></div>
+
+  <!-- Section 1: Build & sign -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">Build &amp; sign a transaction</div>
+
+      <div class="mb-3">
+        <label for="txn-type" class="form-label">Type</label>
+        <select id="txn-type" class="form-select">
+          <option value="transfer">transfer</option>
+          <option value="opposition">opposition</option>
+          <option value="support">support</option>
+          <option value="rescind">rescind</option>
+        </select>
+      </div>
+
+      <div class="mb-3" data-field-group="amount">
+        <label for="field-amount" class="form-label">Amount (grains)</label>
+        <input id="field-amount" type="number" min="1" step="1"
+               class="form-control" placeholder="100">
+      </div>
+
+      <div class="mb-3" data-field-group="address" hidden>
+        <label for="field-address" class="form-label">Destination address</label>
+        <input id="field-address" type="text" class="form-control"
+               placeholder="GC...GC">
+      </div>
+
+      <div class="mb-3" data-field-group="subject" hidden>
+        <label for="field-subject" class="form-label">Subject</label>
+        <input id="field-subject" type="text" class="form-control"
+               placeholder="goblins">
+      </div>
+
+      <div class="mb-3" data-field-group="kind" hidden>
+        <label for="field-kind" class="form-label">Rescind kind</label>
+        <select id="field-kind" class="form-select">
+          <option value="opposition">opposition</option>
+          <option value="support">support</option>
+        </select>
+      </div>
+
+      <hr>
+
+      <div class="mb-3">
+        <label for="key-b58" class="form-label">
+          Import key (base58 private key)
+        </label>
+        <textarea id="key-b58" class="form-control" rows="2"
+                  placeholder="paste base58 private key"></textarea>
+        <div class="mt-2">
+          <label for="key-pem" class="form-label">or upload a .pem</label>
+          <input id="key-pem" type="file" accept=".pem" class="form-control">
+        </div>
+        <div class="mt-2">
+          <button id="import-key-btn" class="btn btn-secondary btn-sm">
+            Import key
+          </button>
+          <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
+            Forget key
+          </button>
+        </div>
+        <div id="key-status" class="mt-2 small"></div>
+      </div>
+
+      <button id="sign-submit-btn" class="btn btn-primary">Sign &amp; submit</button>
+
+      <div class="mt-3">
+        <pre id="confirm-area" class="small bg-light p-2"></pre>
+        <div id="build-result" class="mt-2"></div>
+      </div>
+    </div></div>
+  </div></div>
+
+  <!-- Section 2: Broadcast a pre-signed txn (advanced) -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">
+        <a class="text-decoration-none" data-bs-toggle="collapse"
+           href="#broadcast" role="button" aria-expanded="false"
+           aria-controls="broadcast">
+          Broadcast a pre-signed transaction (advanced)
+        </a>
+      </div>
+      <div id="broadcast" class="collapse">
+        <p class="small text-muted">
+          Paste an already-signed transaction JSON. The submit request itself is
+          still authed, so the imported key signs the request envelope.
+        </p>
+        <textarea id="broadcast-input" class="form-control" rows="6"
+                  placeholder='{"txid":"...","signature":"...", ...}'></textarea>
+        <button id="broadcast-btn" class="btn btn-primary mt-2">Submit</button>
+        <div id="broadcast-result" class="mt-2"></div>
+      </div>
+    </div></div>
+  </div></div>
+
+  <!-- Section 3: Sign attestation (PR 3) -->
+  <div class="row my-3"><div class="col">
+    <section id="attestation" class="card"><div class="card-body">
+      <div class="card-title h5">Sign a stake attestation</div>
+      <p class="text-muted">Coming soon.</p>
+    </div></section>
+  </div></div>
+
+  {% include "transact/extra.html" ignore missing %}
+</div>
+{%- endblock %}
+
+{% block scripts -%}
+{{ super() }}
+<script type="module">
+  import { init } from "{{ url_for('browser.static', filename='js/transact-glue.mjs') }}";
+  const root = document.querySelector('[data-node-host]');
+  init(root, { nodeHost: root.dataset.nodeHost });
+</script>
+{%- endblock %}

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -78,7 +78,8 @@
         <div id="key-status" class="mt-2 small"></div>
       </div>
 
-      <button id="sign-submit-btn" class="btn btn-primary">Sign &amp; submit</button>
+      <button id="build-review-btn" class="btn btn-primary">Build &amp; review</button>
+      <button id="confirm-submit-btn" class="btn btn-success" hidden>Confirm &amp; submit</button>
 
       <div class="mt-3">
         <pre id="confirm-area" class="small bg-light p-2"></pre>

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -1,0 +1,36 @@
+import httpx
+
+
+def test_transact_page_renders(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/transact')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        # The type selector and its four kinds are present.
+        assert 'id="txn-type"' in body
+        assert 'value="transfer"' in body
+        assert 'value="opposition"' in body
+        assert 'value="support"' in body
+        assert 'value="rescind"' in body
+        # The security framing must be loud and present.
+        assert 'never leaves your browser' in body
+        # Build & sign + broadcast + attestation sections.
+        assert 'id="broadcast"' in body
+        assert 'id="attestation"' in body
+        # The page exposes the node host (gc-sig is node-bound).
+        assert 'data-node-host' in body
+        # Glue module is wired in from the blueprint static js dir.
+        assert 'js/transact-glue.mjs' in body
+        assert '/static/gumptionchain/' in body
+        # super() in the scripts block keeps base's bundled JS (Bootstrap).
+        assert 'bootstrap' in body
+
+
+def test_transact_page_carries_configured_node_host(app, test_client):
+    with app.app_context():
+        node_host = app.config['NODE_HOST']
+        resp = test_client.get('/transact')
+        assert resp.status_code == httpx.codes.OK
+        # The exact configured host must reach the page so the glue can sign
+        # node-bound gc-sig-v1 requests against this node.
+        assert node_host in str(resp.data)

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -171,3 +171,18 @@ def test_consumer_base_html_reskins_mempool_page(tmp_path):
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         # base mempool content still rendered
         assert b'Mempool is empty' in resp.data
+
+
+def test_consumer_base_html_reskins_transact_page(tmp_path):
+    # Seam check for the /transact build-sign page. It is a static shell (no
+    # chain needed), so the consumer skin must win while base's transact
+    # content still renders.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/transact')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base transact content still rendered
+        assert b'never leaves your browser' in resp.data


### PR DESCRIPTION
PR 2 of 3 for base-node browser transaction creation. The **`/transact` page**: build a txn via the node's authed server-side endpoints, sign it client-side with an ephemeral imported key, and submit — plus a broadcast-pre-signed mode. (Attestation signing is PR 3; a placeholder section is present.)

## Flow (confirm-before-sign)
1. **Build & review** — `GET /api/transaction/<type>` (gc-sig authed) returns the unsigned, sealed txn; the page independently recomputes the txid (honesty check) and **renders the parsed txn for review**. Nothing is signed yet.
2. **Confirm & submit** — only on the explicit confirm click does the key sign `signing_data` and `POST /api/transaction/<txid>`. Editing type/fields invalidates a pending build. (The txid check proves integrity; the human confirmation proves intent — both needed.)

## What
- `transact_view` (`/transact`, passes `NODE_HOST` for the node-bound gc-sig canonical) + nav link.
- `transact.html` — type selector (transfer/opposition/support/rescind) with reveal-on-type fields, b58 key import (in-memory only, "forget key"), Build & review → Confirm & submit, collapsible Broadcast, attestation placeholder, security banner, `{% include "transact/extra.html" ignore missing %}`.
- `static/js/transact-glue.mjs` — pure helpers (`buildQuery`/`submitPath`/`responseMessage`/`buildUnsigned`/`signAndSubmit`/`submitSigned`) + DOM `init`. Imports the vendored wallet modules; reuses the gc-sig request auth whose JS↔Python canonical parity is already locked by golden vectors.

## Security / correctness
- Subject sent **raw** (the endpoints `encode_subject` server-side — verified against api.py; pre-encoding would double-encode).
- Imported key in a module-scoped var only — never persisted, never sent (only signature + public key leave).
- `submitSigned` rejects a pasted object missing `txid`/`signature` (no POST to `/api/transaction/undefined`).
- 403 (closed node) / 503 (mempool full) / 400 (validation) surfaced distinctly.
- PEM import deferred (b58 primary) with a clear message — documented follow-up.

## Tests
`transact-glue.test.mjs` (16 node tests incl. "no submit & no signed txn before confirm", dishonest-txid rejection, broadcast guard); `tests/test_transact_page.py`; `/transact` seam test. Gates: pytest 462, `node --test` 111, ruff + mypy clean. Independently reviewed; confirm-before-sign + broadcast guard added per review.

Spec: `docs/superpowers/specs/2026-06-08-base-transact-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)