### PR TITLE
fix: ChainDAO session hygiene — enroll on create, synchronize fork prune (#249)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,10 @@ testpaths = [
   "tests",
 ]
 filterwarnings = [
-  "ignore:.*SelectableGroups dict interface is deprecated.*"
+  "ignore:.*SelectableGroups dict interface is deprecated.*",
+  # Session-hygiene gate (#247/#249): an SAWarning means the unit of work
+  # refused (or fumbled) an operation on a DAO graph — lost-row risk.
+  "error::sqlalchemy.exc.SAWarning",
 ]
 env_files = [
   "tests/.test.env",

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -762,6 +762,17 @@ class Chain:
                     dao = ChainDAO.get(block_hash=block_hash)
         if dao is None and create:
             dao = ChainDAO(block_hash)
+            # create=True means "make the row exist" (#249): enroll,
+            # flush, and sync the longest-chain materialization so the
+            # returned DAO is a real, queryable row. Anything less
+            # leaves a half-created chain: a transient linked into the
+            # persistent tip's chains collection makes any later
+            # autoflush warn ("add operation ... will not proceed"),
+            # and once flushed by accident, _is_longest routes reads to
+            # a stale, unsynced materialization.
+            db.session.add(dao)
+            db.session.flush()
+            dao.sync_longest_chain_blocks()
         return dao
 
     def to_db(self, *, commit: bool = True) -> None:

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1024,11 +1024,18 @@ class ChainDAO(Base):
         # `block` (orphan blocks remain for provenance / double-spend /
         # fill_chain).
         depth = current_app.config['FORK_PRUNE_DEPTH']
+        # synchronize_session='fetch' (#249): without it, a pruned row's
+        # in-session instance stays persistent in the identity map; when
+        # SQLite reuses the freed rowid for the next chain INSERT, the
+        # flush collides with the stale entry ("Identity map already had
+        # an identity ... replacing it"). 'fetch' marks matched
+        # instances deleted so they leave the map at commit.
         db.session.execute(
             db.delete(ChainDAO).where(
                 ChainDAO.id != self.id,
                 ChainDAO.tip_idx < self.tip_idx - depth,
-            )
+            ),
+            execution_options={'synchronize_session': 'fetch'},
         )
 
     def _rebuild_longest_chain_blocks(self) -> None:


### PR DESCRIPTION
Closes #249 (follow-up to #247/#248).

## Investigation

Instrumented session-state dumps (dirty objects, relationship history, held-instance state, identity-map membership) showed #249 is actually **two distinct bugs**, not one:

### Flavor A — `to_dao(create=True)` returns a half-created chain

`ChainDAO.__init__` links the new instance into the persistent tip `BlockDAO.chains` collection (backref), so the transient returned by `Chain.to_dao(create=True)` leaves the session dirty until someone adds it — any later query autoflushes and warns. A bare `session.add` is **not** enough: the autoflushed INSERT then wins `_is_longest()` while the `longest_chain_block` materialization is stale, silently routing reads to an empty table (caught live as `0 == 8` in `test_dao` when I tried it). The honest contract for `create=True` is "make the row exist": **add + flush + `sync_longest_chain_blocks()`** — exactly `to_db` minus the commit. `to_db`'s own add/flush/sync remain as cheap no-ops on top.

### Flavor B — fork prune leaves a stale identity-map entry

`_prune_stale_forks` bulk-deletes chain rows with no session synchronization. A pruned row's in-session instance stays *persistent* in the identity map; SQLite then **reuses the freed rowid** for the next chain INSERT and the flush collides: `Identity map already had an identity for (ChainDAO, (2,), None), replacing it`. Fixed with `synchronize_session='fetch'` on the delete. Verified empirically with a held reference: after the prune it now goes properly detached and leaves the identity map.

## The gate

With both flavors fixed the entire suite is SAWarning-clean, so the suite-wide gate #249 proposed lands here: `"error::sqlalchemy.exc.SAWarning"` in `[tool.pytest.ini_options].filterwarnings`. Any future session-hygiene regression (the lost-row-masking class from #247) now fails CI instead of scrolling past. TDD: the gate was added first and watched fail on both tests before either fix.

## How to test

```bash
uv run pytest tests/test_chain.py tests/test_models.py -q
uv run pytest -q   # 520 passed, 1 skipped — under the new gate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)