### PR TITLE
feat(wallet): gc-keyring — DEK-wrapping multi-method keyring (#217 PR1)

### DIFF
--- a/clients/wallet/gc-backup.mjs
+++ b/clients/wallet/gc-backup.mjs
@@ -18,7 +18,7 @@ const td = new TextDecoder();
 // Re-export so consumers can import the typed errors from here.
 export { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
 
-async function deriveKey(passphrase, salt, iterations) {
+export async function deriveKey(passphrase, salt, iterations) {
   const ikm = await crypto.subtle.importKey(
     'raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey'],
   );

--- a/clients/wallet/gc-backup.test.mjs
+++ b/clients/wallet/gc-backup.test.mjs
@@ -3,13 +3,30 @@ import assert from 'node:assert/strict';
 import { Wallet } from './gc-wallet.mjs';
 import { base64decode, base64encode } from './gc-crypto.mjs';
 import {
-  exportEncrypted, importEncrypted, BadBackupError, BadPassphraseError,
+  exportEncrypted, importEncrypted, deriveKey,
+  BadBackupError, BadPassphraseError,
 } from './gc-backup.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
 
 // Keep PBKDF2 cheap in tests; production default (600k) is exercised by the
 // manual browser path. The override is the documented opts.iterations seam.
 const FAST = { iterations: 1000 };
 const PASS = 'correct horse battery staple';
+
+test('exported deriveKey (PBKDF2) is deterministic for a fixed salt/iterations', async () => {
+  // The keyring reuses deriveKey to wrap the DEK under a passphrase-KEK; assert
+  // the exported derivation is stable (same salt+iterations+passphrase -> a key
+  // that decrypts the other's ciphertext) and salt-sensitive (fails closed).
+  const salt = new Uint8Array(16).fill(3);
+  const k1 = await deriveKey(PASS, salt, FAST.iterations);
+  const k2 = await deriveKey(PASS, salt, FAST.iterations);
+  const env = await sealWithKey(k1, new TextEncoder().encode('dek-raw'));
+  assert.deepEqual(
+    await openWithKey(k2, env), new TextEncoder().encode('dek-raw'),
+  );
+  const kOther = await deriveKey(PASS, new Uint8Array(16).fill(9), FAST.iterations);
+  await assert.rejects(() => openWithKey(kOther, env));
+});
 
 test('exportEncrypted -> importEncrypted recovers a wallet that signs identically', async () => {
   const wallet = await Wallet.generate();

--- a/clients/wallet/gc-envelope.mjs
+++ b/clients/wallet/gc-envelope.mjs
@@ -6,7 +6,7 @@
 const HKDF_INFO = new TextEncoder().encode('gc-wallet-aesgcm-v1');
 const IV_BYTES = 12;
 
-async function deriveAesKey(prfOutput) {
+export async function deriveAesKey(prfOutput) {
   const ikm = await crypto.subtle.importKey('raw', prfOutput, 'HKDF', false, [
     'deriveKey',
   ]);

--- a/clients/wallet/gc-envelope.test.mjs
+++ b/clients/wallet/gc-envelope.test.mjs
@@ -32,7 +32,7 @@ test('each seal uses a fresh IV', async () => {
   assert.notEqual(hex(a.ciphertext), hex(b.ciphertext));
 });
 
-import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 
 test('sealWithKey/openWithKey round-trip with a fixed CryptoKey', async () => {
   const raw = new Uint8Array(32).fill(5);
@@ -54,4 +54,17 @@ test('openWithKey fails closed on a tampered ciphertext', async () => {
   const env = await sealWithKey(key, new TextEncoder().encode('x'));
   env.ciphertext[0] ^= 0xff;
   await assert.rejects(() => openWithKey(key, env));
+});
+
+test('exported deriveAesKey backs seal/open (HKDF -> AES-GCM key reuse)', async () => {
+  // The keyring reuses deriveAesKey directly; assert the exported derivation
+  // produces a key whose sealWithKey/openWithKey round-trips and matches the
+  // seal/open PRF wrappers (same HKDF derivation under the hood).
+  const key = await deriveAesKey(PRF);
+  const msg = new TextEncoder().encode('keyring reuse');
+  const env = await sealWithKey(key, msg);
+  assert.deepEqual(await openWithKey(key, env), msg);
+  // Cross-check: open() (PRF wrapper) decrypts a sealWithKey(deriveAesKey)
+  // envelope, proving the exported path is the same derivation.
+  assert.deepEqual(await open(PRF, env), msg);
 });

--- a/clients/wallet/gc-keyring.mjs
+++ b/clients/wallet/gc-keyring.mjs
@@ -131,6 +131,9 @@ export async function unlock({ store, passkey } = {}, { passphrase } = {}) {
 // supplied passphrase, then wrap the SAME dekRaw under the passkey PRF and
 // merge wraps.passkey. The DEK never changes, so both methods unlock the same
 // wallet. A wrong passphrase rejects before any record mutation (fails closed).
+// NOTE: this REPLACES any existing passkey wrap (mints a fresh credential and
+// discards the old wrap) — the caller/UI should gate on whether a passkey is
+// already enrolled if "add vs replace" matters.
 export async function addPasskey({ store, passkey }, { passphrase }, ids) {
   const rec = loadRecord(await store.get());
   const dekRaw = await unwrapDek(rec, {}, { passphrase });

--- a/clients/wallet/gc-keyring.mjs
+++ b/clients/wallet/gc-keyring.mjs
@@ -1,0 +1,112 @@
+// DEK-wrapping multi-method keyring for the persistent browser wallet. ONE
+// persisted wallet, unlockable by EITHER a passphrase OR a passkey — the same
+// wallet, either method. Composes the existing primitives; no crypto is
+// duplicated.
+//
+// Scheme:
+//   - A random 32-byte DEK (AES-GCM) encrypts the wallet's b58 -> wallet_ct.
+//   - The DEK's raw bytes are wrapped SEPARATELY per method's KEK:
+//       passphrase -> deriveKey (PBKDF2 -> AES-GCM)        -> sealWithKey(KEK, dekRaw)
+//   - unlock(method, secret): derive that KEK -> openWithKey the wrap -> dekRaw
+//     -> import DEK -> openWithKey(DEK, wallet_ct) -> b58 -> Wallet.
+//
+// The stored record is ALWAYS ciphertext; the plaintext b58/DEK exist only
+// transiently in function scope. A wrong secret fails closed via the AES-GCM
+// auth tag (openWithKey rejects) — never a partial/garbage wallet.
+//
+// Stored record (IndexedDB structured-cloneable; iv/ciphertext are Uint8Array):
+//   { version, address, wallet_ct: {iv, ciphertext},
+//     wraps: { passphrase?: {salt, iterations, iv, ciphertext} } }
+//
+// DOM-free: store is INJECTED (like gc-store) so the whole flow is Node-testable
+// with fakes.
+//   store (single record): get()->record|null, put(record), delete().
+import { NoWalletError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { deriveKey } from './gc-backup.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const VERSION = 1;
+const SALT_BYTES = 16;
+const DEK_BYTES = 32;
+const PBKDF2_ITERATIONS = 600000;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so consumers/tests can import the typed errors from here.
+export { NoWalletError } from './gc-errors.mjs';
+
+async function newDek() {
+  const raw = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
+  return { raw, key: await importDek(raw) };
+}
+
+async function importDek(raw) {
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+async function passphraseWrap(passphrase, dekRaw) {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const kek = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { salt, iterations: PBKDF2_ITERATIONS, iv, ciphertext };
+}
+
+export async function hasWallet(store) {
+  return (await store.get()) !== null;
+}
+
+// Create the record + the mandatory passphrase wrap. The passphrase is the
+// universal floor; a passkey is added later via addPasskey.
+export async function enroll(wallet, { store }, { passphrase }) {
+  const b58 = await wallet.exportPrivateKeyB58();
+  const { raw: dekRaw, key: dekKey } = await newDek();
+  const wallet_ct = await sealWithKey(dekKey, te.encode(b58));
+  const wraps = { passphrase: await passphraseWrap(passphrase, dekRaw) };
+  await store.put({
+    version: VERSION,
+    address: await wallet.address(),
+    wallet_ct,
+    wraps,
+  });
+  return wallet;
+}
+
+// Unwrap the DEK raw bytes with the supplied passphrase. Wrong secret -> GCM
+// auth-tag failure -> openWithKey rejects (fails closed).
+async function unwrapDek(rec, { passphrase } = {}) {
+  const { wraps } = rec;
+  if (passphrase != null && wraps.passphrase) {
+    const w = wraps.passphrase;
+    const kek = await deriveKey(passphrase, w.salt, w.iterations);
+    return new Uint8Array(await openWithKey(kek, w));
+  }
+  throw new Error('no usable unlock method/secret');
+}
+
+function loadRecord(rec) {
+  if (rec === null) {
+    throw new NoWalletError('no stored wallet');
+  }
+  if (rec.version !== VERSION) {
+    // Fail fast on an unknown/corrupt record rather than mis-decoding fields;
+    // a future schema bump handles migration here explicitly.
+    throw new Error(`unsupported wallet record version: ${rec.version}`);
+  }
+  return rec;
+}
+
+export async function unlock({ store } = {}, { passphrase } = {}) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, { passphrase });
+  const dekKey = await importDek(dekRaw);
+  const b58 = td.decode(new Uint8Array(await openWithKey(dekKey, rec.wallet_ct)));
+  return Wallet.fromPrivateKeyB58(b58);
+}
+
+export async function clear(store) {
+  await store.delete();
+}

--- a/clients/wallet/gc-keyring.mjs
+++ b/clients/wallet/gc-keyring.mjs
@@ -7,6 +7,7 @@
 //   - A random 32-byte DEK (AES-GCM) encrypts the wallet's b58 -> wallet_ct.
 //   - The DEK's raw bytes are wrapped SEPARATELY per method's KEK:
 //       passphrase -> deriveKey (PBKDF2 -> AES-GCM)        -> sealWithKey(KEK, dekRaw)
+//       passkey    -> deriveAesKey (WebAuthn-PRF -> HKDF)  -> sealWithKey(KEK, dekRaw)
 //   - unlock(method, secret): derive that KEK -> openWithKey the wrap -> dekRaw
 //     -> import DEK -> openWithKey(DEK, wallet_ct) -> b58 -> Wallet.
 //
@@ -16,13 +17,16 @@
 //
 // Stored record (IndexedDB structured-cloneable; iv/ciphertext are Uint8Array):
 //   { version, address, wallet_ct: {iv, ciphertext},
-//     wraps: { passphrase?: {salt, iterations, iv, ciphertext} } }
+//     wraps: { passphrase?: {salt, iterations, iv, ciphertext},
+//              passkey?: {credentialId, iv, ciphertext} } }
 //
-// DOM-free: store is INJECTED (like gc-store) so the whole flow is Node-testable
-// with fakes.
+// DOM-free: store + passkey are INJECTED (like gc-store) so the whole flow is
+// Node-testable with fakes.
 //   store (single record): get()->record|null, put(record), delete().
-import { NoWalletError } from './gc-errors.mjs';
-import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+//   passkey: isSupported()->bool, enroll(ids)->{credentialId, prfOutput},
+//            unlock(credentialId)->prfOutput (Uint8Array).
+import { NoWalletError, UnsupportedError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { Wallet } from './gc-wallet.mjs';
 
@@ -34,7 +38,7 @@ const te = new TextEncoder();
 const td = new TextDecoder();
 
 // Re-export so consumers/tests can import the typed errors from here.
-export { NoWalletError } from './gc-errors.mjs';
+export { NoWalletError, UnsupportedError } from './gc-errors.mjs';
 
 async function newDek() {
   const raw = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
@@ -55,12 +59,22 @@ async function passphraseWrap(passphrase, dekRaw) {
   return { salt, iterations: PBKDF2_ITERATIONS, iv, ciphertext };
 }
 
+async function passkeyWrap(passkey, dekRaw, ids) {
+  if (!(await passkey.isSupported())) {
+    throw new UnsupportedError('passkey PRF is not available on this device');
+  }
+  const { credentialId, prfOutput } = await passkey.enroll(ids);
+  const kek = await deriveAesKey(prfOutput);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { credentialId, iv, ciphertext };
+}
+
 export async function hasWallet(store) {
   return (await store.get()) !== null;
 }
 
 // Create the record + the mandatory passphrase wrap. The passphrase is the
-// universal floor; a passkey is added later via addPasskey.
+// universal floor; passkey is added later via addPasskey.
 export async function enroll(wallet, { store }, { passphrase }) {
   const b58 = await wallet.exportPrivateKeyB58();
   const { raw: dekRaw, key: dekKey } = await newDek();
@@ -75,14 +89,20 @@ export async function enroll(wallet, { store }, { passphrase }) {
   return wallet;
 }
 
-// Unwrap the DEK raw bytes with the supplied passphrase. Wrong secret -> GCM
-// auth-tag failure -> openWithKey rejects (fails closed).
-async function unwrapDek(rec, { passphrase } = {}) {
+// Unwrap the DEK raw bytes with whichever method's secret was supplied. An
+// explicitly-supplied passphrase is preferred; otherwise the passkey is used.
+// Wrong secret -> GCM auth-tag failure -> openWithKey rejects (fails closed).
+async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
   const { wraps } = rec;
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);
     return new Uint8Array(await openWithKey(kek, w));
+  }
+  if (passkey && wraps.passkey) {
+    const prfOutput = await passkey.unlock(wraps.passkey.credentialId);
+    const kek = await deriveAesKey(prfOutput);
+    return new Uint8Array(await openWithKey(kek, wraps.passkey));
   }
   throw new Error('no usable unlock method/secret');
 }
@@ -99,12 +119,55 @@ function loadRecord(rec) {
   return rec;
 }
 
-export async function unlock({ store } = {}, { passphrase } = {}) {
+export async function unlock({ store, passkey } = {}, { passphrase } = {}) {
   const rec = loadRecord(await store.get());
-  const dekRaw = await unwrapDek(rec, { passphrase });
+  const dekRaw = await unwrapDek(rec, { passkey }, { passphrase });
   const dekKey = await importDek(dekRaw);
   const b58 = td.decode(new Uint8Array(await openWithKey(dekKey, rec.wallet_ct)));
   return Wallet.fromPrivateKeyB58(b58);
+}
+
+// Add a passkey wrap to an already-enrolled wallet. Unwrap the DEK via the
+// supplied passphrase, then wrap the SAME dekRaw under the passkey PRF and
+// merge wraps.passkey. The DEK never changes, so both methods unlock the same
+// wallet. A wrong passphrase rejects before any record mutation (fails closed).
+export async function addPasskey({ store, passkey }, { passphrase }, ids) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, {}, { passphrase });
+  const passkeyWrapped = await passkeyWrap(passkey, dekRaw, ids);
+  rec.wraps = { ...rec.wraps, passkey: passkeyWrapped };
+  await store.put(rec);
+  return rec.address;
+}
+
+// Add (or replace) the passphrase wrap, unwrapping the DEK via the passkey. The
+// symmetric counterpart of addPasskey.
+export async function addPassphrase({ store, passkey }, { passphrase }) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, { passkey }, {});
+  rec.wraps = { ...rec.wraps, passphrase: await passphraseWrap(passphrase, dekRaw) };
+  await store.put(rec);
+  return rec.address;
+}
+
+// Remove one method's wrap. Refuses to remove the only remaining method (the
+// wallet would become permanently unreachable) or a method that isn't enrolled.
+export async function removeMethod(store, name) {
+  const rec = loadRecord(await store.get());
+  if (!rec.wraps[name]) {
+    const msg = `no '${name}' method to remove`;
+    throw new Error(msg);
+  }
+  const remaining = Object.keys(rec.wraps).filter((k) => k !== name);
+  if (remaining.length === 0) {
+    const msg = `refusing to remove the last method ('${name}')`;
+    throw new Error(msg);
+  }
+  const wraps = { ...rec.wraps };
+  delete wraps[name];
+  rec.wraps = wraps;
+  await store.put(rec);
+  return rec.address;
 }
 
 export async function clear(store) {

--- a/clients/wallet/gc-keyring.test.mjs
+++ b/clients/wallet/gc-keyring.test.mjs
@@ -17,7 +17,18 @@ function fakeStore() {
   };
 }
 
-// --- passphrase enroll/unlock ---
+// Fixed-PRF fake passkey: deterministic 32-byte PRF so the HKDF->AES-GCM KEK is
+// reproducible across enroll/unlock without touching real WebAuthn.
+function fakePasskey(fill = 7, credentialId = 'cred1') {
+  const PRF = new Uint8Array(32).fill(fill);
+  return {
+    isSupported: async () => true,
+    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    unlock: async () => PRF,
+  };
+}
+
+// --- Task 2: passphrase enroll/unlock ---
 
 test('enroll(passphrase) then unlock(passphrase) recovers the same wallet', async () => {
   const store = fakeStore();
@@ -62,4 +73,89 @@ test('clear removes the stored wallet', async () => {
   assert.equal(await keyring.hasWallet(store), true);
   await keyring.clear(store);
   assert.equal(await keyring.hasWallet(store), false);
+});
+
+// --- Task 3: passkey method + add/remove ---
+
+test('a wallet with both methods unlocks by passkey AND by passphrase', async () => {
+  const store = fakeStore();
+  const passkey = fakePasskey();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'pw' });
+  await keyring.addPasskey({ store, passkey }, { passphrase: 'pw' });
+  // passkey path
+  assert.equal(await (await keyring.unlock({ store, passkey }, {})).address(), addr);
+  // passphrase path
+  assert.equal(
+    await (await keyring.unlock({ store }, { passphrase: 'pw' })).address(),
+    addr,
+  );
+});
+
+test('addPasskey with a wrong passphrase fails closed (cannot wrap the DEK)', async () => {
+  const store = fakeStore();
+  const passkey = fakePasskey();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'pw' });
+  await assert.rejects(() =>
+    keyring.addPasskey({ store, passkey }, { passphrase: 'nope' }),
+  );
+  // The record must be unchanged: no passkey wrap was merged in.
+  assert.equal((await store.get()).wraps.passkey, undefined);
+});
+
+test('addPassphrase adds a second passphrase wrap via the passkey-unwrapped DEK', async () => {
+  const store = fakeStore();
+  const passkey = fakePasskey();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'first' });
+  await keyring.addPasskey({ store, passkey }, { passphrase: 'first' });
+  // Re-wrap the DEK under a new passphrase using the passkey to unwrap.
+  await keyring.addPassphrase({ store, passkey }, { passphrase: 'second' });
+  assert.equal(
+    await (await keyring.unlock({ store }, { passphrase: 'second' })).address(),
+    addr,
+  );
+});
+
+test('removeMethod refuses to remove the last remaining method', async () => {
+  const store = fakeStore();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'pw' });
+  await assert.rejects(() => keyring.removeMethod(store, 'passphrase'));
+  // Still intact.
+  assert.ok((await store.get()).wraps.passphrase);
+});
+
+test('after removing passphrase, passkey still unlocks the same wallet', async () => {
+  const store = fakeStore();
+  const passkey = fakePasskey();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'pw' });
+  await keyring.addPasskey({ store, passkey }, { passphrase: 'pw' });
+  await keyring.removeMethod(store, 'passphrase');
+  assert.equal((await store.get()).wraps.passphrase, undefined);
+  assert.equal(await (await keyring.unlock({ store, passkey }, {})).address(), addr);
+});
+
+test('removeMethod on a wallet with no such wrap rejects', async () => {
+  const store = fakeStore();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'pw' });
+  // No passkey wrap exists; refusing (it would also leave only passphrase).
+  await assert.rejects(() => keyring.removeMethod(store, 'passkey'));
+});
+
+test('unlock prefers an explicitly-supplied passphrase over the passkey', async () => {
+  const store = fakeStore();
+  const passkey = fakePasskey();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'pw' });
+  await keyring.addPasskey({ store, passkey }, { passphrase: 'pw' });
+  // Both supplied: passphrase wins. A correct passphrase succeeds.
+  assert.equal(
+    await (await keyring.unlock({ store, passkey }, { passphrase: 'pw' })).address(),
+    addr,
+  );
 });

