### PR TITLE
feat(node): sync_forward — resumable forward block sync (#163 PR2)

### DIFF
--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -399,10 +399,36 @@ def sync_blocks_command() -> None:
         )
         for latest_block, peer in node.request_latest_blocks():
             try:
+                tip = (
+                    node.longest_chain.last_block
+                    if node.longest_chain
+                    else None
+                )
+                local_idx = (
+                    tip.idx if tip is not None and tip.idx is not None else -1
+                )
+                peer_idx = (
+                    latest_block.idx if latest_block.idx is not None else -1
+                )
+                if peer_idx <= local_idx:
+                    # Peer is not ahead of us — nothing to forward-sync.
+                    continue
+                client = node.clients.get(peer)
+                if client is None:
+                    console.print(
+                        f'No client configured for peer {peer}; skipping.',
+                        style='error',
+                    )
+                    continue
                 progress_bar = BlockSyncProgress(peer=peer, console=console)
                 with progress_bar as progress:
-                    node.fill_chain(latest_block, progress=progress)
+                    result = node.sync_forward(client, progress=progress)
                     progress.finish()
+                if result == 'diverged':
+                    console.print(
+                        f'Peer {peer} diverged; stopped before the fork.',
+                        style='error',
+                    )
             except httpx.HTTPStatusError as e:
                 console.print(
                     f'Synchronization failed: {http_error_message(e)}',

--- a/src/gumptionchain/node.py
+++ b/src/gumptionchain/node.py
@@ -11,7 +11,7 @@ from flask import current_app
 from sqlalchemy.exc import SQLAlchemyError
 
 from gumptionchain.block import Block, expiry_cutoff
-from gumptionchain.chain import Chain, is_genesis_block
+from gumptionchain.chain import GENESIS_HASH, Chain, is_genesis_block
 from gumptionchain.database import db
 from gumptionchain.exceptions import (
     DuplicateMinedTransactionError,
@@ -442,3 +442,75 @@ class Node:
             if chain_fill is not None:
                 chain_fill.delete()
         return False
+
+    def sync_forward(self, client: Any, progress: Any | None = None) -> str:
+        """Network-import a peer's longest chain forward by height.
+
+        Fetch the peer's longest-chain blocks in ascending-height batches
+        (`SYNC_BATCH_SIZE` per request) and validate + commit each block
+        genesis-first via `add_block(commit=True)` — the proven per-block
+        `import` model, with a peer's HTTP API as the source instead of a
+        file.
+
+        Resumable: each block is committed as it is validated, so the
+        committed local tip *is* the progress. An interruption leaves a
+        shorter valid chain and a re-run resumes from the new tip. There is
+        no `MAX_CHAIN_FILL_DEPTH` ceiling on this path (that bounds the
+        backward `fill_chain` gossip short-fill, which is untouched).
+
+        Anti-tamper / anti-DoS comes from three checks per block:
+          1. computed-header-hash integrity (`get_header_hash() ==
+             block_hash`) — a peer can't forge a block's identity;
+          2. prev_hash linkage to the current tip (genesis links to
+             `GENESIS_HASH`) — a peer can't splice a fork into our chain;
+          3. full `validate_block` (PoW, merkle, index, txns) inside
+             `add_block` before commit — a peer can't cheaply mint garbage.
+
+        A failure of (1) or (2) means the peer's chain doesn't extend ours
+        (a fork, or a tampered/inconsistent block): this pass is extend-only,
+        so it stops and returns `'diverged'`, having committed nothing past
+        the fork point (full reorg-via-forward-sync is a follow-up). A
+        `validate_block` failure in `add_block` raises and propagates to the
+        caller (the `sync` command's per-peer try/except), having committed
+        only the valid ancestors. A clean run to the peer's tip returns
+        `'caught_up'`.
+        """
+        batch_size = current_app.config['SYNC_BATCH_SIZE']
+        while True:
+            tip = self.longest_chain.last_block if self.longest_chain else None
+            next_idx = (
+                (tip.idx + 1) if tip is not None and tip.idx is not None else 0
+            )
+            blocks = client.get_blocks(next_idx, batch_size)
+            if not blocks:
+                return 'caught_up'
+            for block in blocks:
+                if block.get_header_hash() != block.block_hash:
+                    self.logger.warning(
+                        'sync_forward: header-hash mismatch at idx %s '
+                        '(computed %s != reported %s); aborting',
+                        block.idx,
+                        block.get_header_hash(),
+                        block.block_hash,
+                    )
+                    return 'diverged'
+                tip = (
+                    self.longest_chain.last_block
+                    if self.longest_chain
+                    else None
+                )
+                expected_prev = (
+                    tip.block_hash if tip is not None else GENESIS_HASH
+                )
+                if block.prev_hash != expected_prev:
+                    self.logger.warning(
+                        'sync_forward: diverged at idx %s '
+                        '(expected prev_hash %s, got %s); aborting',
+                        block.idx,
+                        expected_prev,
+                        block.prev_hash,
+                    )
+                    return 'diverged'
+                self.add_block(block, commit=True)
+                if progress is not None:
+                    progress.next()

--- a/src/gumptionchain/node.py
+++ b/src/gumptionchain/node.py
@@ -476,11 +476,23 @@ class Node:
         `'caught_up'`.
         """
         batch_size = current_app.config['SYNC_BATCH_SIZE']
+        last_next_idx: int | None = None
         while True:
             tip = self.longest_chain.last_block if self.longest_chain else None
             next_idx = (
                 (tip.idx + 1) if tip is not None and tip.idx is not None else 0
             )
+            # No-progress guard: if the previous (non-empty) batch failed to
+            # advance the committed tip, the same next_idx recurs — a peer
+            # serving blocks already in our DB but off the longest chain (which
+            # add_block swallows without raising) would otherwise spin forever.
+            # Stop rather than hang.
+            if next_idx == last_next_idx:
+                self.logger.warning(
+                    'sync_forward: no progress at idx %s; aborting', next_idx
+                )
+                return 'diverged'
+            last_next_idx = next_idx
             blocks = client.get_blocks(next_idx, batch_size)
             if not blocks:
                 return 'caught_up'

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,9 +1,16 @@
+import datetime
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest.mock import patch
 
+from gumptionchain.application import create_clients
+from gumptionchain.block import Block
 from gumptionchain.chain import GRAIN_PER_GRIT, REWARD
 from gumptionchain.database import db
+from gumptionchain.miller import Miller
+from gumptionchain.node import Node
+from gumptionchain.util import now
 from gumptionchain.wallet import Wallet
 
 REWARD_GRIT = int(REWARD / GRAIN_PER_GRIT)
@@ -29,20 +36,127 @@ def test_init(app, runner):
         assert 'Initialized the database.' in result.output
 
 
-# def test_sync(
-#     app, remote_app, remote_requests_proxy, runner, remote_chain
-# ):
-#     with app.app_context():
-#         from gumptionchain.miller import Miller
-#         m = Miller(milling_wallet=Wallet())
-#         assert m.longest_chain is None
-#     with remote_app.app_context():
-#         result = runner.invoke(args=['sync'])
-#         assert 'Synchronized the block chain.' in result.output
-#     with app.app_context():
-#         from gumptionchain.miller import Miller
-#         m = Miller(milling_wallet=Wallet())
-#         assert m.longest_chain.block_hash == remote_chain.block_hash
+def _mill_peer_chain(remote_app, miller_2_wallet, count, time_stepper):
+    """Mill `count` blocks on remote_app's chain, returning the tip."""
+    time_step = time_stepper(start=now() - datetime.timedelta(hours=2))
+    with remote_app.app_context():
+        m = Miller(milling_wallet=miller_2_wallet)
+        last = None
+        for _ in range(count):
+            next(time_step)
+            b = m.create_block()
+            m.mill_block(b)
+            last = b
+        return last
+
+
+def _rebuild_local_clients_to_peer(app):
+    """Under the active remote_requests_proxy patch, rebuild app.clients so
+    the local node's peer ApiClient routes into remote_app (the patched
+    _make_client ignores base_url and hits remote_app)."""
+    for c in list(app.clients.values()):
+        c.close()
+    app.clients = create_clients(app)
+
+
+def test_sync_catches_up_to_peer_ahead(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    runner,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """`sync` forward-syncs the local node up to a peer that is ahead."""
+    tip = _mill_peer_chain(remote_app, miller_2_wallet, 4, time_stepper)
+    assert tip.idx == 3
+    with app.app_context():
+        _rebuild_local_clients_to_peer(app)
+        node = Node(
+            host=app.config['NODE_HOST'],
+            peers=app.config['PEERS'],
+            clients=app.clients,
+            logger=app.logger,
+        )
+        assert node.longest_chain is None
+        runner.invoke(args=['sync'])
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        assert lc.last_block.idx == 3
+
+
+def test_sync_noop_when_peer_not_ahead(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    runner,
+    miller_2_wallet,
+    wallet,
+    time_machine,
+    time_stepper,
+):
+    """A peer no further ahead than the local tip is a no-op: sync_forward
+    is never invoked for that peer."""
+    # Peer has a 2-block chain (tip idx 1).
+    _mill_peer_chain(remote_app, miller_2_wallet, 2, time_stepper)
+    with app.app_context():
+        # Local node already has a chain whose tip idx (1) >= peer tip idx.
+        m = Miller(milling_wallet=wallet)
+        b0 = m.create_block()
+        m.mill_block(b0)
+        next(time_stepper(start=now() + datetime.timedelta(seconds=120)))
+        b1 = m.create_block()
+        m.mill_block(b1)
+        _rebuild_local_clients_to_peer(app)
+        node = Node(
+            host=app.config['NODE_HOST'],
+            peers=app.config['PEERS'],
+            clients=app.clients,
+            logger=app.logger,
+        )
+        local_tip = node.longest_chain.last_block.block_hash
+        with patch.object(Node, 'sync_forward') as spy:
+            runner.invoke(args=['sync'])
+            spy.assert_not_called()
+        # Local tip unchanged.
+        assert node.longest_chain.last_block.block_hash == local_tip
+
+
+def test_sync_miller_path_still_uses_fill_chain(
+    app, mill_block, wallet, time_machine
+):
+    """Regression guard: Miller.poll_latest_blocks (the gossip short-fill
+    path) still delegates to fill_chain — NOT sync_forward — for a
+    peer-block not yet in the DB."""
+    with app.app_context():
+        now_dt = now()
+        time_machine.move_to(now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_wallet=wallet)
+        g = m.create_block()
+        m.mill_block(g)
+
+        # A peer-block whose from_db is forced to None below, so
+        # poll_latest_blocks takes the fill_chain (gossip short-fill) branch.
+        time_machine.move_to(now_dt)
+        peer = 'http://peer.host:8000'
+        fresh = Block.from_dict(g.to_dict())
+        assert fresh.block_hash is not None
+
+        with (
+            patch.object(
+                Miller,
+                'request_latest_blocks',
+                return_value=iter([(fresh, peer)]),
+            ),
+            patch.object(Block, 'from_db', return_value=None),
+            patch.object(Miller, 'send_block'),
+            patch.object(Miller, 'fill_chain') as fill_spy,
+            patch.object(Miller, 'sync_forward') as fwd_spy,
+        ):
+            m.poll_latest_blocks()
+        fill_spy.assert_called_once()
+        fwd_spy.assert_not_called()
 
 
 def test_validate(app, mill_block, runner, wallet):

--- a/tests/test_forward_sync.py
+++ b/tests/test_forward_sync.py
@@ -1,0 +1,270 @@
+"""Tests for EGU #163 PR 2 — resumable forward block sync.
+
+`Node.sync_forward` network-imports a peer's longest chain forward by
+height, validating + committing each block genesis-first. These tests stand
+up a peer chain in `remote_app` (routed via `remote_requests_proxy`), build
+an `ApiClient` that signs as the MILLER wallet `remote_app` trusts, and run
+`sync_forward` against the empty/behind local `app`.
+
+The headline case proves the `MAX_CHAIN_FILL_DEPTH` ceiling is gone: a peer
+chain LONGER than the cap is adopted in full, because forward-sync never
+consults that bound.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.block import Block
+from gumptionchain.chain import GENESIS_HASH
+from gumptionchain.miller import Miller
+from gumptionchain.node import Node
+from gumptionchain.util import now
+
+
+def _mill_chain(milling_wallet, count, time_step):
+    """Mill `count` blocks onto the current app's chain (one Miller, the
+    standard create_block -> mill_block flow) under the supplied
+    time_stepper so successive timestamps strictly increase. Returns the
+    final block."""
+    m = Miller(milling_wallet=milling_wallet)
+    last: Block | None = None
+    for _ in range(count):
+        next(time_step)
+        b = m.create_block()
+        m.mill_block(b)
+        last = b
+    assert last is not None
+    return last
+
+
+def _peer_client(remote_host_netloc, miller_2_wallet):
+    """An ApiClient that (under the active remote_requests_proxy) routes
+    into remote_app and signs as miller_2_wallet — MILLER on remote_app,
+    which satisfies the READER-authed /api/blocks endpoint."""
+    host = f'http://{miller_2_wallet.address}@{remote_host_netloc}'
+    return ApiClient(host, miller_2_wallet)
+
+
+def _local_node(app):
+    return Node(
+        host=app.config['NODE_HOST'],
+        peers=app.config['PEERS'],
+        clients=app.clients,
+        logger=app.logger,
+    )
+
+
+def test_sync_forward_adopts_chain_deeper_than_cap(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """Headline #163 test: a peer chain LONGER than MAX_CHAIN_FILL_DEPTH is
+    adopted in full by forward-sync, with SYNC_BATCH_SIZE forcing multiple
+    batches. Proves the depth ceiling does not apply to this path."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    # Peer holds a 7-block chain (idx 0..6).
+    with remote_app.app_context():
+        tip = _mill_chain(miller_2_wallet, 7, time_step)
+        assert tip.idx == 6
+
+    app.config['MAX_CHAIN_FILL_DEPTH'] = 3
+    app.config['SYNC_BATCH_SIZE'] = 2
+    with app.app_context():
+        node = _local_node(app)
+        assert node.longest_chain is None
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+        result = node.sync_forward(client)
+        assert result == 'caught_up'
+        lc = node.longest_chain
+        assert lc is not None
+        assert lc.last_block is not None
+        assert lc.last_block.idx == 6
+
+
+def test_sync_forward_is_resumable_and_idempotent(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """After a partial sync (committed prefix), a re-run resumes from the
+    committed tip and finishes; once caught up it is a no-op returning
+    'caught_up'."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    with remote_app.app_context():
+        tip = _mill_chain(miller_2_wallet, 5, time_step)
+        assert tip.idx == 4
+
+    app.config['SYNC_BATCH_SIZE'] = 2
+    with app.app_context():
+        node = _local_node(app)
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+
+        # Partial sync: stop after the first batch by capping get_blocks.
+        real_get_blocks = client.get_blocks
+        calls = [0]
+
+        def limited_get_blocks(from_idx, limit):
+            calls[0] += 1
+            if calls[0] > 1:
+                return []
+            return real_get_blocks(from_idx, limit)
+
+        client.get_blocks = limited_get_blocks  # type: ignore[method-assign]
+        result = node.sync_forward(client)
+        assert result == 'caught_up'  # saw an empty batch -> stopped
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        partial_idx = lc.last_block.idx
+        assert partial_idx == 1  # only the first batch (idx 0,1) committed
+
+        # Resume from the committed tip with the real client.
+        client.get_blocks = real_get_blocks  # type: ignore[method-assign]
+        result = node.sync_forward(client)
+        assert result == 'caught_up'
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        assert lc.last_block.idx == 4
+
+        # Idempotent: already caught up -> no-op.
+        result = node.sync_forward(client)
+        assert result == 'caught_up'
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        assert lc.last_block.idx == 4
+
+
+def test_sync_forward_detects_divergence(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """A block whose prev_hash does not link to the local tip is a fork:
+    sync_forward stops, returns 'diverged', and commits nothing past the
+    fork point (local tip unchanged)."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    with remote_app.app_context():
+        _mill_chain(miller_2_wallet, 3, time_step)
+
+    app.config['SYNC_BATCH_SIZE'] = 8
+    with app.app_context():
+        node = _local_node(app)
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+        # Sync the genuine chain first so a tip exists.
+        assert node.sync_forward(client) == 'caught_up'
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        tip_before = lc.last_block.block_hash
+        idx_before = lc.last_block.idx
+
+        # Serve, at the NEXT height, a block whose prev_hash does NOT link to
+        # our tip (a forged, well-formed-but-unlinked block).
+        forged = Block.from_dict(lc.last_block.to_dict())
+        # A valid-shaped but non-linking prev_hash (still 64-char hash):
+        forged_prev = 'a' * 64
+        next_idx = idx_before + 1
+
+        def diverging_get_blocks(from_idx, limit):
+            if from_idx > idx_before:
+                # Reuse the real tip block's body but relink it to a
+                # non-tip parent at the next height, recompute its hash so
+                # the integrity check passes (only the LINKAGE check fails).
+                b = Block.from_dict(forged.to_dict())
+                b.link(next_idx, forged_prev, b.target)
+                b.proof_of_work = 0
+                # Re-mill against the easy target so PoW would pass; but the
+                # linkage check fires before validate, so just set a
+                # consistent block_hash for the integrity check.
+                b.block_hash = b.get_header_hash()
+                return [b]
+            return []
+
+        client.get_blocks = diverging_get_blocks  # type: ignore[method-assign]
+        result = node.sync_forward(client)
+        assert result == 'diverged'
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        assert lc.last_block.block_hash == tip_before  # tip unchanged
+        assert lc.last_block.idx == idx_before
+
+
+def test_sync_forward_rejects_header_hash_mismatch(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """A returned block whose computed header hash != its self-reported
+    block_hash is rejected: sync_forward returns 'diverged' and the tip is
+    unchanged."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    with remote_app.app_context():
+        _mill_chain(miller_2_wallet, 2, time_step)
+
+    app.config['SYNC_BATCH_SIZE'] = 8
+    with app.app_context():
+        node = _local_node(app)
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+
+        def tampered_get_blocks(from_idx, limit):
+            # The genesis block, but with a forged self-reported block_hash
+            # that won't equal its computed header hash.
+            blocks = ApiClient.get_blocks(client, from_idx, limit)
+            if blocks:
+                blocks[0].block_hash = 'f' * 64
+            return blocks
+
+        client.get_blocks = tampered_get_blocks  # type: ignore[method-assign]
+        result = node.sync_forward(client)
+        assert result == 'diverged'
+        # Nothing committed: local chain still empty.
+        assert node.longest_chain is None
+
+
+def test_sync_forward_links_genesis_to_sentinel(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+):
+    """From an empty node the first block must link to GENESIS_HASH; a real
+    peer genesis does, so the empty-node path adopts it without diverging."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    with remote_app.app_context():
+        genesis = _mill_chain(miller_2_wallet, 1, time_step)
+        assert genesis.prev_hash == GENESIS_HASH
+
+    app.config['SYNC_BATCH_SIZE'] = 8
+    with app.app_context():
+        node = _local_node(app)
+        assert node.longest_chain is None
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+        assert node.sync_forward(client) == 'caught_up'
+        lc = node.longest_chain
+        assert lc is not None and lc.last_block is not None
+        assert lc.last_block.idx == 0

--- a/tests/test_forward_sync.py
+++ b/tests/test_forward_sync.py
@@ -268,3 +268,34 @@ def test_sync_forward_links_genesis_to_sentinel(
         lc = node.longest_chain
         assert lc is not None and lc.last_block is not None
         assert lc.last_block.idx == 0
+
+
+def test_sync_forward_stops_on_no_progress(
+    app,
+    remote_app,
+    remote_requests_proxy,
+    remote_host_netloc,
+    miller_2_wallet,
+    time_machine,
+    time_stepper,
+    monkeypatch,
+):
+    """No-progress guard: if a non-empty batch fails to advance the committed
+    tip (e.g. blocks already in the DB that add_block swallows), sync_forward
+    stops with 'diverged' instead of spinning forever. SYNC_BATCH_SIZE=1
+    isolates the guard from the per-block linkage check."""
+    start = now() - datetime.timedelta(hours=2)
+    time_step = time_stepper(start=start)
+    with remote_app.app_context():
+        _mill_chain(miller_2_wallet, 2, time_step)  # peer: genesis + block 1
+
+    app.config['SYNC_BATCH_SIZE'] = 1
+    with app.app_context():
+        node = _local_node(app)
+        client = _peer_client(remote_host_netloc, miller_2_wallet)
+        # Simulate the add_block swallow path: never advance the tip.
+        monkeypatch.setattr(node, 'add_block', lambda *a, **k: None)
+        result = node.sync_forward(client)  # must terminate, not hang
+        assert result == 'diverged'
+        # nothing committed (add_block was a no-op), no infinite loop
+        assert node.longest_chain is None


### PR DESCRIPTION
PR 2 of 2 (the core) for **#163**. `Node.sync_forward` lets a node adopt a chain of any depth from genesis — peer-to-peer, resumably, no depth ceiling, no out-of-band export.

## What
- **`Node.sync_forward(client) -> 'caught_up' | 'diverged'`** — fetches the peer's longest chain forward by height in `SYNC_BATCH_SIZE` batches and validates + commits each block genesis-first via `add_block(commit=True)` (the proven per-block `import` model over HTTP). The **committed tip is the resume point** → inherently resumable, no `ChainFill`, no giant transaction, **`MAX_CHAIN_FILL_DEPTH` not consulted**.
- Anti-tamper per block: (1) `get_header_hash()==block_hash` integrity, (2) **prev_hash linkage** to the current tip (re-read each block, so gaps/out-of-order/forks all fail), (3) full `validate_block` (PoW/merkle/idx/txns). A linkage/integrity failure → `'diverged'`, committing nothing past the fork (detect + defer; full reorg is a follow-up).
- **`sync` command** now forward-syncs each peer ahead of us (peer→`node.clients`), reports diverged; the miller/`fill_chain` gossip path is untouched.

## Safety
Reviewed APPROVED — consensus invariants hold (no path commits a non-extending or invalid block; divergence defers with nothing committed past the fork; the depth ceiling is genuinely gone). The review's one non-termination edge (a non-empty batch that fails to advance the tip → infinite refetch) is **fixed here**: a no-progress guard aborts cleanly, with an isolating test.

## Tests
deeper-than-cap adoption (cap 3, chain 7, empty node adopts all), resumable + idempotent, divergence detect, integrity reject, genesis-sentinel linkage, no-progress guard, `sync`-command catch-up + no-op + miller-still-uses-fill_chain. Gates: ruff + mypy + pytest (491).

**Completes #163.** Spec: `docs/superpowers/specs/2026-06-08-egu-163-forward-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)