### PR TITLE
feat(browser): stake-attestation signer on /transact (#transact PR3)

### DIFF
--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -9,6 +9,8 @@
 // DOM wiring is in init().
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import { signHeaders } from '../wallet/gc-sig.mjs';
+import { base64encode } from '../wallet/gc-crypto.mjs';
+import { signStakeAttestation } from '../wallet/gc-attestation.mjs';
 import {
   signUnsignedTxn,
   txid as computeTxid,
@@ -203,6 +205,42 @@ export async function submitSigned({
     status: resp.status,
     message: responseMessage(resp.status, respBody),
   };
+}
+
+// --- Attestation (the producer side of /verify) ----------------------------
+
+// Encode a RAW subject to the base64url, padding-stripped form. This MUST match
+// Python's payload.encode_subject (urlsafe_b64encode(raw.encode()).rstrip('=')),
+// because /verify compares an attestation's claim against on-chain provenance
+// whose subject is the ENCODED form. The literals are locked to a pytest
+// (tests/test_encode_subject_parity.py) so the two stay in sync.
+export function encodeSubject(raw) {
+  return base64encode(new TextEncoder().encode(raw))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// Sign a stake attestation. Takes a RAW subject (consistent with the txn
+// builder, which sends the raw subject and lets the server encode it), encodes
+// it, and builds the claim with the ENCODED subject before signing — so the
+// proof's claim matches on-chain provenance at /verify. Returns the gc-msg-v1
+// proof object.
+export async function signAttestation({
+  txid,
+  kind,
+  rawSubject,
+  amount,
+  wallet,
+  timestamp,
+}) {
+  const claim = {
+    txid,
+    kind,
+    subject: encodeSubject(rawSubject),
+    amount,
+  };
+  return signStakeAttestation(wallet, claim, { timestamp });
 }
 
 // --- DOM wiring ------------------------------------------------------------
@@ -425,6 +463,64 @@ export function init(root = document, { nodeHost } = {}) {
       } catch (e) {
         const m = e instanceof SyntaxError ? `Invalid JSON: ${e.message}` : msgOf(e);
         setStatus(broadcastResult, m, 'error');
+      }
+    });
+  }
+
+  // Sign a stake attestation (producer side of /verify). Reuses the imported
+  // key. The subject input is RAW (like the txn builder); signAttestation
+  // encodes it so the claim matches on-chain provenance at /verify.
+  const attTxid = $('#att-txid');
+  const attKind = $('#att-kind');
+  const attSubject = $('#att-subject');
+  const attAmount = $('#att-amount');
+  const attBtn = $('#att-sign-btn');
+  const attResult = $('#att-result');
+  const attProof = $('#att-proof');
+  const attCopyBtn = $('#att-copy-btn');
+
+  if (attBtn) {
+    attBtn.addEventListener('click', async () => {
+      if (attProof) attProof.textContent = '';
+      if (attCopyBtn) attCopyBtn.hidden = true;
+      if (!importedWallet) {
+        setStatus(attResult, 'Import a key first.', 'error');
+        return;
+      }
+      try {
+        setStatus(attResult, 'Signing attestation…', 'info');
+        const proof = await signAttestation({
+          txid: attTxid ? attTxid.value.trim() : '',
+          kind: attKind ? attKind.value : 'opposition',
+          rawSubject: attSubject ? attSubject.value : '',
+          amount: attAmount ? Number(attAmount.value) : NaN,
+          wallet: importedWallet,
+        });
+        if (attProof) attProof.textContent = JSON.stringify(proof, null, 2);
+        if (attCopyBtn) attCopyBtn.hidden = false;
+        setStatus(
+          attResult,
+          'Attestation signed. Paste this into /verify.',
+          'ok',
+        );
+      } catch (e) {
+        setStatus(attResult, msgOf(e), 'error');
+      }
+    });
+  }
+
+  if (attCopyBtn) {
+    attCopyBtn.addEventListener('click', async () => {
+      const text = attProof ? attProof.textContent : '';
+      try {
+        await navigator.clipboard.writeText(text);
+        setStatus(attResult, 'Copied to clipboard.', 'ok');
+      } catch {
+        setStatus(
+          attResult,
+          'Could not copy automatically — select the JSON and copy it.',
+          'error',
+        );
       }
     });
   }

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -7,7 +7,11 @@ import {
   buildUnsigned,
   signAndSubmit,
   submitSigned,
+  encodeSubject,
+  signAttestation,
 } from './transact-glue.mjs';
+import { Wallet } from '../wallet/gc-wallet.mjs';
+import { parseStakeAttestation } from '../wallet/gc-attestation.mjs';
 
 // --- buildQuery: one query string, used for BOTH the fetch URL and the
 // gc-sig canonical, so it must round-trip exactly the fields the type needs.
