### PR TITLE
fix: suppress autoflush during block/txn DAO graph construction (#247)

### DIFF
--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -15,6 +15,7 @@ from pydantic import (
 )
 from pymerkle import InmemoryTree, InvalidProof, verify_inclusion
 
+from gumptionchain.database import db
 from gumptionchain.exceptions import (
     ExpiredTransactionError,
     FutureTransactionError,
@@ -348,17 +349,25 @@ class Block:
         ):
             msg = 'Block missing identity fields; cannot persist'
             raise InvalidBlockError(msg)
-        return BlockDAO.get(self.block_hash) or BlockDAO(
-            self.block_hash,
-            self.version,
-            self.idx,
-            self.prev_hash,
-            self.timestamp_dt,
-            self.merkle_root,
-            self.proof_of_work,
-            self.target,
-            transaction_daos=[txn.to_dao() for txn in self.txns],
-        )
+        # no_autoflush across the whole get-or-build (#247): while the
+        # txn DAO graph is mid-construction, a transient InflowDAO is
+        # already linked into a persistent OutflowDAO.inflows collection,
+        # so any query that autoflushes here (e.g. BlockDAO.get(prev_hash)
+        # inside BlockDAO.__init__) would warn ("add operation ... will
+        # not proceed") and skip that half-built cascade. The graph is
+        # enrolled explicitly via session.add in commit().
+        with db.session.no_autoflush:
+            return BlockDAO.get(self.block_hash) or BlockDAO(
+                self.block_hash,
+                self.version,
+                self.idx,
+                self.prev_hash,
+                self.timestamp_dt,
+                self.merkle_root,
+                self.proof_of_work,
+                self.target,
+                transaction_daos=[txn.to_dao() for txn in self.txns],
+            )
 
     def to_db(self, *, commit: bool = True) -> None:
         self.to_dao().commit(commit=commit)

--- a/src/gumptionchain/transaction.py
+++ b/src/gumptionchain/transaction.py
@@ -15,6 +15,7 @@ from pydantic import (
     model_validator,
 )
 
+from gumptionchain.database import db
 from gumptionchain.exceptions import (
     InvalidSignatureError,
     InvalidTransactionError,
@@ -285,32 +286,45 @@ class Transaction:
                 raise InvalidTransactionError(msg)
         txid = self.txid
         timestamp_dt = self.timestamp_dt
-        return TransactionDAO.get(txid) or TransactionDAO(
-            txid,
-            self.version,
-            timestamp_dt,
-            address=self.address,
-            public_key=self.public_key,
-            signature=self.signature,
-            prev_hash=self.prev_hash,
-            inflow_daos=[
-                InflowDAO(txid, idx, inflow.outflow_txid, inflow.outflow_idx)  # type: ignore[arg-type]
-                for idx, inflow in enumerate(self.inflows)
-            ],
-            outflow_daos=[
-                OutflowDAO(
-                    txid,
-                    idx,
-                    outflow.amount,  # type: ignore[arg-type]
-                    address=outflow.address,
-                    opposition=outflow.opposition,
-                    rescind=outflow.rescind,
-                    support=outflow.support,
-                    rescind_kind=outflow.rescind_kind,
-                )
-                for idx, outflow in enumerate(self.outflows)
-            ],
-        )
+        # no_autoflush across the whole get-or-build (#247): when
+        # Block.to_dao() builds several txn DAOs before the explicit
+        # session.add in commit(), an earlier sibling's transient
+        # InflowDAO is already linked into a persistent
+        # OutflowDAO.inflows collection; letting this lookup autoflush
+        # would warn ("add operation ... will not proceed") and skip
+        # that half-built cascade.
+        with db.session.no_autoflush:
+            return TransactionDAO.get(txid) or TransactionDAO(
+                txid,
+                self.version,
+                timestamp_dt,
+                address=self.address,
+                public_key=self.public_key,
+                signature=self.signature,
+                prev_hash=self.prev_hash,
+                inflow_daos=[
+                    InflowDAO(
+                        txid,
+                        idx,
+                        inflow.outflow_txid,  # type: ignore[arg-type]
+                        inflow.outflow_idx,  # type: ignore[arg-type]
+                    )
+                    for idx, inflow in enumerate(self.inflows)
+                ],
+                outflow_daos=[
+                    OutflowDAO(
+                        txid,
+                        idx,
+                        outflow.amount,  # type: ignore[arg-type]
+                        address=outflow.address,
+                        opposition=outflow.opposition,
+                        rescind=outflow.rescind,
+                        support=outflow.support,
+                        rescind_kind=outflow.rescind_kind,
+                    )
+                    for idx, outflow in enumerate(self.outflows)
+                ],
+            )
 
     def to_db(self) -> None:
         self.to_dao().commit()

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -19,6 +19,45 @@ from gumptionchain.util import now
 from gumptionchain.wallet import Wallet
 
 
+@pytest.mark.filterwarnings('error::sqlalchemy.exc.SAWarning')
+def test_mill_confirm_emits_no_sawarnings(
+    app, time_machine, time_stepper, wallet
+):
+    # #247: milling a block that confirms a pending spend autoflushed a
+    # half-built DAO graph — a transient InflowDAO already linked into a
+    # persistent OutflowDAO.inflows — emitting an SAWarning ("add
+    # operation along 'OutflowDAO.inflows' will not proceed") from the
+    # next txn's TransactionDAO.get. The block persisted correctly via
+    # the later explicit add/commit, but the warning class can mask real
+    # lost-row bugs; the mill/confirm path must be warning-clean.
+    with app.app_context():
+        now_dt = now()
+        time_step = time_stepper(start=now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_wallet=wallet)
+        _ = next(time_step)
+        b0 = m.create_block()
+        m.mill_block(b0)
+        _ = next(time_step)
+        cb0 = b0.coinbase
+        cb0_amount = next(iter(cb0.outflows)).amount
+        remit = 2 * GPG
+        t0 = Transaction()
+        t0.add_inflow(Inflow(outflow_txid=cb0.txid, outflow_idx=0))
+        t0.add_outflow(Outflow(amount=remit, address=Wallet().address))
+        t0.add_outflow(
+            Outflow(amount=cb0_amount - remit, address=wallet.address)
+        )
+        t0.set_wallet(wallet)
+        t0.seal()
+        t0.sign()
+        m.receive_transaction(t0.txid, t0.to_json())
+        b1 = m.create_block()
+        m.mill_block(b1)  # confirms t0; must not emit any SAWarning
+        _ = next(time_step)
+        assert m.longest_chain.length == 2
+        time_machine.move_to(now_dt)
+
+
 def test_miller_create_block(app, time_machine, time_stepper, wallet):
     with app.app_context():
         now_dt = now()


### PR DESCRIPTION
Closes #247.

## Root cause (traced, not guessed)

Escalating the warning to an error in the suite produced the exact path: `chain.add_block` → `Block.to_db` → `Block.to_dao` → per-txn `Transaction.to_dao()`. During the loop, a transient `InflowDAO` is linked into the **persistent** `OutflowDAO.inflows` collection of the spent outflow (via `InflowDAO.__init__`'s lookup), marking it dirty. Two construction-time queries then autoflush that half-built graph:

1. the **next** txn's `TransactionDAO.get()` (`transaction.py` → `models.py:108` — the site in the issue), and
2. `BlockDAO.get(prev_hash)` inside `BlockDAO.__init__` (`models.py:281`), which runs after the txn DAO list is built and had no autoflush guard at all.

Benign as the issue verified — `commit()`'s explicit `session.add` cascades the full graph before the real commit — but noisy on every mempool-confirm mill and a mask for real lost-row bugs.

## Fix

The DAO constructors already use SQLAlchemy's documented idiom for this (`no_autoflush` while initializing object graphs), just at too narrow a scope. This PR extends that scope over the whole get-or-build in `Transaction.to_dao()` and `Block.to_dao()`, making domain→DAO conversion atomic w.r.t. autoflush. The hazard window closes at `commit()`, which `session.add`s immediately after construction (verified for both `commit=True` and `commit=False` paths).

## Test

`test_mill_confirm_emits_no_sawarnings` (TDD: watched it fail with the issue's exact warning before each fix step) — mills a block confirming a pending transfer under `@pytest.mark.filterwarnings('error::sqlalchemy.exc.SAWarning')`.

Side effect: suite-wide warning count drops 140 → 75 (the mill-path warning fired in many tests).

## Out of scope (follow-up issue)

A full-suite run under `-W error::sqlalchemy.exc.SAWarning` surfaced a pre-existing sibling of the same hazard class — transient `ChainDAO` linked into persistent `BlockDAO.chains` (`test_chain.py::test_dao`, `test_models.py::test_prune_stale_forks_on_canonical_add`, e.g. via `Chain.to_db`). Verified present on unmodified main; left out per the no-scope-creep convention. Once that's fixed, a suite-wide `filterwarnings = error::sqlalchemy.exc.SAWarning` gate becomes possible.

## How to test

```bash
uv run pytest tests/test_miller.py -q
uv run pytest -q   # 520 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)