### PR TITLE
fix: prune confirmed txns from mempool + read-time canonical filter (#208)

### DIFF
--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -698,7 +698,7 @@ class PendingTxnView(MethodView):
             earliest = args.get('earliest')
             expired = expiry_cutoff(now())
             pending_json = node.pending_txns.query_json(
-                earliest=earliest, expired=expired
+                earliest=earliest, expired=expired, exclude_confirmed=True
             )
             return make_json_response([json.loads(j) for j in pending_json])
         except GCError as err:

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -270,9 +270,12 @@ def address_view(address: str) -> Any:
 def mempool_view() -> Any:
     try:
         # Read-only expiry filter (no prune): the API view prunes on GET,
-        # the browser read just excludes expired rows from the query.
+        # the browser read just excludes expired rows from the query,
+        # and excludes canonical-confirmed txns (#208).
         pending_page = db.paginate(
-            PendingTxnDAO.pending_q(expired=expiry_cutoff(now())),
+            PendingTxnDAO.pending_q(
+                expired=expiry_cutoff(now()), exclude_confirmed=True
+            ),
             error_out=False,
         )
         entries = []

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -84,7 +84,10 @@ def index_view() -> Any:
         if lc is not None:
             subject_count, total_staked = lc.stake_stats()
         # Pending-pool size is independent of the chain (always available).
-        pending_count = PendingTxnDAO.count()
+        # Count what /mempool displays: unexpired + unconfirmed (#208).
+        pending_count = PendingTxnDAO.unconfirmed_count(
+            expired=expiry_cutoff(now())
+        )
     except HTTPException as e:
         return e
     except Exception as e:

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1232,6 +1232,17 @@ class PendingTxnDAO(Base):
         )
 
     @classmethod
+    def unconfirmed_count(cls, expired: datetime.datetime | None = None) -> int:
+        # The home-badge count: unexpired + unconfirmed, matching what
+        # /mempool displays via pending_q(exclude_confirmed=True). Same
+        # open-boundary expiry rule as pending_q / json_datas.
+        stmt = db.select(db.func.count()).select_from(cls)
+        if expired is not None:
+            stmt = stmt.where(cls.timestamp >= expired)
+        stmt = stmt.where(cls._unconfirmed_clause())
+        return db.session.scalar(stmt) or 0
+
+    @classmethod
     def _unconfirmed_clause(cls) -> ColumnElement[bool]:
         # True iff this pending txid is NOT in the canonical chain.
         # Correlated NOT EXISTS over the canonical materialization

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -16,7 +16,9 @@ from sqlalchemy import (
     String,
     Text,
     false,
+    literal,
     or_,
+    select,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -1230,10 +1232,33 @@ class PendingTxnDAO(Base):
         )
 
     @classmethod
+    def _unconfirmed_clause(cls) -> ColumnElement[bool]:
+        # True iff this pending txid is NOT in the canonical chain.
+        # Correlated NOT EXISTS over the canonical materialization
+        # (LongestChainBlockDAO), so it is reorg-safe: an orphaned
+        # block leaves the table and its txns re-qualify as pending.
+        # Same idiom as ChainDAO._unspent_clause (#165).
+        # Uses direct sqlalchemy select/literal (not db.select/db.literal)
+        # so the return type is ColumnElement[bool], not Any.
+        confirmed = (
+            select(literal(1))
+            .select_from(TransactionDAO)
+            .join(TransactionDAO.blocks)
+            .join(
+                LongestChainBlockDAO,
+                LongestChainBlockDAO.block_id == BlockDAO.id,
+            )
+            .where(TransactionDAO.txid == cls.txid)
+        )
+        return ~confirmed.exists()
+
+    @classmethod
     def json_datas(
         cls,
         earliest: datetime.datetime | None = None,
         expired: datetime.datetime | None = None,
+        *,
+        exclude_confirmed: bool = False,
     ) -> Generator[str, None, None]:
         stmt = db.select(cls.json_data)
         if earliest is not None:
@@ -1243,6 +1268,8 @@ class PendingTxnDAO(Base):
             # expired iff its timestamp is strictly older than the cutoff,
             # so keep timestamp >= cutoff (the boundary txn is alive).
             stmt = stmt.where(cls.timestamp >= expired)
+        if exclude_confirmed:
+            stmt = stmt.where(cls._unconfirmed_clause())
         stmt = stmt.order_by(cls.timestamp, cls.txid)
         for (json_data,) in db.session.execute(stmt):
             yield json_data
