### PR TITLE
feat(models): prune stale ChainDAO fork rows on canonical add (#164 PR2)

### DIFF
--- a/src/gumptionchain/config.py
+++ b/src/gumptionchain/config.py
@@ -35,6 +35,7 @@ class EnvAppSettings(EnvironSettings):
     PEERS: list[str] = field(default_factory=list)
     API_CLIENT_TIMEOUT: int = field(default=10)
     MAX_CHAIN_FILL_DEPTH: int = field(default=50000)
+    FORK_PRUNE_DEPTH: int = field(default=100)
     SYNC_BATCH_SIZE: int = field(default=256)
     MAX_PENDING_TXNS: int = field(default=10000)
     API_ASYNC_PROCESSING: bool = field(default=False)

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Generator
 from typing import Any, ClassVar
 
+from flask import current_app
 from sqlalchemy import (
     BigInteger,
     DateTime,
@@ -938,6 +939,20 @@ class ChainDAO(Base):
         if not self._is_longest():
             return
 
+        self._sync_materialization()
+
+        # On every canonical block accept, drop stale fork rows that
+        # can no longer win a reorg. Placed at the END (after the
+        # materialization is updated) so it can't interfere with the
+        # reorg walk. self is the canonical chain here, with a current
+        # tip_idx.
+        self._prune_stale_forks()
+
+    def _sync_materialization(self) -> None:
+        """Reconcile the longest_chain_block materialization with this
+        (canonical) chain via the smart-reorg walk. Caller has already
+        confirmed self is the longest chain.
+        """
         # Bootstrap fast-path: empty materialization → use the
         # rebuild method directly, skipping per-step lookups against
         # an empty table.
@@ -998,6 +1013,19 @@ class ChainDAO(Base):
                 )
             )
         ChainDAO._bump_generation()