--- a/clients/wallet/gc-keyring.test.mjs
+++ b/clients/wallet/gc-keyring.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from './gc-wallet.mjs';
+import * as keyring from './gc-keyring.mjs';
+
+// In-memory single-record store mirroring the gc-store-idb contract.
+function fakeStore() {
+  let rec = null;
+  return {
+    get: async () => rec,
+    put: async (r) => {
+      rec = r;
+    },
+    delete: async () => {
+      rec = null;
+    },
+  };
+}
+
+// --- passphrase enroll/unlock ---
+
+test('enroll(passphrase) then unlock(passphrase) recovers the same wallet', async () => {
+  const store = fakeStore();
+  const w = await Wallet.generate();
+  const addr = await w.address();
+  await keyring.enroll(w, { store }, { passphrase: 'correct horse' });
+  assert.equal(await keyring.hasWallet(store), true);
+  const unlocked = await keyring.unlock({ store }, { passphrase: 'correct horse' });
+  assert.equal(await unlocked.address(), addr);
+});
+
+test('wrong passphrase fails closed (unlock rejects)', async () => {
+  const store = fakeStore();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'right' });
+  await assert.rejects(() => keyring.unlock({ store }, { passphrase: 'wrong' }));
+});
+
+test('the stored record is always ciphertext (no plaintext b58/DEK leaks)', async () => {
+  const store = fakeStore();
+  const w = await Wallet.generate();
+  const b58 = await w.exportPrivateKeyB58();
+  await keyring.enroll(w, { store }, { passphrase: 'pw' });
+  const rec = await store.get();
+  const blob = JSON.stringify(rec, (_k, v) =>
+    v instanceof Uint8Array ? Buffer.from(v).toString('hex') : v,
+  );
+  assert.ok(!blob.includes(b58), 'plaintext b58 must not appear in the record');
+  assert.equal(rec.version, 1);
+  assert.equal(rec.address, await w.address());
+  assert.ok(rec.wallet_ct && rec.wallet_ct.iv && rec.wallet_ct.ciphertext);
+  assert.ok(rec.wraps.passphrase.salt && rec.wraps.passphrase.iterations);
+});
+
+test('unlock with no stored wallet rejects', async () => {
+  const store = fakeStore();
+  await assert.rejects(() => keyring.unlock({ store }, { passphrase: 'pw' }));
+});
+
+test('clear removes the stored wallet', async () => {
+  const store = fakeStore();
+  await keyring.enroll(await Wallet.generate(), { store }, { passphrase: 'pw' });
+  assert.equal(await keyring.hasWallet(store), true);
+  await keyring.clear(store);
+  assert.equal(await keyring.hasWallet(store), false);
+});

