### PR TITLE
feat(browser): /wallet persistent wallet management page (#217 PR2)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -413,3 +413,17 @@ def transact_view() -> Any:
         title='Transact',
         node_host=current_app.config['NODE_HOST'],
     )
+
+
+@blueprint.route('/wallet')
+def wallet_view() -> Any:
+    # Static shell — no chain/DB work. All key handling (generate / import /
+    # enroll / unlock / lock / backup / forget) happens client-side: the
+    # passphrase and private key never reach the server. The persisted record
+    # is the gc-keyring ciphertext in the browser's IndexedDB; nothing here
+    # touches it. rp_name labels the WebAuthn passkey (RP name).
+    return render_template(
+        'wallet.html',
+        title='Wallet',
+        rp_name='GumptionChain',
+    )

--- a/src/gumptionchain/static/js/wallet-glue.mjs
+++ b/src/gumptionchain/static/js/wallet-glue.mjs
@@ -156,6 +156,7 @@ export function init(
     unlockStatus: $('#unlock-status'),
     // unlocked actions
     lockBtn: $('#lock-btn'),
+    addPasskeySection: $('#add-passkey-section'),
     addPasskeyBtn: $('#add-passkey-btn'),
     addPasskeyPassphrase: $('#add-passkey-passphrase'),
     addPasskeyStatus: $('#add-passkey-status'),
@@ -191,6 +192,7 @@ export function init(
     show(els.unlockSection, c.showUnlock);
     show(els.unlockPasskeyBtn, c.showUnlockPasskey);
     show(els.lockBtn, c.showLock);
+    show(els.addPasskeySection, c.showAddPasskey);
     show(els.addPasskeyBtn, c.showAddPasskey);
     show(els.addPasskeyPassphrase, c.showAddPasskey);
     show(els.backupBtn, c.showBackup);

--- a/src/gumptionchain/static/js/wallet-glue.mjs
+++ b/src/gumptionchain/static/js/wallet-glue.mjs
@@ -1,0 +1,544 @@
+// Glue for the /wallet management page. All key work is client-side: the
+// passphrase and private key never leave the browser, are never logged, and
+// are never written to the DOM/result text. The ONLY things persisted are the
+// gc-keyring ciphertext record (IndexedDB) and a small per-origin trust-ack
+// flag (localStorage). Backup output is the encrypted blob (safe to download).
+//
+// The pure helpers (whichControls / backupFilename / readTrustAck /
+// writeTrustAck / makePasskey) are exported and DOM-free so they can be
+// unit-tested with fakes. The DOM wiring is in init().
+import { Wallet } from '../wallet/gc-wallet.mjs';
+import * as keyring from '../wallet/gc-keyring.mjs';
+import { makeIdbStore } from '../wallet/gc-store-idb.mjs';
+import { makeWebauthnPasskey } from '../wallet/gc-passkey-webauthn.mjs';
+import { exportEncrypted, importEncrypted } from '../wallet/gc-backup.mjs';
+import { session as defaultSession } from './wallet-session.mjs';
+
+// --- pure helpers ---------------------------------------------------------
+
+// Given the observable page state, decide which sections/buttons show. This is
+// the single source of truth for the state-driven UI, so it's unit-tested for
+// the key states and the passkey secure-context gating.
+export function whichControls({
+  hasWallet,
+  unlocked,
+  secureContext,
+  passkeySupported,
+}) {
+  const passkeyOk = !!secureContext && !!passkeySupported;
+  return {
+    // No-wallet section.
+    showCreate: !hasWallet,
+    showImport: !hasWallet,
+    // Has-wallet section.
+    showHasWallet: !!hasWallet,
+    showUnlock: !!hasWallet && !unlocked,
+    showUnlockPasskey: !!hasWallet && !unlocked && passkeyOk,
+    showLock: !!hasWallet && !!unlocked,
+    // Add-passkey is an unlocked-only action (it re-wraps the live DEK).
+    showAddPasskey: !!hasWallet && !!unlocked && passkeyOk,
+    showBackup: !!hasWallet,
+    showForget: !!hasWallet,
+  };
+}
+
+// A stable, address-tagged filename for the downloaded encrypted backup.
+export function backupFilename(address) {
+  const slug = (address || 'wallet').replace(/[^A-Za-z0-9]/g, '').slice(0, 12);
+  return `gc-wallet-backup-${slug || 'wallet'}.json`;
+}
+
+// Per-origin trust acknowledgment: localStorage is origin-scoped, so this flag
+// is naturally per-origin. Stored as '1' once acknowledged. read/write tolerate
+// a missing or throwing storage (private mode / blocked storage) by failing to
+// "not acknowledged" rather than throwing.
+export const TRUST_ACK_KEY = 'gc-wallet-trust-ack-v1';
+
+export function readTrustAck(storage) {
+  try {
+    return storage?.getItem(TRUST_ACK_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function writeTrustAck(storage) {
+  try {
+    storage?.setItem(TRUST_ACK_KEY, '1');
+  } catch {
+    // best-effort; a blocked storage just means the ack isn't remembered.
+  }
+}
+
+// Build a passkey adapter for THIS origin, but only on a secure context where
+// PRF is actually supported. Returns null (not a half-working adapter) when
+// passkeys aren't usable here, so the UI degrades to passphrase-only.
+export async function makePasskey({ window: win = window, rpName } = {}) {
+  if (!win?.isSecureContext) {
+    return null;
+  }
+  const passkey = makeWebauthnPasskey({
+    rpId: win.location.hostname,
+    rpName,
+  });
+  if (!(await passkey.isSupported())) {
+    return null;
+  }
+  return passkey;
+}
+
+// --- DOM wiring -----------------------------------------------------------
+
+function setStatus(el, text, kind = 'info') {
+  if (!el) return;
+  el.textContent = text;
+  el.dataset.kind = kind;
+}
+
+function msgOf(e) {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// Trigger a client-side download of a text blob (the encrypted backup).
+function downloadText(doc, filename, text) {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = doc.createElement('a');
+  a.href = url;
+  a.download = filename;
+  doc.body.appendChild(a);
+  a.click();
+  doc.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// init wires the page. root defaults to document. rpName labels the passkey
+// (WebAuthn RP name). store/session/win are injectable for completeness but
+// default to the real IndexedDB store / shared session / window.
+export function init(
+  root = document,
+  {
+    rpName = 'GumptionChain',
+    store = makeIdbStore({}),
+    session = defaultSession,
+    win = typeof window !== 'undefined' ? window : undefined,
+    doc = typeof document !== 'undefined' ? document : undefined,
+    storage = typeof localStorage !== 'undefined' ? localStorage : undefined,
+  } = {},
+) {
+  const $ = (sel) => root.querySelector(sel);
+
+  // Section/control elements (any may be absent in a partial DOM).
+  const els = {
+    noWallet: $('#no-wallet'),
+    hasWallet: $('#has-wallet'),
+    addressOut: $('#wallet-address'),
+    // create
+    createPassphrase: $('#create-passphrase'),
+    createBtn: $('#create-btn'),
+    createStatus: $('#create-status'),
+    // import
+    importB58: $('#import-b58'),
+    importPem: $('#import-pem'),
+    importPassphrase: $('#import-passphrase'),
+    importBtn: $('#import-btn'),
+    importStatus: $('#import-status'),
+    importBackupFile: $('#import-backup-file'),
+    importBackupPassphrase: $('#import-backup-passphrase'),
+    importBackupBtn: $('#import-backup-btn'),
+    // trust ack (gates the first persist on this origin)
+    trustAck: $('#trust-ack'),
+    // unlock
+    unlockSection: $('#unlock-section'),
+    unlockPassphrase: $('#unlock-passphrase'),
+    unlockBtn: $('#unlock-btn'),
+    unlockPasskeyBtn: $('#unlock-passkey-btn'),
+    unlockStatus: $('#unlock-status'),
+    // unlocked actions
+    lockBtn: $('#lock-btn'),
+    addPasskeyBtn: $('#add-passkey-btn'),
+    addPasskeyPassphrase: $('#add-passkey-passphrase'),
+    addPasskeyStatus: $('#add-passkey-status'),
+    // backup
+    backupPassphrase: $('#backup-passphrase'),
+    backupBtn: $('#backup-btn'),
+    backupStatus: $('#backup-status'),
+    // forget
+    forgetBtn: $('#forget-btn'),
+    forgetStatus: $('#forget-status'),
+  };
+
+  // Cached passkey capability (resolved once). Drives control visibility.
+  let passkeyState = { secureContext: !!win?.isSecureContext, supported: false };
+  let passkey = null;
+
+  function show(el, visible) {
+    if (el) el.hidden = !visible;
+  }
+
+  // Re-render which controls are visible from the current state.
+  async function render() {
+    const hasWallet = await keyring.hasWallet(store);
+    const unlocked = session.isUnlocked();
+    const c = whichControls({
+      hasWallet,
+      unlocked,
+      secureContext: passkeyState.secureContext,
+      passkeySupported: passkeyState.supported,
+    });
+    show(els.noWallet, c.showCreate || c.showImport);
+    show(els.hasWallet, c.showHasWallet);
+    show(els.unlockSection, c.showUnlock);
+    show(els.unlockPasskeyBtn, c.showUnlockPasskey);
+    show(els.lockBtn, c.showLock);
+    show(els.addPasskeyBtn, c.showAddPasskey);
+    show(els.addPasskeyPassphrase, c.showAddPasskey);
+    show(els.backupBtn, c.showBackup);
+    if (hasWallet && els.addressOut) {
+      const rec = await store.get();
+      els.addressOut.textContent = rec?.address ?? '';
+    }
+  }
+
+  // Clear any passphrase inputs so a secret never lingers in the DOM.
+  function clearSecrets() {
+    for (const el of root.querySelectorAll('input[type="password"]')) {
+      el.value = '';
+    }
+  }
+
+  // The first persist on this origin is gated on the trust acknowledgment.
+  // Returns true if persistence may proceed; otherwise surfaces a message.
+  function trustGateOk(statusEl) {
+    if (readTrustAck(storage)) {
+      return true;
+    }
+    if (els.trustAck && els.trustAck.checked) {
+      writeTrustAck(storage);
+      return true;
+    }
+    setStatus(
+      statusEl,
+      'Acknowledge the trust note first: persist only on a node you trust.',
+      'error',
+    );
+    return false;
+  }
+
+  // --- create ---
+  if (els.createBtn) {
+    els.createBtn.addEventListener('click', async () => {
+      try {
+        const passphrase = els.createPassphrase
+          ? els.createPassphrase.value
+          : '';
+        if (!passphrase) {
+          setStatus(els.createStatus, 'Set a passphrase first.', 'error');
+          return;
+        }
+        if (!trustGateOk(els.createStatus)) return;
+        const wallet = await Wallet.generate();
+        await keyring.enroll(wallet, { store }, { passphrase });
+        const address = await wallet.address();
+        clearSecrets();
+        setStatus(
+          els.createStatus,
+          `Wallet created and saved on this node: ${address}. ` +
+            'Download an encrypted backup now — it is your only recovery.',
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(els.createStatus, `Could not create: ${msgOf(e)}`, 'error');
+      }
+    });
+  }
+
+  // --- import (b58) ---
+  if (els.importBtn) {
+    els.importBtn.addEventListener('click', async () => {
+      try {
+        const b58 = els.importB58 ? els.importB58.value.trim() : '';
+        const passphrase = els.importPassphrase
+          ? els.importPassphrase.value
+          : '';
+        if (!b58) {
+          setStatus(els.importStatus, 'Paste a base58 private key.', 'error');
+          return;
+        }
+        if (!passphrase) {
+          setStatus(
+            els.importStatus,
+            'Set a passphrase to persist the wallet.',
+            'error',
+          );
+          return;
+        }
+        if (!trustGateOk(els.importStatus)) return;
+        const wallet = await Wallet.fromPrivateKeyB58(b58);
+        await keyring.enroll(wallet, { store }, { passphrase });
+        const address = await wallet.address();
+        if (els.importB58) els.importB58.value = '';
+        clearSecrets();
+        setStatus(
+          els.importStatus,
+          `Wallet imported and saved on this node: ${address}.`,
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(els.importStatus, `Could not import: ${msgOf(e)}`, 'error');
+      }
+    });
+  }
+  // .pem import is deferred (mirrors /transact): surface clearly.
+  if (els.importPem) {
+    els.importPem.addEventListener('change', () => {
+      setStatus(
+        els.importStatus,
+        'PEM upload is not supported yet — paste the base58 private key ' +
+          'instead (a follow-up will add .pem import).',
+        'error',
+      );
+      els.importPem.value = '';
+    });
+  }
+
+  // --- import from an encrypted backup ---
+  if (els.importBackupBtn) {
+    els.importBackupBtn.addEventListener('click', async () => {
+      try {
+        const file =
+          els.importBackupFile && els.importBackupFile.files
+            ? els.importBackupFile.files[0]
+            : null;
+        const passphrase = els.importBackupPassphrase
+          ? els.importBackupPassphrase.value
+          : '';
+        if (!file) {
+          setStatus(els.importStatus, 'Choose a backup file.', 'error');
+          return;
+        }
+        if (!passphrase) {
+          setStatus(els.importStatus, 'Enter the backup passphrase.', 'error');
+          return;
+        }
+        if (!trustGateOk(els.importStatus)) return;
+        const backup = JSON.parse(await file.text());
+        const wallet = await importEncrypted(backup, passphrase);
+        // Persist under the SAME passphrase the backup used (the user has it).
+        await keyring.enroll(wallet, { store }, { passphrase });
+        const address = await wallet.address();
+        clearSecrets();
+        setStatus(
+          els.importStatus,
+          `Wallet restored from backup and saved: ${address}.`,
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(
+          els.importStatus,
+          `Could not restore backup: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- unlock (passphrase) ---
+  if (els.unlockBtn) {
+    els.unlockBtn.addEventListener('click', async () => {
+      try {
+        const passphrase = els.unlockPassphrase
+          ? els.unlockPassphrase.value
+          : '';
+        if (!passphrase) {
+          setStatus(els.unlockStatus, 'Enter your passphrase.', 'error');
+          return;
+        }
+        const wallet = await keyring.unlock({ store }, { passphrase });
+        session.setWallet(wallet);
+        clearSecrets();
+        setStatus(
+          els.unlockStatus,
+          'Unlocked for this page session. It auto-locks on idle or when ' +
+            'you leave.',
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(
+          els.unlockStatus,
+          'Could not unlock (wrong passphrase?).',
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- unlock (passkey) ---
+  if (els.unlockPasskeyBtn) {
+    els.unlockPasskeyBtn.addEventListener('click', async () => {
+      try {
+        if (!passkey) {
+          setStatus(
+            els.unlockStatus,
+            'Passkeys are not available here.',
+            'error',
+          );
+          return;
+        }
+        const wallet = await keyring.unlock({ store, passkey }, {});
+        session.setWallet(wallet);
+        setStatus(
+          els.unlockStatus,
+          'Unlocked with a passkey for this page session.',
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(
+          els.unlockStatus,
+          `Could not unlock with a passkey: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- lock ---
+  if (els.lockBtn) {
+    els.lockBtn.addEventListener('click', async () => {
+      session.lock();
+      setStatus(els.unlockStatus, 'Locked.', 'info');
+      await render();
+    });
+  }
+
+  // --- add passkey (unlocked, secure-origin only) ---
+  if (els.addPasskeyBtn) {
+    els.addPasskeyBtn.addEventListener('click', async () => {
+      try {
+        if (!passkey) {
+          setStatus(
+            els.addPasskeyStatus,
+            'Passkeys are not available here.',
+            'error',
+          );
+          return;
+        }
+        const passphrase = els.addPasskeyPassphrase
+          ? els.addPasskeyPassphrase.value
+          : '';
+        if (!passphrase) {
+          setStatus(
+            els.addPasskeyStatus,
+            'Confirm your passphrase to add a passkey.',
+            'error',
+          );
+          return;
+        }
+        const rec = await store.get();
+        await keyring.addPasskey({ store, passkey }, { passphrase }, {
+          userId: rec?.address,
+          userName: rec?.address,
+        });
+        clearSecrets();
+        setStatus(
+          els.addPasskeyStatus,
+          'Passkey added — you can now unlock with it on this device.',
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(
+          els.addPasskeyStatus,
+          `Could not add a passkey: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- backup (download encrypted JSON) ---
+  if (els.backupBtn) {
+    els.backupBtn.addEventListener('click', async () => {
+      try {
+        const passphrase = els.backupPassphrase
+          ? els.backupPassphrase.value
+          : '';
+        if (!passphrase) {
+          setStatus(els.backupStatus, 'Enter your passphrase.', 'error');
+          return;
+        }
+        // Unlock just to re-export — the passphrase decrypts the keyring.
+        const wallet = await keyring.unlock({ store }, { passphrase });
+        const backup = await exportEncrypted(wallet, passphrase);
+        const address = await wallet.address();
+        if (doc) {
+          downloadText(
+            doc,
+            backupFilename(address),
+            JSON.stringify(backup, null, 2),
+          );
+        }
+        clearSecrets();
+        setStatus(
+          els.backupStatus,
+          'Encrypted backup downloaded. Keep it (and the passphrase) safe.',
+          'ok',
+        );
+      } catch (e) {
+        setStatus(
+          els.backupStatus,
+          'Could not back up (wrong passphrase?).',
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- forget (with confirm) ---
+  if (els.forgetBtn) {
+    els.forgetBtn.addEventListener('click', async () => {
+      const ok = win
+        ? win.confirm(
+            'Forget this wallet on this node? This deletes the saved ' +
+              'encrypted record. If you have no backup and no passphrase ' +
+              'elsewhere, the wallet is unrecoverable.',
+          )
+        : true;
+      if (!ok) return;
+      try {
+        session.lock();
+        await keyring.clear(store);
+        setStatus(els.forgetStatus, 'Wallet forgotten on this node.', 'info');
+        await render();
+      } catch (e) {
+        setStatus(
+          els.forgetStatus,
+          `Could not forget: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
+  }
+
+  // Resolve passkey capability, install auto-lock, then render. Auto-lock
+  // re-renders on lock so the controls reflect the locked state.
+  (async () => {
+    passkey = await makePasskey({ window: win, rpName });
+    passkeyState = {
+      secureContext: !!win?.isSecureContext,
+      supported: passkey != null,
+    };
+    session.onLock(() => {
+      render().catch(() => {});
+    });
+    if (doc && win) {
+      session.installAutoLock({ document: doc, window: win });
+    }
+    await render();
+  })().catch(() => {});
+}

--- a/src/gumptionchain/static/js/wallet-glue.test.mjs
+++ b/src/gumptionchain/static/js/wallet-glue.test.mjs
@@ -1,0 +1,154 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  whichControls,
+  backupFilename,
+  TRUST_ACK_KEY,
+  readTrustAck,
+  writeTrustAck,
+} from './wallet-glue.mjs';
+
+// --- whichControls: state -> which sections/buttons are visible ----------
+
+test('no wallet: create/import shown, has-wallet controls hidden', () => {
+  const c = whichControls({
+    hasWallet: false,
+    unlocked: false,
+    secureContext: true,
+    passkeySupported: true,
+  });
+  assert.equal(c.showCreate, true);
+  assert.equal(c.showImport, true);
+  assert.equal(c.showHasWallet, false);
+  assert.equal(c.showUnlock, false);
+  assert.equal(c.showLock, false);
+  assert.equal(c.showAddPasskey, false);
+  assert.equal(c.showBackup, false);
+  assert.equal(c.showForget, false);
+});
+
+test('has wallet, locked: unlock/backup/forget shown, lock hidden', () => {
+  const c = whichControls({
+    hasWallet: true,
+    unlocked: false,
+    secureContext: true,
+    passkeySupported: true,
+  });
+  assert.equal(c.showCreate, false);
+  assert.equal(c.showImport, false);
+  assert.equal(c.showHasWallet, true);
+  assert.equal(c.showUnlock, true);
+  assert.equal(c.showLock, false);
+  assert.equal(c.showBackup, true);
+  assert.equal(c.showForget, true);
+  // Passkey unlock button shown only when supported + secure.
+  assert.equal(c.showUnlockPasskey, true);
+  // Add-passkey is an unlocked-only action.
+  assert.equal(c.showAddPasskey, false);
+});
+
+test('has wallet, unlocked: lock + add-passkey shown, unlock hidden', () => {
+  const c = whichControls({
+    hasWallet: true,
+    unlocked: true,
+    secureContext: true,
+    passkeySupported: true,
+  });
+  assert.equal(c.showHasWallet, true);
+  assert.equal(c.showUnlock, false);
+  assert.equal(c.showLock, true);
+  assert.equal(c.showAddPasskey, true);
+  assert.equal(c.showBackup, true);
+  assert.equal(c.showForget, true);
+});
+
+test('non-secure origin: every passkey control is hidden', () => {
+  const locked = whichControls({
+    hasWallet: true,
+    unlocked: false,
+    secureContext: false,
+    passkeySupported: true,
+  });
+  assert.equal(locked.showUnlockPasskey, false);
+  const unlocked = whichControls({
+    hasWallet: true,
+    unlocked: true,
+    secureContext: false,
+    passkeySupported: true,
+  });
+  assert.equal(unlocked.showAddPasskey, false);
+});
+
+test('passkey unsupported (even on secure origin): passkey controls hidden', () => {
+  const unlocked = whichControls({
+    hasWallet: true,
+    unlocked: true,
+    secureContext: true,
+    passkeySupported: false,
+  });
+  assert.equal(unlocked.showAddPasskey, false);
+  const locked = whichControls({
+    hasWallet: true,
+    unlocked: false,
+    secureContext: true,
+    passkeySupported: false,
+  });
+  assert.equal(locked.showUnlockPasskey, false);
+});
+
+// --- backupFilename ------------------------------------------------------
+
+test('backupFilename embeds a short address slug and the .json ext', () => {
+  const name = backupFilename('GCabcdef1234567890GC');
+  assert.match(name, /^gc-wallet-backup-/);
+  assert.match(name, /\.json$/);
+  // It carries part of the address so multiple backups are distinguishable.
+  assert.match(name, /GCabcdef/);
+});
+
+test('backupFilename tolerates a null/empty address', () => {
+  const name = backupFilename('');
+  assert.match(name, /^gc-wallet-backup/);
+  assert.match(name, /\.json$/);
+});
+
+// --- trust-ack flag (per-origin, localStorage) ---------------------------
+
+function fakeStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+  };
+}
+
+test('trust-ack defaults to false and flips to true once written', () => {
+  const store = fakeStorage();
+  assert.equal(readTrustAck(store), false);
+  writeTrustAck(store);
+  assert.equal(readTrustAck(store), true);
+  // The flag is stored under the documented per-origin key.
+  assert.equal(store.getItem(TRUST_ACK_KEY), '1');
+});
+
+test('readTrustAck tolerates a missing/throwing storage', () => {
+  assert.equal(readTrustAck(null), false);
+  assert.equal(readTrustAck(undefined), false);
+  const boom = {
+    getItem() {
+      throw new Error('blocked');
+    },
+  };
+  assert.equal(readTrustAck(boom), false);
+});
+
+test('writeTrustAck tolerates a missing/throwing storage', () => {
+  assert.doesNotThrow(() => writeTrustAck(null));
+  const boom = {
+    setItem() {
+      throw new Error('blocked');
+    },
+  };
+  assert.doesNotThrow(() => writeTrustAck(boom));
+});

--- a/src/gumptionchain/static/js/wallet-session.mjs
+++ b/src/gumptionchain/static/js/wallet-session.mjs
@@ -1,0 +1,146 @@
+// Shared per-page wallet session + auto-lock policy. An unlocked Wallet lives
+// ONLY in this module-scoped holder for the life of the page; it is never
+// persisted (the persisted record is always the gc-keyring ciphertext) and
+// never sent (only the signature + public key leave the browser).
+//
+// The wallet is dropped — best-effort lock — on:
+//   - a manual lock(),
+//   - an idle timeout (default ~15 min, reset on user activity via touch()),
+//   - the page being hidden (visibilitychange -> hidden) or unloaded (pagehide).
+//
+// On lock the reference is released. An RSA CryptoKey can't be zeroed in JS, so
+// this is best-effort: dropping the reference is the strongest available
+// guarantee. The page reload that follows a navigation away clears it fully.
+//
+// makeSession() returns a fresh, self-contained session so the logic is
+// unit-testable with an injected clock/timer and fake document/window (no real
+// DOM). A module-level default `session` is also exported for page glue.
+
+export const DEFAULT_IDLE_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_ACTIVITY_EVENTS = [
+  'pointerdown',
+  'keydown',
+  'pointermove',
+  'scroll',
+  'touchstart',
+];
+
+export function makeSession() {
+  let wallet = null;
+  const lockCbs = [];
+
+  // Idle-timer state: the injected timer + the current timer handle. Kept on
+  // the session so touch() can clear/re-arm without re-passing the deps.
+  let idleMs = null;
+  let timerDeps = null; // { now, setTimer, clearTimer }
+  let timerHandle = null;
+
+  function getWallet() {
+    return wallet;
+  }
+
+  function isUnlocked() {
+    return wallet !== null;
+  }
+
+  function setWallet(w) {
+    wallet = w ?? null;
+  }
+
+  function onLock(cb) {
+    lockCbs.push(cb);
+  }
+
+  function clearTimerHandle() {
+    if (timerHandle != null && timerDeps) {
+      timerDeps.clearTimer(timerHandle);
+    }
+    timerHandle = null;
+  }
+
+  function lock() {
+    // Drop the reference first, then notify — a callback observing the session
+    // must already see it locked.
+    wallet = null;
+    clearTimerHandle();
+    for (const cb of lockCbs) {
+      cb();
+    }
+  }
+
+  // Arm (or re-arm) the idle timer. The deps make the clock/timer injectable;
+  // defaults use the real ones. now() is reserved for future deadline math but
+  // accepted now so callers wire a single clock.
+  function armIdle(
+    ms,
+    {
+      now = () => Date.now(),
+      setTimer = (cb, t) => setTimeout(cb, t),
+      clearTimer = (id) => clearTimeout(id),
+    } = {},
+  ) {
+    idleMs = ms;
+    timerDeps = { now, setTimer, clearTimer };
+    clearTimerHandle();
+    timerHandle = setTimer(() => {
+      timerHandle = null;
+      lock();
+    }, ms);
+  }
+
+  // Reset the idle countdown on user activity. A no-op until armIdle has run.
+  function touch() {
+    if (idleMs == null || !timerDeps) {
+      return;
+    }
+    armIdle(idleMs, timerDeps);
+  }
+
+  // Wire the page lifecycle + activity handlers. Thin: it only registers
+  // listeners that delegate to lock()/touch(), so the timer logic above stays
+  // unit-testable without a DOM. The clock/timer are injectable for tests.
+  function installAutoLock({
+    document,
+    window,
+    idleMs: ms = DEFAULT_IDLE_MS,
+    activityEvents = DEFAULT_ACTIVITY_EVENTS,
+    now,
+    setTimer,
+    clearTimer,
+  } = {}) {
+    const deps = {};
+    if (now) deps.now = now;
+    if (setTimer) deps.setTimer = setTimer;
+    if (clearTimer) deps.clearTimer = clearTimer;
+
+    if (document) {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          lock();
+        }
+      });
+    }
+    if (window) {
+      window.addEventListener('pagehide', () => lock());
+      for (const type of activityEvents) {
+        window.addEventListener(type, () => touch());
+      }
+    }
+    armIdle(ms, deps);
+  }
+
+  return {
+    getWallet,
+    setWallet,
+    isUnlocked,
+    lock,
+    onLock,
+    armIdle,
+    touch,
+    installAutoLock,
+  };
+}
+
+// A module-level default session for page glue that wants a single shared
+// holder per page load.
+export const session = makeSession();

--- a/src/gumptionchain/static/js/wallet-session.mjs
+++ b/src/gumptionchain/static/js/wallet-session.mjs
@@ -45,6 +45,13 @@ export function makeSession() {
 
   function setWallet(w) {
     wallet = w ?? null;
+    // Becoming unlocked (re)starts the idle countdown, so the documented idle
+    // auto-lock holds across lock -> re-unlock (the timer is cleared on lock
+    // and otherwise wouldn't re-arm until the next activity event). touch() is
+    // a no-op until the idle timer has been configured (installAutoLock).
+    if (wallet !== null) {
+      touch();
+    }
   }
 
   function onLock(cb) {

--- a/src/gumptionchain/static/js/wallet-session.test.mjs
+++ b/src/gumptionchain/static/js/wallet-session.test.mjs
@@ -1,0 +1,228 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeSession } from './wallet-session.mjs';
+
+// A fake wallet is just an opaque token here — the session never inspects it.
+const fakeWallet = (id = 'w') => ({ id });
+
+// --- the holder: set/get/lock/isUnlocked + onLock callbacks --------------
+
+test('setWallet/getWallet/isUnlocked track the held reference', () => {
+  const s = makeSession();
+  assert.equal(s.isUnlocked(), false);
+  assert.equal(s.getWallet(), null);
+  const w = fakeWallet();
+  s.setWallet(w);
+  assert.equal(s.isUnlocked(), true);
+  assert.equal(s.getWallet(), w);
+});
+
+test('lock() drops the wallet reference and fires onLock callbacks', () => {
+  const s = makeSession();
+  let fired = 0;
+  s.onLock(() => {
+    fired += 1;
+  });
+  s.setWallet(fakeWallet());
+  s.lock();
+  assert.equal(s.getWallet(), null);
+  assert.equal(s.isUnlocked(), false);
+  assert.equal(fired, 1);
+});
+
+test('lock() while already locked still fires onLock (idempotent drop)', () => {
+  const s = makeSession();
+  let fired = 0;
+  s.onLock(() => {
+    fired += 1;
+  });
+  s.lock();
+  assert.equal(fired, 1);
+  assert.equal(s.getWallet(), null);
+});
+
+test('multiple onLock callbacks all fire', () => {
+  const s = makeSession();
+  const seen = [];
+  s.onLock(() => seen.push('a'));
+  s.onLock(() => seen.push('b'));
+  s.setWallet(fakeWallet());
+  s.lock();
+  assert.deepEqual(seen, ['a', 'b']);
+});
+
+// --- the idle timer: armIdle + touch with an injected clock/timer --------
+
+function fakeTimer() {
+  // A minimal setTimeout/clearTimeout that records the scheduled callback +
+  // delay and lets a test fire it deterministically.
+  let next = 1;
+  const timers = new Map();
+  return {
+    setTimer(cb, ms) {
+      const id = next;
+      next += 1;
+      timers.set(id, { cb, ms });
+      return id;
+    },
+    clearTimer(id) {
+      timers.delete(id);
+    },
+    // test helpers
+    pending() {
+      return [...timers.values()];
+    },
+    fireAll() {
+      const cbs = [...timers.values()].map((t) => t.cb);
+      timers.clear();
+      for (const cb of cbs) cb();
+    },
+  };
+}
+
+test('armIdle schedules a lock after idleMs', () => {
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const timer = fakeTimer();
+  s.armIdle(1000, {
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+  assert.equal(timer.pending().length, 1);
+  assert.equal(timer.pending()[0].ms, 1000);
+  timer.fireAll();
+  assert.equal(locked, 1);
+  assert.equal(s.isUnlocked(), false);
+});
+
+test('touch() resets the idle timer (clears the old, arms a new one)', () => {
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const timer = fakeTimer();
+  s.armIdle(1000, {
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+  const firstId = timer.pending();
+  assert.equal(firstId.length, 1);
+  // touch clears the prior timer and arms a fresh one — still exactly one.
+  s.touch();
+  assert.equal(timer.pending().length, 1);
+  // The fresh timer fires the lock.
+  timer.fireAll();
+  assert.equal(locked, 1);
+});
+
+test('touch() before arming is a harmless no-op', () => {
+  const s = makeSession();
+  assert.doesNotThrow(() => s.touch());
+});
+
+// --- installAutoLock: wire fake document/window events -------------------
+
+function fakeDom() {
+  const docHandlers = {};
+  const winHandlers = {};
+  return {
+    document: {
+      visibilityState: 'visible',
+      addEventListener(type, cb) {
+        docHandlers[type] = cb;
+      },
+    },
+    window: {
+      addEventListener(type, cb) {
+        winHandlers[type] = cb;
+      },
+    },
+    docHandlers,
+    winHandlers,
+  };
+}
+
+test('installAutoLock locks when the page becomes hidden', () => {
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const dom = fakeDom();
+  const timer = fakeTimer();
+  s.installAutoLock({
+    document: dom.document,
+    window: dom.window,
+    idleMs: 1000,
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+  // Visible visibilitychange does not lock.
+  dom.document.visibilityState = 'visible';
+  dom.docHandlers.visibilitychange();
+  assert.equal(locked, 0);
+  // Hidden visibilitychange locks.
+  dom.document.visibilityState = 'hidden';
+  dom.docHandlers.visibilitychange();
+  assert.equal(locked, 1);
+  assert.equal(s.isUnlocked(), false);
+});
+
+test('installAutoLock locks on pagehide', () => {
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const dom = fakeDom();
+  const timer = fakeTimer();
+  s.installAutoLock({
+    document: dom.document,
+    window: dom.window,
+    idleMs: 1000,
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+  dom.winHandlers.pagehide();
+  assert.equal(locked, 1);
+});
+
+test('installAutoLock arms the idle timer and touch resets it on activity', () => {
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const dom = fakeDom();
+  const timer = fakeTimer();
+  s.installAutoLock({
+    document: dom.document,
+    window: dom.window,
+    idleMs: 1000,
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+    activityEvents: ['pointerdown', 'keydown'],
+  });
+  // An idle timer is armed up front.
+  assert.equal(timer.pending().length, 1);
+  // An activity event touches (resets) the timer — still exactly one pending.
+  dom.winHandlers.pointerdown();
+  assert.equal(timer.pending().length, 1);
+  // Eventually the idle timer fires → lock.
+  timer.fireAll();
+  assert.equal(locked, 1);
+});

--- a/src/gumptionchain/static/js/wallet-session.test.mjs
+++ b/src/gumptionchain/static/js/wallet-session.test.mjs
@@ -128,6 +128,36 @@ test('touch() before arming is a harmless no-op', () => {
   assert.doesNotThrow(() => s.touch());
 });
 
+test('re-unlock re-arms the idle timer after a prior auto-lock', () => {
+  // Regression: idle auto-lock must hold across lock -> re-unlock. Arm, let it
+  // fire (auto-lock), then setWallet again (a re-unlock) must re-arm exactly
+  // one fresh timer that auto-locks again.
+  const s = makeSession();
+  let locked = 0;
+  s.onLock(() => {
+    locked += 1;
+  });
+  s.setWallet(fakeWallet());
+  const timer = fakeTimer();
+  s.armIdle(1000, {
+    now: () => 0,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+  timer.fireAll(); // idle elapses -> auto-lock
+  assert.equal(locked, 1);
+  assert.equal(s.isUnlocked(), false);
+  assert.equal(timer.pending().length, 0);
+
+  // Re-unlock: setWallet must re-arm the (still-configured) idle timer.
+  s.setWallet(fakeWallet());
+  assert.equal(s.isUnlocked(), true);
+  assert.equal(timer.pending().length, 1);
+  timer.fireAll();
+  assert.equal(locked, 2); // idle auto-lock fired again
+  assert.equal(s.isUnlocked(), false);
+});
+
 // --- installAutoLock: wire fake document/window events -------------------
 
 function fakeDom() {

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -22,6 +22,7 @@
     <a class="navbar-nav" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
     <a class="navbar-nav" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
     <a class="navbar-nav" href="{{ url_for('browser.transact_view') }}">Transact</a>
+    <a class="navbar-nav" href="{{ url_for('browser.wallet_view') }}">Wallet</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/wallet.html
+++ b/src/gumptionchain/templates/wallet.html
@@ -136,7 +136,7 @@
       </div>
 
       <!-- Add a passkey (unlocked + secure origin only) -->
-      <div class="mb-4">
+      <div id="add-passkey-section" class="mb-4" hidden>
         <div class="h6">Add a passkey</div>
         <p class="small text-muted">
           Add a passkey as a second way to unlock this wallet on this device.

--- a/src/gumptionchain/templates/wallet.html
+++ b/src/gumptionchain/templates/wallet.html
@@ -1,0 +1,209 @@
+{% extends "base.html" %}
+
+{% block title %}Wallet{% endblock %}
+
+{% block content -%}
+<div class="container-fluid" data-rp-name="{{ rp_name }}">
+
+  <!-- Security banner: persistence is a trust decision in this node. -->
+  <div class="row my-3"><div class="col">
+    <div class="alert alert-warning" role="alert">
+      <strong>Persist only on a node you trust &mdash; its page can use your
+      key while unlocked.</strong>
+      A saved wallet is stored <em>encrypted</em> in this browser (IndexedDB),
+      scoped to this origin. Your passphrase and private key never leave the
+      browser and are never sent to the node &mdash; only your signature and
+      public key are. Unlocking holds the key in memory for this page only;
+      it auto-locks on idle, when the tab is hidden, or when you leave.
+    </div>
+  </div></div>
+
+  <!-- No-wallet: create or import (each requires a passphrase to persist). -->
+  <section id="no-wallet" class="row my-3" hidden><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">No saved wallet on this node</div>
+
+      <!-- first-persist trust acknowledgment (remembered per origin) -->
+      <div class="form-check mb-3">
+        <input id="trust-ack" type="checkbox" class="form-check-input">
+        <label for="trust-ack" class="form-check-label">
+          I understand: I'm choosing to persist an encrypted wallet on this
+          node, and its page can use my key while it's unlocked. I only do this
+          on a node I trust.
+        </label>
+      </div>
+
+      <hr>
+
+      <!-- Create a new wallet -->
+      <div class="mb-4">
+        <div class="h6">Create a new wallet</div>
+        <p class="small text-muted">
+          Generates a fresh key in your browser. Useful only once persisted
+          &mdash; to receive grit and spend later. Download an encrypted backup
+          afterward: it is your only recovery.
+        </p>
+        <div class="mb-2">
+          <label for="create-passphrase" class="form-label">Passphrase</label>
+          <input id="create-passphrase" type="password"
+                 class="form-control" autocomplete="new-password"
+                 placeholder="a strong passphrase">
+        </div>
+        <button id="create-btn" class="btn btn-primary">Create &amp; save</button>
+        <div id="create-status" class="mt-2 small"></div>
+      </div>
+
+      <hr>
+
+      <!-- Import an existing key -->
+      <div class="mb-3">
+        <div class="h6">Import an existing key</div>
+        <div class="mb-2">
+          <label for="import-b58" class="form-label">
+            base58 private key
+          </label>
+          <textarea id="import-b58" class="form-control" rows="2"
+                    placeholder="paste base58 private key"></textarea>
+        </div>
+        <div class="mb-2">
+          <label for="import-pem" class="form-label">or upload a .pem</label>
+          <input id="import-pem" type="file" accept=".pem" class="form-control">
+        </div>
+        <div class="mb-2">
+          <label for="import-passphrase" class="form-label">Passphrase</label>
+          <input id="import-passphrase" type="password"
+                 class="form-control" autocomplete="new-password"
+                 placeholder="a strong passphrase">
+        </div>
+        <button id="import-btn" class="btn btn-primary">Import &amp; save</button>
+        <div id="import-status" class="mt-2 small"></div>
+      </div>
+
+      <hr>
+
+      <!-- Restore from an encrypted backup -->
+      <div class="mb-3">
+        <div class="h6">Restore from an encrypted backup</div>
+        <div class="mb-2">
+          <label for="import-backup-file" class="form-label">Backup JSON</label>
+          <input id="import-backup-file" type="file" accept=".json,application/json"
+                 class="form-control">
+        </div>
+        <div class="mb-2">
+          <label for="import-backup-passphrase" class="form-label">
+            Backup passphrase
+          </label>
+          <input id="import-backup-passphrase" type="password"
+                 class="form-control" autocomplete="current-password"
+                 placeholder="the passphrase the backup was made with">
+        </div>
+        <button id="import-backup-btn" class="btn btn-secondary">
+          Restore backup
+        </button>
+      </div>
+    </div></div>
+  </div></section>
+
+  <!-- Has-wallet: address, unlock/lock, add passkey, backup, forget. -->
+  <section id="has-wallet" class="row my-3" hidden><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">Saved wallet on this node</div>
+      <p class="mb-3">
+        Address: <code id="wallet-address"></code>
+      </p>
+
+      <!-- Unlock (passphrase + optional passkey) -->
+      <div id="unlock-section" class="mb-4" hidden>
+        <div class="h6">Unlock</div>
+        <div class="mb-2">
+          <label for="unlock-passphrase" class="form-label">Passphrase</label>
+          <input id="unlock-passphrase" type="password"
+                 class="form-control" autocomplete="current-password"
+                 placeholder="your passphrase">
+        </div>
+        <button id="unlock-btn" class="btn btn-primary">Unlock</button>
+        <button id="unlock-passkey-btn" class="btn btn-outline-primary" hidden>
+          Unlock with a passkey
+        </button>
+        <div id="unlock-status" class="mt-2 small"></div>
+      </div>
+
+      <!-- Unlocked actions -->
+      <div class="mb-4">
+        <button id="lock-btn" class="btn btn-outline-secondary" hidden>
+          Lock
+        </button>
+      </div>
+
+      <!-- Add a passkey (unlocked + secure origin only) -->
+      <div class="mb-4">
+        <div class="h6">Add a passkey</div>
+        <p class="small text-muted">
+          Add a passkey as a second way to unlock this wallet on this device.
+          Your passphrase always stays as the portable recovery method.
+        </p>
+        <div class="mb-2">
+          <label for="add-passkey-passphrase" class="form-label">
+            Confirm passphrase
+          </label>
+          <input id="add-passkey-passphrase" type="password"
+                 class="form-control" autocomplete="current-password"
+                 placeholder="your passphrase" hidden>
+        </div>
+        <button id="add-passkey-btn" class="btn btn-outline-primary" hidden>
+          Add passkey
+        </button>
+        <div id="add-passkey-status" class="mt-2 small"></div>
+      </div>
+
+      <hr>
+
+      <!-- Backup -->
+      <div class="mb-4">
+        <div class="h6">Download an encrypted backup</div>
+        <p class="small text-muted">
+          Exports the encrypted backup blob (safe to store). This is your
+          recovery, cross-device, and cross-method path. Lose both the
+          passphrase and the backup and the wallet is unrecoverable.
+        </p>
+        <div class="mb-2">
+          <label for="backup-passphrase" class="form-label">Passphrase</label>
+          <input id="backup-passphrase" type="password"
+                 class="form-control" autocomplete="current-password"
+                 placeholder="your passphrase">
+        </div>
+        <button id="backup-btn" class="btn btn-secondary" hidden>
+          Download backup
+        </button>
+        <div id="backup-status" class="mt-2 small"></div>
+      </div>
+
+      <hr>
+
+      <!-- Forget -->
+      <div class="mb-2">
+        <div class="h6">Forget this wallet</div>
+        <p class="small text-muted">
+          Deletes the saved encrypted record from this node. Make sure you have
+          a backup first.
+        </p>
+        <button id="forget-btn" class="btn btn-outline-danger">
+          Forget wallet
+        </button>
+        <div id="forget-status" class="mt-2 small"></div>
+      </div>
+    </div></div>
+  </div></section>
+
+  {% include "wallet/extra.html" ignore missing %}
+</div>
+{%- endblock %}
+
+{% block scripts -%}
+{{ super() }}
+<script type="module">
+  import { init } from "{{ url_for('browser.static', filename='js/wallet-glue.mjs') }}";
+  const root = document.querySelector('[data-rp-name]');
+  init(root, { rpName: root.dataset.rpName });
+</script>
+{%- endblock %}

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -186,3 +186,18 @@ def test_consumer_base_html_reskins_transact_page(tmp_path):
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         # base transact content still rendered
         assert b'never leaves your browser' in resp.data
+
+
+def test_consumer_base_html_reskins_wallet_page(tmp_path):
+    # Seam check for the /wallet management page. It is a static shell (all key
+    # work is client-side, no chain), so the consumer skin must win while
+    # base's wallet content still renders.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/wallet')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base wallet content still rendered
+        assert b'Persist only on a node you trust' in resp.data

--- a/tests/test_wallet_page.py
+++ b/tests/test_wallet_page.py
@@ -1,0 +1,61 @@
+import httpx
+
+
+def test_wallet_page_renders(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/wallet')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+
+        # Prominent security banner: persistence is a trust decision.
+        assert 'Persist only on a node you trust' in body
+        assert 'never sent to the node' in body
+
+        # No-wallet section: create + import, each with a passphrase field.
+        assert 'id="no-wallet"' in body
+        assert 'id="create-btn"' in body
+        assert 'id="create-passphrase"' in body
+        assert 'id="import-b58"' in body
+        assert 'id="import-passphrase"' in body
+        assert 'id="import-btn"' in body
+        # .pem is deferred-with-message (like /transact), but the input is here.
+        assert 'id="import-pem"' in body
+
+        # First-persist trust acknowledgment element.
+        assert 'id="trust-ack"' in body
+
+        # Has-wallet section: address, unlock/lock, add passkey, backup, forget.
+        assert 'id="has-wallet"' in body
+        assert 'id="wallet-address"' in body
+        assert 'id="unlock-section"' in body
+        assert 'id="unlock-passphrase"' in body
+        assert 'id="unlock-btn"' in body
+        assert 'id="unlock-passkey-btn"' in body
+        assert 'id="lock-btn"' in body
+        assert 'id="add-passkey-btn"' in body
+        assert 'id="backup-btn"' in body
+        assert 'id="forget-btn"' in body
+
+        # Glue module is wired in from the blueprint static js dir.
+        assert 'js/wallet-glue.mjs' in body
+        assert '/static/gumptionchain/' in body
+        # super() in the scripts block keeps base's bundled JS (Bootstrap).
+        assert 'bootstrap' in body
+
+
+def test_wallet_page_passes_rp_name(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/wallet')
+        assert resp.status_code == httpx.codes.OK
+        # The WebAuthn RP name reaches the page (labels the passkey).
+        assert 'data-rp-name="GumptionChain"' in str(resp.data)
+
+
+def test_wallet_in_nav(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        # Nav link to /wallet is present (after Transact).
+        assert 'href="/wallet"' in body
+        assert '>Wallet</a>' in body


### PR DESCRIPTION
PR 2 of 3 for the persistent browser wallet (#217). The **`/wallet` management page** + a shared **auto-lock session helper**.

## What
- **`/wallet`** — state-driven UI: **No wallet** → Create (generate) / Import (b58; PEM deferred) / Restore-from-backup, each with a passphrase (the mandatory floor); **Has wallet** → address, Unlock (passphrase + passkey-if-supported), Lock, Add passkey (unlocked + secure origin only), Backup (download encrypted JSON), Forget (confirm). Prominent security banner; nav link.
- **First-persist trust acknowledgment** — a one-time, per-origin (`localStorage`) gate; every enroll path blocks until acknowledged.
- **`wallet-session.mjs`** — the unlocked `Wallet` lives only here; **auto-lock** on tab hide/close, idle timeout (15 min), and manual Lock; `lock()` drops the reference.
- **`wallet-glue.mjs`** — wires `gc-keyring` + `gc-store-idb` + `gc-backup` + `gc-passkey-webauthn`; passkey controls only on a secure context where PRF is supported (else passphrase-only, no dead controls).

## Security
Passphrases are `type="password"`, cleared after each op, never logged/rendered; the private key/b58 never leaves the browser or hits the DOM; only the **encrypted** keyring record (IndexedDB) + the trust-ack flag are persisted; backup download is the encrypted blob.

## Review fixes
- **Idle auto-lock now re-arms on unlock** (was armed once at load → an idle re-unlock kept the key live; centralized in `session.setWallet` so `/transact` inherits it). Regression-tested.
- "Add a passkey" block fully hidden on non-passkey origins.

## Tests
`wallet-session` (11) + `wallet-glue` helpers (10) node tests; `/wallet` page markup + trust-ack + seam. Gates: pytest 469, `node --test` 152, ruff + mypy clean, drift guard green. Independently reviewed (trust-ack gate, lock-drops-ref, secret hygiene, passkey gating all confirmed); the one must-fix (idle re-arm) addressed.

Spec: `docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)