### PR TITLE
feat(chain): honest "still confirming" message for pending-locked funds

### DIFF
--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -32,6 +32,7 @@ from gumptionchain.exceptions import (
     MissingInflowOutflowError,
     MissingPreviousBlockError,
     OutOfOrderBlockError,
+    PendingFundsError,
     SpentTransactionError,
 )
 from gumptionchain.milling import mill_hash_str
@@ -515,6 +516,19 @@ class Chain:
     def balance(self, address: str) -> int:
         return int(self.to_dao().wallet_balance(address))
 
+    def _funds_error(self, address: str, amount: int) -> InsufficientFundsError:
+        # Distinguish a genuine shortfall from funds tied up in an unconfirmed
+        # txn. balance() counts confirmed-unspent outputs (it ignores pending
+        # consumption), while the builders gather with filter_pending=True. So
+        # if the confirmed balance covers the amount but the pending-filtered
+        # gather fell short, the shortfall is just change waiting on a block.
+        if self.balance(address) >= amount:
+            return PendingFundsError(
+                'your previous transaction is still confirming; its change '
+                'becomes spendable once a block is mined'
+            )
+        return InsufficientFundsError()
+
     def wallet_leaderboard(self, limit: int | None = None) -> Select[Any]:
         return self.to_dao().wallet_leaderboard(limit=limit)
 
@@ -594,7 +608,7 @@ class Chain:
             balance += outflow.amount or 0
             t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
         if balance < amount:
-            raise InsufficientFundsError()
+            raise self._funds_error(address, amount)
         t.add_outflow(Outflow(amount=amount, address=dest_address))
         if balance - amount:
             t.add_outflow(Outflow(amount=balance - amount, address=address))
@@ -632,7 +646,7 @@ class Chain:
                 balance += unspent_outflow.amount or 0
                 t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
         if balance < amount:
-            raise InsufficientFundsError()
+            raise self._funds_error(address, amount)
         t.add_outflow(Outflow(amount=amount, opposition=subject))
         if balance - amount:
             t.add_outflow(Outflow(amount=balance - amount, address=address))
@@ -703,7 +717,7 @@ class Chain:
                 balance += unspent_outflow.amount or 0
                 t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
         if balance < amount:
-            raise InsufficientFundsError()
+            raise self._funds_error(address, amount)
         t.add_outflow(Outflow(amount=amount, support=subject))
         if balance - amount:
             t.add_outflow(Outflow(amount=balance - amount, address=address))

--- a/src/gumptionchain/exceptions.py
+++ b/src/gumptionchain/exceptions.py
@@ -78,6 +78,15 @@ class InsufficientFundsError(InvalidTransactionError):
     pass
 
 
+class PendingFundsError(InsufficientFundsError):
+    """Funds exist but are tied up in an unconfirmed (pending) transaction.
+
+    A subclass of InsufficientFundsError so existing handlers still treat it as
+    a funding failure, but distinguishable for an honest user message: the
+    change from a recent spend isn't spendable until a block confirms it.
+    """
+
+
 class ImbalancedTransactionError(InvalidTransactionError):
     pass
 

--- a/tests/test_pending_funds.py
+++ b/tests/test_pending_funds.py
@@ -1,0 +1,51 @@
+import pytest
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.exceptions import InsufficientFundsError, PendingFundsError
+from gumptionchain.wallet import Wallet
+
+
+def test_pending_change_raises_pending_funds_error(
+    app, host, mill_block, requests_proxy, wallet
+):
+    # Spend most of a single coinbase UTXO in an UNCONFIRMED txn, then try to
+    # spend again. The change is pending (not yet a confirmed UTXO) and the
+    # coinbase is spoken-for, so the builder must report PendingFundsError
+    # ("still confirming"), not a generic shortfall — the funds DO exist.
+    with app.app_context():
+        m, _b = mill_block(wallet)  # wallet earns one coinbase reward
+        dest = Wallet().address
+        first = m.longest_chain.create_transfer(wallet, 400, dest)
+        first.sign()
+        ApiClient(host, wallet).post_transaction(first)  # pending, NOT mined
+
+        with pytest.raises(PendingFundsError):
+            m.longest_chain.create_transfer(wallet, 100, dest)
+        # the confirmed balance still shows the funds — they're just locked.
+        assert m.longest_chain.balance(wallet.address) >= 100
+
+
+def test_pending_funds_error_for_stakes_too(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        first = m.longest_chain.create_opposition(wallet, 400, subject)
+        first.sign()
+        ApiClient(host, wallet).post_transaction(first)
+
+        with pytest.raises(PendingFundsError):
+            m.longest_chain.create_support(wallet, 100, subject)
+
+
+def test_empty_wallet_raises_plain_insufficient_funds(
+    app, host, mill_block, requests_proxy, wallet
+):
+    # A wallet with no funds and nothing pending gets the genuine error — NOT
+    # PendingFundsError (there's no in-flight txn locking anything).
+    with app.app_context():
+        m, _b = mill_block(wallet)  # funds `wallet`, not `empty`
+        empty = Wallet()
+        with pytest.raises(InsufficientFundsError) as exc:
+            m.longest_chain.create_transfer(empty, 100, Wallet().address)
+        assert not isinstance(exc.value, PendingFundsError)


### PR DESCRIPTION
Surfaced while testing a freshly-funded wallet: spend once, then you can't spend again — the node says **"insufficient funds"** even though you clearly have grit. The cause is the UTXO model: your spend consumes your output and produces **change in an *unconfirmed* transaction**, which isn't a spendable UTXO until a block confirms it (`filter_pending` correctly refuses to reuse the just-spent output). A single-UTXO wallet can therefore only have one in-flight spend until it confirms — and the error message lies about why.

## Fix
Distinguish the two cases honestly:
- **`PendingFundsError`** (a subclass of `InsufficientFundsError`, so existing handlers are unaffected) — raised when the **confirmed** balance covers the amount but the **pending-filtered** gather fell short, i.e. the funds are just confirming.
- **`Chain._funds_error(address, amount)`** picks the right one; wired into `create_transfer` / `create_opposition` / `create_support`.

`/transact` now reads: *"Couldn't build the transaction: your previous transaction is still confirming; its change becomes spendable once a block is mined."* — instead of `InsufficientFundsError`.

## Notes
- In production (~5-min blocks) the change confirms within a block; this just makes the brief window legible. The deeper option — **spending unconfirmed change** (txn chaining) — is filed separately for deliberation (it has reorg-cascade semantics).
- `create_rescind` is left as plain `InsufficientFundsError` (its funding source is staked outputs, a different semantic).

## Tests
`tests/test_pending_funds.py`: pending change → `PendingFundsError` (transfer + stake); a genuinely empty wallet → plain `InsufficientFundsError` (not pending). Gates green: ruff + mypy + pytest (473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)