### PR TITLE
feat(browser): unlock a saved wallet on /transact (#217 PR3)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -412,6 +412,9 @@ def transact_view() -> Any:
         'transact.html',
         title='Transact',
         node_host=current_app.config['NODE_HOST'],
+        # rp_name labels the WebAuthn passkey (RP name) for the saved-wallet
+        # passkey unlock path; gc-sig is node-bound so node_host stays too.
+        rp_name='GumptionChain',
     )
 
 

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -1,12 +1,18 @@
 // Base /transact glue: build (via the node's authed server-side endpoints),
-// sign client-side with an ephemeral imported key, and submit. Plus a
-// "broadcast a pre-signed txn" mode. The imported Wallet lives ONLY in a
-// module-scoped variable here — never persisted (no IndexedDB/localStorage),
-// never sent (only the signature + public key leave the browser).
+// sign client-side with an unlocked key, and submit. Plus a "broadcast a
+// pre-signed txn" mode. The active Wallet lives ONLY in the shared per-page
+// wallet-session holder — never persisted from here, never sent (only the
+// signature + public key leave the browser). Two ways to obtain that wallet:
+//   - "Unlock your saved wallet" — decrypt the gc-keyring record persisted on
+//     /wallet (passphrase or, on a secure origin, passkey), OR
+//   - "use a key just for this session" — paste a base58 private key (ephemeral
+//     import; nothing is saved).
+// Either way the unlocked key is subject to the same auto-lock policy (idle /
+// tab-hide / page-unload / manual forget) via wallet-session.
 //
-// The pure helpers (buildQuery / submitPath / responseMessage / buildSignSubmit)
-// are exported and DOM-free so they can be unit-tested with a fake fetch. The
-// DOM wiring is in init().
+// The pure helpers (buildQuery / submitPath / responseMessage / buildUnsigned /
+// signAndSubmit / whichKeyControls / unlockSaved) are exported and DOM-free so
+// they can be unit-tested with fakes. The DOM wiring is in init().
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import { signHeaders } from '../wallet/gc-sig.mjs';
 import { base64encode } from '../wallet/gc-crypto.mjs';
@@ -15,6 +21,10 @@ import {
   signUnsignedTxn,
   txid as computeTxid,
 } from '../wallet/gc-transaction.mjs';
+import * as keyring from '../wallet/gc-keyring.mjs';
+import { makeIdbStore } from '../wallet/gc-store-idb.mjs';
+import { session as defaultSession } from './wallet-session.mjs';
+import { makePasskey } from './wallet-passkey.mjs';
 
 const API_PREFIX = '/api';
 
