### PR TITLE
fix(transact): build-time vs submit-time error wording

### DIFF
--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -81,10 +81,14 @@ function errorDetail(body) {
   return '';
 }
 
-// Map a submit/build response to a single user-facing string. Each documented
-// status is surfaced distinctly (closed node, mempool full, validation).
-export function responseMessage(status, body) {
+// Map a response to a user-facing string. `phase` distinguishes the two calls
+// the node makes: 'build' is the GET that CONSTRUCTS the unsigned txn (where
+// e.g. insufficient funds surfaces — nothing has been signed/submitted yet),
+// 'submit' is the POST that admits the signed txn to the mempool. The wording
+// reflects which one failed.
+export function responseMessage(status, body, phase = 'submit') {
   const detail = errorDetail(body);
+  const building = phase === 'build';
   if (status === 200 || status === 201 || status === 202) {
     return 'Transaction submitted and received by the node.';
   }
@@ -98,11 +102,14 @@ export function responseMessage(status, body) {
     return 'The node is busy: its mempool is full. Try again shortly.';
   }
   if (status === 400) {
-    return `The node rejected the transaction: ${detail || 'validation error'}.`;
+    return building
+      ? `Couldn't build the transaction: ${detail || 'invalid request'}.`
+      : `The node rejected the transaction: ${detail || 'validation error'}.`;
   }
-  return `Unexpected response from the node (HTTP ${status})${
-    detail ? `: ${detail}` : ''
-  }.`;
+  const lead = building
+    ? "Couldn't build the transaction"
+    : 'Unexpected response from the node';
+  return `${lead} (HTTP ${status})${detail ? `: ${detail}` : ''}.`;
 }
 
 // Read a fetch Response's JSON, tolerating an empty/non-JSON body.
@@ -168,7 +175,7 @@ export async function buildUnsigned({
   });
   if (!buildResp.ok) {
     const body = await readBody(buildResp);
-    throw new Error(responseMessage(buildResp.status, body));
+    throw new Error(responseMessage(buildResp.status, body, 'build'));
   }
   const unsigned = await buildResp.json();
   // Honesty check: the node-built txid must match a fresh recompute from its

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -119,9 +119,28 @@ test('responseMessage 400 surfaces a dict error detail (pydantic)', () => {
   assert.match(m, /amount/);
 });
 
+test('responseMessage 400 build phase says "build", not "rejected"', () => {
+  // A build-GET failure (insufficient funds etc.) happens before signing/submit
+  // — it couldn't BUILD the txn; it didn't "reject" a submitted one.
+  const m = responseMessage(400, { error: ['InsufficientFundsError'] }, 'build');
+  assert.match(m, /Couldn't build the transaction: InsufficientFundsError/);
+  assert.doesNotMatch(m, /rejected the transaction/);
+});
+
+test('responseMessage 400 submit phase says "rejected"', () => {
+  const m = responseMessage(400, { error: ['SpentTransactionError'] }, 'submit');
+  assert.match(m, /rejected the transaction: SpentTransactionError/);
+  assert.doesNotMatch(m, /build the transaction/);
+});
+
 test('responseMessage falls back for an unmapped status', () => {
   const m = responseMessage(418, {});
   assert.match(m, /418/);
+});
+
+test('responseMessage unmapped status reflects the phase', () => {
+  assert.match(responseMessage(500, {}, 'build'), /build the transaction.*500/s);
+  assert.match(responseMessage(500, {}, 'submit'), /Unexpected response.*500/s);
 });
 
 // --- two-step flow: buildUnsigned (GET, verify txid, NO sign) then


### PR DESCRIPTION
Follow-up to #225. `/transact` makes two calls — a **build GET** (`/api/transaction/<type>` that *constructs* the unsigned txn) and a **submit POST** (admits the signed txn). They shared one `responseMessage`, so a **build-time** failure (e.g. insufficient funds — which happens during construction, before any signing/submission) read **"The node rejected the transaction"** — inaccurate; nothing was submitted.

## Fix
`responseMessage(status, body, phase = 'submit')`:
- **build** phase → "Couldn't build the transaction: `<detail>`."
- **submit** phase → "The node rejected the transaction: `<detail>`." (unchanged)

`buildUnsigned` passes `'build'`; `submitSigned`/broadcast keep the `'submit'` default. So an unfunded-wallet build now reads: *"Couldn't build the transaction: InsufficientFundsError."*

## Tests
build-phase says "build" not "rejected"; submit-phase says "rejected"; unmapped status reflects the phase. `node --test` all pass, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)