### PR TITLE
fix(transact): surface real error detail (e.g. insufficient funds), not "validation error"

### DIFF
--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -66,10 +66,25 @@ export function submitPath(txid) {
   return `${API_PREFIX}/transaction/${encodeURIComponent(txid)}`;
 }
 
+// Pull a human detail out of an error body. The node returns `{error: msgs}`
+// where `msgs` is a LIST of message strings (GCError.messages), e.g.
+// `['InsufficientFundsError']`, or a dict for pydantic validation errors — not
+// a bare string. Surface all of those, not just the string case (otherwise a
+// real reason like insufficient funds shows as a generic "validation error").
+function errorDetail(body) {
+  const e = body && body.error;
+  if (typeof e === 'string') return e;
+  if (Array.isArray(e)) {
+    return e.filter((x) => typeof x === 'string').join('; ');
+  }
+  if (e && typeof e === 'object') return JSON.stringify(e);
+  return '';
+}
+
 // Map a submit/build response to a single user-facing string. Each documented
 // status is surfaced distinctly (closed node, mempool full, validation).
 export function responseMessage(status, body) {
-  const detail = body && typeof body.error === 'string' ? body.error : '';
+  const detail = errorDetail(body);
   if (status === 200 || status === 201 || status === 202) {
     return 'Transaction submitted and received by the node.';
   }

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -107,6 +107,18 @@ test('responseMessage 400 surfaces the validation error', () => {
   assert.match(m, /bad amount/);
 });
 
+test('responseMessage 400 surfaces a LIST error detail (GCError.messages)', () => {
+  // The node returns {error: [...]} (a list), e.g. an insufficient-funds build.
+  const m = responseMessage(400, { error: ['InsufficientFundsError'] });
+  assert.match(m, /InsufficientFundsError/);
+  assert.doesNotMatch(m, /^The node rejected the transaction: validation error/);
+});
+
+test('responseMessage 400 surfaces a dict error detail (pydantic)', () => {
+  const m = responseMessage(400, { error: { amount: 'must be >= 1' } });
+  assert.match(m, /amount/);
+});
+
 test('responseMessage falls back for an unmapped status', () => {
   const m = responseMessage(418, {});
   assert.match(m, /418/);


### PR DESCRIPTION
Building a txn from an unfunded wallet showed **"The node rejected the transaction: validation error."** — the generic fallback — instead of the actual reason (insufficient funds).

## Cause
The node returns `{error: <msgs>}` where `<msgs>` is **`GCError.messages`** — always a **list** (e.g. `['InsufficientFundsError']`), or a **dict** for pydantic validation errors. But `responseMessage` only read `body.error` when it was a `string`, so every list/dict error fell through to "validation error."

## Fix
Add `errorDetail(body)` that surfaces a string as-is, **joins a list**, and stringifies a dict — so `/transact` shows the real cause across 400 / 503 / generic responses. (Client-side only; the API error shape is unchanged.)

Now an unfunded-wallet build reads: *"The node rejected the transaction: InsufficientFundsError."*

## Tests
`responseMessage` for a list error (`['InsufficientFundsError']` → shown, not "validation error") and a dict error. `node --test` 161 pass, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)