@@ -243,10 +253,40 @@ export async function signAttestation({
   return signStakeAttestation(wallet, claim, { timestamp });
 }
 
-// --- DOM wiring ------------------------------------------------------------
+// --- Saved-wallet unlock ----------------------------------------------------
 
-// Module-scoped, in-memory only. Cleared by forgetKey() / page reload.
-let importedWallet = null;
+// Which saved-wallet unlock affordances to show, given the observable state.
+// The passphrase unlock shows whenever a wallet is persisted on this origin;
+// the passkey button shows only when a passkey is actually usable here.
+export function whichKeyControls({ hasWallet, passkeySupported }) {
+  return {
+    showUnlockSaved: !!hasWallet,
+    showUnlockPasskey: !!hasWallet && !!passkeySupported,
+  };
+}
+
+// Unlock the saved (gc-keyring) wallet and hold it in the shared session for
+// this page's life (auto-locked like the ephemeral path). passphrase OR passkey
+// is supplied. A wrong secret rejects out of the keyring (GCM auth-tag failure)
+// and the session is left untouched (still locked). keyringImpl is injectable
+// for tests; it defaults to the real gc-keyring.
+export async function unlockSaved({
+  store,
+  session,
+  passphrase,
+  passkey,
+  keyringImpl = keyring,
+}) {
+  const deps = { store };
+  const secrets = {};
+  if (passkey) deps.passkey = passkey;
+  if (passphrase != null) secrets.passphrase = passphrase;
+  const wallet = await keyringImpl.unlock(deps, secrets);
+  session.setWallet(wallet);
+  return wallet;
+}
+
+// --- DOM wiring ------------------------------------------------------------
 
 function setStatus(el, text, kind = 'info') {
   if (!el) return;
@@ -280,8 +320,20 @@ function describeUnsigned(unsigned) {
 }
 
 // init attaches the handlers. root defaults to document; nodeHost is the
-// node's configured host (gc-sig is node-bound).
-export function init(root = document, { nodeHost } = {}) {
+// node's configured host (gc-sig is node-bound). rpName labels the WebAuthn
+// passkey RP. store / session / win / doc are injectable but default to the
+// real IndexedDB store / shared session / window / document.
+export function init(
+  root = document,
+  {
+    nodeHost,
+    rpName = 'GumptionChain',
+    store = makeIdbStore({}),
+    session = defaultSession,
+    win = typeof window !== 'undefined' ? window : undefined,
+    doc = typeof document !== 'undefined' ? document : undefined,
+  } = {},
+) {
   const $ = (sel) => root.querySelector(sel);
 
   // Reveal type-specific fields when the type changes.
@@ -298,6 +350,13 @@ export function init(root = document, { nodeHost } = {}) {
     updateFields();
   }
 
+  // --- Saved-wallet unlock (gc-keyring record persisted on /wallet) ---
+  const savedSection = $('#saved-wallet');
+  const unlockPassphrase = $('#unlock-passphrase');
+  const unlockBtn = $('#unlock-saved-btn');
+  const unlockPasskeyBtn = $('#unlock-saved-passkey-btn');
+  const unlockStatus = $('#unlock-status');
+
   // Key import (b58 textarea / .pem file) + forget.
   const keyStatus = $('#key-status');
   const b58Input = $('#key-b58');
@@ -305,14 +364,107 @@ export function init(root = document, { nodeHost } = {}) {
   const importBtn = $('#import-key-btn');
   const forgetBtn = $('#forget-key-btn');
 
-  const onImported = async () => {
+  // Cached passkey capability (resolved once below). Drives which unlock
+  // controls show, plus the passkey-unlock click.
+  let passkey = null;
+  // Whether a wallet was unlocked since the last lock — so an idle/hide lock
+  // only reports "locked" when there was actually a key to drop.
+  let wasUnlocked = false;
+
+  function show(el, visible) {
+    if (el) el.hidden = !visible;
+  }
+
+  // Clear any passphrase inputs so a secret never lingers in the DOM.
+  function clearSecrets() {
+    for (const el of root.querySelectorAll('input[type="password"]')) {
+      el.value = '';
+    }
+  }
+
+  // Is a wallet available for signing (from a saved-wallet unlock OR an
+  // ephemeral import)? If not, surface the no-key message and return null.
+  const NO_KEY_MSG =
+    'Unlock your saved wallet or import a key for this session first.';
+  function requireWallet(statusEl) {
+    const wallet = session.getWallet();
+    if (!wallet) {
+      setStatus(statusEl, NO_KEY_MSG, 'error');
+      return null;
+    }
+    return wallet;
+  }
+
+  // Re-render the saved-wallet unlock controls from the current state. Hidden
+  // entirely when no wallet is persisted on this origin (ephemeral import is
+  // then the only path).
+  async function renderKeyControls() {
+    const hasWallet = await keyring.hasWallet(store);
+    const c = whichKeyControls({ hasWallet, passkeySupported: passkey != null });
+    show(savedSection, c.showUnlockSaved);
+    show(unlockPasskeyBtn, c.showUnlockPasskey);
+  }
+
+  // After any unlock/import, report the now-available address (in memory only).
+  const onUnlocked = async (statusEl, label) => {
+    const wallet = session.getWallet();
+    wasUnlocked = true;
     setStatus(
-      keyStatus,
-      `Key imported (in memory only): ${await importedWallet.address()}`,
+      statusEl,
+      `${label}: ${await wallet.address()} (in memory only).`,
       'ok',
     );
   };
 
+  if (unlockBtn) {
+    unlockBtn.addEventListener('click', async () => {
+      try {
+        const passphrase = unlockPassphrase ? unlockPassphrase.value : '';
+        if (!passphrase) {
+          setStatus(unlockStatus, 'Enter your passphrase.', 'error');
+          return;
+        }
+        await unlockSaved({ store, session, passphrase });
+        clearSecrets();
+        await onUnlocked(
+          unlockStatus,
+          'Unlocked your saved wallet for this session',
+        );
+      } catch {
+        // Fixed message, no secret echo: a wrong passphrase fails closed in the
+        // keyring (GCM auth tag), and the session is left locked.
+        setStatus(
+          unlockStatus,
+          'Could not unlock (wrong passphrase?).',
+          'error',
+        );
+      }
+    });
+  }
+
+  if (unlockPasskeyBtn) {
+    unlockPasskeyBtn.addEventListener('click', async () => {
+      try {
+        if (!passkey) {
+          setStatus(unlockStatus, 'Passkeys are not available here.', 'error');
+          return;
+        }
+        await unlockSaved({ store, session, passkey });
+        await onUnlocked(
+          unlockStatus,
+          'Unlocked your saved wallet with a passkey',
+        );
+      } catch (e) {
+        setStatus(
+          unlockStatus,
+          `Could not unlock with a passkey: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- Ephemeral import (a key just for this session; nothing is saved) ---
   if (importBtn) {
     importBtn.addEventListener('click', async () => {
       try {
@@ -321,10 +473,10 @@ export function init(root = document, { nodeHost } = {}) {
           setStatus(keyStatus, 'Paste a base58 private key first.', 'error');
           return;
         }
-        importedWallet = await importB58(b58);
-        await onImported();
+        session.setWallet(await importB58(b58));
+        await onUnlocked(keyStatus, 'Key imported');
       } catch (e) {
-        importedWallet = null;
+        session.lock();
         setStatus(keyStatus, `Could not import key: ${msgOf(e)}`, 'error');
       }
     });
@@ -344,8 +496,11 @@ export function init(root = document, { nodeHost } = {}) {
   }
   if (forgetBtn) {
     forgetBtn.addEventListener('click', () => {
-      importedWallet = null;
+      // Lock clears the session wallet (whether it came from a saved-wallet
+      // unlock or an ephemeral import); the persisted ciphertext is untouched.
+      session.lock();
       if (b58Input) b58Input.value = '';
+      clearSecrets();
       setStatus(keyStatus, 'Key forgotten — cleared from memory.', 'info');
     });
   }
@@ -376,10 +531,8 @@ export function init(root = document, { nodeHost } = {}) {
   if (buildBtn) {
     buildBtn.addEventListener('click', async () => {
       resetPending();
-      if (!importedWallet) {
-        setStatus(buildResult, 'Import a key first.', 'error');
-        return;
-      }
+      const wallet = requireWallet(buildResult);
+      if (!wallet) return;
       const type = typeSelect.value;
       const fields = collectFields(root, type);
       try {
@@ -387,7 +540,7 @@ export function init(root = document, { nodeHost } = {}) {
         const { unsigned } = await buildUnsigned({
           type,
           fields,
-          wallet: importedWallet,
+          wallet,
           nodeHost,
         });
         pendingUnsigned = unsigned;
@@ -413,15 +566,13 @@ export function init(root = document, { nodeHost } = {}) {
         setStatus(buildResult, 'Build a transaction first.', 'error');
         return;
       }
-      if (!importedWallet) {
-        setStatus(buildResult, 'Import a key first.', 'error');
-        return;
-      }
+      const wallet = requireWallet(buildResult);
+      if (!wallet) return;
       try {
         setStatus(buildResult, 'Signing & submitting…', 'info');
         const result = await signAndSubmit({
           unsigned: pendingUnsigned,
-          wallet: importedWallet,
+          wallet,
           nodeHost,
         });
         setStatus(
@@ -443,16 +594,14 @@ export function init(root = document, { nodeHost } = {}) {
   const broadcastBtn = $('#broadcast-btn');
   if (broadcastBtn) {
     broadcastBtn.addEventListener('click', async () => {
-      if (!importedWallet) {
-        setStatus(broadcastResult, 'Import a key first.', 'error');
-        return;
-      }
+      const wallet = requireWallet(broadcastResult);
+      if (!wallet) return;
       try {
         const signed = JSON.parse(broadcastInput.value);
         setStatus(broadcastResult, 'Submitting…', 'info');
         const result = await submitSigned({
           signed,
-          wallet: importedWallet,
+          wallet,
           nodeHost,
         });
         setStatus(
@@ -483,10 +632,8 @@ export function init(root = document, { nodeHost } = {}) {
     attBtn.addEventListener('click', async () => {
       if (attProof) attProof.textContent = '';
       if (attCopyBtn) attCopyBtn.hidden = true;
-      if (!importedWallet) {
-        setStatus(attResult, 'Import a key first.', 'error');
-        return;
-      }
+      const wallet = requireWallet(attResult);
+      if (!wallet) return;
       try {
         setStatus(attResult, 'Signing attestation…', 'info');
         const proof = await signAttestation({
@@ -494,7 +641,7 @@ export function init(root = document, { nodeHost } = {}) {
           kind: attKind ? attKind.value : 'opposition',
           rawSubject: attSubject ? attSubject.value : '',
           amount: attAmount ? Number(attAmount.value) : NaN,
-          wallet: importedWallet,
+          wallet,
         });
         if (attProof) attProof.textContent = JSON.stringify(proof, null, 2);
         if (attCopyBtn) attCopyBtn.hidden = false;
@@ -524,6 +671,25 @@ export function init(root = document, { nodeHost } = {}) {
       }
     });
   }
+
+  // Resolve passkey capability, reveal the saved-wallet controls if a wallet is
+  // persisted here, and install the shared auto-lock policy so an unlocked key
+  // (saved OR ephemeral) is dropped on idle / tab-hide / page-unload. A lock
+  // re-renders the controls (and surfaces it on the key status).
+  (async () => {
+    passkey = await makePasskey({ window: win, rpName });
+    session.onLock(() => {
+      if (wasUnlocked && keyStatus) {
+        setStatus(keyStatus, 'Key locked — cleared from memory.', 'info');
+      }
+      wasUnlocked = false;
+      renderKeyControls().catch(() => {});
+    });
+    if (doc && win) {
+      session.installAutoLock({ document: doc, window: win });
+    }
+    await renderKeyControls();
+  })().catch(() => {});
 }
 
 function msgOf(e) {

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -9,9 +9,12 @@ import {
   submitSigned,
   encodeSubject,
   signAttestation,
+  whichKeyControls,
+  unlockSaved,
 } from './transact-glue.mjs';
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import { parseStakeAttestation } from '../wallet/gc-attestation.mjs';
+import { makeSession } from './wallet-session.mjs';
 
 // --- buildQuery: one query string, used for BOTH the fetch URL and the
 // gc-sig canonical, so it must round-trip exactly the fields the type needs.
@@ -327,6 +330,126 @@ test('signAttestation supports the support kind', async () => {
   const claim = parseStakeAttestation(proof);
   assert.equal(claim.kind, 'support');
   assert.equal(claim.subject, 'Y2FuY2VsIG1l');
+});
+
+// --- whichKeyControls: the saved-wallet unlock affordances show only when a
+// wallet exists; the passkey button shows only when a passkey is usable.
+
+test('whichKeyControls hides the unlock affordances when no saved wallet', () => {
+  const c = whichKeyControls({ hasWallet: false, passkeySupported: true });
+  assert.equal(c.showUnlockSaved, false);
+  assert.equal(c.showUnlockPasskey, false);
+});
+
+test('whichKeyControls shows unlock (passphrase) when a wallet exists', () => {
+  const c = whichKeyControls({ hasWallet: true, passkeySupported: false });
+  assert.equal(c.showUnlockSaved, true);
+  // No passkey support -> no passkey button even with a saved wallet.
+  assert.equal(c.showUnlockPasskey, false);
+});
+
+test('whichKeyControls shows the passkey button only when supported', () => {
+  const c = whichKeyControls({ hasWallet: true, passkeySupported: true });
+  assert.equal(c.showUnlockSaved, true);
+  assert.equal(c.showUnlockPasskey, true);
+});
+
+// --- unlockSaved: the seam between the keyring and the shared session. A fake
+// store + fake keyring prove that unlocking sets the session wallet (which the
+// build flow then guards on) without touching real IndexedDB.
+
+function fakeStore(rec = { address: 'GCsavedGC' }) {
+  return {
+    get: async () => rec,
+    put: async () => {},
+    delete: async () => {},
+  };
+}
+
+test('unlockSaved (passphrase) sets the session wallet', async () => {
+  const session = makeSession();
+  const unlockedWallet = fakeWallet();
+  let seenArgs = null;
+  const keyringImpl = {
+    unlock: async (deps, secrets) => {
+      seenArgs = { deps, secrets };
+      return unlockedWallet;
+    },
+  };
+  const store = fakeStore();
+  const wallet = await unlockSaved({
+    store,
+    session,
+    passphrase: 'correct horse',
+    keyringImpl,
+  });
+  assert.equal(wallet, unlockedWallet);
+  // The wallet is now available to the build/confirm/broadcast/attestation
+  // flow via the shared session.
+  assert.equal(session.getWallet(), unlockedWallet);
+  assert.equal(session.isUnlocked(), true);
+  // The passphrase reached the keyring; no passkey was used.
+  assert.equal(seenArgs.secrets.passphrase, 'correct horse');
+  assert.equal(seenArgs.deps.passkey, undefined);
+});
+
+test('unlockSaved (passkey) sets the session wallet via the adapter', async () => {
+  const session = makeSession();
+  const unlockedWallet = fakeWallet();
+  const passkey = { unlock: async () => new Uint8Array(32) };
+  let seenArgs = null;
+  const keyringImpl = {
+    unlock: async (deps, secrets) => {
+      seenArgs = { deps, secrets };
+      return unlockedWallet;
+    },
+  };
+  const wallet = await unlockSaved({
+    store: fakeStore(),
+    session,
+    passkey,
+    keyringImpl,
+  });
+  assert.equal(wallet, unlockedWallet);
+  assert.equal(session.getWallet(), unlockedWallet);
+  assert.equal(seenArgs.deps.passkey, passkey);
+  assert.equal(seenArgs.secrets.passphrase, undefined);
+});
+
+test('unlockSaved propagates a wrong-secret failure (session stays locked)', async () => {
+  const session = makeSession();
+  const keyringImpl = {
+    unlock: async () => {
+      throw new Error('boom: bad secret');
+    },
+  };
+  await assert.rejects(
+    () =>
+      unlockSaved({
+        store: fakeStore(),
+        session,
+        passphrase: 'wrong',
+        keyringImpl,
+      }),
+  );
+  // A failed unlock must NOT leave a wallet in the session.
+  assert.equal(session.getWallet(), null);
+  assert.equal(session.isUnlocked(), false);
+});
+
+test('locking the session after unlock clears the wallet', async () => {
+  const session = makeSession();
+  const keyringImpl = { unlock: async () => fakeWallet() };
+  await unlockSaved({
+    store: fakeStore(),
+    session,
+    passphrase: 'pw',
+    keyringImpl,
+  });
+  assert.equal(session.isUnlocked(), true);
+  session.lock();
+  assert.equal(session.getWallet(), null);
+  assert.equal(session.isUnlocked(), false);
 });
 
 test('submitSigned rejects a pasted object missing txid/signature', async () => {

--- a/src/gumptionchain/static/js/wallet-glue.mjs
+++ b/src/gumptionchain/static/js/wallet-glue.mjs
@@ -10,9 +10,14 @@
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import * as keyring from '../wallet/gc-keyring.mjs';
 import { makeIdbStore } from '../wallet/gc-store-idb.mjs';
-import { makeWebauthnPasskey } from '../wallet/gc-passkey-webauthn.mjs';
 import { exportEncrypted, importEncrypted } from '../wallet/gc-backup.mjs';
 import { session as defaultSession } from './wallet-session.mjs';
+import { makePasskey } from './wallet-passkey.mjs';
+
+// Re-exported so existing importers (and tests) of wallet-glue keep working;
+// the implementation now lives in the shared wallet-passkey module so /transact
+// can reuse the same secure-context gating.
+export { makePasskey };
 
 // --- pure helpers ---------------------------------------------------------
 
@@ -68,23 +73,6 @@ export function writeTrustAck(storage) {
   } catch {
     // best-effort; a blocked storage just means the ack isn't remembered.
   }
-}
-
-// Build a passkey adapter for THIS origin, but only on a secure context where
-// PRF is actually supported. Returns null (not a half-working adapter) when
-// passkeys aren't usable here, so the UI degrades to passphrase-only.
-export async function makePasskey({ window: win = window, rpName } = {}) {
-  if (!win?.isSecureContext) {
-    return null;
-  }
-  const passkey = makeWebauthnPasskey({
-    rpId: win.location.hostname,
-    rpName,
-  });
-  if (!(await passkey.isSupported())) {
-    return null;
-  }
-  return passkey;
 }
 
 // --- DOM wiring -----------------------------------------------------------

--- a/src/gumptionchain/static/js/wallet-passkey.mjs
+++ b/src/gumptionchain/static/js/wallet-passkey.mjs
@@ -1,0 +1,22 @@
+// Shared passkey-adapter factory for the browser wallet glue. Both /wallet
+// (wallet-glue.mjs) and /transact (transact-glue.mjs) gate passkey unlock on a
+// secure context where WebAuthn-PRF is actually supported, so the gating lives
+// in one place rather than being duplicated per page.
+import { makeWebauthnPasskey } from '../wallet/gc-passkey-webauthn.mjs';
+
+// Build a passkey adapter for THIS origin, but only on a secure context where
+// PRF is actually supported. Returns null (not a half-working adapter) when
+// passkeys aren't usable here, so the UI degrades to passphrase-only.
+export async function makePasskey({ window: win = window, rpName } = {}) {
+  if (!win?.isSecureContext) {
+    return null;
+  }
+  const passkey = makeWebauthnPasskey({
+    rpId: win.location.hostname,
+    rpName,
+  });
+  if (!(await passkey.isSupported())) {
+    return null;
+  }
+  return passkey;
+}

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -3,7 +3,8 @@
 {% block title %}Transact{% endblock %}
 
 {% block content -%}
-<div class="container-fluid" data-node-host="{{ node_host }}">
+<div class="container-fluid" data-node-host="{{ node_host }}"
+     data-rp-name="{{ rp_name }}">
 
   <div class="row my-3"><div class="col">
     <div class="alert alert-warning" role="alert">
@@ -57,9 +58,41 @@
 
       <hr>
 
+      <!-- Key area: two ways to obtain a signing key for this page session.
+           Either is held in memory only and auto-locks (idle / tab-hide /
+           leave / Forget). -->
+
+      <!-- (a) Unlock the wallet saved on this node (gc-keyring / IndexedDB).
+           Hidden by JS unless a wallet is actually persisted on this origin. -->
+      <div id="saved-wallet" class="mb-3" hidden>
+        <div class="fw-semibold">Unlock your saved wallet</div>
+        <p class="small text-muted mb-2">
+          You saved a wallet on this node (on
+          <a href="{{ url_for('browser.wallet_view') }}">Wallet</a>). Unlock it
+          for this session &mdash; it stays in memory only and auto-locks.
+        </p>
+        <label for="unlock-passphrase" class="form-label">Passphrase</label>
+        <input id="unlock-passphrase" type="password" autocomplete="off"
+               class="form-control" placeholder="your wallet passphrase">
+        <div class="mt-2">
+          <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
+            Unlock
+          </button>
+          <button id="unlock-saved-passkey-btn"
+                  class="btn btn-outline-primary btn-sm" hidden>
+            Unlock with passkey
+          </button>
+        </div>
+        <div id="unlock-status" class="mt-2 small"></div>
+        <hr>
+        <div class="small text-muted">or use a key just for this session:</div>
+      </div>
+
+      <!-- (b) Ephemeral import: paste a key for THIS session only; nothing is
+           saved (the alternative to a saved-wallet unlock). -->
       <div class="mb-3">
         <label for="key-b58" class="form-label">
-          Import key (base58 private key)
+          Use a key just for this session (base58 private key)
         </label>
         <textarea id="key-b58" class="form-control" rows="2"
                   placeholder="paste base58 private key"></textarea>
@@ -168,6 +201,9 @@
 <script type="module">
   import { init } from "{{ url_for('browser.static', filename='js/transact-glue.mjs') }}";
   const root = document.querySelector('[data-node-host]');
-  init(root, { nodeHost: root.dataset.nodeHost });
+  init(root, {
+    nodeHost: root.dataset.nodeHost,
+    rpName: root.dataset.rpName,
+  });
 </script>
 {%- endblock %}

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -35,6 +35,29 @@ def test_transact_page_renders(app, test_client):
         assert 'bootstrap' in body
 
 
+def test_transact_page_has_saved_wallet_unlock_markup(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/transact')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        # The "Unlock saved wallet" affordance is present (revealed by JS only
+        # when a wallet is actually persisted on this origin).
+        assert 'id="saved-wallet"' in body
+        assert 'Unlock your saved wallet' in body
+        assert 'id="unlock-passphrase"' in body
+        assert 'id="unlock-saved-btn"' in body
+        # The passkey unlock button is present (JS hides it off secure origins).
+        assert 'id="unlock-saved-passkey-btn"' in body
+        # The two options read clearly as distinct: a saved unlock vs an
+        # ephemeral, this-session-only key.
+        assert 'just for this session' in body
+        # The passphrase input is masked and never autofilled.
+        assert 'type="password"' in body
+        # The RP name reaches the page for the passkey adapter.
+        assert 'data-rp-name' in body
+        assert app.config.get('NODE_HOST') is not None
+
+
 def test_transact_page_carries_configured_node_host(app, test_client):
     with app.app_context():
         node_host = app.config['NODE_HOST']


### PR DESCRIPTION
PR 3 of 3 (final) for the persistent browser wallet (#217). `/transact` can now **unlock a saved wallet** (passphrase/passkey) as an alternative to ephemeral import — both routed through the shared auto-lock session.

## What
- **"Unlock your saved wallet"** section on `/transact` (shown when `keyring.hasWallet(store)`): passphrase + passkey-if-supported → `keyring.unlock(...)` → held in the shared `wallet-session`. The existing ephemeral b58 import is relabeled "use a key just for this session."
- **Both key paths now flow through `wallet-session`**, so the same **auto-lock** (idle / tab-hide / page-unload / manual forget) applies; the build/confirm/broadcast/attestation guards became one `requireWallet(session.getWallet())`.
- **`makePasskey` extracted** to a shared `wallet-passkey.mjs` (re-exported from `wallet-glue.mjs`) so `/transact` reuses it without coupling to the `/wallet` page glue.

## Correctness / security
- **Fail-safe:** the confirm step re-checks `requireWallet` — if auto-lock fires between Build and Confirm, it won't sign with a stale/null wallet.
- Wrong passphrase/passkey → keyring rejects (GCM tag), session left **locked**, fixed message, no secret echo. Passwords `type=password`, cleared after use, never logged/rendered; key never leaves the browser.

## Tests
`whichKeyControls`/`unlockSaved` helper tests (passphrase + passkey, session-stays-locked-on-failure, lock clears), ephemeral path intact; `/transact` unlock markup + `data-rp-name`. Gates: pytest 470, `node --test` 159, ruff + mypy clean, drift guard green. Independently reviewed — APPROVED (session refactor preserves build→confirm→sign, end-to-end coherent with /wallet via the shared store/record/session).

**Completes #217 (Tier 1.5).** Spec: `docs/superpowers/specs/2026-06-08-egu-217-persistent-wallet-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)