### PR TITLE
docs(egu-164): indexed longest() + prune stale fork rows — spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-06-09-egu-164-chaindao-prune-indexed-longest.md
+++ b/docs/superpowers/plans/2026-06-09-egu-164-chaindao-prune-indexed-longest.md
@@ -1,0 +1,118 @@
+# EGU #164 indexed longest() + prune stale forks — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ChainDAO.longest()` cost independent of F (fork-tip count) via a denormalized indexed `tip_idx`, and bound F by pruning stale fork `ChainDAO` rows on canonical block-add — preserving the exact consensus tiebreak.
+
+**Architecture:** `ChainDAO` gains an indexed `tip_idx` (the tip block's height), maintained wherever the tip is set. `longest()` becomes a `MAX(tip_idx)` index lookup + the existing (timestamp, block_hash) tiebreak over only the tied rows. Pruning deletes non-canonical rows >`FORK_PRUNE_DEPTH` behind, hooked into `sync_longest_chain_blocks`'s is-longest branch (chain rows only — no cascade to blocks). Schema change folded into the baseline migration (greenfield, no backfill).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-egu-164-chaindao-prune-indexed-longest-design.md`
+
+**Reference (read first):**
+- `src/gumptionchain/models.py` — `ChainDAO` (`:701`), `__init__`/`set_block_hash`, `chains()`/`longest()` (`:1141`), `_is_longest()`, `sync_longest_chain_blocks` (the `if not self._is_longest(): return` guard + is-longest body), `count()`. `BlockDAO.idx` is `Mapped[int]` (non-null).
+- `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py` — `op.create_table('chain', ...)` (`:80`) + the `batch_alter_table('chain')` index block (`:87`). EDIT THIS (greenfield rule), don't stack a new migration.
+- `src/gumptionchain/config.py` — `EnvAppSettings` (`MAX_CHAIN_FILL_DEPTH`/`SYNC_BATCH_SIZE` fields to mirror).
+- `src/gumptionchain/chain.py` — `Chain.to_db()` calls `dao.sync_longest_chain_blocks()`.
+- Memory: greenfield — fold migrations into the single baseline (rev `63d32cd7621a`), don't stack.
+
+---
+
+## PR 1 — `tip_idx` column + indexed `longest()`
+
+Branch: `feat/egu-164-indexed-longest` off fresh `main`.
+
+### Task 1: add the `tip_idx` column (model + baseline migration)
+
+**Files:** `src/gumptionchain/models.py`, `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py`
+
+- [ ] **Step 1: Model** — add to `ChainDAO`:
+  ```python
+  tip_idx: Mapped[int] = mapped_column(Integer, index=True)
+  ```
+  Maintain it where the tip is set:
+  - in `__init__`, after `self.block = block_dao or BlockDAO.get(block_hash)`, add `self.tip_idx = self.block.idx`.
+  - in `set_block_hash`, after `self.block = BlockDAO.get(block_hash)`, add `self.tip_idx = self.block.idx`.
+  (`self.block.idx` is a non-null `int`.)
+
+- [ ] **Step 2: Baseline migration** — in `63d32cd7621a_initial_schema.py`, add `sa.Column('tip_idx', sa.Integer(), nullable=False)` to the `chain` `create_table`, and a `batch_op.create_index(batch_op.f('ix_chain_tip_idx'), ['tip_idx'], unique=False)` alongside the existing chain indexes.
+
+- [ ] **Step 3: db check** — `uv run gumptionchain db check` passes (model == migration). Commit: `feat(models): denormalized indexed tip_idx on ChainDAO`.
+
+### Task 2: rewrite `longest()` (TDD)
+
+**Files:** `src/gumptionchain/models.py`, `tests/test_models.py`
+
+- [ ] **Step 1: Failing/parity test** — build a multi-fork fixture (mirror the existing `test_longest_chain_block_non_longest_extend_noop` fork-building pattern: chain_a + chain_b, plus a same-height tie). Assert:
+  - `ChainDAO.longest()` returns the chain with the **highest tip idx**;
+  - on a same-tip-idx **tie**, returns the one with the (earliest timestamp, then lowest block_hash) tip — i.e. the SAME row the old `chains().first()` would (you can compute the expected directly from the fork blocks);
+  - empty DB → `None`.
+
+- [ ] **Step 2: Implement** the MAX-subquery `longest()`:
+  ```python
+  @classmethod
+  def longest(cls) -> ChainDAO | None:
+      max_idx = db.select(db.func.max(cls.tip_idx)).scalar_subquery()
+      return (  # type: ignore[no-any-return]
+          db.session.execute(
+              db.select(cls)
+              .join(cls.block)
+              .where(cls.tip_idx == max_idx)
+              .order_by(BlockDAO.timestamp, BlockDAO.block_hash)
+          )
+          .scalars()
+          .first()
+      )
+  ```
+  Leave `chains()` and `_is_longest()` unchanged (chains() still backs the browser /chains view; _is_longest() benefits from the cheaper longest()).
+
+- [ ] **Step 3: Run** → PASS. Confirm the existing materialization/longest tests (`test_unspent_outflows`, `test_longest_chain_block_*`, the oracle-fork tests) still pass (they exercise reorg + longest selection). `uv run mypy`.
+
+- [ ] **Step 4: tip_idx maintenance test** — extending the canonical chain advances the in-place row's `tip_idx`; a fork creates a new row whose `tip_idx` is the fork tip's height. Run full gates. Commit: `feat(models): indexed longest() via tip_idx MAX subquery`. Open PR.
+
+---
+
+## PR 2 — prune stale fork rows
+
+Branch: `feat/egu-164-prune-forks` off fresh `main` (after PR 1).
+
+### Task 3: `FORK_PRUNE_DEPTH` config
+
+**Files:** `src/gumptionchain/config.py`
+
+- [ ] Add `FORK_PRUNE_DEPTH: int = field(default=100)` to `EnvAppSettings` (env `GC_FORK_PRUNE_DEPTH`). Commit: `feat(config): FORK_PRUNE_DEPTH for stale-fork pruning`.
+
+### Task 4: prune on canonical block-add (TDD)
+
+**Files:** `src/gumptionchain/models.py`, `tests/test_models.py`
+
+- [ ] **Step 1: Failing test** — set `app.config['FORK_PRUNE_DEPTH'] = 2`; build a fork at height H (a `ChainDAO` row at tip_idx H that loses), then advance the canonical chain to height > H + 2 (mill several blocks). Assert:
+  - the stale fork's `ChainDAO` row is **deleted** (`ChainDAO.count()` reflects it; or query by the fork tip hash → None);
+  - the canonical `ChainDAO` row remains;
+  - a fork **within** depth (tip_idx >= canonical_tip_idx - 2) is **not** pruned;
+  - the fork's **`BlockDAO` rows still exist** (`BlockDAO.get(fork_tip_hash)` is not None) — no cascade — and the materialization/ancestry are intact.
+
+- [ ] **Step 2: Implement** — add `from flask import current_app` to `models.py` (runs in app context here). Add:
+  ```python
+  def _prune_stale_forks(self) -> None:
+      # Drop non-canonical fork rows whose tip is too far behind to win a
+      # reorg. Deletes `chain` rows only — no cascade to `block` (orphan
+      # blocks remain for provenance / double-spend / fill_chain).
+      depth = current_app.config['FORK_PRUNE_DEPTH']
+      db.session.execute(
+          db.delete(ChainDAO).where(
+              ChainDAO.id != self.id,
+              ChainDAO.tip_idx < self.tip_idx - depth,
+          )
+      )
+  ```
+  Call `self._prune_stale_forks()` inside `sync_longest_chain_blocks`, in the **is-longest path** (i.e. after the early `if not self._is_longest(): return` — `self` is the canonical chain there, with a current `tip_idx`). Place it after the materialization is updated (end of the method) so a prune can't interfere with the reorg walk.
+
+- [ ] **Step 3: Run** → PASS. Confirm no existing reorg/materialization test regresses (prune only removes rows far behind the canonical tip; the within-depth fork tests must still pass). `uv run mypy`.
+
+- [ ] **Step 4: Full gates** (`uv run ruff format src tests && uv run ruff check src tests && uv run mypy && uv run pytest`) + `uv run gumptionchain db check`. Commit: `feat(models): prune stale ChainDAO fork rows on canonical add`. Open PR.
+
+---
+
+## Final
+
+After both PRs merge: final reviewer over the combined diff (focus the `longest()` tiebreak equivalence + the prune safety/no-cascade); update the EGU checklist (#190) to mark #164. Note the deferred milling-round `longest()` caching as a possible follow-up if profiling shows it.

--- a/docs/superpowers/specs/2026-06-09-egu-164-chaindao-prune-indexed-longest-design.md
+++ b/docs/superpowers/specs/2026-06-09-egu-164-chaindao-prune-indexed-longest-design.md
@@ -1,0 +1,144 @@
+# EGU #164 — indexed `longest()` + prune stale fork rows
+
+**Date:** 2026-06-09
+**Issue:** #164 (`ChainDAO.longest()` re-sorts all fork tips on every add/read; stale fork rows never pruned). EGU readiness (#151), launch checklist (#190).
+**Status:** design approved
+
+## Goal
+
+Make `ChainDAO.longest()` cost **independent of F** (the number of `ChainDAO`
+fork-tip rows) and **bound F** so the `chain` table doesn't grow forever — both
+without changing the canonical-chain winner rule. Correctness is unaffected;
+this is a slow-growing perf item that worsens under EGU 1b's faster blocks.
+
+## Background (from the audit map)
+
+- `longest() = SELECT chain JOIN block ORDER BY block.idx DESC, block.timestamp
+  ASC, block.block_hash ASC` → `.first()` — sorts **all** F chain rows (no
+  index covers the join+sort because `chain` doesn't store the tip's idx).
+  Called on every API request and every milling round (the hot path).
+- Winner rule = **pure tip height** (`block.idx`), tiebroken by (timestamp asc,
+  block_hash asc). The tiebreak is **consensus-critical** (nodes must agree on
+  the canonical tip) and must be preserved exactly.
+- A `ChainDAO` row's tip updates **in place** on extend (`set_block_hash`); a new
+  row is born only on a fork (a block whose parent isn't any chain's tip).
+  Stale fork rows are **never deleted**.
+- Pruning a fork's `ChainDAO` row is **safe**: no cascade to `BlockDAO`, so
+  orphan blocks remain (provenance / double-spend detection / `fill_chain` /
+  ancestry all read `BlockDAO`, not fork `ChainDAO` rows). The only effect: a
+  block later building on a pruned fork tip starts a fresh `ChainDAO` row.
+- There is **no `CONFIRMATION_DEPTH`** today; the prune depth is a new knob.
+
+## Part A — indexed `longest()` via a denormalized `tip_idx`
+
+Add `tip_idx: Mapped[int]` to `ChainDAO` (the tip block's height), maintained
+wherever the tip is set:
+- `ChainDAO.__init__(block_hash, block_dao=None)` — after resolving `self.block`,
+  set `self.tip_idx = self.block.idx`.
+- `ChainDAO.set_block_hash(block_hash)` — after re-resolving `self.block`, set
+  `self.tip_idx = self.block.idx`.
+
+Index it: `index=True` on the column (and the baseline migration, see Migration).
+
+Rewrite `longest()` to a MAX-subquery + tiebreak over ties:
+
+```python
+@classmethod
+def longest(cls) -> ChainDAO | None:
+    max_idx = db.select(db.func.max(cls.tip_idx)).scalar_subquery()
+    return (
+        db.session.execute(
+            db.select(cls)
+            .join(cls.block)
+            .where(cls.tip_idx == max_idx)
+            .order_by(BlockDAO.timestamp, BlockDAO.block_hash)
+        )
+        .scalars()
+        .first()
+    )
+```
+
+- `MAX(tip_idx)` is served by the `tip_idx` index — O(log F), no full sort.
+- The outer query joins `block` only for the rows **at** the max tip_idx
+  (usually exactly 1; rarely a few near-simultaneous tied tips), preserving the
+  **exact** existing tiebreak (timestamp asc, block_hash asc). Empty table → no
+  rows → `None`.
+
+`chains()` is **kept unchanged** for the browser `/chains` display (paginated,
+shows all tips) — it's not the hot path, and after pruning F is bounded.
+`longest()` no longer depends on `chains()`.
+
+`_is_longest()` is **unchanged** — it calls `longest()`, which is now cheap, so
+it benefits automatically. (No need to rewrite it; the generation-cache stays.)
+
+## Part B — prune stale fork rows on block-add
+
+When a chain becomes/extends the canonical chain, drop non-canonical fork rows
+whose tip is more than `FORK_PRUNE_DEPTH` blocks behind:
+
+```python
+def _prune_stale_forks(self) -> None:
+    depth = current_app.config['FORK_PRUNE_DEPTH']
+    db.session.execute(
+        db.delete(ChainDAO).where(
+            ChainDAO.id != self.id,
+            ChainDAO.tip_idx < self.tip_idx - depth,
+        )
+    )
+```
+
+- Called from `sync_longest_chain_blocks`'s **is-longest branch** (after it
+  updates the materialization) — the one spot that already knows `self` is the
+  canonical chain and its `tip_idx`, runs in the same session/transaction, and
+  fires on every canonical block accept. (`models.py` gains
+  `from flask import current_app`; it runs in app context here.)
+- A bulk `DELETE` filtered on the indexed `tip_idx` — cheap. Deletes **only**
+  `chain` rows (no cascade to `block`); orphan blocks remain.
+- `FORK_PRUNE_DEPTH` is a new `EnvAppSettings` field (env `GC_FORK_PRUNE_DEPTH`,
+  default **100** — ~8h behind at 5-min blocks; a fork that far back can't
+  realistically out-work the confirmed suffix to win a reorg).
+
+## Migration (greenfield — fold into the baseline)
+
+Per the greenfield rule, **edit the single baseline migration**
+(`src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py`), not a
+new stacked one: add the `tip_idx` column to the `chain` `create_table` + a
+`ix_chain_tip_idx` index (mirroring `ix_chain_block_id`). No backfill (no prod
+data). Tests use `db.create_all()` (the model), so they pick up `tip_idx`
+automatically; `gumptionchain db check` enforces model == migration.
+
+## Testing
+
+- **`longest()` correctness + tiebreak preserved:** build forks at the same and
+  different tip heights; assert `longest()` returns the highest-tip chain, and on
+  an equal-height tie returns the (earliest-timestamp, then lowest-hash) one —
+  identical to the old behavior. A focused test that the new `longest()` agrees
+  with the old `chains().first()` over a multi-fork fixture.
+- **`tip_idx` maintained:** extend the canonical chain → the in-place row's
+  `tip_idx` advances; create a fork → a new row with the fork tip's `tip_idx`.
+- **Prune:** with `FORK_PRUNE_DEPTH` small (e.g. 2), advance the canonical chain
+  past a fork → the stale fork `ChainDAO` row is deleted, the canonical row and
+  recent (within-depth) forks remain; assert the fork's **`BlockDAO` rows still
+  exist** (no cascade) and ancestry/provenance still resolve them.
+- **`db check`:** `uv run gumptionchain db check` passes (model matches the
+  edited baseline).
+- Hard gates: ruff + format, mypy strict, pytest.
+
+## PR decomposition (sequential)
+
+0. **docs** — this spec + the plan.
+1. **`tip_idx` + indexed `longest()`** — the column (model + baseline migration),
+   maintenance in `__init__`/`set_block_hash`, the rewritten `longest()`,
+   `db check` green, and the longest()-correctness/tiebreak + tip_idx tests.
+2. **Prune stale forks** — `FORK_PRUNE_DEPTH` config + `_prune_stale_forks`
+   wired into `sync_longest_chain_blocks`, with the prune/no-cascade tests.
+
+## Out of scope / follow-ups
+
+- Caching `longest()`/`longest_chain` **within a milling round** (the miller
+  calls it per PoW iteration) — a separate per-call-frequency optimization,
+  orthogonal to this F-dependence fix.
+- Pruning orphan `BlockDAO` rows (dangerous — breaks provenance/double-spend
+  detection; explicitly not done).
+- A `CONFIRMATION_DEPTH`/finality policy (the prune depth is a perf bound, not a
+  consensus finality rule).


### PR DESCRIPTION
Design + plan for **#164** — `ChainDAO.longest()` re-sorts all fork tips on every add/read, and stale fork rows are never pruned.

## Approach (both fixes, per the issue)
- **Indexed `longest()`:** denormalize an indexed `tip_idx` onto `ChainDAO` (the tip block's height, maintained in `__init__` + `set_block_hash`). `longest()` becomes `WHERE tip_idx = MAX(tip_idx)` (index-served) + the **exact existing (timestamp asc, block_hash asc) consensus tiebreak** over only the tied rows — O(log F), no sort-all-tips. `chains()` (browser `/chains` display) and `_is_longest()` unchanged.
- **Prune stale forks:** on canonical block-add (in `sync_longest_chain_blocks`'s is-longest branch), delete non-canonical `ChainDAO` rows whose tip is >`FORK_PRUNE_DEPTH` (default 100 ≈ 8h at 5-min blocks) behind. **Chain rows only — no cascade to `BlockDAO`**, so orphan blocks remain for provenance / double-spend / `fill_chain`.

## Notes
- Winner rule is pure tip height; the tiebreak is consensus-critical and preserved exactly.
- Pruning a fork's `ChainDAO` row is safe (no cascade; a later block on that tip just starts a fresh row).
- Schema change **folded into the baseline migration** (greenfield, no backfill); `db check` enforces model == migration.

Two sequential PRs: (1) tip_idx + indexed longest(), (2) prune + config.

Spec: `docs/superpowers/specs/2026-06-09-egu-164-chaindao-prune-indexed-longest-design.md`
Plan: `docs/superpowers/plans/2026-06-09-egu-164-chaindao-prune-indexed-longest.md`

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)