### PR TITLE
feat(api): GET /api/blocks height-range fetch for forward sync (#163 PR1)

### DIFF
--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -31,6 +31,7 @@ from gumptionchain.api_client import PEER_HOST_HEADER
 from gumptionchain.block import Block, expiry_cutoff
 from gumptionchain.cache import cache
 from gumptionchain.chain import Chain
+from gumptionchain.database import db
 from gumptionchain.exceptions import (
     EmptyChainError,
     GCError,
@@ -38,7 +39,7 @@ from gumptionchain.exceptions import (
     MempoolFullError,
     MissingBlockError,
 )
-from gumptionchain.models import ChainDAO
+from gumptionchain.models import BlockDAO, ChainDAO
 from gumptionchain.node import Node
 from gumptionchain.payload import (
     StakeKind,
@@ -377,6 +378,42 @@ blueprint.add_url_rule(
     '/block/<mill_hash:block_hash>/<process>',
     view_func=miller_block_view,
     methods=['POST'],
+)
+
+
+class BlocksQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    from_idx: int = Field(ge=0)
+    limit: int = Field(ge=1)
+
+
+class BlocksView(MethodView):
+    def get(self, **kwargs: Any) -> Response:
+        try:
+            model = BlocksQueryModel.model_validate(
+                request.args.to_dict(flat=True)
+            )
+        except ValidationError as e:
+            return make_error_response(_pydantic_validation_error(e))
+        try:
+            limit = min(model.limit, current_app.config['SYNC_BATCH_SIZE'])
+            rows = db.session.scalars(
+                BlockDAO.longest_chain_blocks_range(model.from_idx, limit)
+            ).all()
+            return make_json_response(
+                [json.loads(Block.from_dao(b).to_json()) for b in rows]
+            )
+        except GCError as err:
+            return make_error_response(err)
+        except Exception as e:
+            exception_response(e)
+
+
+blueprint.add_url_rule(
+    '/blocks',
+    view_func=authorize_reader(BlocksView.as_view('blocks_reader')),
+    methods=['GET'],
 )
 
 

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -262,6 +262,23 @@ class ApiClient:
             raise_for_status=raise_for_status,
         )
 
+    def get_blocks(
+        self,
+        from_idx: int,
+        limit: int,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> list[Block]:
+        """Fetch the peer's longest-chain blocks for the height range
+        [from_idx, from_idx+limit), ascending by idx (forward sync)."""
+        response = self.get(
+            '/api/blocks',
+            params={'from_idx': str(from_idx), 'limit': str(limit)},
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )
+        return [Block.from_dict(b) for b in response.json()]
+
     def post_block(
         self,
         block: Block,

--- a/src/gumptionchain/config.py
+++ b/src/gumptionchain/config.py
@@ -35,6 +35,7 @@ class EnvAppSettings(EnvironSettings):
     PEERS: list[str] = field(default_factory=list)
     API_CLIENT_TIMEOUT: int = field(default=10)
     MAX_CHAIN_FILL_DEPTH: int = field(default=50000)
+    SYNC_BATCH_SIZE: int = field(default=256)
     MAX_PENDING_TXNS: int = field(default=10000)
     API_ASYNC_PROCESSING: bool = field(default=False)
     DEFAULT_COMMAND_HOST: str | None = field(default=None)

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -531,6 +531,27 @@ class BlockDAO(Base):
         )
 
     @classmethod
+    def longest_chain_blocks_range(
+        cls, from_idx: int, limit: int
+    ) -> Select[tuple[BlockDAO]]:
+        """Longest-chain blocks at positions from_idx .. from_idx+limit-1,
+        ascending (genesis→tip). `position` is 0-at-genesis and equals the
+        block height, so this serves a height-range fetch (forward sync).
+        """
+        return (  # type: ignore[no-any-return]
+            db.select(BlockDAO)
+            .join(
+                LongestChainBlockDAO,
+                BlockDAO.id == LongestChainBlockDAO.block_id,
+            )
+            .where(
+                LongestChainBlockDAO.position >= from_idx,
+                LongestChainBlockDAO.position < from_idx + limit,
+            )
+            .order_by(LongestChainBlockDAO.position)
+        )
+
+    @classmethod
     def transaction_counts(cls, block_ids: list[int]) -> dict[int, int]:
         """Map block id → transaction count for the given blocks.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+import datetime
+import json
 from datetime import timedelta
 
 import httpx
@@ -7,11 +9,12 @@ from gumptionchain import create_app, signing
 from gumptionchain.api import Role
 from gumptionchain.api_client import ApiClient
 from gumptionchain.block import Block
+from gumptionchain.chain import Chain
 from gumptionchain.exceptions import InvalidRoleConfigError
 from gumptionchain.miller import Miller
 from gumptionchain.milling import mill_hash_str
 from gumptionchain.tasks import post_process
-from gumptionchain.transaction import Transaction
+from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import host_address, now
 from gumptionchain.wallet import Wallet
 
@@ -116,6 +119,117 @@ def test_get_invalid_block(app, host, mill_block, requests_proxy, wallet):
         _m, _b = mill_block(wallet)
         with pytest.raises(httpx.HTTPStatusError, match='404'):
             ApiClient(host, wallet).get_block(block_hash='foo')
+
+
+def test_get_blocks_range(app, host, mill_block, requests_proxy, wallet):
+    with app.app_context():
+        _m, b0 = mill_block(wallet)  # idx 0 (genesis)
+        _m, b1 = mill_block(wallet)  # idx 1
+        response = ApiClient(host, wallet).get(
+            '/api/blocks', params={'from_idx': '0', 'limit': '2'}
+        )
+        assert response.status_code == httpx.codes.OK
+        blocks = [Block.from_json(json.dumps(b)) for b in response.json()]
+        assert [b.idx for b in blocks] == [0, 1]
+        assert blocks[0].block_hash == b0.block_hash
+        assert blocks[1].block_hash == b1.block_hash
+
+
+def test_get_blocks_clamps_limit(app, host, mill_block, requests_proxy, wallet):
+    with app.app_context():
+        for _ in range(4):
+            mill_block(wallet)
+        app.config['SYNC_BATCH_SIZE'] = 2
+        response = ApiClient(host, wallet).get(
+            '/api/blocks', params={'from_idx': '0', 'limit': '1000'}
+        )
+        assert response.status_code == httpx.codes.OK
+        assert len(response.json()) == 2
+
+
+def test_get_blocks_past_tip_empty(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        response = ApiClient(host, wallet).get(
+            '/api/blocks', params={'from_idx': '50', 'limit': '10'}
+        )
+        assert response.status_code == httpx.codes.OK
+        assert response.json() == []
+
+
+def test_get_blocks_invalid_query(
+    app, host, mill_block, requests_proxy, wallet
+):
+    with app.app_context():
+        mill_block(wallet)
+        client = ApiClient(host, wallet)
+        bad_from = client.get(
+            '/api/blocks',
+            params={'from_idx': '-1', 'limit': '2'},
+            raise_for_status=False,
+        )
+        assert bad_from.status_code == httpx.codes.BAD_REQUEST
+        bad_limit = client.get(
+            '/api/blocks',
+            params={'from_idx': '0', 'limit': '0'},
+            raise_for_status=False,
+        )
+        assert bad_limit.status_code == httpx.codes.BAD_REQUEST
+
+
+def test_get_blocks_excludes_fork(
+    app, host, mill_block, requests_proxy, time_stepper, wallet
+):
+    """Only longest-chain blocks are returned; a fork block at a shared
+    height is absent."""
+    with app.app_context():
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        response = ApiClient(host, wallet).get(
+            '/api/blocks', params={'from_idx': '1', 'limit': '1'}
+        )
+        assert response.status_code == httpx.codes.OK
+        rows = response.json()
+        assert len(rows) == 1
+        canonical = rows[0]['block_hash']
+        assert canonical in {block_2a.block_hash, block_2b.block_hash}
+        other = (
+            block_2b.block_hash
+            if canonical == block_2a.block_hash
+            else block_2a.block_hash
+        )
+        assert all(r['block_hash'] != other for r in rows)
 
 
 def test_post_block(app, host, requests_proxy, wallet):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,6 +3,7 @@ import pytest
 
 from gumptionchain import signing
 from gumptionchain.api_client import ApiClient
+from gumptionchain.block import Block
 from gumptionchain.wallet import Wallet
 
 
@@ -48,6 +49,22 @@ def test_get_attaches_signature_headers(
         assert sent['headers'][signing.H_VERSION] == signing.SIG_VERSION
         assert sent['headers'][signing.H_ADDRESS] == wallet.address
         assert signing.H_SIGNATURE in sent['headers']
+
+
+def test_get_blocks_returns_block_list(
+    app, host, mill_block, requests_proxy, wallet
+):
+    """get_blocks parses the JSON array into a list[Block], ascending by
+    idx."""
+    with app.app_context():
+        _m, b0 = mill_block(wallet)  # idx 0
+        _m, b1 = mill_block(wallet)  # idx 1
+        blocks = ApiClient(host, wallet).get_blocks(0, 2)
+        assert isinstance(blocks, list)
+        assert all(isinstance(b, Block) for b in blocks)
+        assert [b.idx for b in blocks] == [0, 1]
+        assert blocks[0].block_hash == b0.block_hash
+        assert blocks[1].block_hash == b1.block_hash
 
 
 def test_api_client_close_releases_underlying_client(app, host, wallet):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1129,3 +1129,84 @@ def test_ancestry_read_paths_match_oracle_bootstrap(
         assert tip is not None
         oracle_ids = sorted(_pythonic_ancestry_ids(tip))
         assert _oracle_block_ids(tip.ancestry_blocks_q()) == oracle_ids
+
+
+def test_longest_chain_blocks_range_ascending(app, mill_block, wallet):
+    """longest_chain_blocks_range returns the canonical blocks at the
+    requested positions, ascending (genesis→tip)."""
+    with app.app_context():
+        _m, b0 = mill_block(wallet)  # idx 0 (genesis)
+        _m, b1 = mill_block(wallet)  # idx 1
+        _m, b2 = mill_block(wallet)  # idx 2
+
+        rows = db.session.scalars(
+            BlockDAO.longest_chain_blocks_range(1, 2)
+        ).all()
+        assert [r.idx for r in rows] == [1, 2]
+        assert rows[0].block_hash == b1.block_hash
+        assert rows[1].block_hash == b2.block_hash
+        # sanity: genesis is excluded by the from_idx bound.
+        assert b0.idx == 0
+
+
+def test_longest_chain_blocks_range_past_tip_empty(app, mill_block, wallet):
+    """A range entirely past the tip returns no rows."""
+    with app.app_context():
+        mill_block(wallet)  # idx 0
+        mill_block(wallet)  # idx 1
+        rows = db.session.scalars(
+            BlockDAO.longest_chain_blocks_range(5, 3)
+        ).all()
+        assert list(rows) == []
+
+
+def test_longest_chain_blocks_range_excludes_fork(app, time_stepper, wallet):
+    """A fork block at a shared height is not returned — only the
+    longest-chain (materialized) block per position."""
+    with app.app_context():
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+
+        # block_2a and block_2b both live at height 1, but only the
+        # longest chain's block is materialized at that position.
+        rows = db.session.scalars(
+            BlockDAO.longest_chain_blocks_range(1, 1)
+        ).all()
+        assert len(rows) == 1
+        canonical_hash = rows[0].block_hash
+        assert canonical_hash in {block_2a.block_hash, block_2b.block_hash}
+        # The fork block at the same height is absent.
+        other = (
+            block_2b.block_hash
+            if canonical_hash == block_2a.block_hash
+            else block_2a.block_hash
+        )
+        assert all(r.block_hash != other for r in rows)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1210,3 +1210,9 @@ def test_longest_chain_blocks_range_excludes_fork(app, time_stepper, wallet):
             else block_2a.block_hash
         )
         assert all(r.block_hash != other for r in rows)
+        # Pin WHICH block is canonical: the range query must agree with the
+        # established longest-chain query at this height. A wrong join/filter
+        # that returned the fork block would disagree here.
+        lc_blocks = db.session.scalars(BlockDAO.longest_chain_blocks_q()).all()
+        lc_at_1 = next(b for b in lc_blocks if b.idx == 1)
+        assert canonical_hash == lc_at_1.block_hash


### PR DESCRIPTION
PR 1 of 2 for **#163** (resumable forward block sync). The **server primitive**: a READER-authed endpoint that serves the longest-chain blocks for a height range, plus the client method + config. No sync logic yet (that's PR 2).

## What
- **`GET /api/blocks?from_idx=K&limit=N`** (READER) → JSON array of the **longest-chain** blocks at heights K..K+N-1, ascending. `limit` clamped to `SYNC_BATCH_SIZE` server-side; past-tip → `[]`; `from_idx<0`/`limit<1`/unknown params → 400 (pydantic, `extra='forbid'`).
- **`BlockDAO.longest_chain_blocks_range`** — joins `LongestChainBlockDAO` (so only canonical blocks; fork blocks at a shared height excluded), filters `position` (0-at-genesis == height), ascending.
- **`ApiClient.get_blocks(from_idx, limit) -> list[Block]`** (signed GET, round-trips via `Block.from_dict`).
- **`SYNC_BATCH_SIZE`** config (default 256; env `GC_SYNC_BATCH_SIZE`) — batch size + server clamp.

## Safety
Peer-facing but no new info (same block data as `GET /block/<hash>`); READER auth; `limit` clamped before SQL (≤256 rows); `from_idx` is an indexed range scan (no table scan past tip). Reviewed APPROVED — query correctness, DoS surface, round-trip, validation all confirmed; strengthened the fork test to pin the canonical block.

## Tests
range/clamp/empty-past-tip/400s/fork-excluded (model + API)/client round-trip. Gates: ruff + mypy + pytest (482).

Spec: `docs/superpowers/specs/2026-06-08-egu-163-forward-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)