### PR TITLE
feat: set benchmarked mainnet MAX_TARGET floor — Z=5 from Pi 3B+ (#169)

### DIFF
--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -50,12 +50,14 @@ from gumptionchain.wallet import Wallet
 GRAIN_PER_GRIT = 100
 GENESIS_HASH = mill_hash_str('GENESIS')
 # MAX_TARGET is the difficulty floor (easiest target) and genesis/initial
-# target. BENCHMARK-PENDING: set the mainnet value on real Pi sha256(sha512)
-# hashrate so a lone Pi finds a block in <=300s. Err easier (too-easy is a
-# self-correcting fast-start that retargeting raises; too-hard stalls genesis
-# before the first retarget at block TARGET_INTERVAL). This is an easy
-# placeholder for dev/testnet.
-MAX_TARGET = '0' * 4 + 'F' * 60
+# target. Benchmarked on the target hardware (#169): Pi 3 B+ single-core
+# mill_hash = 55,547 H/s -> recommended_z floors to Z=5 (expected solve
+# ~19s single-core, ~4.5s --multi; Z=6 would be ~302s, just over the
+# 300s goal). Err-easier by design: the fast-start burst at the floor
+# self-corrects at the first retarget (block TARGET_INTERVAL); a
+# too-hard floor would stall genesis. Re-derive with
+# scripts/benchmark_max_target.py if the baseline hardware changes.
+MAX_TARGET = '0' * 5 + 'F' * 59
 # EGU 1b: flat 5-GRIT non-halving reward, 5-min blocks, 24-block retarget.
 REWARD = 5 * GRAIN_PER_GRIT
 TARGET_GOAL_SECONDS = 300


### PR DESCRIPTION
## Summary
The launch-gate constant, measured on the real target hardware. A Pi 3 Model B+ (Raspberry Pi OS Lite 64-bit, Python 3.12.13) runs the production `mill_work` loop at **55,547 H/s single-core** (231 kH/s on 4 cores). `recommended_z` floors to **Z=5**:

- expected single-core solve @ Z=5: **18.9 s** (≤ 300 s goal; ~4.5 s with `--multi`)
- expected single-core solve @ Z=6: **~302 s** — a hair over the goal, so the err-easier rule steps down

`MAX_TARGET` moves from the `'0'*4` dev placeholder to `'0'*5 + 'F'*59`, and the constant's comment now records the benchmark instead of BENCHMARK-PENDING. No test changes needed: the suite patches `MAX_TARGET` via `easy_mill_chain`, and the consensus guard's assertions (64 hex digits, strictly easier than the legacy 6-zero floor) hold for Z=5.

Full benchmark report: https://github.com/gumptionthomas/gumptionchain/issues/169#issuecomment-4664901924 (harness from #242). Closes #169 — the last EGU 1b launch gate.

## Test plan
- [x] `uv run pytest` — 516 passed, 1 skipped
- [x] ruff format/check + mypy clean
- [x] `tests/test_consensus_constants.py` guard passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)