### PR TITLE
docs(egu-251): social binding envelope — design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-06-10-egu-251-social-binding-envelope.md
+++ b/docs/superpowers/plans/2026-06-10-egu-251-social-binding-envelope.md
@@ -1,0 +1,147 @@
+# EGU #251 — Social Binding Envelope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the base-side primitives for wallet↔social bindings: a
+`gc-msg-v1` claim envelope (`{platform, handle, proof_url?}`), Python
+sign/parse/verify, mirrored JS in the wallet ESM, byte-parity + vector
+tests, and the public envelope spec doc.
+
+**Architecture:** Per the approved spec
+(`docs/superpowers/specs/2026-06-10-egu-251-social-binding-envelope-design.md`):
+no new scheme — bindings reuse `gc-msg-v1` exactly as stake attestations do.
+New functions live beside the stake family in
+`src/gumptionchain/attestation.py` and `clients/wallet/gc-attestation.mjs`.
+`verify_binding` is pure (shape + signature; never fetches `proof_url`).
+
+**Tech Stack:** Python (stdlib `json`/`re` + existing `message.py` /
+`wallet.py` primitives), browser-grade ESM (WebCrypto via `gc-wallet.mjs`),
+pytest with Node-subprocess parity harness. Gates:
+`uv run ruff format --check src tests`, `uv run ruff check src tests`,
+`uv run mypy`, `uv run pytest`. No schema change; `db check` unaffected.
+
+**Branch:** `feat/egu-251-social-binding-envelope` off `main` (after this
+docs PR merges). Single implementation PR.
+
+**Verified-in-code facts the implementer needs:**
+
+- `attestation.py` template: `_validate_claim` (raises `BadAttestationError`
+  with single-purpose messages), `build_stake_message` (ordered dict →
+  `json.dumps(..., separators=(',', ':'), ensure_ascii=False)`),
+  `sign_stake_attestation` (wraps `sign_message`), `parse_stake_attestation`
+  (json-load + validate + canonical-reconstruction equality check),
+  `verify_stake` (catches `BadProofError` → re-raises `BadAttestationError`;
+  reasons `'expired'`/`'bad-signature'` chosen via
+  `sig.get('reason') == 'expired'`).
+- `message.py`: `sign_message(wallet, message, timestamp=None)`,
+  `verify_message(proof, max_age=None, now=None)`, `to_armored`/
+  `from_armored`. `BadProofError` importable from `gumptionchain.message`.
+- JS mirror: `clients/wallet/gc-attestation.mjs` — `validateClaim` uses
+  `!== undefined` for off-side key presence; `buildStakeMessage` relies on
+  `JSON.stringify` default separators matching Python's compact form;
+  `parseStakeAttestation` enforces canonical equality;
+  `verifyStake(proof, {fetchProvenance, maxAge, minConfirmations})`.
+- CLI harness: `clients/wallet/attestation-cli.mjs` — `process.argv[2]` is
+  the mode, `process.argv[3]` is a JSON arg; existing modes `build` / `sign`
+  / `verify`. Add `build-binding` / `sign-binding` / `verify-binding`.
+- Parity tests spawn `node` via `subprocess.run([..., mode, json.dumps(p)])`
+  and `@pytest.mark.skipif(shutil.which('node') is None, ...)`; the shared
+  fixed key is `VECTOR_WALLET_B58` from `tests/test_browser_wallet_vectors.py`.
+- Vector fixtures live in `clients/wallet/testdata/` (e.g.
+  `gc-attestation-vectors.json`), regenerated when `GC_REGEN_VECTORS=1`;
+  vector dicts store `{claim, timestamp, message, signature, address}`.
+- `scripts/sync_wallet.py` copies `clients/wallet/*.mjs` →
+  `src/gumptionchain/static/wallet/`, excluding `*.test.mjs` and `*-cli.mjs`.
+  Run it after editing `gc-attestation.mjs`; the vendored copy is part of
+  the diff.
+- Platform regex: keep one source of truth per language —
+  `_PLATFORM_RE = re.compile(r'[a-z0-9-]{1,32}')` with `.fullmatch`
+  (Python) and `/^[a-z0-9-]{1,32}$/` (JS), like `_TXID_RE`/`TXID_RE`.
+- Ruff: 80-col, single quotes; mypy strict (annotate `dict[str, Any]`
+  returns; `parse_social_binding` needs the same
+  `# type: ignore[no-any-return]` as `parse_stake_attestation` if returning
+  a `json.loads` product).
+
+---
+
+### Task 1: Python — claim validation + canonical message + sign/parse (TDD)
+
+**Files:** modify `src/gumptionchain/attestation.py`, `tests/test_attestation.py`
+
+- [ ] **Step 1 (RED):** failing tests in `tests/test_attestation.py`:
+  canonical bytes for minimal claim
+  (`{"platform":"github","handle":"gumptionthomas"}`), field order with
+  `proof_url`, UTF-8 handle unescaped; validation rejections (uppercase /
+  33-char / empty platform; empty / 257-char handle; `http://` and
+  non-string `proof_url`; non-dict claim); sign→parse round-trip;
+  parse rejections (extra key e.g. `txid`, reordered keys, whitespace,
+  `\u`-escaped Unicode, missing message). Also: stake parser rejects a
+  binding proof and vice versa (domain-separation pin).
+- [ ] **Step 2:** watch them fail (ImportError / missing functions).
+- [ ] **Step 3 (GREEN):** implement `_validate_binding_claim`,
+  `build_binding_message`, `sign_social_binding`, `parse_social_binding`
+  mirroring the stake functions.
+- [ ] **Step 4:** full attestation test file green.
+
+### Task 2: Python — `verify_binding` (TDD)
+
+**Files:** modify `src/gumptionchain/attestation.py`, `tests/test_attestation.py`
+
+- [ ] **Step 1 (RED):** verdict tests — valid proof →
+  `{valid: True, checks: {'signature': True}, signer, claim, reasons: []}`;
+  tampered message → `bad-signature`; `max_age` exceeded → `expired`;
+  malformed envelope (no `public_key`) → `BadAttestationError`; signer
+  reported from `proof['address']`.
+- [ ] **Step 2 (GREEN):** implement, mirroring `verify_stake`'s
+  signature-check block (incl. `BadProofError` → `BadAttestationError`).
+
+### Task 3: JS mirrors + CLI modes
+
+**Files:** modify `clients/wallet/gc-attestation.mjs`,
+`clients/wallet/attestation-cli.mjs`
+
+- [ ] **Step 1:** `validateBindingClaim`, `buildBindingMessage`,
+  `signSocialBinding`, `parseSocialBinding`, `verifyBinding` — exact
+  mirrors (off-side/extra handling via canonical equality; `!== undefined`
+  presence checks; `PLATFORM_RE` anchored).
+- [ ] **Step 2:** CLI modes `build-binding` (stdout canonical string),
+  `sign-binding` (`{private_key_b58, claim, timestamp}` → proof JSON),
+  `verify-binding` (`{proof, maxAge?}` → verdict JSON).
+- [ ] **Step 3:** validated by Task 4's parity tests (no separate JS test
+  runner in this repo's suite).
+
+### Task 4: Parity + vectors (TDD against the JS just written)
+
+**Files:** modify `tests/test_attestation_parity.py`,
+`tests/test_attestation_vectors.py`; create
+`clients/wallet/testdata/gc-binding-vectors.json`
+
+- [ ] **Step 1:** parity — `_node('build-binding', CLAIM) ==
+  build_binding_message(CLAIM)` with UTF-8 handle `'tøm'` and a
+  `proof_url` claim; JS `sign-binding` → Python
+  `verify_binding(...)['valid']`; Python `sign_social_binding` → JS
+  `verify-binding` verdict valid.
+- [ ] **Step 2:** vectors — three cases (minimal, `proof_url`, UTF-8
+  handle) with fixed timestamps; generate via `GC_REGEN_VECTORS=1
+  uv run pytest tests/test_attestation_vectors.py`; commit the fixture;
+  verify a clean run validates signatures against the committed bytes.
+
+### Task 5: Vendor sync + public spec doc
+
+**Files:** run `uv run python scripts/sync_wallet.py`; create
+`docs/social-binding-envelope.md`
+
+- [ ] **Step 1:** sync; confirm `git status` shows only the expected
+  vendored `static/wallet/gc-attestation.mjs` change.
+- [ ] **Step 2:** write `docs/social-binding-envelope.md` per the spec's
+  Docs section (claim table, canonical rules, armored statement, worked
+  example with the vector wallet + fixed timestamp, bidirectional model:
+  base checks vs directory-service checks).
+
+### Task 6: Gates + PR
+
+- [ ] `uv run ruff format --check src tests && uv run ruff check src tests`
+- [ ] `uv run mypy`
+- [ ] `uv run pytest` (full suite, SAWarning gate active)
+- [ ] PR `feat(identity): wallet↔social binding envelope — sign, parse,
+  verify (#251)`; subagent review; hold for author review.

