### PR TITLE
docs(egu-217): persistent browser wallet (Tier 1.5) — spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-06-08-egu-217-persistent-wallet.md
+++ b/docs/superpowers/plans/2026-06-08-egu-217-persistent-wallet.md
@@ -1,0 +1,220 @@
+# EGU #217 persistent browser wallet (Tier 1.5) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A persisted, browser-resident wallet (IndexedDB, zero server state) unlockable by passphrase OR passkey, managed on a `/wallet` page and usable from `/transact`, with generation + encrypted backup. Ephemeral import stays the default; persistence is opt-in behind a trust acknowledgment.
+
+**Architecture:** A DEK-wrapping keyring (`gc-keyring.mjs`) encrypts the wallet under a random data key (DEK); the DEK is wrapped separately by a passphrase-KEK (PBKDF2) and a passkey-KEK (WebAuthn-PRF→HKDF), so either method unlocks the same wallet. Persistence lives in IndexedDB (origin-scoped, single record); unlock is per-page-session with auto-lock.
+
+**Tech Stack:** Web Crypto (AES-GCM, PBKDF2, HKDF, RSA), IndexedDB, vanilla ESM; Flask/Jinja/Bootstrap; pytest + `node --test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md`
+
+**Primitives to reuse (READ FIRST):**
+- `clients/wallet/gc-envelope.mjs`: `sealWithKey(aesKey, bytes) -> {iv, ciphertext}`, `openWithKey(aesKey, {iv, ciphertext}) -> bytes`, `deriveAesKey(prfOutput) -> AES-GCM key` (HKDF; currently NOT exported — export it), `seal/open` (PRF wrappers).
+- `clients/wallet/gc-backup.mjs`: `deriveKey(passphrase, salt, iterations) -> AES-GCM key` (PBKDF2; currently a module-internal `async function` — export it), `exportEncrypted(wallet, passphrase)` / `importEncrypted(backup, passphrase)`, `SALT_BYTES`/default `iterations`.
+- `clients/wallet/gc-store-idb.mjs`: `makeIdbStore({dbName}) -> { get()->record|null, put(record), delete() }` (single `singleton` record; stores structured-cloneable objects incl. `Uint8Array`).
+- `clients/wallet/gc-passkey-webauthn.mjs`: `makeWebauthnPasskey({rpId, rpName}) -> { isSupported()->bool, enroll({userId,userName})->{credentialId, prfOutput}, unlock(credentialId)->prfOutput }`.
+- `clients/wallet/gc-wallet.mjs`: `Wallet.generate()`, `Wallet.fromPrivateKeyB58(b58)`, `await wallet.exportPrivateKeyB58()`, `await wallet.address()`.
+- `clients/wallet/gc-store.mjs` is the single-method (passkey-only) predecessor — read it for the enroll/unlock shape, but the persistent path uses the new `gc-keyring`.
+
+**Conventions:** ruff/mypy/pytest gates; `node --test clients/wallet/*.test.mjs src/gumptionchain/static/js/*.test.mjs`; vendor wallet modules via `scripts/sync_wallet.py`; drift guard `tests/test_wallet_vendored.py` must stay green. Commit bodies end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## PR 1 — `gc-keyring.mjs` (DEK-wrapping multi-method keyring)
+
+Branch: `feat/wallet-keyring` off fresh `main`.
+
+### Task 1: expose the KEK derivations
+
+**Files:** `clients/wallet/gc-envelope.mjs`, `clients/wallet/gc-backup.mjs`
+
+- [ ] **Step 1:** `export` `deriveAesKey` in `gc-envelope.mjs` (currently internal). Add a node:test asserting `seal/open` still round-trip (no behavior change).
+- [ ] **Step 2:** `export` `deriveKey` (PBKDF2) from `gc-backup.mjs`; confirm `exportEncrypted`/`importEncrypted` still pass their tests.
+- [ ] **Step 3:** `uv run python scripts/sync_wallet.py`; gates green. Commit: `refactor(wallet): export deriveAesKey + deriveKey for keyring reuse`.
+
+### Task 2: `gc-keyring.mjs` enroll/unlock (passphrase) — TDD
+
+**Files:** Create `clients/wallet/gc-keyring.mjs`, `clients/wallet/gc-keyring.test.mjs`
+
+- [ ] **Step 1: Failing test** (node:test, in-memory fake store):
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import * as keyring from './gc-keyring.mjs';
+
+function fakeStore() {
+  let rec = null;
+  return { get: async () => rec, put: async (r) => { rec = r; }, delete: async () => { rec = null; } };
+}
+
+test('enroll(passphrase) then unlock(passphrase) recovers the same wallet', async () => {
+  const store = fakeStore();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'correct horse' });
+  assert.equal(await keyring.hasWallet(store), true);
+  const unlocked = await keyring.unlock({ store }, { passphrase: 'correct horse' });
+  assert.equal(await unlocked.address(), addr);
+});
+
+test('wrong passphrase fails closed', async () => {
+  const store = fakeStore();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'right' });
+  await assert.rejects(() => keyring.unlock({ store }, { passphrase: 'wrong' }));
+});
+```
+Run `node --test clients/wallet/gc-keyring.test.mjs` → FAIL.
+
+- [ ] **Step 2: Implement** `gc-keyring.mjs`:
+
+```js
+import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
+import { deriveKey } from './gc-backup.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const VERSION = 1;
+const SALT_BYTES = 16;
+const PBKDF2_ITERATIONS = 600000;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+async function newDek() {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  const key = await crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['encrypt', 'decrypt']);
+  return { raw, key };
+}
+async function importDek(raw) {
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+async function passphraseWrap(passphrase, dekRaw) {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const kek = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { salt, iterations: PBKDF2_ITERATIONS, iv, ciphertext };
+}
+async function passkeyWrap(passkey, dekRaw, ids) {
+  const { credentialId, prfOutput } = await passkey.enroll(ids);
+  const kek = await deriveAesKey(prfOutput);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { credentialId, iv, ciphertext };
+}
+
+export async function hasWallet(store) {
+  return (await store.get()) !== null;
+}
+
+export async function enroll(wallet, { store }, { passphrase }) {
+  const b58 = await wallet.exportPrivateKeyB58();
+  const { raw: dekRaw, key: dekKey } = await newDek();
+  const wallet_ct = await sealWithKey(dekKey, te.encode(b58));
+  const wraps = { passphrase: await passphraseWrap(passphrase, dekRaw) };
+  await store.put({ version: VERSION, address: await wallet.address(), wallet_ct, wraps });
+  return wallet;
+}
+
+// Unwrap the DEK with whichever method's secret was supplied, then decrypt the
+// wallet. Wrong secret -> GCM auth-tag failure -> reject (fails closed).
+async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
+  const { wraps } = rec;
+  if (passphrase != null && wraps.passphrase) {
+    const w = wraps.passphrase;
+    const kek = await deriveKey(passphrase, w.salt, w.iterations);
+    return new Uint8Array(await openWithKey(kek, w));
+  }
+  if (passkey && wraps.passkey) {
+    const prfOutput = await passkey.unlock(wraps.passkey.credentialId);
+    const kek = await deriveAesKey(prfOutput);
+    return new Uint8Array(await openWithKey(kek, wraps.passkey));
+  }
+  throw new Error('no usable unlock method/secret');
+}
+
+export async function unlock({ store, passkey } = {}, { passphrase } = {}) {
+  const rec = await store.get();
+  if (!rec) throw new Error('no stored wallet');
+  const dekRaw = await unwrapDek(rec, { passkey }, { passphrase });
+  const dekKey = await importDek(dekRaw);
+  const b58 = td.decode(new Uint8Array(await openWithKey(dekKey, rec.wallet_ct)));
+  return Wallet.fromPrivateKeyB58(b58);
+}
+
+export async function clear(store) { await store.delete(); }
+```
+
+> Match `sealWithKey`/`openWithKey`'s exact arg/return shapes from `gc-envelope.mjs` (iv/ciphertext types). Store iv/ciphertext as the types IndexedDB structured-clones (Uint8Array is fine). `deriveKey(passphrase, salt, iterations)` takes the salt as bytes — store/read it consistently.
+
+- [ ] **Step 3:** Run → PASS. `node --test`.
+- [ ] **Step 4: Commit** — `feat(wallet): gc-keyring — DEK-wrapped passphrase enroll/unlock`.
+
+### Task 3: passkey method (add/unlock by either) — TDD
+
+**Files:** `gc-keyring.mjs`, `gc-keyring.test.mjs`
+
+- [ ] **Step 1: Failing test** with a fake PRF passkey:
+
+```js
+function fakePasskey() {
+  const PRF = new Uint8Array(32).fill(7);
+  return { isSupported: async () => true, enroll: async () => ({ credentialId: 'cred1', prfOutput: PRF }), unlock: async () => PRF };
+}
+
+test('a wallet with both methods unlocks by passkey AND by passphrase', async () => {
+  const store = fakeStore(); const passkey = fakePasskey();
+  const w = await Wallet.generate(); const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'pw' });
+  await keyring.addPasskey({ store, passkey }, { passphrase: 'pw' });
+  assert.equal(await (await keyring.unlock({ store, passkey }, {})).address(), addr); // passkey
+  assert.equal(await (await keyring.unlock({ store }, { passphrase: 'pw' })).address(), addr); // passphrase
+});
+```
+
+- [ ] **Step 2: Implement** `addPasskey({store, passkey}, {passphrase})`: unlock the DEK via the supplied passphrase (reuse `unwrapDek`), then `passkeyWrap` the same `dekRaw` and merge `wraps.passkey` into the stored record. Add `removeMethod(store, name)` (delete a wrap; refuse to remove the last one). `unlock` already prefers passphrase when supplied, else passkey — confirm both branches.
+
+- [ ] **Step 3:** Run → PASS. Add tests: removing passphrase when it's the only method is refused; `removeMethod` leaves the other method working.
+
+- [ ] **Step 4: Sync + drift guard + gates.** `uv run python scripts/sync_wallet.py`; `uv run pytest tests/test_wallet_vendored.py`; full gates incl. both node globs. Commit: `feat(wallet): gc-keyring passkey method + add/remove`. Open PR.
+
+---
+
+## PR 2 — `/wallet` page (management) + session helper
+
+Branch: `feat/wallet-page` off fresh `main` (after PR 1).
+
+### Task 4: `wallet-session.mjs` auto-lock helper (TDD)
+
+**Files:** Create `src/gumptionchain/static/js/wallet-session.mjs` (+ `.test.mjs`)
+
+- [ ] Pure, testable session holder: `setWallet(w)` / `getWallet()` / `lock()` (drops the reference), `onLock(cb)`, an idle-timer (`armIdle(ms, now=Date.now)` + `touch()`), and `installAutoLock({document, window, idleMs})` wiring `visibilitychange`/`pagehide` → `lock()`. Tests: lock clears the wallet + fires `onLock`; idle timer locks after the interval (inject a fake clock); touch resets it. Commit: `feat(wallet): wallet-session auto-lock helper`.
+
+### Task 5: `/wallet` view + template + glue (TDD)
+
+**Files:** `browser.py` (`wallet_view` → `/wallet`, passes `node_host` + a `rp_name`), `base.html` (nav), `templates/wallet.html`, `src/gumptionchain/static/js/wallet-glue.mjs` (+ test), `tests/test_wallet_page.py`, `tests/test_ui_seam.py`
+
+- [ ] **View:** `wallet_view` renders `wallet.html` (static shell; all key work is client-side). No DB/chain.
+- [ ] **Template** (`wallet.html`, extends base, content only): the state-driven UI from the spec — **No wallet** (Create / Import, each with a passphrase field) and **Has wallet** (address, Unlock [passphrase + passkey-if-supported], Lock, Add passkey [secure-origin], Backup [download], Forget [confirm]). A prominent **security banner**. The **first-persist trust acknowledgment** (a checkbox/confirm gating the first enroll on this origin; remember via a small `localStorage` flag). `{% include "wallet/extra.html" ignore missing %}`. Inline `<script type="module">` importing `wallet-glue.mjs` (mirror `/transact`).
+- [ ] **`wallet-glue.mjs`**: wire the flows using `gc-keyring` + `gc-store-idb` + `gc-backup` + `gc-wallet` + `wallet-session`; passkey via `makeWebauthnPasskey({rpId: location.hostname, rpName})` gated on `window.isSecureContext && await passkey.isSupported()`. Pure helpers (state→which-controls-shown, backup filename, the trust-ack flag read/write) unit-tested with fakes; DOM `init()`.
+- [ ] **Tests:** `/wallet` renders the states/markup + security banner + trust-ack; passkey controls hidden when not secure (drive via a flag/stub); backup helper round-trip; seam test. Commit: `feat(browser): /wallet persistent wallet management page`. Open PR.
+
+---
+
+## PR 3 — `/transact` integration
+
+Branch: `feat/transact-saved-wallet` off fresh `main` (after PR 2).
+
+### Task 6: "Unlock saved wallet" on `/transact` (TDD)
+
+**Files:** `templates/transact.html`, `src/gumptionchain/static/js/transact-glue.mjs` (+ test), `tests/test_transact_page.py`
+
+- [ ] Add an **"Unlock saved wallet"** affordance to the key area, shown when `await keyring.hasWallet(store)`: passphrase input (+ passkey button if supported) → `keyring.unlock(...)` → set `importedWallet` via the shared `wallet-session` (reuse PR 2's helper). Keep the existing ephemeral import path as the alternative. Apply the same auto-lock policy to `/transact`'s session.
+- [ ] Tests: `/transact` shows the "Unlock saved wallet" controls when a wallet exists (stub `hasWallet`); unlocking yields a usable wallet for the build/confirm/sign flow; ephemeral import still works. Commit: `feat(browser): unlock a saved wallet on /transact`. Open PR.
+
+---
+
+## Final
+
+After all three merge: final reviewer over the combined diff (focus the keyring crypto + the session/lock handling); update the EGU checklist (#190) to mark #217 (Tier 1.5) shipped; note multiple-wallets as the remaining wallet follow-up. Security note: get a focused security read on `gc-keyring` (the DEK-wrap scheme) before/at merge — it's the key-custody core.

--- a/docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md
+++ b/docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md
@@ -1,0 +1,170 @@
+# EGU #217 — persistent browser wallet (Tier 1.5)
+
+**Date:** 2026-06-08
+**Issue:** #217 (deferred from base transact Tiers 0+1; on the EGU checklist #190)
+**Status:** design approved
+
+## Goal
+
+Let a wallet **persist in the user's browser** (IndexedDB, zero server state) so
+they don't re-import a key every visit, and let a node **generate** a new wallet
+(only useful once persisted — to receive grit and spend later). Unlockable by
+**passphrase (universal) or passkey (secure-origin upgrade)** — the same wallet,
+either method. Ephemeral import (Tier 1) stays the default; persistence is an
+explicit, origin-scoped opt-in.
+
+Out of scope (Tier 2, stays hub / EGU #5): cross-device *hosted* sync, the
+handle→address identity directory, recovery-as-a-service. (Manual encrypted
+backup export/import IS in scope — it's client-side.)
+
+## Boundary (restated)
+
+Base ships the full client-side self-custody wallet; the **hub** is the
+*recommended* trusted origin for persistence and owns the server-only features.
+A persisted wallet is **origin-bound** — see the security model.
+
+## The model: locked wallet in IndexedDB, unlock per page-session
+
+A persisted wallet lives **encrypted in IndexedDB** (`gc-store-idb`,
+origin-scoped, single `singleton` record). `/wallet` and `/transact` are
+**separate full-page loads**, so an unlocked in-memory key CANNOT be shared
+across them. Therefore **unlock is per-page-session**: each page that needs the
+key reads the locked record and unlocks its own in-memory copy.
+
+- `/wallet` — management (create / import / enroll methods / unlock / lock /
+  backup / forget).
+- `/transact` — gains an **"Unlock saved wallet"** option (passphrase/passkey)
+  alongside the existing ephemeral import; the unlocked key is held for that
+  page's session.
+
+## The crypto: one wallet, either method unlocks it (`gc-keyring`)
+
+"Enroll both" requires a **DEK-wrapping keyring** — a new orchestration module
+(`clients/wallet/gc-keyring.mjs`) over the existing primitives. (The current
+`gc-store` is single-method/passkey-only and is superseded by this for the
+persistent path.)
+
+- Generate a random 32-byte **DEK**; `wallet_ct = sealWithKey(DEK, b58_bytes)`.
+- Wrap the DEK separately per enrolled method's KEK:
+  - **passphrase** → PBKDF2-SHA256 → AES-GCM key (`gc-backup`'s `deriveKey`):
+    `ppWrap = sealWithKey(KEK_pp, DEK_raw)`, store `{salt, iterations, ...ppWrap}`.
+  - **passkey** → WebAuthn-PRF → HKDF-SHA256 → AES-GCM key
+    (`gc-envelope.deriveAesKey`): `pkWrap = sealWithKey(KEK_pk, DEK_raw)`, store
+    `{credentialId, ...pkWrap}`.
+- Stored record (IndexedDB singleton):
+  `{ version, address, wallet_ct, wraps: { passphrase?: {...}, passkey?: {...} } }`.
+- **`unlock(method, secret)`** → derive that method's KEK → `openWithKey` the
+  wrap → DEK → `openWithKey(DEK, wallet_ct)` → b58 → `Wallet.fromPrivateKeyB58`.
+  A wrong passphrase fails closed via the GCM auth tag.
+
+`gc-keyring` API (DOM-free, injected `store` + `passkey` like `gc-store`):
+`enroll(wallet, {store}, {passphrase})` (create the record + passphrase wrap),
+`addPasskey(wallet-or-unlocked, {store, passkey})`, `addPassphrase(...)`,
+`unlock({store, passkey?}, {passphrase?})` → `Wallet`, `removeMethod(...)`,
+`hasWallet(store)`, `clear(store)`. Reuses `gc-envelope.sealWithKey/openWithKey`
++ exposes `gc-envelope.deriveAesKey` and `gc-backup.deriveKey` (currently
+internal) so no crypto is duplicated.
+
+**Enrollment rule:** **passphrase is the mandatory floor** (set at create/import,
+universal). **Passkey is an optional add**, offered only on a **secure context**
+where `passkey.isSupported()` (PRF available). A user cannot go passkey-only —
+passphrase is always present as the portable/recovery method.
+
+## `/wallet` page (management)
+
+States:
+- **No wallet** → **Create** (`Wallet.generate()`) or **Import** (b58 / PEM).
+  Both require setting a passphrase to persist; create then prompts to download
+  an encrypted backup.
+- **Has wallet (locked)** → show address; **Unlock** (passphrase or, if enrolled
+  + supported, passkey); **Backup**; **Forget** (with confirm).
+- **Has wallet (unlocked)** → **Lock**; **Add passkey** (secure origin only);
+  Backup; Forget.
+
+On the **first persist on an origin**, an **explicit trust acknowledgment**
+(one-time, remembered in a small flag) gates it: a plain-language confirm —
+"Persist only on a node you trust: its page can use your key while unlocked."
+
+## Generation + backup/recovery
+
+- **Create**: `Wallet.generate()` (RSA) → show the new address → set passphrase →
+  persist → prompt "download an encrypted backup now" (self-custody: this is the
+  only recovery).
+- **Backup**: `gc-backup.exportEncrypted` (passphrase) → downloadable JSON;
+  **import-from-backup** (`importEncrypted`) on `/wallet`. This is the recovery +
+  cross-device + cross-method path. Stated plainly: lose the passphrase AND the
+  backup → the wallet is unrecoverable (no server, no reset).
+
+## Passkey specifics
+
+`makeWebauthnPasskey({ rpId, rpName })` with `rpId` = the serving origin's
+hostname (from `location.hostname`), `rpName` from a sensible default/title.
+Enroll/unlock via passkey only when `window.isSecureContext` AND
+`await passkey.isSupported()` (PRF). On plain-HTTP/LAN nodes, passphrase is the
+whole story — the passkey controls are simply absent (graceful degradation).
+
+## Security model / session
+
+- Ephemeral import (Tier 1) stays the **default**; persistence is opt-in behind
+  the trust acknowledgment.
+- **Session unlock + auto-lock** (a shared `wallet-session.mjs` helper used by
+  both `/wallet` and `/transact`): the unlocked `Wallet` is held in a
+  module-scoped var for the page; **auto-lock** on tab close/hide
+  (`visibilitychange`/`pagehide`), after an **idle timeout** (default ~15 min,
+  reset on activity), and via a manual **Lock**. On lock, drop the key reference
+  (best-effort; RSA `CryptoKey` can't be zeroed, but the reference is released).
+- Only signatures + public key ever leave the browser. The stored record is
+  always ciphertext (DEK-wrapped); the plaintext key exists only transiently
+  while unlocked.
+
+## `/transact` integration
+
+`/transact`'s key area becomes: **"Unlock saved wallet"** (passphrase / passkey,
+shown when `hasWallet()`) **or** "Import a key (this session only)" (the existing
+ephemeral path). Either yields an in-memory `Wallet` for the page session under
+the same auto-lock policy. No change to the build→confirm→sign→submit flow.
+
+## Data flow
+
+```
+/wallet create:  Wallet.generate -> set passphrase -> gc-keyring.enroll(store) -> backup prompt
+/wallet unlock:  gc-keyring.unlock({store, passkey?}, {passphrase?}) -> Wallet (session)
+/wallet backup:  gc-backup.exportEncrypted(wallet, passphrase) -> download
+/transact:       hasWallet? -> Unlock (as above) | ephemeral import -> sign+submit
+session:         wallet held in memory; auto-lock on idle/hide/close/manual
+```
+
+## Testing
+
+- **`gc-keyring` (node:test) — the heart:** enroll(passphrase)→unlock round-trip;
+  add passkey (fake PRF passkey injected) → unlock by passkey AND by passphrase
+  (same wallet); wrong passphrase fails closed (no DEK, no wallet); remove a
+  method; record shape/versioning. Plus the exposed `deriveAesKey`/`deriveKey`
+  reuse (no duplicated crypto).
+- **`/wallet` + `/transact`**: page renders, the create/import/unlock/forget +
+  trust-acknowledgment markup, secure-context gating of passkey controls
+  (testable via a flag), backup export/import round-trip (pure helper), seam
+  tests.
+- **Session/auto-lock**: pure helper tests (idle timer, lock clears reference,
+  hide/close handlers wired).
+- **Hard gates:** ruff + format, mypy strict, pytest, `node --test` (both globs);
+  vendored-drift guard stays green (new `gc-keyring.mjs` synced).
+
+## PR decomposition (sequential, off fresh main)
+
+0. **docs** — this spec + the plan.
+1. **`gc-keyring.mjs`** — DEK-wrap enroll/unlock/add/remove for passphrase +
+   passkey over `gc-store-idb`; expose `deriveAesKey`/`deriveKey`; round-trip +
+   fail-closed tests with a fake passkey. Crypto core, no UI. Vendor + drift
+   guard.
+2. **`/wallet` page** — create / import / enroll(passphrase + optional passkey) /
+   unlock / lock / forget + trust acknowledgment + backup export/import +
+   warnings; the `wallet-session.mjs` auto-lock helper; nav link; tests + seam.
+3. **`/transact` integration** — "Unlock saved wallet" alongside ephemeral
+   import; reuse `wallet-session.mjs`; tests.
+
+## Out of scope / follow-ups
+
+- Multiple wallets + active selector (gc-store-idb is single-record today).
+- Cross-device hosted sync / identity directory / hosted recovery — hub (Tier 2).
+- A passkey-managed *list* of credentials (single passkey per wallet for now).


### PR DESCRIPTION
Design + plan for **#217** — the deferred Tier 1.5: a persistent browser wallet.

## Decisions (from the brainstorm)
- **Both unlock methods together:** passphrase (universal) + passkey (secure-origin upgrade), the **same wallet** unlockable by either — via a new **DEK-wrapping keyring** (`gc-keyring`): a random data key encrypts the wallet; the DEK is wrapped separately by a passphrase-KEK (PBKDF2) and a passkey-KEK (WebAuthn-PRF→HKDF). Passphrase is the mandatory floor; passkey is an optional add.
- **Dedicated `/wallet` page** (create/import/unlock/lock/backup/forget); `/transact` gains an "Unlock saved wallet" option alongside ephemeral import.
- **Per-page-session unlock + auto-lock:** locked wallet in IndexedDB (origin-scoped, single record); each page unlocks its own in-memory copy (separate page loads can't share memory); auto-lock on tab close/hide, idle timeout, and manual Lock.
- **Explicit trust acknowledgment** gates first-persist; ephemeral import stays the default.
- **Single wallet** (matches `gc-store-idb`); generation ships here (a generated wallet is only useful once persisted).

## Reuse vs new
All crypto primitives exist (`gc-envelope` seal/openWithKey + HKDF, `gc-backup` PBKDF2, `gc-store-idb`, `gc-passkey-webauthn`); the only new code is the `gc-keyring` orchestration (DEK + multi-method wrap) + the page glue + an auto-lock session helper.

## Scope / boundary
In: persistence, both unlock methods, generation, encrypted backup/restore. Out (hub / Tier 2): hosted cross-device sync, identity directory, recovery-as-a-service. Out (later): multiple wallets.

Spec: `docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md`
Plan: `docs/superpowers/plans/2026-06-08-egu-217-persistent-wallet.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)