+
+    def _prune_stale_forks(self) -> None:
+        # Drop non-canonical fork rows whose tip is too far behind to
+        # win a reorg. Deletes `chain` rows only — no cascade to
+        # `block` (orphan blocks remain for provenance / double-spend /
+        # fill_chain).
+        depth = current_app.config['FORK_PRUNE_DEPTH']
+        db.session.execute(
+            db.delete(ChainDAO).where(
+                ChainDAO.id != self.id,
+                ChainDAO.tip_idx < self.tip_idx - depth,
+            )
+        )
 
     def _rebuild_longest_chain_blocks(self) -> None:
         """Wipe and repopulate longest_chain_block by walking the

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -350,9 +350,10 @@ def test_prune_stale_forks_on_canonical_add(app, time_stepper, wallet):
         chain_b2.to_db()
         shallow_fork_hash = block_5b.block_hash
 
-        # Drive canonical past depth: idx 5, 6, 7 so canonical tip_idx (7)
-        # > deep fork (1) + depth (2), and > shallow fork (4) is NOT yet
-        # 4 < 7 - 2 = 5 → shallow within depth, must survive.
+        # Drive canonical to idx 6 (two extends off block_5a at idx 4), so the
+        # prune threshold is 6 - depth(2) = 4: the deep fork (tip_idx 1) is
+        # pruned (1 < 4) while the shallow fork (tip_idx 4) survives (4 is NOT
+        # < 4 — within depth).
         _extend(chain_a)
         canonical_tip = _extend(chain_a)
         canonical_idx = canonical_tip.idx
@@ -361,9 +362,9 @@ def test_prune_stale_forks_on_canonical_add(app, time_stepper, wallet):
         assert canonical_row is not None
         assert canonical_row.tip_idx == canonical_idx
 
-        # Deep fork (tip_idx 1 < 7 - 2 = 5): pruned.
+        # Deep fork (tip_idx 1 < 6 - 2 = 4): pruned.
         assert ChainDAO.get(block_hash=fork_tip_hash) is None
-        # Shallow fork (tip_idx 4 >= 5): NOT pruned (within depth).
+        # Shallow fork (tip_idx 4, NOT < 4): NOT pruned (within depth).
         assert ChainDAO.get(block_hash=shallow_fork_hash) is not None
         # Canonical row survives.
         assert ChainDAO.get(block_hash=canonical_tip.block_hash) is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -260,6 +260,122 @@ def test_longest_chain_block_non_longest_extend_noop(app, time_stepper, wallet):
         ]
 
 
+def test_prune_stale_forks_on_canonical_add(app, time_stepper, wallet):
+    """Advancing the canonical chain past FORK_PRUNE_DEPTH prunes the
+    stale fork's ChainDAO row — chain rows only, no cascade to blocks.
+
+    Builds a deep fork at height 2 (a losing block_2b sharing block_1)
+    plus a shallow within-depth fork near the canonical tip, then drives
+    the canonical chain forward until tip_idx > fork_tip_idx + depth.
+    Asserts the deep fork's ChainDAO row is deleted, the canonical and
+    within-depth rows remain, and the deep fork's BlockDAO survives
+    (ancestry still resolves it).
+    """
+    app.config['FORK_PRUNE_DEPTH'] = 2
+    with app.app_context():
+        time_step = time_stepper(start=datetime.datetime.now(datetime.UTC))
+
+        def _extend(chain):
+            _ = next(time_step)
+            block = Block()
+            chain.link_block(block)
+            chain.seal_block(block, wallet, CoinbaseMetrics())
+            block.mill()
+            chain.add_block(block)
+            chain.to_db()
+            return block
+
+        # block_1 (idx 0), shared root.
+        _ = next(time_step)
+        chain_a = Chain()
+        block_1 = Block()
+        chain_a.link_block(block_1)
+        chain_a.seal_block(block_1, wallet, CoinbaseMetrics())
+        block_1.mill()
+        chain_a.add_block(block_1)
+        chain_a.to_db()
+
+        # block_2a (idx 1, canonical) + block_2b (idx 1, losing fork).
+        _ = next(time_step)
+        block_2a = Block()
+        chain_a.link_block(block_2a)
+        chain_a.seal_block(block_2a, wallet, CoinbaseMetrics())
+        block_2a.mill()
+
+        _ = next(time_step)
+        block_2b = Block()
+        chain_a.link_block(block_2b)
+        chain_a.seal_block(block_2b, wallet, CoinbaseMetrics())
+        block_2b.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_2a)
+        chain_a.to_db()
+
+        _ = next(time_step)
+        chain_b = Chain()
+        chain_b.add_block(block_2b)
+        chain_b.to_db()
+        fork_tip_hash = block_2b.block_hash
+
+        # Deep fork row exists and is at tip_idx 1.
+        deep_fork_row = ChainDAO.get(block_hash=fork_tip_hash)
+        assert deep_fork_row is not None
+        assert deep_fork_row.tip_idx == 1
+
+        # Advance canonical chain to idx 3 (block_3a, block_4a), then
+        # branch a shallow within-depth fork off block_4a at idx 4.
+        _block_3a = _extend(chain_a)
+        _block_4a = _extend(chain_a)
+
+        # Shallow fork: block_5b off block_4a (idx 4), a losing branch.
+        _ = next(time_step)
+        block_5b = Block()
+        chain_a.link_block(block_5b)
+        chain_a.seal_block(block_5b, wallet, CoinbaseMetrics())
+        block_5b.mill()
+        # block_5a (idx 4) is the canonical winner at this height.
+        _ = next(time_step)
+        block_5a = Block()
+        chain_a.link_block(block_5a)
+        chain_a.seal_block(block_5a, wallet, CoinbaseMetrics())
+        block_5a.mill()
+
+        _ = next(time_step)
+        chain_a.add_block(block_5a)
+        chain_a.to_db()
+        _ = next(time_step)
+        chain_b2 = Chain()
+        chain_b2.add_block(block_5b)
+        chain_b2.to_db()
+        shallow_fork_hash = block_5b.block_hash
+
+        # Drive canonical past depth: idx 5, 6, 7 so canonical tip_idx (7)
+        # > deep fork (1) + depth (2), and > shallow fork (4) is NOT yet
+        # 4 < 7 - 2 = 5 → shallow within depth, must survive.
+        _extend(chain_a)
+        canonical_tip = _extend(chain_a)
+        canonical_idx = canonical_tip.idx
+
+        canonical_row = ChainDAO.longest()
+        assert canonical_row is not None
+        assert canonical_row.tip_idx == canonical_idx
+
+        # Deep fork (tip_idx 1 < 7 - 2 = 5): pruned.
+        assert ChainDAO.get(block_hash=fork_tip_hash) is None
+        # Shallow fork (tip_idx 4 >= 5): NOT pruned (within depth).
+        assert ChainDAO.get(block_hash=shallow_fork_hash) is not None
+        # Canonical row survives.
+        assert ChainDAO.get(block_hash=canonical_tip.block_hash) is not None
+
+        # No cascade: the pruned fork's BlockDAO still exists and its
+        # ancestry resolves back to genesis.
+        fork_block = BlockDAO.get(block_hash=fork_tip_hash)
+        assert fork_block is not None
+        ancestry = _pythonic_ancestry_ids(fork_block)
+        assert len(ancestry) == 2  # block_2b + block_1
+
+
 def test_longest_chain_block_property_matches_prev_walk(
     app, mill_block, wallet
 ):


### PR DESCRIPTION
PR 2 of 2 (final) for **#164**. Bounds F (fork-tip count) so the `chain` table doesn't grow forever — using the indexed `tip_idx` from PR 1.

## What
- **`FORK_PRUNE_DEPTH`** config (default 100; env `GC_FORK_PRUNE_DEPTH`).
- **`_prune_stale_forks`** — on each **canonical** block accept, `DELETE FROM chain WHERE id != self.id AND tip_idx < self.tip_idx - depth`. A bulk delete on the indexed `tip_idx`, in the same transaction as the chain save.
- Hooked into `sync_longest_chain_blocks` after the `if not _is_longest(): return` guard (so only the canonical chain prunes).

## Consensus-write-path safety
`sync_longest_chain_blocks` had four exit paths, so the materialization walk was **extracted into `_sync_materialization()`** and the method became `guard → _sync_materialization() → _prune_stale_forks()` — guaranteeing the prune fires on every is-longest path. Reviewed APPROVED:
- **Materialization logic byte-for-byte unchanged** (reviewer diffed pre/post bodies line-by-line).
- Prune gated to the canonical chain; fires on all is-longest paths incl. already-in-sync (idempotent).
- **No cascade to `BlockDAO`** (FK is on the chain side; orphan blocks remain for provenance/double-spend/fill_chain — test asserts ancestry intact).
- Boundary `< tip - depth` (a fork exactly `depth` behind survives); reorg-safety holds (a pruned fork was already too far back to win, and its blocks remain so a later block just starts a fresh row).

## Tests
deep fork pruned, within-depth fork + canonical survive, orphan `BlockDAO` survives + ancestry intact. Gates: ruff + mypy + pytest (496) + `db check`.

**Completes #164.** Spec: `docs/superpowers/specs/2026-06-09-egu-164-chaindao-prune-indexed-longest-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)