@@ -1251,12 +1278,16 @@ class PendingTxnDAO(Base):
     def pending_q(
         cls,
         expired: datetime.datetime | None = None,
+        *,
+        exclude_confirmed: bool = False,
     ) -> Select[tuple[PendingTxnDAO]]:
         stmt = db.select(cls)
         if expired is not None:
             # open-boundary expiry, read-only (no prune): keep
             # timestamp >= cutoff (mirrors json_datas / txn_is_expired).
             stmt = stmt.where(cls.timestamp >= expired)
+        if exclude_confirmed:
+            stmt = stmt.where(cls._unconfirmed_clause())
         return stmt.order_by(  # type: ignore[no-any-return]
             cls.received.desc(), cls.txid
         )

--- a/src/gumptionchain/node.py
+++ b/src/gumptionchain/node.py
@@ -180,9 +180,28 @@ class Node:
         if block.block_hash and Block.from_db(block.block_hash):
             return None
         if block := self.add_block(block):  # type: ignore[assignment]
+            self._discard_confirmed_pending(block)
             new_block_signal.send(self, block=block)
             self.send_block(block, visited_hosts=visited_hosts)
         return block
+
+    def _discard_confirmed_pending(self, block: Block) -> None:
+        # A confirmed txn no longer belongs in the mempool: discard the
+        # accepted block's regular txns from the pending pool (discard
+        # is a no-op for txids not pooled here, e.g. txns first seen
+        # inside a gossip-received block). Lives in process_block — not
+        # add_block — so it fires only on live acceptance and never
+        # inside fill_chain's commit=False batch.
+        #
+        # Orphan caveat (accept + document, #208): if this block is
+        # later orphaned by a reorg, its txns are already gone from
+        # THIS node's pool and will not be re-mined here unless a peer
+        # re-gossips them or the sender re-submits. The read-time
+        # canonical filter (exclude_confirmed) keeps the mempool views
+        # correct regardless, so this is a resource trade-off, not a
+        # display or consensus bug.
+        for txn in block.regular_txns:
+            self.pending_txns.discard(txn)
 
     def add_block(self, block: Block, *, commit: bool = True) -> Block | None:
         try:

--- a/src/gumptionchain/node.py
+++ b/src/gumptionchain/node.py
@@ -208,9 +208,6 @@ class Node:
             for txn in block.regular_txns:
                 self.pending_txns.discard(txn)
         except SQLAlchemyError as e:
-            # Best-effort: a failed prune must never block acceptance or
-            # gossip of an already-committed block; the read-time
-            # canonical filter keeps the mempool views correct.
             rollback_session()
             self.logger.warning(e)
 

--- a/src/gumptionchain/node.py
+++ b/src/gumptionchain/node.py
@@ -200,8 +200,19 @@ class Node:
         # canonical filter (exclude_confirmed) keeps the mempool views
         # correct regardless, so this is a resource trade-off, not a
         # display or consensus bug.
-        for txn in block.regular_txns:
-            self.pending_txns.discard(txn)
+        #
+        # Fail-soft: a transient DB error during the prune must never
+        # block acceptance or gossip of an already-committed block; the
+        # read-time canonical filter is the correctness backstop.
+        try:
+            for txn in block.regular_txns:
+                self.pending_txns.discard(txn)
+        except SQLAlchemyError as e:
+            # Best-effort: a failed prune must never block acceptance or
+            # gossip of an already-committed block; the read-time
+            # canonical filter keeps the mempool views correct.
+            rollback_session()
+            self.logger.warning(e)
 
     def add_block(self, block: Block, *, commit: bool = True) -> Block | None:
         try:

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -470,5 +470,11 @@ class PendingTxnSet(MutableSet[Transaction]):
         self,
         earliest: datetime | None = None,
         expired: datetime | None = None,
+        *,
+        exclude_confirmed: bool = False,
     ) -> Iterator[str]:
-        return PendingTxnDAO.json_datas(earliest=earliest, expired=expired)
+        return PendingTxnDAO.json_datas(
+            earliest=earliest,
+            expired=expired,
+            exclude_confirmed=exclude_confirmed,
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from gumptionchain.chain import Chain
 from gumptionchain.exceptions import InvalidRoleConfigError
 from gumptionchain.miller import Miller
 from gumptionchain.milling import mill_hash_str
+from gumptionchain.models import PendingTxnDAO
 from gumptionchain.tasks import post_process
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import host_address, now
@@ -341,6 +342,36 @@ def test_pending_transactions_earliest_returns_recent_txns(
         txns = [Transaction.from_dict(t) for t in response.json()]
         assert len(txns) >= 1
         assert txn in txns
+
+
+def test_pending_transactions_exclude_confirmed(
+    app, host, mill_block, requests_proxy, subject, time_stepper, wallet
+):
+    with app.app_context():
+        time_step = time_stepper()
+        _ = next(time_step)
+        m, _b = mill_block(wallet)
+        _ = next(time_step)
+        confirmed = m.longest_chain.create_opposition(wallet, 1, subject)
+        confirmed.sign()
+        ApiClient(host, wallet).post_transaction(confirmed)
+        _ = next(time_step)
+        m, _b = mill_block(wallet)  # confirms + prunes `confirmed`
+        # simulate re-gossip of the already-mined txn
+        PendingTxnDAO(
+            txid=confirmed.txid,
+            timestamp=confirmed.timestamp_dt,
+            json_data=confirmed.to_json(),
+        ).commit()
+        _ = next(time_step)
+        txn2 = m.longest_chain.create_opposition(wallet, 2, subject)
+        txn2.sign()
+        ApiClient(host, wallet).post_transaction(txn2)
+
+        response = ApiClient(host, wallet).get_pending_transactions()
+        assert response.status_code == httpx.codes.OK
+        txids = [t['txid'] for t in response.json()]
+        assert txids == [txn2.txid]
 
 
 # NOTE: the `app` fixture pre-loads all four *_ADDRESSES (the `wallet`

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -316,10 +316,12 @@ def test_rescind(
             runner, subject_raw, txn_wallet, txnwf, confirm=False
         )
         assert 'Rescind aborted' in result.output
-        assert len(m.pending_txns) == 1
+        assert (
+            len(m.pending_txns) == 0
+        )  # the mill confirmed + pruned the opposition (#208)
         result = run_txn_rescind(runner, subject_raw, txn_wallet, txnwf)
         assert 'Rescind created' in result.output
-        assert len(m.pending_txns) == 2
+        assert len(m.pending_txns) == 1
 
 
 def test_invalid_rescind(
@@ -405,12 +407,14 @@ def test_rescind_support_kind(
             kind='support',
         )
         assert 'Rescind aborted' in result.output
-        assert len(m.pending_txns) == 1
+        assert (
+            len(m.pending_txns) == 0
+        )  # the mill confirmed + pruned the support stake (#208)
         result = run_txn_rescind(
             runner, subject_raw, txn_wallet, txnwf, kind='support'
         )
         assert 'Rescind created' in result.output
-        assert len(m.pending_txns) == 2
+        assert len(m.pending_txns) == 1
 
 
 def test_create_wallet(app, runner):

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,4 +1,10 @@
+import datetime
+import re
+
 from gumptionchain.api_client import ApiClient
+from gumptionchain.block import expiry_cutoff
+from gumptionchain.models import PendingTxnDAO
+from gumptionchain.util import now
 
 
 def _stake_opposition(host, chain, wallet, amount, subject):
@@ -49,3 +55,50 @@ def test_home_shows_pending_count(
         # a Pending stat card with the pool count (1 pending txn)
         assert b'Pending' in body
         assert b'>1<' in body
+
+
+def test_home_pending_count_excludes_confirmed_and_expired(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        confirmed = _stake_opposition(
+            host, m.longest_chain, wallet, 300, subject
+        )
+        m, _b = mill_block(wallet)  # confirms + prunes `confirmed`
+        # re-insert the confirmed txn (simulates re-gossip after mining)
+        PendingTxnDAO(
+            txid=confirmed.txid,
+            timestamp=confirmed.timestamp_dt,
+            json_data=confirmed.to_json(),
+        ).commit()
+        # an expired row (the /mempool view hides it; so must the badge)
+        PendingTxnDAO(
+            txid='a' * 64,
+            timestamp=now() - datetime.timedelta(hours=8),
+            json_data='{}',
+        ).commit()
+        # one live, unconfirmed txn
+        _stake_opposition(host, m.longest_chain, wallet, 200, subject)
+
+        # raw count sees all three; the badge count sees only the live one
+        assert PendingTxnDAO.count() == 3
+        assert (
+            PendingTxnDAO.unconfirmed_count(expired=expiry_cutoff(now())) == 1
+        )
+
+        resp = app.test_client().get('/')
+        assert resp.status_code == 200
+        # Use a regex anchored to the Pending card's HTML structure to
+        # avoid collision: subject_count=1 and pending_count=1 both render
+        # ">1<" in the page. Matching "Pending" label + value div uniquely
+        # identifies the Pending stat card regardless of other card values.
+        assert re.search(
+            rb'Pending</div>\s*<div[^>]*>\s*1\s*</div>',
+            resp.data,
+        ), 'Pending badge should show 1 (live unconfirmed only)'
+        # also verify the raw pool size (3) is NOT shown in the badge
+        assert not re.search(
+            rb'Pending</div>\s*<div[^>]*>\s*3\s*</div>',
+            resp.data,
+        ), 'Pending badge must not show the raw pool count (3)'

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -141,3 +141,19 @@ def test_json_datas_exclude_confirmed(
         top_txid = json.loads(datas[0])['txid']
         assert top_txid == unconfirmed.txid
         assert top_txid != confirmed.txid
+
+
+def test_mempool_view_hides_confirmed_txn(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        confirmed = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        m, _b = mill_block(wallet)  # confirms + prunes `confirmed`
+        _reinsert_pending(confirmed)
+        unconfirmed = _post_pending(host, m.longest_chain, wallet, 200, subject)
+
+        resp = app.test_client().get('/mempool')
+        assert resp.status_code == 200
+        assert unconfirmed.txid.encode() in resp.data
+        assert confirmed.txid.encode() not in resp.data

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -3,9 +3,11 @@ import json
 
 from gumptionchain.api_client import ApiClient
 from gumptionchain.block import expiry_cutoff
+from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import PendingTxnDAO
 from gumptionchain.util import now
+from gumptionchain.wallet import Wallet
 
 
 def _post_pending(host, chain, wallet, amount, subject):
@@ -157,3 +159,43 @@ def test_mempool_view_hides_confirmed_txn(
         assert resp.status_code == 200
         assert unconfirmed.txid.encode() in resp.data
         assert confirmed.txid.encode() not in resp.data
+
+
+def test_exclude_confirmed_is_reorg_safe(
+    add_chain_block, app, host, mill_block, requests_proxy, subject, wallet
+):
+    # An orphaned block leaves LongestChainBlockDAO, so its txns
+    # re-qualify as pending in the filtered reads — i.e. the filter
+    # excludes canonical membership, not any-block membership. Fork
+    # construction mirrors tests/test_chain.py::
+    # test_transaction_provenance_orphaned.
+    with app.app_context():
+        # wallet2 needs no role: add_chain_block writes via
+        # Chain.add_block directly, bypassing the HTTP/auth layer.
+        wallet2 = Wallet()
+        m, b1 = mill_block(wallet)  # genesis
+        txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        m, _b2 = mill_block(wallet)  # b2 confirms + prunes txn
+        _reinsert_pending(txn)
+
+        # while canonical-confirmed: excluded
+        rows = db.session.scalars(
+            PendingTxnDAO.pending_q(exclude_confirmed=True)
+        ).all()
+        assert rows == []
+
+        # orphan b2 with a strictly-longer fork off b1
+        alt = Chain(block_hash=b1.block_hash)
+        add_chain_block(chain=alt, milling_wallet=wallet2)
+        _, _ = add_chain_block(chain=alt, milling_wallet=wallet2)
+        alt.to_db()  # sync_longest_chain_blocks -> alt is canonical
+
+        # txn now sits only in a non-canonical fork block -> it
+        # re-qualifies as pending
+        txids = [
+            row.txid
+            for row in db.session.scalars(
+                PendingTxnDAO.pending_q(exclude_confirmed=True)
+            )
+        ]
+        assert txids == [txn.txid]

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from gumptionchain.api_client import ApiClient
 from gumptionchain.block import expiry_cutoff
@@ -81,3 +82,62 @@ def test_mempool_shows_pending_txn(
         assert str(total_out).encode() in body
         # link-free: no /transaction/<txid> link rendered for it
         assert f'/transaction/{txn.txid}'.encode() not in body
+
+
+def _reinsert_pending(txn):
+    # Simulate re-gossip of an already-mined txn: its pending row exists
+    # while its txid is already canonical.
+    PendingTxnDAO(
+        txid=txn.txid,
+        timestamp=txn.timestamp_dt,
+        json_data=txn.to_json(),
+    ).commit()
+
+
+def test_pending_q_exclude_confirmed(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        confirmed = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        m, _b = mill_block(wallet)  # confirms + prunes `confirmed`
+        _reinsert_pending(confirmed)
+        unconfirmed = _post_pending(host, m.longest_chain, wallet, 200, subject)
+
+        # default (opt-out): both rows return -> no behavior change for
+        # the miller's pending_chain_txns / PendingTxnSet.__iter__
+        txids = {
+            row.txid for row in db.session.scalars(PendingTxnDAO.pending_q())
+        }
+        assert txids == {confirmed.txid, unconfirmed.txid}
+
+        # opt-in: the canonical-confirmed row is excluded
+        txids = {
+            row.txid
+            for row in db.session.scalars(
+                PendingTxnDAO.pending_q(exclude_confirmed=True)
+            )
+        }
+        assert txids == {unconfirmed.txid}
+
+
+def test_json_datas_exclude_confirmed(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b = mill_block(wallet)
+        confirmed = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        m, _b = mill_block(wallet)  # confirms + prunes `confirmed`
+        _reinsert_pending(confirmed)
+        unconfirmed = _post_pending(host, m.longest_chain, wallet, 200, subject)
+
+        # default: both
+        datas = list(PendingTxnDAO.json_datas())
+        assert len(datas) == 2
+
+        # opt-in: only the unconfirmed txn
+        datas = list(PendingTxnDAO.json_datas(exclude_confirmed=True))
+        assert len(datas) == 1
+        top_txid = json.loads(datas[0])['txid']
+        assert top_txid == unconfirmed.txid
+        assert top_txid != confirmed.txid

--- a/tests/test_mempool_prune.py
+++ b/tests/test_mempool_prune.py
@@ -1,0 +1,46 @@
+"""EGU #208: confirmed txns are pruned from the pending pool on live
+block acceptance (Node.process_block), and a txn pruned on a
+later-orphaned block stays out of the pool (accept + document)."""
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.database import db
+from gumptionchain.models import PendingIOflowDAO, PendingTxnDAO
+
+
+def _post_pending(host, chain, wallet, amount, subject):
+    txn = chain.create_opposition(wallet, amount, subject)
+    txn.sign()
+    ApiClient(host, wallet).post_transaction(txn)
+    return txn
+
+
+def _count_ioflows():
+    return (
+        db.session.scalar(
+            db.select(db.func.count()).select_from(PendingIOflowDAO)
+        )
+        or 0
+    )
+
+
+def test_process_block_prunes_confirmed_pending(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b1 = mill_block(wallet)  # genesis funds the wallet
+        txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        assert PendingTxnDAO.count() == 1
+        assert _count_ioflows() == 1  # spends the mined coinbase
+
+        m2, b2 = mill_block(wallet)  # b2 confirms txn
+
+        # the confirmed txn is pruned from the pool (ioflow children
+        # cascade with it)...
+        assert PendingTxnDAO.get(txn.txid) is None
+        assert _count_ioflows() == 0
+        # ...and only it: the coinbase discard is a no-op, so the pool
+        # count drops by exactly the number of regular txns
+        assert len(b2.regular_txns) == 1
+        assert PendingTxnDAO.count() == 0
+        # the txn is canonical
+        assert m2.longest_chain.get_transaction(txn.txid) is not None

--- a/tests/test_mempool_prune.py
+++ b/tests/test_mempool_prune.py
@@ -5,9 +5,11 @@ later-orphaned block stays out of the pool (accept + document)."""
 from sqlalchemy.exc import OperationalError
 
 from gumptionchain.api_client import ApiClient
+from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import PendingIOflowDAO, PendingTxnDAO
 from gumptionchain.transaction import PendingTxnSet
+from gumptionchain.wallet import Wallet
 
 
 def _post_pending(host, chain, wallet, amount, subject):
@@ -71,3 +73,47 @@ def test_prune_failure_does_not_block_acceptance(
         assert m2.longest_chain.get_transaction(txn.txid) is not None
         # ...and the pool row simply lingers (read filter handles display)
         assert PendingTxnDAO.count() == 1
+
+
+def test_orphaned_block_txn_stays_pruned(
+    add_chain_block, app, host, mill_block, requests_proxy, subject, wallet
+):
+    # Accept + document (#208): a txn pruned on a later-orphaned block
+    # is NOT auto-re-added to this node's pool; recovery relies on peer
+    # re-gossip or sender re-submit. Fork construction mirrors
+    # tests/test_chain.py::test_transaction_provenance_orphaned.
+    with app.app_context():
+        wallet2 = Wallet()
+        m, b1 = mill_block(wallet)  # genesis
+        txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        m, _b2 = mill_block(wallet)  # b2 confirms + prunes txn
+        assert PendingTxnDAO.count() == 0
+
+        # build a strictly-longer fork off b1 that excludes b2
+        alt = Chain(block_hash=b1.block_hash)
+        add_chain_block(chain=alt, milling_wallet=wallet2)
+        _, _ = add_chain_block(chain=alt, milling_wallet=wallet2)
+        alt.to_db()  # sync_longest_chain_blocks -> alt is canonical
+
+        # the txn is orphaned (not in the canonical chain)...
+        assert m.longest_chain.get_transaction(txn.txid) is None
+        # ...and stays out of the pool (the documented trade-off)
+        assert PendingTxnDAO.count() == 0
+
+
+def test_prune_handles_multiple_regular_txns(
+    app, host, mill_block, requests_proxy, subject, wallet
+):
+    with app.app_context():
+        m, _b1 = mill_block(wallet)
+        m, _b2 = mill_block(wallet)  # two coinbases to spend from
+        txn1 = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        txn2 = _post_pending(host, m.longest_chain, wallet, 200, subject)
+        assert PendingTxnDAO.count() == 2
+
+        m3, b3 = mill_block(wallet)  # confirms both
+
+        assert len(b3.regular_txns) == 2
+        assert PendingTxnDAO.count() == 0
+        assert m3.longest_chain.get_transaction(txn1.txid) is not None
+        assert m3.longest_chain.get_transaction(txn2.txid) is not None

--- a/tests/test_mempool_prune.py
+++ b/tests/test_mempool_prune.py
@@ -2,9 +2,12 @@
 block acceptance (Node.process_block), and a txn pruned on a
 later-orphaned block stays out of the pool (accept + document)."""
 
+from sqlalchemy.exc import OperationalError
+
 from gumptionchain.api_client import ApiClient
 from gumptionchain.database import db
 from gumptionchain.models import PendingIOflowDAO, PendingTxnDAO
+from gumptionchain.transaction import PendingTxnSet
 
 
 def _post_pending(host, chain, wallet, amount, subject):
@@ -44,3 +47,27 @@ def test_process_block_prunes_confirmed_pending(
         assert PendingTxnDAO.count() == 0
         # the txn is canonical
         assert m2.longest_chain.get_transaction(txn.txid) is not None
+
+
+def test_prune_failure_does_not_block_acceptance(
+    app, host, mill_block, monkeypatch, requests_proxy, subject, wallet
+):
+    # Best-effort prune: a DB error while discarding must not abort
+    # acceptance of the already-committed block (or its gossip).
+    with app.app_context():
+        m, _b1 = mill_block(wallet)
+        txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
+        assert PendingTxnDAO.count() == 1
+
+        def boom(self, txn):
+            stmt = 'stmt'
+            raise OperationalError(stmt, {}, Exception('db down'))
+
+        monkeypatch.setattr(PendingTxnSet, 'discard', boom)
+        m2, b2 = mill_block(wallet)  # must not raise
+
+        # the block was accepted despite the failed prune...
+        assert b2 is not None
+        assert m2.longest_chain.get_transaction(txn.txid) is not None
+        # ...and the pool row simply lingers (read filter handles display)
+        assert PendingTxnDAO.count() == 1

--- a/tests/test_mempool_prune.py
+++ b/tests/test_mempool_prune.py
@@ -83,6 +83,8 @@ def test_orphaned_block_txn_stays_pruned(
     # re-gossip or sender re-submit. Fork construction mirrors
     # tests/test_chain.py::test_transaction_provenance_orphaned.
     with app.app_context():
+        # wallet2 needs no role: add_chain_block writes via Chain.add_block
+        # directly, bypassing the HTTP/auth layer entirely.
         wallet2 = Wallet()
         m, b1 = mill_block(wallet)  # genesis
         txn = _post_pending(host, m.longest_chain, wallet, 300, subject)
@@ -115,5 +117,6 @@ def test_prune_handles_multiple_regular_txns(
 
         assert len(b3.regular_txns) == 2
         assert PendingTxnDAO.count() == 0
+        assert _count_ioflows() == 0
         assert m3.longest_chain.get_transaction(txn1.txid) is not None
         assert m3.longest_chain.get_transaction(txn2.txid) is not None

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -138,20 +138,21 @@ def test_duplicate_transaction(app, time_machine, wallet):
         assert len(m.pending_txns) == 1
         m.mill_block(b1)
         assert len(b1.txns) == 2
-        assert len(m.pending_txns) == 1
+        # b1 confirmed t0 -> pruned from the pool on acceptance (#208)
+        assert len(m.pending_txns) == 0
         b2 = m.create_block()
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
         m.mill_block(b2)
         assert len(b2.txns) == 1
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
         when_dt = when_dt + datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
         b3 = m.create_block()
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
         m.mill_block(b3)
         assert len(b3.txns) == 1
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
         when_dt = when_dt + datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
         t1 = Transaction()
@@ -163,12 +164,13 @@ def test_duplicate_transaction(app, time_machine, wallet):
         m.receive_transaction(t1.txid, t1.to_json())
         when_dt = when_dt + datetime.timedelta(minutes=1)
         time_machine.move_to(when_dt)
-        assert len(m.pending_txns) == 2
-        b4 = m.create_block()
         assert len(m.pending_txns) == 1
+        b4 = m.create_block()
+        # t1 double-spends t0's confirmed inflow -> discarded at build
+        assert len(m.pending_txns) == 0
         m.mill_block(b4)
         assert len(b4.txns) == 1
-        assert len(m.pending_txns) == 1
+        assert len(m.pending_txns) == 0
 
 
 @patch('gumptionchain.miller.MAX_TRANSACTIONS', 10)

--- a/tests/test_query_plans.py
+++ b/tests/test_query_plans.py
@@ -1,8 +1,10 @@
+import datetime
+
 from sqlalchemy import event
 from test_models import _build_canonical_chain_with_spend
 
 from gumptionchain.database import db
-from gumptionchain.models import BlockDAO, ChainDAO
+from gumptionchain.models import BlockDAO, ChainDAO, PendingTxnDAO
 
 
 def _explain_plans(fn):
@@ -104,3 +106,50 @@ def test_balance_read_builds_no_automatic_index(
         assert ('ix_outflow_' in joined) or (
             'ix_inflow_outflow_id' in joined
         ), joined
+
+
+def test_pending_q_exclude_confirmed_uses_index(
+    app, add_chain_block, time_stepper, wallet
+):
+    """pending_q(exclude_confirmed=True) correlated NOT EXISTS must seek via
+    ix_transaction_txid, not SCAN the transaction table or build an AUTOMATIC
+    covering index.
+    """
+    with app.app_context():
+        _chain, _block1, _block2, spend_txid = (
+            _build_canonical_chain_with_spend(
+                add_chain_block, time_stepper, wallet
+            )
+        )
+        # Insert a pending row for the canonical txn so the filter is exercised.
+        PendingTxnDAO(
+            txid=spend_txid,
+            timestamp=datetime.datetime.now(datetime.UTC),
+            json_data='{}',
+        ).commit()
+
+        plans = _explain_plans(
+            lambda: db.session.scalars(
+                PendingTxnDAO.pending_q(exclude_confirmed=True)
+            ).all()
+        )
+        # Isolate the plan lines belonging to the NOT-EXISTS subquery — they
+        # will reference the 'transaction' table.
+        subquery_plans = [p for s, p in plans if 'transaction' in s.lower()]
+        assert subquery_plans, (
+            'expected a query involving the transaction table'
+        )
+        joined = '\n'.join(subquery_plans)
+        # The correlated lookup must use the ix_transaction_txid covering index.
+        assert 'ix_transaction_txid' in joined, joined
+        # No AUTOMATIC covering index should appear on base tables (an AUTOMATIC
+        # on an anon_ materialized subquery is acceptable and out of scope, but
+        # transaction/block_transaction are base tables).
+        base_table_automatic = [
+            line
+            for line in joined.splitlines()
+            if 'AUTOMATIC' in line and ' anon_' not in line
+        ]
+        assert not base_table_automatic, '\n'.join(base_table_automatic)
+        # Full-table scan of transaction must not occur.
+        assert 'SCAN transaction' not in joined, joined

--- a/tests/test_query_plans.py
+++ b/tests/test_query_plans.py
@@ -133,8 +133,9 @@ def test_pending_q_exclude_confirmed_uses_index(
                 PendingTxnDAO.pending_q(exclude_confirmed=True)
             ).all()
         )
-        # Isolate the plan lines belonging to the NOT-EXISTS subquery — they
-        # will reference the 'transaction' table.
+        # Keep the statements that reference the 'transaction' table — i.e.
+        # the one carrying the NOT-EXISTS subquery. Anti-vacuity: if
+        # exclude_confirmed were dropped, no statement would qualify.
         subquery_plans = [p for s, p in plans if 'transaction' in s.lower()]
         assert subquery_plans, (
             'expected a query involving the transaction table'
@@ -142,14 +143,7 @@ def test_pending_q_exclude_confirmed_uses_index(
         joined = '\n'.join(subquery_plans)
         # The correlated lookup must use the ix_transaction_txid covering index.
         assert 'ix_transaction_txid' in joined, joined
-        # No AUTOMATIC covering index should appear on base tables (an AUTOMATIC
-        # on an anon_ materialized subquery is acceptable and out of scope, but
-        # transaction/block_transaction are base tables).
-        base_table_automatic = [
-            line
-            for line in joined.splitlines()
-            if 'AUTOMATIC' in line and ' anon_' not in line
-        ]
-        assert not base_table_automatic, '\n'.join(base_table_automatic)
-        # Full-table scan of transaction must not occur.
+        # This plan materializes nothing, so no AUTOMATIC covering index may
+        # appear anywhere; nor a full scan of transaction.
+        assert 'AUTOMATIC' not in joined, joined
         assert 'SCAN transaction' not in joined, joined


### PR DESCRIPTION
## Summary
- **Part A — prune on acceptance:** `Node.process_block` discards an accepted block's regular txns from the pending pool (new `_discard_confirmed_pending`, fail-soft on `SQLAlchemyError` so a pool hiccup can never block acceptance or gossip of an already-committed block). Live paths only — `fill_chain`'s `commit=False` batch intentionally bypasses. Orphan policy: **accept + document** (pinned by test).
- **Part B — read-time canonical filter:** `PendingTxnDAO._unconfirmed_clause()` — correlated `NOT EXISTS` over `LongestChainBlockDAO` (reorg-safe; same idiom as #165), opt-in via keyword-only `exclude_confirmed=` on `pending_q`/`json_datas`/`PendingTxnSet.query_json`; wired into `/mempool` and `GET /api/transaction/pending`. Miller (`pending_chain_txns`) and `PendingTxnSet.__iter__` keep current semantics (flag defaults off).
- **Part C — home badge consistency:** the Pending stat switches to `unconfirmed_count` (unexpired + unconfirmed), so all three read surfaces share one clause and agree by construction.

Spec: `docs/superpowers/specs/2026-06-09-egu-208-mempool-prune-confirmed-design.md` · Plan: `docs/superpowers/plans/2026-06-09-egu-208-mempool-prune-confirmed.md` (docs PR #239). Closes #208.

Notes for review:
- The spec's `populate_dev_chain.py` cleanup is a no-op — the script never had a manual pool-clear workaround; with Part A, in-process mining naturally leaves an empty mempool.
- The prune loop commits per txn (via `PendingTxnSet.discard`); fine at 5-min blocks, and a one-commit bulk `DELETE` (the `delete_expired` precedent) is a clean follow-up if it ever matters.
- Three pre-existing tests pinned the old lingering-pool behavior and were updated: `test_miller.py::test_duplicate_transaction`, `test_command.py::test_rescind`, `test_command.py::test_rescind_support_kind`.

## Test plan
- [x] `uv run pytest` — 509 passed, 1 skipped (`--runmulti` gate)
- [x] New: `tests/test_mempool_prune.py` (prune, fail-soft, orphan policy, multi-txn); extended: `test_mempool_page.py` (DAO filter, view, reorg-safety), `test_api.py` (API filter), `test_home_page.py` (badge), `test_query_plans.py` (NOT-EXISTS stays index-seeking, anti-vacuous)
- [x] `uv run ruff format --check src tests` / `uv run ruff check src tests` / `uv run mypy` — clean
- [x] `uv run gumptionchain db check` — clean (no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)