@@ -262,6 +266,67 @@ test('signAndSubmit: signs the confirmed txn and POSTs it', async () => {
   assert.equal(post.opts.headers['GC-Signature'], 'SIGNATURE_B64');
   assert.equal(result.status, 201);
   assert.match(result.message, /submitted|accepted|received/i);
+});
+
+// --- encodeSubject: must produce the base64url, padding-stripped form that
+// Python's encode_subject produces, since /verify compares the claim's subject
+// against on-chain provenance (which is the ENCODED form). The literals here
+// are locked to a Python pytest (tests/test_encode_subject_parity.py).
+
+test('encodeSubject matches Python encode_subject for ascii', () => {
+  assert.equal(encodeSubject('goblins'), 'Z29ibGlucw');
+});
+
+test('encodeSubject matches Python for a value with a space', () => {
+  assert.equal(encodeSubject('cancel me'), 'Y2FuY2VsIG1l');
+});
+
+test('encodeSubject matches Python for a multi-byte (UTF-8) value', () => {
+  assert.equal(encodeSubject('café'), 'Y2Fmw6k');
+});
+
+test('encodeSubject is base64url with no padding (no +, /, =)', () => {
+  const enc = encodeSubject('the quick brown fox????');
+  assert.equal(/[+/=]/.test(enc), false);
+});
+
+// --- signAttestation: encodes the RAW subject, builds a claim with the ENCODED
+// subject, signs it, and round-trips through parseStakeAttestation.
+
+test('signAttestation builds a claim with the ENCODED subject', async () => {
+  const wallet = await Wallet.generate();
+  const proof = await signAttestation({
+    txid: '1'.repeat(64),
+    kind: 'opposition',
+    rawSubject: 'goblins',
+    amount: 300,
+    wallet,
+    timestamp: '1700002000',
+  });
+  // The signed message's subject is the encoded form, not the raw input.
+  const claim = parseStakeAttestation(proof);
+  assert.equal(claim.subject, 'Z29ibGlucw');
+  assert.notEqual(claim.subject, 'goblins');
+  assert.equal(claim.txid, '1'.repeat(64));
+  assert.equal(claim.kind, 'opposition');
+  assert.equal(claim.amount, 300);
+  // The proof is a gc-msg-v1 envelope signed by this wallet.
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.address, await wallet.address());
+});
+
+test('signAttestation supports the support kind', async () => {
+  const wallet = await Wallet.generate();
+  const proof = await signAttestation({
+    txid: '2'.repeat(64),
+    kind: 'support',
+    rawSubject: 'cancel me',
+    amount: 5,
+    wallet,
+  });
+  const claim = parseStakeAttestation(proof);
+  assert.equal(claim.kind, 'support');
+  assert.equal(claim.subject, 'Y2FuY2VsIG1l');
 });
 
 test('submitSigned rejects a pasted object missing txid/signature', async () => {

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -115,7 +115,47 @@
   <div class="row my-3"><div class="col">
     <section id="attestation" class="card"><div class="card-body">
       <div class="card-title h5">Sign a stake attestation</div>
-      <p class="text-muted">Coming soon.</p>
+      <p class="small text-muted">
+        Produce a signed <code>gc-msg-v1</code> proof that you staked on a
+        subject &mdash; the producer side of
+        <a href="{{ url_for('browser.verify_view') }}">Verify</a>. Reuses the
+        key you imported above. The subject is the same RAW subject you staked.
+      </p>
+
+      <div class="mb-3">
+        <label for="att-txid" class="form-label">Transaction id (txid)</label>
+        <input id="att-txid" type="text" class="form-control"
+               placeholder="64-char hex txid of your stake">
+      </div>
+
+      <div class="mb-3">
+        <label for="att-kind" class="form-label">Kind</label>
+        <select id="att-kind" class="form-select">
+          <option value="opposition">opposition</option>
+          <option value="support">support</option>
+        </select>
+      </div>
+
+      <div class="mb-3">
+        <label for="att-subject" class="form-label">Subject</label>
+        <input id="att-subject" type="text" class="form-control"
+               placeholder="goblins">
+      </div>
+
+      <div class="mb-3">
+        <label for="att-amount" class="form-label">Amount (grains)</label>
+        <input id="att-amount" type="number" min="1" step="1"
+               class="form-control" placeholder="300">
+      </div>
+
+      <button id="att-sign-btn" class="btn btn-primary">Sign attestation</button>
+      <button id="att-copy-btn" class="btn btn-outline-secondary" hidden>Copy</button>
+
+      <div class="mt-3">
+        <div id="att-result" class="mb-2"></div>
+        <pre id="att-proof" class="small bg-light p-2"></pre>
+        <p class="small text-muted">Paste this into /verify.</p>
+      </div>
     </div></section>
   </div></div>
 

--- a/src/gumptionchain/templates/verify.html
+++ b/src/gumptionchain/templates/verify.html
@@ -20,6 +20,10 @@
         </ul>
         <pre id="verdict-reasons"></pre>
       </div>
+      <p class="small text-muted mt-3 mb-0">
+        Have a stake to prove? Create a signed attestation on the
+        <a href="{{ url_for('browser.transact_view') }}#attestation">Transact page</a>.
+      </p>
     </div></div>
   </div></div>
   {% include "verify/extra.html" ignore missing %}

--- a/tests/test_encode_subject_parity.py
+++ b/tests/test_encode_subject_parity.py
@@ -1,0 +1,24 @@
+"""Lock the JS encodeSubject literals (in static/js/transact-glue.test.mjs) to
+Python's payload.encode_subject. /verify compares an attestation's claim
+subject against on-chain provenance, whose subject is the ENCODED form, so the
+attestation signer must encode the subject identically to the chain.
+"""
+
+from gumptionchain.payload import encode_subject
+
+
+def test_encode_subject_matches_js_literals():
+    # These exact strings are asserted in the JS test
+    # (src/gumptionchain/static/js/transact-glue.test.mjs). Keep them in sync.
+    assert encode_subject('goblins') == 'Z29ibGlucw'
+    assert encode_subject('cancel me') == 'Y2FuY2VsIG1l'
+    # A multi-byte (UTF-8) subject exercises base64url over non-ASCII bytes.
+    assert encode_subject('café') == 'Y2Fmw6k'
+
+
+def test_encode_subject_is_base64url_without_padding():
+    # base64url alphabet ('-'/'_'), and no '=' padding.
+    encoded = encode_subject('the quick brown fox????')
+    assert '+' not in encoded
+    assert '/' not in encoded
+    assert '=' not in encoded

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -17,6 +17,15 @@ def test_transact_page_renders(app, test_client):
         # Build & sign + broadcast + attestation sections.
         assert 'id="broadcast"' in body
         assert 'id="attestation"' in body
+        # The attestation section is wired (not a "coming soon" placeholder):
+        # it has its inputs and a Sign attestation button.
+        assert 'Coming soon' not in body
+        assert 'id="att-txid"' in body
+        assert 'id="att-kind"' in body
+        assert 'id="att-subject"' in body
+        assert 'id="att-amount"' in body
+        assert 'id="att-sign-btn"' in body
+        assert 'Sign attestation' in body
         # The page exposes the node host (gc-sig is node-bound).
         assert 'data-node-host' in body
         # Glue module is wired in from the blueprint static js dir.

--- a/tests/test_verify_page.py
+++ b/tests/test_verify_page.py
@@ -15,3 +15,12 @@ def test_verify_page_renders(app, test_client):
         assert 'verdict-reasons' in body
         # super() in the scripts block must keep base's bundled JS (Bootstrap).
         assert 'bootstrap' in body
+
+
+def test_verify_page_links_to_the_attestation_signer(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/verify')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        # /verify points producers at the signer on /transact#attestation.
+        assert '/transact#attestation' in body


### PR DESCRIPTION
PR 3 of 3 (final) for base-node browser transaction creation. Fills the `/transact` attestation placeholder with a **stake-attestation signer** — the producer side of `/verify` — and links `/verify` to it.

## What
- **Attestation section** on `/transact`: txid / kind (opposition·support) / subject (raw) / amount → reuses the in-memory imported key → `signStakeAttestation` → renders the gc-msg-v1 proof JSON + Copy + "paste into /verify".
- **`encodeSubject(raw)`** + **`signAttestation(...)`** helpers in `transact-glue.mjs`: the form takes a RAW subject (consistent with the txn builder) and encodes it (base64url, strip padding) so the claim's `subject` matches on-chain provenance, which is what `/verify` compares against.
- **`/verify` → signer link** (`/transact#attestation`).

## Correctness
- Subject-encoding parity locked both sides: JS `encodeSubject` ↔ Python `encode_subject` (`goblins`→`Z29ibGlucw`, `café`→`Y2Fmw6k`), via `tests/test_encode_subject_parity.py` + JS literals.
- Amount coerced to a `Number` and re-validated by `validateClaim`/`parseStakeAttestation` (no string in the canonical).
- Proof output is public-only (no private key rendered); attestation section is independent of the build's pending-confirm state.

## Tests
encodeSubject parity, signAttestation round-trip (both kinds, encoded subject), page markup, verify link. Gates: pytest 465, `node --test` 117, ruff + mypy clean. Independently reviewed — APPROVED.

Completes the Tiers 0+1 transact effort (spec: `docs/superpowers/specs/2026-06-08-base-transact-design.md`). Tier 1.5 (persistent wallet + passkey) deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)