### PR TITLE
docs(egu-254): Pi miller distribution — design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-06-10-egu-254-pi-miller-distribution.md
+++ b/docs/superpowers/plans/2026-06-10-egu-254-pi-miller-distribution.md
@@ -1,0 +1,838 @@
+# EGU #254 — Pi Miller Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `deploy/pi/` runtime kit (miller service, auto-update
+timer + script, installer, bench provisioner) plus the public roll-your-own
+HOWTO and the operator appliance runbook.
+
+**Architecture:** Per the approved spec
+(`docs/superpowers/specs/2026-06-10-egu-254-pi-miller-distribution-design.md`):
+one kit, two wrappers. The updater follows a channel (`tags` = highest
+semver `v*` tag for appliances, a branch name for the gcm-01 canary),
+applies `git checkout → uv sync --frozen → db upgrade → unit re-sync →
+restart`, health-gates, and rolls back + skip-files a bad tag. No remote
+access to appliances; everything is outbound.
+
+**Tech Stack:** bash (`set -euo pipefail`, shellcheck-clean), systemd
+units, pytest (script behavior against a local fixture git repo with
+stubbed `systemctl`/`uv` seams), pre-commit shellcheck.
+
+**Branch:** `feat/egu-254-pi-deploy-kit` off `main` (after this docs PR
+merges). Single implementation PR.
+
+**Verified-in-code facts the implementer needs:**
+
+- `gumptionchain mill --peer <peer> <address>` runs forever by default
+  (`--blocks` default 0, `src/gumptionchain/command.py` `mill_command`),
+  polls the peer between PoW rounds (`src/gumptionchain/miller.py`
+  `mill_block` → `poll_latest_blocks`), pushes mined blocks outbound, and
+  catches per-block exceptions (the loop survives transient hub outages).
+  No Flask server runs on a miller.
+- The CLI autoloads `.env` from CWD (python-dotenv); `uv run gumptionchain`
+  works from the repo checkout. `uv` for user `gc` lives at
+  `/home/gc/.local/bin/uv` (gcm-01 precedent).
+- `gumptionchain init` / `db upgrade` need `FLASK_SQLALCHEMY_DATABASE_URI`
+  set — installer must not run them before `.env` exists. Use an
+  **absolute** sqlite path (relative resolves into `src/instance/`).
+- `GC_PEERS` entries are `http(s)://<address>@host` where `<address>` is
+  the **local** wallet address the node signs as; that wallet's `.pem`
+  must be in `GC_WALLET_DIR` and the hub must allowlist the address in
+  its `GC_MILLER_ADDRESSES`.
+- Tests run with the suite-wide `error::sqlalchemy.exc.SAWarning` gate;
+  the new tests here don't touch the DB at all.
+- Ruff only lints `src`/`tests` Python; shell scripts get shellcheck via
+  pre-commit (Task 5). Repo has no `deploy/` directory yet.
+- `git tag --list 'v*' --sort=-version:refname | head -n 1` resolves the
+  highest semver tag (git version-sort handles `v0.10.0 > v0.9.0`).
+- systemd `EnvironmentFile` + `ExecStart=... ${VAR}` expands `${VAR}` as
+  a single word — correct for peer URLs.
+
+## File structure
+
+```
+deploy/pi/
+  gumptionchain-miller.service   # Task 1
+  gumptionchain-update.service   # Task 1
+  gumptionchain-update.timer     # Task 1
+  update.sh                      # Task 2
+  install.sh                     # Task 3
+  provision-appliance.sh         # Task 4
+  custom.toml.example            # Task 4
+tests/test_deploy_pi.py          # Tasks 1–2
+docs/howto-miller-pi.md          # Task 6
+docs/pi-appliance-runbook.md     # Task 7
+.pre-commit-config.yaml          # Task 5 (modify)
+```
+
+---
+
+### Task 1: systemd units + sanity tests
+
+**Files:**
+- Create: `deploy/pi/gumptionchain-miller.service`,
+  `deploy/pi/gumptionchain-update.service`,
+  `deploy/pi/gumptionchain-update.timer`
+- Create: `tests/test_deploy_pi.py`
+
+- [ ] **Step 1: Write the failing sanity tests**
+
+```python
+"""Sanity checks for the deploy/pi kit (string-level; no systemd in CI)."""
+
+from pathlib import Path
+
+DEPLOY = Path(__file__).parent.parent / 'deploy' / 'pi'
+
+
+def test_unit_files_exist_and_are_consistent():
+    miller = (DEPLOY / 'gumptionchain-miller.service').read_text()
+    update = (DEPLOY / 'gumptionchain-update.service').read_text()
+    timer = (DEPLOY / 'gumptionchain-update.timer').read_text()
+    # the miller runs as the gc user from the repo checkout
+    assert 'User=gc' in miller
+    assert 'WorkingDirectory=/home/gc/gumptionchain' in miller
+    assert 'mill --peer ${GC_MILL_PEER} ${GC_MILL_ADDRESS}' in miller
+    assert 'Restart=always' in miller
+    # the updater is root (it restarts units and writes /etc) and points
+    # at a script that exists in the kit
+    assert 'update.sh' in update
+    assert 'User=' not in update  # root
+    script = update.split('ExecStart=')[1].splitlines()[0].strip()
+    assert script == '/home/gc/gumptionchain/deploy/pi/update.sh'
+    assert (DEPLOY / 'update.sh').name in script
+    # timer fires daily with jitter and catches up after downtime
+    assert 'OnCalendar=daily' in timer
+    assert 'RandomizedDelaySec=' in timer
+    assert 'Persistent=true' in timer
+
+
+def test_kit_scripts_are_executable():
+    for name in ('update.sh', 'install.sh', 'provision-appliance.sh'):
+        path = DEPLOY / name
+        assert path.exists(), name
+        assert path.stat().st_mode & 0o111, f'{name} not executable'
+```
+
+(`test_kit_scripts_are_executable` will stay red until Tasks 2–4 land
+their scripts; that's expected — run only the first test for this task's
+GREEN, and keep the second as the cross-task tracker.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_deploy_pi.py -q`
+Expected: FAIL (`FileNotFoundError` — `deploy/pi` doesn't exist)
+
+- [ ] **Step 3: Write the unit files**
+
+`deploy/pi/gumptionchain-miller.service`:
+
+```ini
+[Unit]
+Description=GumptionChain miller
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=exec
+User=gc
+WorkingDirectory=/home/gc/gumptionchain
+EnvironmentFile=/home/gc/gumptionchain/deploy.env
+ExecStart=/home/gc/.local/bin/uv run gumptionchain mill --peer ${GC_MILL_PEER} ${GC_MILL_ADDRESS}
+Restart=always
+RestartSec=10
+# 1 GB Pi 3: a leak degrades to a service restart, not a frozen box.
+MemoryMax=700M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`deploy/pi/gumptionchain-update.service`:
+
+```ini
+[Unit]
+Description=GumptionChain channel update
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/home/gc/gumptionchain/deploy.env
+ExecStart=/home/gc/gumptionchain/deploy/pi/update.sh
+```
+
+`deploy/pi/gumptionchain-update.timer`:
+
+```ini
+[Unit]
+Description=Daily GumptionChain update check
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=4h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 4: Run the first test to verify it passes**
+
+Run: `uv run pytest tests/test_deploy_pi.py::test_unit_files_exist_and_are_consistent -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/pi tests/test_deploy_pi.py
+git commit -m "feat(deploy): Pi miller + update systemd units (#254)"
+```
+
+---
+
+### Task 2: `update.sh` — channel follower with health gate + rollback
+
+**Files:**
+- Create: `deploy/pi/update.sh` (mode 755)
+- Modify: `tests/test_deploy_pi.py`
+
+- [ ] **Step 1: Write the failing behavior tests**
+
+Append to `tests/test_deploy_pi.py`:
+
+```python
+import os
+import shutil
+import subprocess
+
+import pytest
+
+UPDATE_SH = DEPLOY / 'update.sh'
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ['git', *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def kit(tmp_path):
+    """A fixture 'origin' with tags v0.1.0/v0.2.0, a clone on v0.1.0,
+    and stubbed seams (uv, systemctl) that log their invocations."""
+    origin = tmp_path / 'origin.git'
+    work = tmp_path / 'seed'
+    work.mkdir()
+    _git(work, 'init', '-q', '-b', 'main')
+    _git(work, 'config', 'user.email', 't@example.com')
+    _git(work, 'config', 'user.name', 't')
+    (work / 'deploy' / 'pi').mkdir(parents=True)
+    for unit in (
+        'gumptionchain-miller.service',
+        'gumptionchain-update.service',
+        'gumptionchain-update.timer',
+    ):
+        shutil.copy(DEPLOY / unit, work / 'deploy' / 'pi' / unit)
+    (work / 'f.txt').write_text('one\n')
+    _git(work, 'add', '-A')
+    _git(work, 'commit', '-qm', 'one')
+    _git(work, 'tag', 'v0.1.0')
+    (work / 'f.txt').write_text('two\n')
+    _git(work, 'commit', '-aqm', 'two')
+    _git(work, 'tag', 'v0.2.0')
+    _git(work, 'clone', '-q', '--bare', '.', str(origin))
+    repo = tmp_path / 'repo'
+    _git(tmp_path, 'clone', '-q', str(origin), str(repo))
+    _git(repo, 'checkout', '-q', 'v0.1.0')
+
+    log = tmp_path / 'calls.log'
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    uv = bin_dir / 'uv'
+    uv.write_text(f'#!/bin/sh\necho "uv $@" >> {log}\nexit 0\n')
+    uv.chmod(0o755)
+    sysctl = bin_dir / 'systemctl'
+    sysctl.write_text(f'#!/bin/sh\necho "systemctl $@" >> {log}\nexit 0\n')
+    sysctl.chmod(0o755)
+
+    env = os.environ | {
+        'REPO_DIR': str(repo),
+        'AS_GC': '',
+        'SKIP_FILE': str(tmp_path / 'skip'),
+        'UNIT_DIR': str(tmp_path / 'units'),
+        'HEALTH_SETTLE': '0',
+        'PATH': f'{bin_dir}:{os.environ["PATH"]}',
+    }
+    (tmp_path / 'units').mkdir()
+    return {'repo': repo, 'env': env, 'log': log, 'tmp': tmp_path}
+
+
+def _head_tag(repo):
+    out = subprocess.run(
+        ['git', 'describe', '--tags', '--exact-match'],
+        cwd=repo, capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip()
+
+
+def _run_update(kit, **extra):
+    return subprocess.run(
+        [str(UPDATE_SH)],
+        env=kit['env'] | {k: str(v) for k, v in extra.items()},
+        capture_output=True, text=True,
+    )
+
+
+def test_update_follows_highest_tag(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0, result.stderr
+    assert _head_tag(kit['repo']) == 'v0.2.0'
+    calls = kit['log'].read_text()
+    assert 'uv sync --frozen' in calls
+    assert 'gumptionchain db upgrade' in calls
+    assert 'systemctl restart gumptionchain-miller' in calls
+    assert 'systemctl is-active' in calls
+
+
+def test_update_noop_when_current(kit):
+    _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    kit['log'].write_text('')
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0
+    assert 'restart' not in kit['log'].read_text()
+
+
+def test_update_rolls_back_and_skips_bad_tag(kit):
+    # health gate fails (is-active exits 1) -> rollback to v0.1.0 + skip
+    sysctl = kit['tmp'] / 'bin' / 'systemctl'
+    sysctl.write_text(
+        f'#!/bin/sh\necho "systemctl $@" >> {kit["log"]}\n'
+        'case "$1" in is-active) exit 1;; esac\nexit 0\n'
+    )
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode != 0
+    assert _head_tag(kit['repo']) == 'v0.1.0'
+    skip = (kit['tmp'] / 'skip').read_text()
+    assert 'v0.2.0' in skip
+    # next run: bad tag is skipped, exit 0, still on v0.1.0
+    sysctl.write_text(f'#!/bin/sh\necho "systemctl $@" >> {kit["log"]}\nexit 0\n')
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0
+    assert _head_tag(kit['repo']) == 'v0.1.0'
+
+
+def test_update_branch_channel_follows_main(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='main')
+    assert result.returncode == 0, result.stderr
+    head = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'], cwd=kit['repo'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    main = subprocess.run(
+        ['git', 'rev-parse', 'origin/main'], cwd=kit['repo'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head == main
+
+
+def test_update_syncs_changed_unit_files(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0, result.stderr
+    units = kit['tmp'] / 'units'
+    assert (units / 'gumptionchain-miller.service').exists()
+    assert 'systemctl daemon-reload' in kit['log'].read_text()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_deploy_pi.py -q`
+Expected: new tests FAIL (`update.sh` missing)
+
+- [ ] **Step 3: Write `deploy/pi/update.sh`**
+
+```bash
+#!/usr/bin/env bash
+# GumptionChain Pi updater (#254): follow the release channel, migrate,
+# re-sync units, restart, health-gate, roll back on failure. Runs as
+# root from gumptionchain-update.service; repo operations run as the
+# unprivileged gc user. Seams (REPO_DIR/AS_GC/SKIP_FILE/UNIT_DIR/
+# HEALTH_SETTLE and PATH-resolved uv/systemctl) exist for the tests.
+set -euo pipefail
+
+GC_USER="${GC_USER:-gc}"
+REPO_DIR="${REPO_DIR:-/home/${GC_USER}/gumptionchain}"
+CHANNEL="${GC_UPDATE_CHANNEL:-tags}"
+SKIP_FILE="${SKIP_FILE:-/home/${GC_USER}/.gumptionchain-skip-tags}"
+MILLER_UNIT="${MILLER_UNIT:-gumptionchain-miller}"
+AS_GC="${AS_GC-runuser -u ${GC_USER} --}"
+HEALTH_SETTLE="${HEALTH_SETTLE:-60}"
+UNIT_DIR="${UNIT_DIR:-/etc/systemd/system}"
+
+cd "$REPO_DIR"
+
+run_gc() {
+  if [ -n "$AS_GC" ]; then
+    # shellcheck disable=SC2086  # AS_GC is intentionally word-split
+    $AS_GC "$@"
+  else
+    "$@"
+  fi
+}
+
+current_ref() {
+  if [ "$CHANNEL" = 'tags' ]; then
+    run_gc git describe --tags --exact-match 2>/dev/null || echo none
+  else
+    run_gc git rev-parse HEAD
+  fi
+}
+
+target_ref() {
+  if [ "$CHANNEL" = 'tags' ]; then
+    run_gc git tag --list 'v*' --sort=-version:refname | head -n 1
+  else
+    run_gc git rev-parse "origin/${CHANNEL}"
+  fi
+}
+
+apply() {
+  run_gc git checkout --quiet "$1"
+  run_gc uv sync --frozen
+  run_gc uv run gumptionchain db upgrade
+}
+
+sync_units() {
+  local changed=0 name
+  for unit in deploy/pi/*.service deploy/pi/*.timer; do
+    name="$(basename "$unit")"
+    if ! cmp -s "$unit" "${UNIT_DIR}/${name}"; then
+      cp "$unit" "${UNIT_DIR}/${name}"
+      changed=1
+    fi
+  done
+  if [ "$changed" = 1 ]; then
+    systemctl daemon-reload
+  fi
+}
+
+healthy() {
+  sleep "$HEALTH_SETTLE"
+  systemctl is-active --quiet "$MILLER_UNIT"
+}
+
+run_gc git fetch --tags origin
+
+target="$(target_ref)"
+if [ -z "$target" ]; then
+  echo "no release target on channel ${CHANNEL}"
+  exit 0
+fi
+current="$(current_ref)"
+if [ "$target" = "$current" ]; then
+  exit 0
+fi
+if [ "$CHANNEL" = 'tags' ] && [ -f "$SKIP_FILE" ] \
+  && grep -qxF "$target" "$SKIP_FILE"; then
+  echo "skipping known-bad tag ${target}"
+  exit 0
+fi
+
+echo "updating ${current} -> ${target}"
+if apply "$target" && sync_units \
+  && systemctl restart "$MILLER_UNIT" && healthy; then
+  echo "updated to ${target}"
+  exit 0
+fi
+
+echo "update to ${target} failed; rolling back" >&2
+if [ "$CHANNEL" = 'tags' ]; then
+  echo "$target" >>"$SKIP_FILE"
+fi
+if [ "$current" != 'none' ]; then
+  apply "$current" || true
+  sync_units || true
+  systemctl restart "$MILLER_UNIT" || true
+fi
+exit 1
+```
+
+`chmod 755 deploy/pi/update.sh`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_deploy_pi.py -q`
+Expected: all PASS except `test_kit_scripts_are_executable` (waits on
+Tasks 3–4). Also run `bash -n deploy/pi/update.sh` — clean. (shellcheck
+arrives as a pre-commit hook in Task 5 and re-gates every kit script.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/pi/update.sh tests/test_deploy_pi.py
+git commit -m "feat(deploy): channel-following updater with health gate + rollback (#254)"
+```
+
+---
+
+### Task 3: `install.sh` — shared idempotent installer
+
+**Files:**
+- Create: `deploy/pi/install.sh` (mode 755)
+
+No pytest (needs root + network); gate with `bash -n` + shellcheck, and
+the gcm-01 runbook execution validates it for real.
+
+- [ ] **Step 1: Write `deploy/pi/install.sh`**
+
+```bash
+#!/usr/bin/env bash
+# GumptionChain miller installer (#254). Idempotent; run as root:
+#   sudo bash install.sh
+# Used verbatim by the roll-your-own HOWTO and by provision-appliance.sh.
+set -euo pipefail
+
+GC_USER="${GC_USER:-gc}"
+GC_HOME="$(getent passwd "$GC_USER" | cut -d: -f6)"
+REPO_DIR="${REPO_DIR:-${GC_HOME}/gumptionchain}"
+REPO_URL="${REPO_URL:-https://github.com/gumptionthomas/gumptionchain.git}"
+CHANNEL="${GC_UPDATE_CHANNEL:-tags}"
+UNIT_DIR='/etc/systemd/system'
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo 'run as root: sudo bash install.sh' >&2
+  exit 1
+fi
+if [ -z "$GC_HOME" ]; then
+  echo "user ${GC_USER} does not exist; create it first (see HOWTO)" >&2
+  exit 1
+fi
+
+as_gc() { runuser -u "$GC_USER" -- "$@"; }
+
+apt-get install -y --no-install-recommends git curl ca-certificates
+
+if [ ! -x "${GC_HOME}/.local/bin/uv" ]; then
+  curl -LsSf https://astral.sh/uv/install.sh | as_gc sh
+fi
+export PATH="${GC_HOME}/.local/bin:${PATH}"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  as_gc git clone "$REPO_URL" "$REPO_DIR"
+fi
+cd "$REPO_DIR"
+as_gc git fetch --tags origin
+if [ "$CHANNEL" = 'tags' ]; then
+  tag="$(as_gc git tag --list 'v*' --sort=-version:refname | head -n 1)"
+  if [ -n "$tag" ]; then
+    as_gc git checkout --quiet "$tag"
+  else
+    echo 'no release tags yet; staying on default branch' >&2
+  fi
+else
+  as_gc git checkout --quiet "$CHANNEL"
+  as_gc git pull --ff-only origin "$CHANNEL"
+fi
+as_gc "${GC_HOME}/.local/bin/uv" sync --frozen
+
+for unit in deploy/pi/*.service deploy/pi/*.timer; do
+  cp "$unit" "${UNIT_DIR}/$(basename "$unit")"
+done
+systemctl daemon-reload
+systemctl enable gumptionchain-update.timer
+
+if [ -f "${REPO_DIR}/.env" ] && [ -f "${REPO_DIR}/deploy.env" ]; then
+  as_gc "${GC_HOME}/.local/bin/uv" run gumptionchain init
+  systemctl enable --now gumptionchain-update.timer gumptionchain-miller
+  echo 'miller enabled and started.'
+else
+  cat <<'EOF'
+Installed. Before the miller can start you must:
+  1. put your wallet .pem in the wallet dir,
+  2. write .env and deploy.env in the repo root (see docs/howto-miller-pi.md),
+  3. ask the hub operator to allowlist your address,
+then run:
+  sudo systemctl enable --now gumptionchain-miller
+EOF
+fi
+```
+
+`chmod 755 deploy/pi/install.sh`
+
+- [ ] **Step 2: Lint**
+
+Run: `bash -n deploy/pi/install.sh`
+Expected: clean (shellcheck gates this in Task 5)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/pi/install.sh
+git commit -m "feat(deploy): idempotent miller installer (#254)"
+```
+
+---
+
+### Task 4: `provision-appliance.sh` + `custom.toml.example`
+
+**Files:**
+- Create: `deploy/pi/provision-appliance.sh` (mode 755)
+- Create: `deploy/pi/custom.toml.example`
+
+- [ ] **Step 1: Write `deploy/pi/provision-appliance.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Bench provisioner (#254): run from the operator workstation against a
+# freshly imaged Pi on the bench LAN. Usage:
+#   provision-appliance.sh <host> <wallet.pem> <env-file> <deploy-env-file>
+# e.g. provision-appliance.sh gcm-07.local secrets/gcm-07.pem \
+#        secrets/gcm-07.env secrets/gcm-07.deploy.env
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <host> <wallet.pem> <env-file> <deploy-env-file>" >&2
+  exit 64
+fi
+HOST="$1" WALLET_PEM="$2" ENV_FILE="$3" DEPLOY_ENV="$4"
+GC_USER="${GC_USER:-gc}"
+REPO_DIR="/home/${GC_USER}/gumptionchain"
+WALLET_DIR="/home/${GC_USER}/wallets"
+SSH=(ssh "${GC_USER}@${HOST}")
+
+for f in "$WALLET_PEM" "$ENV_FILE" "$DEPLOY_ENV"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 66; }
+done
+
+echo "==> ${HOST}: base packages + repo + kit install"
+"${SSH[@]}" "sudo apt-get update -qq \
+  && sudo apt-get install -y --no-install-recommends unattended-upgrades \
+  && sudo systemctl enable --now unattended-upgrades"
+"${SSH[@]}" "command -v git >/dev/null || sudo apt-get install -y git"
+"${SSH[@]}" "[ -d ${REPO_DIR}/.git ] \
+  || git clone https://github.com/gumptionthomas/gumptionchain.git ${REPO_DIR}"
+
+echo "==> ${HOST}: secrets + config"
+"${SSH[@]}" "mkdir -p ${WALLET_DIR} && chmod 700 ${WALLET_DIR}"
+scp "$WALLET_PEM" "${GC_USER}@${HOST}:${WALLET_DIR}/"
+scp "$ENV_FILE" "${GC_USER}@${HOST}:${REPO_DIR}/.env"
+scp "$DEPLOY_ENV" "${GC_USER}@${HOST}:${REPO_DIR}/deploy.env"
+"${SSH[@]}" "chmod 600 ${WALLET_DIR}/* ${REPO_DIR}/.env ${REPO_DIR}/deploy.env"
+
+echo "==> ${HOST}: install + start"
+"${SSH[@]}" "sudo bash ${REPO_DIR}/deploy/pi/install.sh"
+
+echo "==> ${HOST}: status"
+"${SSH[@]}" "systemctl is-active gumptionchain-miller \
+  && journalctl -u gumptionchain-miller -n 20 --no-pager"
+echo "==> ${HOST}: provisioned. Begin the 24h bench soak (see runbook)."
+```
+
+`chmod 755 deploy/pi/provision-appliance.sh`
+
+- [ ] **Step 2: Write `deploy/pi/custom.toml.example`**
+
+```toml
+# Raspberry Pi Imager customization (#254) — HAND-WRITE this file onto
+# the boot partition of a freshly flashed Raspberry Pi OS Lite card as
+# custom.toml. (The rpi-imager snap silently drops GUI customization;
+# do not rely on it.) Verify the schema against the Raspberry Pi OS
+# Bookworm documentation when the OS image major-version changes.
+config_version = 1
+
+[system]
+hostname = "gcm-NN"
+
+[user]
+name = "gc"
+# generate with: openssl passwd -6
+password = "$6$replace$me"
+
+[ssh]
+enabled = true
+# bench access only; appliances are unreachable behind the member's NAT
+authorized_keys = ["ssh-ed25519 AAAA... operator@bench"]
+
+[wlan]
+# leave commented for ethernet-only appliances
+# ssid = "member-network"
+# password = "member-psk"
+# country = "US"
+```
+
+- [ ] **Step 3: Lint + full deploy tests**
+
+Run: `bash -n deploy/pi/provision-appliance.sh`
+Expected: clean (shellcheck gates this in Task 5)
+Run: `uv run pytest tests/test_deploy_pi.py -q`
+Expected: ALL pass now (including `test_kit_scripts_are_executable`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/pi/provision-appliance.sh deploy/pi/custom.toml.example
+git commit -m "feat(deploy): bench provisioner + imager customization template (#254)"
+```
+
+---
+
+### Task 5: shellcheck in pre-commit
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the hook** (append to the existing `repos:` list,
+matching the file's existing pinning style — pin a specific rev):
+
+```yaml
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: ^deploy/pi/.*\.sh$
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `uv run pre-commit run shellcheck --all-files`
+Expected: Passed
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "chore: shellcheck pre-commit hook for deploy scripts (#254)"
+```
+
+---
+
+### Task 6: `docs/howto-miller-pi.md` (public roll-your-own)
+
+**Files:**
+- Create: `docs/howto-miller-pi.md`
+
+- [ ] **Step 1: Write the HOWTO.** Tone/structure like
+`docs/api-auth-protocol.md` (definitive, no fluff). Required sections,
+each with the exact commands shown:
+
+1. **What you're building** — an outbound-only milling node that peers
+   with gumption-hub; no port forwarding, no inbound; ~Pi 3B+ or better,
+   ethernet recommended, 16 GB+ SD.
+2. **Flash the OS** — Raspberry Pi OS Lite (64-bit); hand-write
+   `custom.toml` from `deploy/pi/custom.toml.example` onto the boot
+   partition (include the rpi-imager-snap warning); user `gc`.
+3. **Install the kit** —
+   ```bash
+   sudo apt-get install -y git
+   git clone https://github.com/gumptionthomas/gumptionchain.git ~/gumptionchain
+   sudo bash ~/gumptionchain/deploy/pi/install.sh
+   ```
+4. **Create a wallet** — `uv run gumptionchain wallet create` from the
+   repo dir (implementer: verify the exact `wallet` subcommand name with
+   `uv run gumptionchain wallet --help` and document the real one),
+   where the `.pem` lands, and **back up the .pem** (it is the only copy
+   of your milling rewards).
+5. **Get allowlisted** — send your address to the hub operator; your
+   address must appear in the hub's `GC_MILLER_ADDRESSES` before blocks
+   are accepted.
+6. **Configure** — full `.env` example (absolute
+   `FLASK_SQLALCHEMY_DATABASE_URI=sqlite:////home/gc/gumptionchain/gumptionchain.db`,
+   `FLASK_SECRET_KEY`, `GC_NODE_HOST`, `GC_WALLET_DIR=/home/gc/wallets`,
+   `GC_PEERS=["https://<your-address>@hub.gumption.com"]` with the
+   username-is-your-own-address explanation) and full `deploy.env`
+   example (`GC_MILL_ADDRESS`, `GC_MILL_PEER`, `GC_UPDATE_CHANNEL=tags`).
+7. **Start + verify** —
+   ```bash
+   sudo systemctl enable --now gumptionchain-miller
+   journalctl -u gumptionchain-miller -f
+   ```
+   what healthy milling output looks like; first sync from genesis
+   expectations.
+8. **Updates** — the auto-update timer (what it does nightly, the
+   health-gate + rollback behavior, the skip file), and the manual path:
+   ```bash
+   cd ~/gumptionchain
+   git fetch --tags origin
+   git checkout <new-tag>
+   uv sync --frozen
+   uv run gumptionchain db upgrade
+   sudo systemctl restart gumptionchain-miller
+   ```
+9. **Troubleshooting** — journalctl recipes, `systemctl status`,
+   re-sync-from-scratch (delete DB + restart; chain rebuilds from the
+   hub), where the skip file lives and how to clear it.
+
+- [ ] **Step 2: Verify commands against the code** — every CLI
+invocation in the doc must be checked against `--help` output before
+committing (especially the wallet-creation subcommand).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/howto-miller-pi.md
+git commit -m "docs: roll-your-own miller Pi HOWTO (#254)"
+```
+
+---
+
+### Task 7: `docs/pi-appliance-runbook.md` (operator)
+
+**Files:**
+- Create: `docs/pi-appliance-runbook.md`
+
+- [ ] **Step 1: Write the runbook.** Required sections:
+
+1. **Fleet roster** — table: hostname (`gcm-NN`), hardware, location,
+   wallet address, channel (`tags`/`main`), shipped date. Seed with
+   gcm-01 (canary, `main`).
+2. **Wallet ceremony** — generate on the bench workstation (never on the
+   Pi); encrypted backup (`age` or `gpg --symmetric` of the `.pem`,
+   stored with the operator's other secrets — name the actual location
+   pattern, not the secret); add the address to the hub's
+   `GC_MILLER_ADDRESSES`; **deliver a key copy to the member** over a
+   pre-agreed secure channel — their game backend transacts (faucet
+   txns) with the same wallet, and MILLER role covers TRANSACTOR.
+3. **Bench provisioning** — flash + `custom.toml` (hostname from the
+   roster); boot on bench LAN; run
+   `deploy/pi/provision-appliance.sh gcm-NN.local <pem> <env> <deploy.env>`;
+   the per-device secrets files live outside the repo (give the
+   directory convention, e.g. `~/gc-fleet/gcm-NN/`).
+4. **24 h bench soak checklist** — miller active and milling against the
+   real hub; at least one block accepted (visible on the hub explorer);
+   one forced update-timer run (`sudo systemctl start
+   gumptionchain-update.service`) completing cleanly; reboot test
+   (services come back unattended); only then ship.
+5. **Ship checklist** — what the member receives (Pi, PSU, ethernet
+   expectation, "plug into power + router; nothing else"), what to tell
+   them (it updates itself; if it dies, mail it back / re-flash).
+6. **Release discipline** — tagging is the fleet deploy: soak on gcm-01
+   (`GC_UPDATE_CHANNEL=main`) first; never tag a release whose migration
+   breaks the previous tag's code (rollback reverts code only);
+   annotated tags `vX.Y.Z`.
+7. **Recovery flow** — member mails the Pi back or operator mails a new
+   SD: re-flash, re-provision with the SAME wallet from the encrypted
+   backup; chain DB re-syncs from the hub; roster updated.
+8. **First execution = gcm-01** — explicit step list to re-provision
+   gcm-01 with this kit (it currently runs an ad-hoc rsync setup),
+   set `GC_UPDATE_CHANNEL=main`, and soak one real tag cycle before
+   building the first member appliance.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/pi-appliance-runbook.md
+git commit -m "docs: managed Pi appliance runbook (#254)"
+```
+
+---
+
+### Task 8: Gates + PR
+
+- [ ] `uv run ruff format --check src tests && uv run ruff check src tests`
+- [ ] `uv run mypy`
+- [ ] `uv run pytest -q` (full suite + the new deploy tests)
+- [ ] `uv run pre-commit run --all-files`
+- [ ] PR `feat(deploy): Pi miller kit — units, updater, installer, bench
+  provisioner + HOWTO/runbook (#254)`; subagent review; hold for author
+  review. PR body must note the operational follow-through (gcm-01
+  re-provision + first tag) is intentionally not part of the PR.

--- a/docs/superpowers/specs/2026-06-10-egu-254-pi-miller-distribution-design.md
+++ b/docs/superpowers/specs/2026-06-10-egu-254-pi-miller-distribution-design.md
@@ -1,0 +1,198 @@
+# EGU #254 — Pi miller distribution: HOWTO + managed appliance kit
+
+**Date:** 2026-06-10
+**Issue:** #254 (EGU fleet: 2× Pi 3 + 4× Pi 4; first external member is a
+friend's Pi 3 hosting the first "extended" EGU game)
+**Status:** design approved (brainstormed 2026-06-10)
+
+## Goal
+
+Make a milling Raspberry Pi reproducible for two audiences with **one
+maintained runtime kit**:
+
+1. **Roll-your-own** — a public HOWTO: stock Raspberry Pi OS Lite → milling
+   node, including how to update the gumptionchain package.
+2. **Managed appliance** — the operator's bench process that produces
+   "plug it in and forget it" Pis for EGU members. The member supplies
+   power + ethernet; everything else (updates included) is autonomous.
+
+### Decisions locked during brainstorming
+
+- **Distribution = git clone + release tag + `uv sync`.** No PyPI, no
+  wheel pipeline today. The auto-update path is designed so an easier
+  channel (PyPI, hub-served update channel) can replace the tag-follower
+  later without re-imaging devices — the updater updates itself.
+- **Appliances are pull-only with NO remote access.** No Tailscale, no
+  standing SSH path, no inbound anything. A wedged device is recovered by
+  re-flashing an SD card at the bench (or mailing one). This makes the
+  update health-gate + rollback the load-bearing safety mechanism.
+- **The operator generates each appliance wallet at the bench**, bakes it
+  into the device, keeps an **encrypted backup** (re-flash preserves the
+  address and its rewards), registers the address in the hub's
+  `MILLER_ADDRESSES`, and **delivers a copy of the key to the member** —
+  their game backend signs faucet transactions with the same wallet.
+  (Role hierarchy: MILLER ⊇ TRANSACTOR, so one allowlist entry covers
+  both milling and the game's transacting.)
+- **Deliverables = docs + shared runtime artifacts**, validated on gcm-01
+  before any member Pi ships.
+
+## Non-goals
+
+- PyPI publishing, GitHub release wheels (future "easier updates" path).
+- Hub-managed update channels / fleet telemetry (future; see Updates).
+- Docker / golden-image build pipeline (premature for ~7 devices).
+- Remote management of shipped appliances (explicitly rejected).
+- Wi-Fi onboarding UX. Appliances are **ethernet-first**; Wi-Fi creds can
+  be baked at the bench when a member's placement requires it.
+
+## Why outbound-only works (verified in code)
+
+`gumptionchain mill --peer <hub> <address>` runs forever by default
+(`--blocks 0`, `command.py mill_command`) and **polls the hub between PoW
+rounds**: `Miller.mill_block` calls `poll_latest_blocks()` inside the
+milling generator loop (`miller.py`), aborting the current block when a
+longer chain appears, and mined blocks are pushed outbound via the
+gossip path (`receive_block` → `send_block`, wallet-signed `gc-sig-v1`).
+A miller spoke therefore needs **zero inbound ports and never runs the
+Flask server**. Hub-and-spoke: every miller peers only with gumption-hub.
+
+## Architecture: one kit, two wrappers
+
+New `deploy/pi/` directory in this repo (public, secret-free):
+
+```
+deploy/pi/
+  gumptionchain-miller.service     # the milling node
+  gumptionchain-update.service     # oneshot: runs update.sh
+  gumptionchain-update.timer       # daily + RandomizedDelaySec
+  update.sh                        # tag-follower with health gate + rollback
+  install.sh                       # idempotent installer (both tiers)
+  provision-appliance.sh           # bench-side, ssh-driven (operator tier)
+  custom.toml.example              # hand-written imager customization
+```
+
+### `gumptionchain-miller.service`
+
+Runs `uv run gumptionchain mill --peer <hub-peer-url> <address>` as the
+`gc` user with `WorkingDirectory=` the repo checkout (python-dotenv
+autoloads `.env` from CWD). `Restart=always` + `RestartSec` handles
+crashes (the mill loop already catches per-block exceptions itself).
+`After=network-online.target`. Memory limits sized for the 1 GB Pi 3
+(`MemoryMax` guard so a leak degrades to a restart, not a frozen box).
+The peer URL and milling address come from an `EnvironmentFile`
+(`deploy.env`, written at install time) so the unit file itself is
+generic.
+
+### `update.sh` — the tag-follower
+
+Daily (timer with randomized delay to avoid a fleet stampede):
+
+1. `git fetch --tags origin`; resolve the highest semver `v*` tag.
+2. Exit 0 if it equals the current checkout or is listed in the
+   **bad-tag skip file** (`~/.gumptionchain-skip-tags`).
+3. `git checkout <tag>` && `uv sync --frozen`.
+4. `uv run gumptionchain db upgrade` (schema migrations).
+5. `systemctl restart gumptionchain-miller` + re-copy/`daemon-reload`
+   the unit files if the repo's copies changed (the updater updates the
+   units and itself — this is the hook that lets the update *mechanism*
+   evolve later without re-imaging).
+6. **Health gate:** `db upgrade` succeeded AND the service is still
+   `active` after a 60 s settle. On failure: check out the previous tag,
+   `uv sync --frozen`, restart, append the bad tag to the skip file, and
+   exit non-zero (visible in the journal). Migrations are **not**
+   downgraded — see Release discipline.
+
+### `install.sh` — shared installer (HOWTO step *and* bench step)
+
+Idempotent: installs `uv` if absent, clones (or updates) the repo into
+`~gc/gumptionchain`, checks out the latest release tag, `uv sync
+--frozen`, `gumptionchain init`, installs + enables the units, prints
+the remaining manual steps (wallet, `.env`, hub allowlisting). The HOWTO
+walks a person through running it; `provision-appliance.sh` runs it
+non-interactively.
+
+### `provision-appliance.sh` — the bench process
+
+SSH-driven, matching how gcm-01 was actually built (more debuggable than
+firstboot magic):
+
+1. Operator flashes stock Raspberry Pi OS Lite and **hand-writes
+   `custom.toml`** onto the boot partition (hostname `gcm-NN`, `gc` user,
+   operator SSH key, optional member Wi-Fi). Hand-written because the
+   rpi-imager snap silently drops GUI customization.
+2. Pi boots on the bench LAN; the script provisions it over SSH:
+   runs `install.sh`, copies the device wallet `.pem` + `.env` +
+   `deploy.env`, enables `unattended-upgrades` (security pocket only),
+   starts the services.
+3. The operator SSH key stays on the device — it is unreachable once the
+   appliance is behind the member's NAT (no inbound), but works again if
+   the device ever returns to the bench. This is deliberate: bench
+   access without standing remote access.
+
+## Config model (per device)
+
+- `.env`: `FLASK_SQLALCHEMY_DATABASE_URI` (**absolute** sqlite path —
+  the relative-path-resolves-into-src gotcha is documented),
+  `FLASK_SECRET_KEY`, `GC_NODE_HOST`, `GC_WALLET_DIR`,
+  `GC_PEERS=["https://<device-address>@<hub-host>"]` (the username is
+  the *local* wallet address this node signs as).
+- `deploy.env`: `GC_MILL_ADDRESS`, `GC_MILL_PEER` for the unit file, and
+  `GC_UPDATE_CHANNEL` for the updater: `tags` (default — highest semver
+  `v*` tag) or a branch name (`main`). The canary tracks `main`; member
+  appliances track `tags`. This knob is also the seam where a future
+  channel (PyPI version, hub-served pointer) plugs in.
+- Wallet `.pem` in `GC_WALLET_DIR`. Hub side: the address goes into the
+  hub's `GC_MILLER_ADDRESSES`.
+
+## Release discipline (the operator contract)
+
+Tagging a release **is** the fleet deploy trigger. The runbook encodes:
+
+- **gcm-01 is the canary.** It runs the same kit with
+  `GC_UPDATE_CHANNEL=main`, so it auto-updates to main nightly; a commit
+  soaks there before it gets a `v*` tag.
+- **Migrations are forward-only** at a tag boundary: never tag a release
+  whose schema migration breaks the *previous* tag's code, because
+  rollback reverts code only. (Same constraint most fleets adopt;
+  cheap to honor at this scale.)
+- A bad tag costs one failed nightly update per device (rollback +
+  skip-file), then the fleet waits for the next tag. No crash-loops.
+
+## Docs
+
+1. **`docs/howto-miller-pi.md`** (public, roll-your-own): hardware list,
+   flash + `custom.toml`, run `install.sh`, create a wallet, request
+   allowlisting from the hub operator, write `.env`, enable services,
+   verify milling, updates (auto-default via the timer; manual =
+   `git checkout <tag> && uv sync && systemctl restart ...`),
+   troubleshooting (journalctl recipes, sync-from-scratch expectations).
+2. **`docs/pi-appliance-runbook.md`** (operator): bench inventory +
+   fleet roster table, the **wallet ceremony** (generate → encrypted
+   backup → hub allowlist → secure key delivery to the member for their
+   game), provisioning steps, 24 h bench soak checklist (device mills
+   real blocks against the hub before shipping), ship checklist,
+   **recovery flow** (re-flash + re-provision from the wallet backup;
+   chain DB rebuilds by sync), and the release-discipline section above.
+
+## Testing
+
+- `update.sh` / `install.sh` / `provision-appliance.sh`: `shellcheck` +
+  `bash -n` wired into pre-commit (cheap, catches the classic quoting
+  bugs); the scripts' tag-resolution logic factored so it can be
+  exercised with a local fixture repo in a pytest (no network).
+- Unit files: a small pytest asserting they reference existing script
+  paths and the `gc` user consistently (string-level sanity, no systemd
+  dependency in CI).
+- **Real validation is gcm-01**: the runbook's first execution
+  re-provisions gcm-01 itself with this kit (it currently runs an
+  ad-hoc rsync setup), and gcm-01 then soaks the auto-update path across
+  at least one real tag bump before the first member Pi ships.
+
+## PR decomposition
+
+1. **This docs PR** — spec + implementation plan.
+2. **One implementation PR** — `deploy/pi/` + the two docs (+ pre-commit
+   shellcheck hook). Code-free at the package level; no schema changes.
+3. **Operational follow-through (not a PR)** — re-provision gcm-01 via
+   the runbook, cut the first `v*` tag, watch one auto-update cycle,
+   then build the friend's appliance.


### PR DESCRIPTION
Design checkpoint for #254 — the milling-Pi distribution story. Docs only; implementation follows in a separate PR after this merges.

## Decisions captured (from the brainstorming session)

- **Two audiences, one runtime kit**: a public roll-your-own HOWTO and the operator's managed-appliance bench process both install the same `deploy/pi/` artifacts (miller service, daily update timer, updater, installer).
- **Distribution = git clone + release tag + `uv sync`** — no PyPI/wheel infra today; the updater's channel knob (`GC_UPDATE_CHANNEL`) is the seam where an easier channel plugs in later without re-imaging.
- **Appliances are pull-only with NO remote access** — auto-update follows `v*` tags with a health gate, rollback, and a bad-tag skip file; recovery is re-flash at the bench. gcm-01 is the canary on `GC_UPDATE_CHANNEL=main`; tagging is the fleet deploy.
- **Wallet ceremony**: operator generates at the bench, keeps an encrypted backup (re-flash preserves rewards), allowlists the address at the hub, and delivers a key copy to the member — their game backend signs faucet txns with the same wallet (MILLER ⊇ TRANSACTOR).
- **Outbound-only verified in code**: `mill --peer` polls the hub between PoW rounds and pushes mined blocks; appliances need zero inbound and never run Flask.

The plan ships complete artifact contents (units, `update.sh` with pytest-able seams + a local fixture-repo test harness, installer, bench provisioner, `custom.toml` template), a shellcheck pre-commit hook, and section-by-section requirements for the two docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)