--- a/docs/superpowers/specs/2026-06-10-egu-251-social-binding-envelope-design.md
+++ b/docs/superpowers/specs/2026-06-10-egu-251-social-binding-envelope-design.md
@@ -1,0 +1,171 @@
+# EGU #251 — wallet↔social binding envelope (base side of hub#17)
+
+**Date:** 2026-06-10
+**Issue:** #251 (base half of gumptionthomas/gumption-hub#17, under the EGU #3
+federated-identity umbrella #153)
+**Status:** design proposed
+
+## Goal
+
+Define the **claim format and crypto** for binding a wallet address to a
+social handle — the stateless truth primitives every node and EGU app must
+agree on byte-for-byte. The hub keeps the stateful half (fetching the
+social-side post, SSRF guard, binding storage in the proof store, revocation
+UX, handle display): same boundary as verify (base) vs proof store (hub).
+
+A binding is a **Keybase-style bidirectional proof**:
+
+1. **Wallet side (this spec):** the wallet signs a claim
+   `{platform, handle, proof_url?}` as a `gc-msg-v1` proof.
+2. **Social side (hub#17):** the handle's account posts the armored proof at
+   a publicly fetchable URL under its control (gist, Mastodon post,
+   `rel="me"` page).
+3. Verifiers check both directions; base ships direction 1's primitives only.
+
+## Non-goals
+
+- Fetching/validating `proof_url` (hub: outbound HTTP, SSRF allowlist).
+- Binding storage, registry, revocation UX, handle display (hub).
+- On-chain anchoring (possible later via EGU #3 attestation txns;
+  off-chain-first keeps bindings revocable and chain-spam-free).
+
+## Envelope: a `gc-msg-v1` message, like stake attestations
+
+No new scheme. Exactly as `sign_stake_attestation` wraps `sign_message`, a
+binding is a `gc-msg-v1` proof whose `message` is a canonical claim JSON.
+Everything inherited from `gc-msg-v1` stays inherited: RSASSA-PKCS1-v1_5 /
+SHA-384, address self-certification, the armored copy-paste form, and the
+canonical string `gc-msg-v1\n1\n<address>\n<timestamp>\n<sha256(message)>`.
+
+### Claim schema
+
+| Field       | Required | Validation                                          |
+|-------------|----------|-----------------------------------------------------|
+| `platform`  | yes      | `fullmatch([a-z0-9-]{1,32})` — lowercase identifier |
+| `handle`    | yes      | non-empty `str`, ≤ 256 chars                        |
+| `proof_url` | no       | when present: `str` starting `https://`, ≤ 512 chars |
+
+- **`platform`** is an open namespace (`github`, `mastodon`, `web`, `dns`,
+  …) validated by *shape* only. Which platforms a verifier accepts is policy
+  (hub MVP: gist first, Mastodon second) — adding one requires no envelope
+  change.
+- **`handle`** syntax is platform-specific and is the hub's business
+  (`gumptionthomas` vs `@tom@mastodon.social`); base enforces only
+  non-empty/length so canonical bytes are well-defined.
+- **`proof_url` is optional by design** (chicken-and-egg): a gist's URL
+  exists only *after* the signed statement is posted, and DNS TXT proofs
+  have no URL at all. The hub's binding record stores the resolved location;
+  claims include it only for platforms with stable, predictable URLs.
+  `https://` is required when present — an unencrypted proof location is not
+  acceptable evidence.
+- **No `address` field in the claim**: the wallet side of the binding is the
+  envelope's own signer (`proof['address']`, self-certified by `gc-msg-v1`).
+  Duplicating it invites mismatch bugs.
+- **No expiry semantics**: bindings are durable, unlike API signatures.
+  `verify_binding` defaults `max_age=None`; re-verification cadence (and
+  treating a deleted social post as revocation) is hub policy.
+
+### Canonical message
+
+Mirrors `build_stake_message` exactly — ordered dict, compact JSON,
+`ensure_ascii=False` (UTF-8 unescaped, byte-identical to JS
+`JSON.stringify`):
+
+```python
+ordered = {'platform': claim['platform'], 'handle': claim['handle']}
+if claim.get('proof_url') is not None:
+    ordered['proof_url'] = claim['proof_url']
+json.dumps(ordered, separators=(',', ':'), ensure_ascii=False)
+```
+
+Example: `{"platform":"github","handle":"gumptionthomas"}`
+
+Parsing enforces **canonical reconstruction** (same as
+`parse_stake_attestation`): `build_binding_message(claim) != proof['message']`
+→ reject. Extra keys, reordered keys, whitespace, or escaped Unicode are all
+non-canonical; JS and Python agree on accept/reject for any input.
+
+### Domain separation from stake attestations
+
+Structural and total: a binding claim requires `platform` + `handle` and the
+canonical check rejects any extra key; a stake claim requires a 64-hex
+`txid` + `kind` ∈ KINDS. Each parser rejects the other family's messages, so
+no signature can be replayed across claim types. (The optional `handle` field
+on *stake* claims remains what it always was — self-asserted display sugar;
+this envelope is the verifiable link the hub can cross-check it against.)
+
+## Social-side statement
+
+What gets posted publicly is the **armored proof** (`to_armored`/`toArmored`
+— already designed for copy-paste):
+
+```
+-----BEGIN GUMPTION SIGNED MESSAGE-----
+{"platform":"github","handle":"gumptionthomas"}
+-----BEGIN GUMPTION SIGNATURE-----
+<base64 proof JSON>
+-----END GUMPTION SIGNED MESSAGE-----
+```
+
+Byte-reproducible by third parties: armor the proof dict per the existing
+`gc-msg-v1` armored form, no new rules. The hub's fetch step confirms the
+fetched document contains an armored proof whose signature verifies and
+whose claim matches the binding being registered.
+
+## API surface
+
+### Python — `src/gumptionchain/attestation.py` (same module: it is the EGU #3 attestation family)
+
+| Function | Mirrors | Behavior |
+|---|---|---|
+| `build_binding_message(claim) -> str` | `build_stake_message` | validate + canonical JSON |
+| `sign_social_binding(wallet, claim, timestamp=None) -> dict` | `sign_stake_attestation` | `sign_message(wallet, build_binding_message(claim), ...)` |
+| `parse_social_binding(proof) -> dict` | `parse_stake_attestation` | shape + canonical enforcement, returns claim |
+| `verify_binding(proof, max_age=None) -> dict` | `verify_stake` minus on-chain | pure: shape + signature only |
+
+`verify_binding` returns `{valid, checks: {'signature': bool}, signer,
+claim, reasons}` — the same verdict shape as `verify_stake` so the hub can
+merge its own `proofside` check into `checks` and compose `valid`. Malformed
+envelopes raise `BadAttestationError` (reusing the existing error types);
+signature failures report `reasons` `['bad-signature']` or `['expired']`
+exactly as `verify_stake` does. **It never fetches `proof_url`.**
+
+### JS — `clients/wallet/gc-attestation.mjs` (vendored to `static/wallet/` via `scripts/sync_wallet.py`)
+
+`buildBindingMessage(claim)`, `signSocialBinding(wallet, claim,
+{timestamp})`, `parseSocialBinding(proof)`, `verifyBinding(proof,
+{maxAge})` — exact mirrors, same file as the stake functions so consumers
+keep a single import. `attestation-cli.mjs` gains `build-binding` /
+`sign-binding` / `verify-binding` modes for the parity harness.
+
+## Testing
+
+Replicates the stake-attestation pattern wholesale:
+
+- **Unit** (`tests/test_attestation.py`): claim validation table (bad
+  platform charset/length, empty handle, http `proof_url`, extra keys,
+  non-canonical encodings), sign→parse round-trip, `verify_binding` verdict
+  paths (valid / bad-signature / expired / malformed envelope).
+- **Parity** (`tests/test_attestation_parity.py`): byte-identical canonical
+  (`_node('build-binding', CLAIM) == build_binding_message(CLAIM)`) with a
+  UTF-8 handle (e.g. `'tøm'`); JS-signed → Python-verified and vice versa.
+- **Vectors**: new `clients/wallet/testdata/gc-binding-vectors.json`
+  (regen via `GC_REGEN_VECTORS=1`), exercised from
+  `tests/test_attestation_vectors.py` — minimal claim, claim with
+  `proof_url`, UTF-8 handle.
+
+## Docs
+
+`docs/social-binding-envelope.md` — public spec mirroring
+`docs/api-auth-protocol.md`'s level of detail: claim table,
+canonicalization rules, armored statement format, a worked example with
+fixed key/timestamp, and the bidirectional-verification model (what base
+checks vs what a directory service must additionally check).
+
+## PR decomposition
+
+1. **This docs PR** — spec + implementation plan.
+2. **One implementation PR** — Python + JS + CLI modes + tests + vectors +
+   vendored sync + public spec doc (the pieces are byte-coupled by the
+   parity tests; splitting them would create un-mergeable intermediate
+   states).


### PR DESCRIPTION
Design checkpoint for #251 (base side of gumptionthomas/gumption-hub#17, EGU #3 umbrella #153). Spec + plan only — implementation follows in a separate PR once this merges.

## Key design decisions (from the spec)

- **No new scheme**: a binding is a `gc-msg-v1` proof whose `message` is canonical claim JSON — exactly how stake attestations work. Everything (crypto, armored form, freshness machinery) is inherited.
- **Claim** `{platform, handle, proof_url?}`: `platform` is an open lowercase-identifier namespace (shape-validated only — accepting a platform is hub policy, adding one needs no envelope change); `handle` syntax is platform-specific (hub's business); **`proof_url` is optional by design** — a gist URL only exists *after* the statement is posted, and DNS TXT proofs have no URL. `https://` required when present.
- **No `address` in the claim** — the wallet side of the binding is the envelope's self-certified signer; duplicating it invites mismatch bugs.
- **Domain separation is structural and total**: binding claims require `platform`+`handle`; stake claims require `txid`+`kind`; canonical-reconstruction checks reject any cross-family or extended message. (The existing optional `handle` on *stake* claims stays self-asserted display sugar — this envelope is the verifiable link it can be checked against.)
- **`verify_binding` is pure** (shape + signature, `verify_stake`-shaped verdict so the hub can merge its own proof-side check into `checks`); it never fetches `proof_url`.
- **Social-side statement = the armored proof** (`to_armored`) — byte-reproducible, copy-pasteable, no new format.
- **No expiry semantics**: bindings are durable; revocation/recheck cadence is hub policy.

Plan follows the stake-attestation testing pattern wholesale: unit + Node-subprocess byte-parity + regenerable vectors (`gc-binding-vectors.json`), vendor sync, and `docs/social-binding-envelope.md` as the public spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)