--- a/src/gumptionchain/static/wallet/gc-backup.mjs
+++ b/src/gumptionchain/static/wallet/gc-backup.mjs
@@ -18,7 +18,7 @@ const td = new TextDecoder();
 // Re-export so consumers can import the typed errors from here.
 export { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
 
-async function deriveKey(passphrase, salt, iterations) {
+export async function deriveKey(passphrase, salt, iterations) {
   const ikm = await crypto.subtle.importKey(
     'raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey'],
   );

--- a/src/gumptionchain/static/wallet/gc-envelope.mjs
+++ b/src/gumptionchain/static/wallet/gc-envelope.mjs
@@ -6,7 +6,7 @@
 const HKDF_INFO = new TextEncoder().encode('gc-wallet-aesgcm-v1');
 const IV_BYTES = 12;
 
-async function deriveAesKey(prfOutput) {
+export async function deriveAesKey(prfOutput) {
   const ikm = await crypto.subtle.importKey('raw', prfOutput, 'HKDF', false, [
     'deriveKey',
   ]);

--- a/src/gumptionchain/static/wallet/gc-keyring.mjs
+++ b/src/gumptionchain/static/wallet/gc-keyring.mjs
@@ -131,6 +131,9 @@ export async function unlock({ store, passkey } = {}, { passphrase } = {}) {
 // supplied passphrase, then wrap the SAME dekRaw under the passkey PRF and
 // merge wraps.passkey. The DEK never changes, so both methods unlock the same
 // wallet. A wrong passphrase rejects before any record mutation (fails closed).
+// NOTE: this REPLACES any existing passkey wrap (mints a fresh credential and
+// discards the old wrap) — the caller/UI should gate on whether a passkey is
+// already enrolled if "add vs replace" matters.
 export async function addPasskey({ store, passkey }, { passphrase }, ids) {
   const rec = loadRecord(await store.get());
   const dekRaw = await unwrapDek(rec, {}, { passphrase });

--- a/src/gumptionchain/static/wallet/gc-keyring.mjs
+++ b/src/gumptionchain/static/wallet/gc-keyring.mjs
@@ -1,0 +1,112 @@
+// DEK-wrapping multi-method keyring for the persistent browser wallet. ONE
+// persisted wallet, unlockable by EITHER a passphrase OR a passkey — the same
+// wallet, either method. Composes the existing primitives; no crypto is
+// duplicated.
+//
+// Scheme:
+//   - A random 32-byte DEK (AES-GCM) encrypts the wallet's b58 -> wallet_ct.
+//   - The DEK's raw bytes are wrapped SEPARATELY per method's KEK:
+//       passphrase -> deriveKey (PBKDF2 -> AES-GCM)        -> sealWithKey(KEK, dekRaw)
+//   - unlock(method, secret): derive that KEK -> openWithKey the wrap -> dekRaw
+//     -> import DEK -> openWithKey(DEK, wallet_ct) -> b58 -> Wallet.
+//
+// The stored record is ALWAYS ciphertext; the plaintext b58/DEK exist only
+// transiently in function scope. A wrong secret fails closed via the AES-GCM
+// auth tag (openWithKey rejects) — never a partial/garbage wallet.
+//
+// Stored record (IndexedDB structured-cloneable; iv/ciphertext are Uint8Array):
+//   { version, address, wallet_ct: {iv, ciphertext},
+//     wraps: { passphrase?: {salt, iterations, iv, ciphertext} } }
+//
+// DOM-free: store is INJECTED (like gc-store) so the whole flow is Node-testable
+// with fakes.
+//   store (single record): get()->record|null, put(record), delete().
+import { NoWalletError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+import { deriveKey } from './gc-backup.mjs';
+import { Wallet } from './gc-wallet.mjs';
+
+const VERSION = 1;
+const SALT_BYTES = 16;
+const DEK_BYTES = 32;
+const PBKDF2_ITERATIONS = 600000;
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+// Re-export so consumers/tests can import the typed errors from here.
+export { NoWalletError } from './gc-errors.mjs';
+
+async function newDek() {
+  const raw = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
+  return { raw, key: await importDek(raw) };
+}
+
+async function importDek(raw) {
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+async function passphraseWrap(passphrase, dekRaw) {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const kek = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { salt, iterations: PBKDF2_ITERATIONS, iv, ciphertext };
+}
+
+export async function hasWallet(store) {
+  return (await store.get()) !== null;
+}
+
+// Create the record + the mandatory passphrase wrap. The passphrase is the
+// universal floor; a passkey is added later via addPasskey.
+export async function enroll(wallet, { store }, { passphrase }) {
+  const b58 = await wallet.exportPrivateKeyB58();
+  const { raw: dekRaw, key: dekKey } = await newDek();
+  const wallet_ct = await sealWithKey(dekKey, te.encode(b58));
+  const wraps = { passphrase: await passphraseWrap(passphrase, dekRaw) };
+  await store.put({
+    version: VERSION,
+    address: await wallet.address(),
+    wallet_ct,
+    wraps,
+  });
+  return wallet;
+}
+
+// Unwrap the DEK raw bytes with the supplied passphrase. Wrong secret -> GCM
+// auth-tag failure -> openWithKey rejects (fails closed).
+async function unwrapDek(rec, { passphrase } = {}) {
+  const { wraps } = rec;
+  if (passphrase != null && wraps.passphrase) {
+    const w = wraps.passphrase;
+    const kek = await deriveKey(passphrase, w.salt, w.iterations);
+    return new Uint8Array(await openWithKey(kek, w));
+  }
+  throw new Error('no usable unlock method/secret');
+}
+
+function loadRecord(rec) {
+  if (rec === null) {
+    throw new NoWalletError('no stored wallet');
+  }
+  if (rec.version !== VERSION) {
+    // Fail fast on an unknown/corrupt record rather than mis-decoding fields;
+    // a future schema bump handles migration here explicitly.
+    throw new Error(`unsupported wallet record version: ${rec.version}`);
+  }
+  return rec;
+}
+
+export async function unlock({ store } = {}, { passphrase } = {}) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, { passphrase });
+  const dekKey = await importDek(dekRaw);
+  const b58 = td.decode(new Uint8Array(await openWithKey(dekKey, rec.wallet_ct)));
+  return Wallet.fromPrivateKeyB58(b58);
+}
+
+export async function clear(store) {
+  await store.delete();
+}

--- a/src/gumptionchain/static/wallet/gc-keyring.mjs
+++ b/src/gumptionchain/static/wallet/gc-keyring.mjs
@@ -7,6 +7,7 @@
 //   - A random 32-byte DEK (AES-GCM) encrypts the wallet's b58 -> wallet_ct.
 //   - The DEK's raw bytes are wrapped SEPARATELY per method's KEK:
 //       passphrase -> deriveKey (PBKDF2 -> AES-GCM)        -> sealWithKey(KEK, dekRaw)
+//       passkey    -> deriveAesKey (WebAuthn-PRF -> HKDF)  -> sealWithKey(KEK, dekRaw)
 //   - unlock(method, secret): derive that KEK -> openWithKey the wrap -> dekRaw
 //     -> import DEK -> openWithKey(DEK, wallet_ct) -> b58 -> Wallet.
 //
@@ -16,13 +17,16 @@
 //
 // Stored record (IndexedDB structured-cloneable; iv/ciphertext are Uint8Array):
 //   { version, address, wallet_ct: {iv, ciphertext},
-//     wraps: { passphrase?: {salt, iterations, iv, ciphertext} } }
+//     wraps: { passphrase?: {salt, iterations, iv, ciphertext},
+//              passkey?: {credentialId, iv, ciphertext} } }
 //
-// DOM-free: store is INJECTED (like gc-store) so the whole flow is Node-testable
-// with fakes.
+// DOM-free: store + passkey are INJECTED (like gc-store) so the whole flow is
+// Node-testable with fakes.
 //   store (single record): get()->record|null, put(record), delete().
-import { NoWalletError } from './gc-errors.mjs';
-import { sealWithKey, openWithKey } from './gc-envelope.mjs';
+//   passkey: isSupported()->bool, enroll(ids)->{credentialId, prfOutput},
+//            unlock(credentialId)->prfOutput (Uint8Array).
+import { NoWalletError, UnsupportedError } from './gc-errors.mjs';
+import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { Wallet } from './gc-wallet.mjs';
 
@@ -34,7 +38,7 @@ const te = new TextEncoder();
 const td = new TextDecoder();
 
 // Re-export so consumers/tests can import the typed errors from here.
-export { NoWalletError } from './gc-errors.mjs';
+export { NoWalletError, UnsupportedError } from './gc-errors.mjs';
 
 async function newDek() {
   const raw = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
@@ -55,12 +59,22 @@ async function passphraseWrap(passphrase, dekRaw) {
   return { salt, iterations: PBKDF2_ITERATIONS, iv, ciphertext };
 }
 
+async function passkeyWrap(passkey, dekRaw, ids) {
+  if (!(await passkey.isSupported())) {
+    throw new UnsupportedError('passkey PRF is not available on this device');
+  }
+  const { credentialId, prfOutput } = await passkey.enroll(ids);
+  const kek = await deriveAesKey(prfOutput);
+  const { iv, ciphertext } = await sealWithKey(kek, dekRaw);
+  return { credentialId, iv, ciphertext };
+}
+
 export async function hasWallet(store) {
   return (await store.get()) !== null;
 }
 
 // Create the record + the mandatory passphrase wrap. The passphrase is the
-// universal floor; a passkey is added later via addPasskey.
+// universal floor; passkey is added later via addPasskey.
 export async function enroll(wallet, { store }, { passphrase }) {
   const b58 = await wallet.exportPrivateKeyB58();
   const { raw: dekRaw, key: dekKey } = await newDek();
@@ -75,14 +89,20 @@ export async function enroll(wallet, { store }, { passphrase }) {
   return wallet;
 }
 
-// Unwrap the DEK raw bytes with the supplied passphrase. Wrong secret -> GCM
-// auth-tag failure -> openWithKey rejects (fails closed).
-async function unwrapDek(rec, { passphrase } = {}) {
+// Unwrap the DEK raw bytes with whichever method's secret was supplied. An
+// explicitly-supplied passphrase is preferred; otherwise the passkey is used.
+// Wrong secret -> GCM auth-tag failure -> openWithKey rejects (fails closed).
+async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
   const { wraps } = rec;
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);
     return new Uint8Array(await openWithKey(kek, w));
+  }
+  if (passkey && wraps.passkey) {
+    const prfOutput = await passkey.unlock(wraps.passkey.credentialId);
+    const kek = await deriveAesKey(prfOutput);
+    return new Uint8Array(await openWithKey(kek, wraps.passkey));
   }
   throw new Error('no usable unlock method/secret');
 }
@@ -99,12 +119,55 @@ function loadRecord(rec) {
   return rec;
 }
 
-export async function unlock({ store } = {}, { passphrase } = {}) {
+export async function unlock({ store, passkey } = {}, { passphrase } = {}) {
   const rec = loadRecord(await store.get());
-  const dekRaw = await unwrapDek(rec, { passphrase });
+  const dekRaw = await unwrapDek(rec, { passkey }, { passphrase });
   const dekKey = await importDek(dekRaw);
   const b58 = td.decode(new Uint8Array(await openWithKey(dekKey, rec.wallet_ct)));
   return Wallet.fromPrivateKeyB58(b58);
+}
+
+// Add a passkey wrap to an already-enrolled wallet. Unwrap the DEK via the
+// supplied passphrase, then wrap the SAME dekRaw under the passkey PRF and
+// merge wraps.passkey. The DEK never changes, so both methods unlock the same
+// wallet. A wrong passphrase rejects before any record mutation (fails closed).
+export async function addPasskey({ store, passkey }, { passphrase }, ids) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, {}, { passphrase });
+  const passkeyWrapped = await passkeyWrap(passkey, dekRaw, ids);
+  rec.wraps = { ...rec.wraps, passkey: passkeyWrapped };
+  await store.put(rec);
+  return rec.address;
+}
+
+// Add (or replace) the passphrase wrap, unwrapping the DEK via the passkey. The
+// symmetric counterpart of addPasskey.
+export async function addPassphrase({ store, passkey }, { passphrase }) {
+  const rec = loadRecord(await store.get());
+  const dekRaw = await unwrapDek(rec, { passkey }, {});
+  rec.wraps = { ...rec.wraps, passphrase: await passphraseWrap(passphrase, dekRaw) };
+  await store.put(rec);
+  return rec.address;
+}
+
+// Remove one method's wrap. Refuses to remove the only remaining method (the
+// wallet would become permanently unreachable) or a method that isn't enrolled.
+export async function removeMethod(store, name) {
+  const rec = loadRecord(await store.get());
+  if (!rec.wraps[name]) {
+    const msg = `no '${name}' method to remove`;
+    throw new Error(msg);
+  }
+  const remaining = Object.keys(rec.wraps).filter((k) => k !== name);
+  if (remaining.length === 0) {
+    const msg = `refusing to remove the last method ('${name}')`;
+    throw new Error(msg);
+  }
+  const wraps = { ...rec.wraps };
+  delete wraps[name];
+  rec.wraps = wraps;
+  await store.put(rec);
+  return rec.address;
 }
 
 export async function clear(store) {


### PR DESCRIPTION
PR 1 of 3 for the persistent browser wallet (#217). The **key-custody core**: a DEK-wrapping keyring letting ONE persisted wallet be unlocked by EITHER a passphrase OR a passkey. No UI in this PR.

## Scheme
- A random 32-byte **DEK** (AES-GCM) encrypts the wallet's b58 → `wallet_ct`.
- The DEK's raw bytes are wrapped **separately** per method's KEK: passphrase → PBKDF2 (`gc-backup.deriveKey`), passkey → WebAuthn-PRF→HKDF (`gc-envelope.deriveAesKey`). Same DEK, so either method unlocks the same wallet.
- `unlock(method, secret)` → derive KEK → unwrap DEK → decrypt wallet → `Wallet`. Wrong secret **fails closed** via the AES-GCM auth tag.
- Record: `{version, address, wallet_ct, wraps:{passphrase?, passkey?}}`, stored as IndexedDB-cloneable Uint8Arrays.

## API
`enroll` (passphrase floor), `addPasskey`/`addPassphrase`, `unlock`, `removeMethod` (refuses the last method), `hasWallet`, `clear`. Exposes `deriveAesKey`/`deriveKey` (previously internal) so no crypto is duplicated.

## Security review (independent, focused)
Verified: fresh random DEK per wallet; **no (key, IV) reuse** (random IV per `sealWithKey`, distinct keys per wrap); **fail-closed on every path** (no swallowed decrypt errors, no silent passphrase→passkey fallback); **no lockout/brick** (last-method protection, wrong-secret rejects before any write); clean secret hygiene (no logging/cleartext persistence); PBKDF2 600k / 16B salt / 32B DEK / 12B IV from `getRandomValues`. **APPROVED.**

## Tests
12 `gc-keyring` node tests (passphrase round-trip, both-methods-unlock-same-wallet, wrong-passphrase fail-closed, add/remove, last-method refusal) + derivation-reuse tests. Gates: `node --test` 131, pytest 465, ruff + mypy clean, vendored-drift guard green.

Spec: `docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)