### PR TITLE
feat(deploy): Pi miller kit — units, updater, installer, bench provisioner + HOWTO/runbook (#254)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        files: ^deploy/pi/.*\.sh$

--- a/deploy/pi/custom.toml.example
+++ b/deploy/pi/custom.toml.example
@@ -1,0 +1,25 @@
+# Raspberry Pi Imager customization (#254) — HAND-WRITE this file onto
+# the boot partition of a freshly flashed Raspberry Pi OS Lite card as
+# custom.toml. (The rpi-imager snap silently drops GUI customization;
+# do not rely on it.) Verify the schema against the Raspberry Pi OS
+# Bookworm documentation when the OS image major-version changes.
+config_version = 1
+
+[system]
+hostname = "gcm-NN"
+
+[user]
+name = "gc"
+# generate with: openssl passwd -6
+password = "$6$replace$me"
+
+[ssh]
+enabled = true
+# bench access only; appliances are unreachable behind the member's NAT
+authorized_keys = ["ssh-ed25519 AAAA... operator@bench"]
+
+[wlan]
+# leave commented for ethernet-only appliances
+# ssid = "member-network"
+# password = "member-psk"
+# country = "US"

--- a/deploy/pi/gumptionchain-miller.service
+++ b/deploy/pi/gumptionchain-miller.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=GumptionChain miller
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=exec
+User=gc
+WorkingDirectory=/home/gc/gumptionchain
+EnvironmentFile=/home/gc/gumptionchain/deploy.env
+ExecStart=/home/gc/.local/bin/uv run gumptionchain mill --peer ${GC_MILL_PEER} ${GC_MILL_ADDRESS}
+Restart=always
+RestartSec=10
+# 1 GB Pi 3: a leak degrades to a service restart, not a frozen box.
+MemoryMax=700M
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pi/gumptionchain-update.service
+++ b/deploy/pi/gumptionchain-update.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=GumptionChain channel update
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/home/gc/gumptionchain/deploy.env
+ExecStart=/home/gc/gumptionchain/deploy/pi/update.sh

--- a/deploy/pi/gumptionchain-update.timer
+++ b/deploy/pi/gumptionchain-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily GumptionChain update check
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=4h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/pi/install.sh
+++ b/deploy/pi/install.sh
@@ -3,6 +3,9 @@
 #   sudo bash install.sh
 # Used verbatim by the roll-your-own HOWTO and by provision-appliance.sh.
 set -euo pipefail
+# non-matching globs vanish (the unit-copy loop must tolerate kits
+# without all unit types)
+shopt -s nullglob
 
 GC_USER="${GC_USER:-gc}"
 GC_HOME="$(getent passwd "$GC_USER" | cut -d: -f6)"
@@ -22,6 +25,9 @@ fi
 
 as_gc() { runuser -u "$GC_USER" -- "$@"; }
 
+# fresh Raspberry Pi OS images ship stale apt indexes; update first or
+# the install fails with 'Unable to locate package'
+apt-get update -qq
 apt-get install -y --no-install-recommends git curl ca-certificates
 
 if [ ! -x "${GC_HOME}/.local/bin/uv" ]; then

--- a/deploy/pi/install.sh
+++ b/deploy/pi/install.sh
@@ -31,6 +31,11 @@ apt-get update -qq
 apt-get install -y --no-install-recommends git curl ca-certificates
 
 if [ ! -x "${GC_HOME}/.local/bin/uv" ]; then
+  # Official uv install method (HTTPS to astral.sh). Supply-chain
+  # tradeoff acknowledged: piping a remote script to sh trusts astral.sh
+  # at install time. The cautious alternative is to pre-install uv
+  # yourself (any method that lands it at ~gc/.local/bin/uv) — this
+  # block is skipped when uv is already present.
   curl -LsSf https://astral.sh/uv/install.sh | as_gc sh
 fi
 export PATH="${GC_HOME}/.local/bin:${PATH}"

--- a/deploy/pi/install.sh
+++ b/deploy/pi/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# GumptionChain miller installer (#254). Idempotent; run as root:
+#   sudo bash install.sh
+# Used verbatim by the roll-your-own HOWTO and by provision-appliance.sh.
+set -euo pipefail
+
+GC_USER="${GC_USER:-gc}"
+GC_HOME="$(getent passwd "$GC_USER" | cut -d: -f6)"
+REPO_DIR="${REPO_DIR:-${GC_HOME}/gumptionchain}"
+REPO_URL="${REPO_URL:-https://github.com/gumptionthomas/gumptionchain.git}"
+CHANNEL="${GC_UPDATE_CHANNEL:-tags}"
+UNIT_DIR='/etc/systemd/system'
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo 'run as root: sudo bash install.sh' >&2
+  exit 1
+fi
+if [ -z "$GC_HOME" ]; then
+  echo "user ${GC_USER} does not exist; create it first (see HOWTO)" >&2
+  exit 1
+fi
+
+as_gc() { runuser -u "$GC_USER" -- "$@"; }
+
+apt-get install -y --no-install-recommends git curl ca-certificates
+
+if [ ! -x "${GC_HOME}/.local/bin/uv" ]; then
+  curl -LsSf https://astral.sh/uv/install.sh | as_gc sh
+fi
+export PATH="${GC_HOME}/.local/bin:${PATH}"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  as_gc git clone "$REPO_URL" "$REPO_DIR"
+fi
+cd "$REPO_DIR"
+as_gc git fetch --tags origin
+if [ "$CHANNEL" = 'tags' ]; then
+  tag="$(as_gc git tag --list 'v*' --sort=-version:refname | head -n 1)"
+  if [ -n "$tag" ]; then
+    as_gc git checkout --quiet "$tag"
+  else
+    echo 'no release tags yet; staying on default branch' >&2
+  fi
+else
+  as_gc git checkout --quiet "$CHANNEL"
+  as_gc git pull --ff-only origin "$CHANNEL"
+fi
+as_gc "${GC_HOME}/.local/bin/uv" sync --frozen
+
+for unit in deploy/pi/*.service deploy/pi/*.timer; do
+  cp "$unit" "${UNIT_DIR}/$(basename "$unit")"
+done
+systemctl daemon-reload
+systemctl enable gumptionchain-update.timer
+
+if [ -f "${REPO_DIR}/.env" ] && [ -f "${REPO_DIR}/deploy.env" ]; then
+  as_gc "${GC_HOME}/.local/bin/uv" run gumptionchain init
+  systemctl enable --now gumptionchain-update.timer gumptionchain-miller
+  echo 'miller enabled and started.'
+else
+  cat <<'EOF'
+Installed. Before the miller can start you must:
+  1. put your wallet .pem in the wallet dir,
+  2. write .env and deploy.env in the repo root (see docs/howto-miller-pi.md),
+  3. ask the hub operator to allowlist your address,
+then run:
+  sudo systemctl enable --now gumptionchain-miller
+EOF
+fi

--- a/deploy/pi/install.sh
+++ b/deploy/pi/install.sh
@@ -57,7 +57,7 @@ for unit in deploy/pi/*.service deploy/pi/*.timer; do
   cp "$unit" "${UNIT_DIR}/$(basename "$unit")"
 done
 systemctl daemon-reload
-systemctl enable gumptionchain-update.timer
+systemctl enable --now gumptionchain-update.timer
 
 if [ -f "${REPO_DIR}/.env" ] && [ -f "${REPO_DIR}/deploy.env" ]; then
   as_gc "${GC_HOME}/.local/bin/uv" run gumptionchain init

--- a/deploy/pi/install.sh
+++ b/deploy/pi/install.sh
@@ -69,7 +69,9 @@ Installed. Before the miller can start you must:
   1. put your wallet .pem in the wallet dir,
   2. write .env and deploy.env in the repo root (see docs/howto-miller-pi.md),
   3. ask the hub operator to allowlist your address,
-then run:
+then re-run this installer (it will init the database and start the
+miller), or by hand:
+  cd ~gc/gumptionchain && uv run gumptionchain init
   sudo systemctl enable --now gumptionchain-miller
 EOF
 fi

--- a/deploy/pi/provision-appliance.sh
+++ b/deploy/pi/provision-appliance.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Bench provisioner (#254): run from the operator workstation against a
+# freshly imaged Pi on the bench LAN. Usage:
+#   provision-appliance.sh <host> <wallet.pem> <env-file> <deploy-env-file>
+# e.g. provision-appliance.sh gcm-07.local secrets/gcm-07.pem \
+#        secrets/gcm-07.env secrets/gcm-07.deploy.env
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <host> <wallet.pem> <env-file> <deploy-env-file>" >&2
+  exit 64
+fi
+HOST="$1" WALLET_PEM="$2" ENV_FILE="$3" DEPLOY_ENV="$4"
+GC_USER="${GC_USER:-gc}"
+REPO_DIR="/home/${GC_USER}/gumptionchain"
+WALLET_DIR="/home/${GC_USER}/wallets"
+SSH=(ssh "${GC_USER}@${HOST}")
+
+for f in "$WALLET_PEM" "$ENV_FILE" "$DEPLOY_ENV"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 66; }
+done
+
+echo "==> ${HOST}: base packages + repo + kit install"
+"${SSH[@]}" "sudo apt-get update -qq \
+  && sudo apt-get install -y --no-install-recommends unattended-upgrades \
+  && sudo systemctl enable --now unattended-upgrades"
+"${SSH[@]}" "command -v git >/dev/null || sudo apt-get install -y git"
+"${SSH[@]}" "[ -d ${REPO_DIR}/.git ] \
+  || git clone https://github.com/gumptionthomas/gumptionchain.git ${REPO_DIR}"
+
+echo "==> ${HOST}: secrets + config"
+"${SSH[@]}" "mkdir -p ${WALLET_DIR} && chmod 700 ${WALLET_DIR}"
+scp "$WALLET_PEM" "${GC_USER}@${HOST}:${WALLET_DIR}/"
+scp "$ENV_FILE" "${GC_USER}@${HOST}:${REPO_DIR}/.env"
+scp "$DEPLOY_ENV" "${GC_USER}@${HOST}:${REPO_DIR}/deploy.env"
+"${SSH[@]}" "chmod 600 ${WALLET_DIR}/* ${REPO_DIR}/.env ${REPO_DIR}/deploy.env"
+
+echo "==> ${HOST}: install + start"
+"${SSH[@]}" "sudo bash ${REPO_DIR}/deploy/pi/install.sh"
+
+echo "==> ${HOST}: status"
+"${SSH[@]}" "systemctl is-active gumptionchain-miller \
+  && journalctl -u gumptionchain-miller -n 20 --no-pager"
+echo "==> ${HOST}: provisioned. Begin the 24h bench soak (see runbook)."

--- a/deploy/pi/update.sh
+++ b/deploy/pi/update.sh
@@ -5,6 +5,8 @@
 # unprivileged gc user. Seams (REPO_DIR/AS_GC/SKIP_FILE/UNIT_DIR/
 # HEALTH_SETTLE and PATH-resolved uv/systemctl) exist for the tests.
 set -euo pipefail
+# non-matching globs vanish (sync_units must tolerate kits without all unit types)
+shopt -s nullglob
 
 GC_USER="${GC_USER:-gc}"
 REPO_DIR="${REPO_DIR:-/home/${GC_USER}/gumptionchain}"
@@ -42,6 +44,10 @@ target_ref() {
   fi
 }
 
+# Rollback re-runs `db upgrade` (no downgrade); safe only under the release
+# rule that migrations never break the previous tag's code — see
+# docs/superpowers/specs/2026-06-10-egu-254-pi-miller-distribution-design.md
+# "Release discipline".
 apply() {
   run_gc git checkout --quiet "$1"
   run_gc uv sync --frozen
@@ -67,7 +73,10 @@ healthy() {
   systemctl is-active --quiet "$MILLER_UNIT"
 }
 
-run_gc git fetch --tags origin
+if ! run_gc git fetch --tags origin; then
+  echo 'fetch failed; will retry on next timer run'
+  exit 0
+fi
 
 target="$(target_ref)"
 if [ -z "$target" ]; then

--- a/deploy/pi/update.sh
+++ b/deploy/pi/update.sh
@@ -16,6 +16,10 @@ MILLER_UNIT="${MILLER_UNIT:-gumptionchain-miller}"
 AS_GC="${AS_GC-runuser -u ${GC_USER} --}"
 HEALTH_SETTLE="${HEALTH_SETTLE:-60}"
 UNIT_DIR="${UNIT_DIR:-/etc/systemd/system}"
+# Absolute path: this script runs under systemd as root, whose PATH does
+# not include the gc user's ~/.local/bin (the miller unit also uses the
+# absolute path for the same reason).
+UV="${UV:-/home/${GC_USER}/.local/bin/uv}"
 
 cd "$REPO_DIR"
 
@@ -50,8 +54,8 @@ target_ref() {
 # "Release discipline".
 apply() {
   run_gc git checkout --quiet "$1"
-  run_gc uv sync --frozen
-  run_gc uv run gumptionchain db upgrade
+  run_gc "$UV" sync --frozen
+  run_gc "$UV" run gumptionchain db upgrade
 }
 
 sync_units() {

--- a/deploy/pi/update.sh
+++ b/deploy/pi/update.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# GumptionChain Pi updater (#254): follow the release channel, migrate,
+# re-sync units, restart, health-gate, roll back on failure. Runs as
+# root from gumptionchain-update.service; repo operations run as the
+# unprivileged gc user. Seams (REPO_DIR/AS_GC/SKIP_FILE/UNIT_DIR/
+# HEALTH_SETTLE and PATH-resolved uv/systemctl) exist for the tests.
+set -euo pipefail
+
+GC_USER="${GC_USER:-gc}"
+REPO_DIR="${REPO_DIR:-/home/${GC_USER}/gumptionchain}"
+CHANNEL="${GC_UPDATE_CHANNEL:-tags}"
+SKIP_FILE="${SKIP_FILE:-/home/${GC_USER}/.gumptionchain-skip-tags}"
+MILLER_UNIT="${MILLER_UNIT:-gumptionchain-miller}"
+AS_GC="${AS_GC-runuser -u ${GC_USER} --}"
+HEALTH_SETTLE="${HEALTH_SETTLE:-60}"
+UNIT_DIR="${UNIT_DIR:-/etc/systemd/system}"
+
+cd "$REPO_DIR"
+
+run_gc() {
+  if [ -n "$AS_GC" ]; then
+    # shellcheck disable=SC2086  # AS_GC is intentionally word-split
+    $AS_GC "$@"
+  else
+    "$@"
+  fi
+}
+
+current_ref() {
+  if [ "$CHANNEL" = 'tags' ]; then
+    run_gc git describe --tags --exact-match 2>/dev/null || echo none
+  else
+    run_gc git rev-parse HEAD
+  fi
+}
+
+target_ref() {
+  if [ "$CHANNEL" = 'tags' ]; then
+    run_gc git tag --list 'v*' --sort=-version:refname | head -n 1
+  else
+    run_gc git rev-parse "origin/${CHANNEL}"
+  fi
+}
+
+apply() {
+  run_gc git checkout --quiet "$1"
+  run_gc uv sync --frozen
+  run_gc uv run gumptionchain db upgrade
+}
+
+sync_units() {
+  local changed=0 name
+  for unit in deploy/pi/*.service deploy/pi/*.timer; do
+    name="$(basename "$unit")"
+    if ! cmp -s "$unit" "${UNIT_DIR}/${name}"; then
+      cp "$unit" "${UNIT_DIR}/${name}"
+      changed=1
+    fi
+  done
+  if [ "$changed" = 1 ]; then
+    systemctl daemon-reload
+  fi
+}
+
+healthy() {
+  sleep "$HEALTH_SETTLE"
+  systemctl is-active --quiet "$MILLER_UNIT"
+}
+
+run_gc git fetch --tags origin
+
+target="$(target_ref)"
+if [ -z "$target" ]; then
+  echo "no release target on channel ${CHANNEL}"
+  exit 0
+fi
+current="$(current_ref)"
+if [ "$target" = "$current" ]; then
+  exit 0
+fi
+if [ "$CHANNEL" = 'tags' ] && [ -f "$SKIP_FILE" ] \
+  && grep -qxF "$target" "$SKIP_FILE"; then
+  echo "skipping known-bad tag ${target}"
+  exit 0
+fi
+
+echo "updating ${current} -> ${target}"
+if apply "$target" && sync_units \
+  && systemctl restart "$MILLER_UNIT" && healthy; then
+  echo "updated to ${target}"
+  exit 0
+fi
+
+echo "update to ${target} failed; rolling back" >&2
+if [ "$CHANNEL" = 'tags' ]; then
+  echo "$target" >>"$SKIP_FILE"
+fi
+if [ "$current" != 'none' ]; then
+  apply "$current" || true
+  sync_units || true
+  systemctl restart "$MILLER_UNIT" || true
+fi
+exit 1

--- a/docs/howto-miller-pi.md
+++ b/docs/howto-miller-pi.md
@@ -1,0 +1,329 @@
+# GumptionChain: Roll Your Own Miller Pi
+
+This guide walks through setting up an outbound-only GumptionChain milling
+node on a Raspberry Pi. The node peers with gumption-hub, mines blocks, and
+pushes them outbound. No port forwarding, no inbound connections, no server
+port to expose.
+
+Minimum hardware: Raspberry Pi 3B+ (1 GB RAM). Pi 4 or better is recommended
+for comfortable headroom. Use ethernet — Wi-Fi introduces latency jitter that
+hurts the polling loop. 16 GB SD card minimum; 32 GB preferred.
+
+---
+
+## 1. What you're building
+
+A headless Pi that runs two systemd services:
+
+- `gumptionchain-miller` — the milling loop. Polls gumption-hub for the
+  current chain tip, races to extend it with proof-of-work, and pushes
+  accepted blocks outbound. The loop is written to survive transient hub
+  outages; `Restart=always` handles crashes. No Flask server runs on a
+  miller node.
+- `gumptionchain-update.timer` — a daily nightly-update timer that follows
+  a release channel (`tags` by default), applies schema migrations, re-syncs
+  unit files, health-gates the restart, and rolls back automatically if the
+  new version fails the health check.
+
+Your wallet address earns coinbase GRIT on every block you mine. The `.pem`
+file is the only copy — back it up before the node ever mines a block.
+
+---
+
+## 2. Flash the OS
+
+Flash **Raspberry Pi OS Lite (64-bit)** to the SD card using
+[Raspberry Pi Imager](https://www.raspberrypi.com/software/).
+
+**Warning:** The rpi-imager snap (the Linux version from the Snap Store)
+silently drops GUI customization without error. Do not rely on the "Advanced
+options" dialog if you installed via snap. Instead, hand-write a
+`custom.toml` file directly onto the boot partition after flashing.
+
+Copy `deploy/pi/custom.toml.example` from the repo as a starting point.
+Mount the SD card's boot partition (the FAT32 partition, typically
+`/boot/firmware/` on Bookworm) and write the file there:
+
+```
+config_version = 1
+
+[system]
+hostname = "gcm-NN"          # pick a unique name, e.g. gcm-02
+
+[user]
+name = "gc"
+# generate with: openssl passwd -6
+password = "$6$yoursalt$yourhash"
+
+[ssh]
+enabled = true
+authorized_keys = ["ssh-ed25519 AAAA... you@yourhost"]
+
+# [wlan]  — leave commented for ethernet-only nodes
+# ssid = "your-network"
+# password = "your-psk"
+# country = "US"
+```
+
+Unmount and boot the Pi. Confirm you can SSH in as `gc` before continuing.
+
+---
+
+## 3. Install the kit
+
+From a shell on the Pi (or over SSH as `gc`):
+
+```bash
+sudo apt-get install -y git
+git clone https://github.com/gumptionthomas/gumptionchain.git ~/gumptionchain
+sudo bash ~/gumptionchain/deploy/pi/install.sh
+```
+
+`install.sh` is idempotent. It:
+
+1. Runs `apt-get update` and installs `git`, `curl`, and `ca-certificates`.
+2. Installs `uv` under `/home/gc/.local/bin/uv` if absent.
+3. Clones the repo into `~/gumptionchain` if not already there, then checks
+   out the latest release tag.
+4. Runs `uv sync --frozen` to install Python dependencies.
+5. Copies the systemd unit files to `/etc/systemd/system/`, reloads the
+   daemon, and enables the update timer.
+
+If `.env` and `deploy.env` are not yet present, the installer prints the
+remaining steps and exits cleanly — it will not attempt `gumptionchain init`
+until the config files exist. Complete sections 4–6 below, then run:
+
+```bash
+sudo systemctl enable --now gumptionchain-miller
+```
+
+---
+
+## 4. Create a wallet
+
+From the repo directory as the `gc` user:
+
+```bash
+cd ~/gumptionchain
+uv run gumptionchain wallet create -d /home/gc/wallets
+```
+
+The `-d` / `--walletdir` option sets the directory where the `.pem` is
+written. If omitted, it falls back to the `GC_WALLET_DIR` value in your
+`.env` (which must exist first). Using an explicit path here is safe.
+
+The command prints the path to the created file, e.g.
+`/home/gc/wallets/GCabc123...GC.pem`. The file name is the wallet address.
+That address string is what you give to the hub operator and put in your
+config.
+
+**Back up the `.pem` now.** Copy it to at least one offline location (USB
+drive, encrypted cloud storage, printed key material — your choice). The
+`.pem` is the only record of your private key. If it is lost, any GRIT
+mined to that address is unrecoverable.
+
+---
+
+## 5. Get allowlisted by the hub operator
+
+Your wallet address must appear in the hub's `GC_MILLER_ADDRESSES`
+configuration before the hub will accept blocks from you.
+
+Send your address (the filename of the `.pem`, without the `.pem` extension)
+to the gumption-hub operator. Once they add it and restart the hub, your node
+can submit blocks.
+
+The hub's MILLER role also covers TRANSACTOR — once allowlisted, your address
+can submit transactions to the hub directly.
+
+---
+
+## 6. Configure
+
+Create two files in `~/gumptionchain/`.
+
+**`.env`** — loaded automatically by python-dotenv at startup:
+
+```
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:////home/gc/gumptionchain/gumptionchain.db
+FLASK_SECRET_KEY=<random-string-at-least-32-chars>
+
+GC_NODE_HOST=http://localhost:5000
+GC_WALLET_DIR=/home/gc/wallets
+
+# GC_PEERS entries have the form https://<your-address>@<hub-host>.
+# The username portion is your LOCAL wallet address — the address this
+# node signs outgoing API requests as when talking to that peer.
+# That wallet's .pem must be in GC_WALLET_DIR, and the hub must list
+# the address in its GC_MILLER_ADDRESSES.
+GC_PEERS=["https://<your-address>@hub.gumption.com"]
+```
+
+Use an **absolute** path for the database URI (four slashes: `sqlite:////`).
+A relative path resolves from within the installed package directory
+(`src/instance/`), not the repo root.
+
+**`deploy.env`** — read by the systemd unit at runtime:
+
+```
+GC_MILL_ADDRESS=<your-address>
+GC_MILL_PEER=https://hub.gumption.com
+GC_UPDATE_CHANNEL=tags
+```
+
+`GC_MILL_ADDRESS` is the wallet address that receives coinbase rewards.
+`GC_MILL_PEER` is the URL the miller polls before each round.
+`GC_UPDATE_CHANNEL=tags` means the updater follows the highest semver
+`v*` release tag (the standard appliance channel).
+
+Once both files are in place, initialize the database:
+
+```bash
+cd ~/gumptionchain
+uv run gumptionchain init
+```
+
+---
+
+## 7. Start and verify
+
+Enable and start the miller:
+
+```bash
+sudo systemctl enable --now gumptionchain-miller
+```
+
+Watch the live log:
+
+```bash
+journalctl -u gumptionchain-miller -f
+```
+
+Healthy milling output looks like: repeated lines showing proof-of-work
+rounds progressing, periodic "Polling peer" messages, and eventually
+"Block accepted" when a block is mined and the hub accepts it.
+
+**First-sync expectations:** on first start the node has no chain history.
+The miller polls the hub for the current tip and begins milling from
+genesis — this is correct behavior. It does not need a full chain copy to
+mine; it only needs the current tip from the peer, which it fetches each
+round. There is no explicit sync step for a miller-only node.
+
+Check service status at any time:
+
+```bash
+systemctl status gumptionchain-miller
+systemctl status gumptionchain-update.timer
+```
+
+---
+
+## 8. Updates
+
+### Automatic (default)
+
+The `gumptionchain-update.timer` fires once daily with a randomized delay
+of up to 4 hours (`RandomizedDelaySec=4h`). The timer is `Persistent=true`,
+so a Pi that was off at the scheduled time will run the update on next boot.
+
+When the timer fires, `update.sh`:
+
+1. Fetches all tags from origin.
+2. Resolves the highest semver `v*` tag.
+3. Exits cleanly if the node is already on that tag, or if the tag appears
+   in the skip file (see below).
+4. Checks out the new tag, runs `uv sync --frozen`, runs
+   `gumptionchain db upgrade` to apply any schema migrations.
+5. Re-copies any changed unit files to `/etc/systemd/system/` and reloads
+   the daemon.
+6. Restarts `gumptionchain-miller` and waits 60 seconds.
+7. **Health gate:** if the service is not `active` after the settle period,
+   the updater rolls back to the previous tag (runs `uv sync --frozen` +
+   `db upgrade` again on the old code, restarts the service), appends the
+   bad tag to the skip file at `~gc/.gumptionchain-skip-tags`, and exits
+   non-zero. The failure is visible in the journal.
+
+Migrations are never downgraded on rollback — only code is reverted. This
+is safe as long as release discipline is followed: never tag a version whose
+migration breaks the previous tag's code.
+
+### Manual
+
+To update to a specific tag without waiting for the timer:
+
+```bash
+cd ~/gumptionchain
+git fetch --tags origin
+git checkout <new-tag>
+uv sync --frozen
+uv run gumptionchain db upgrade
+sudo systemctl restart gumptionchain-miller
+```
+
+To trigger the automatic updater immediately (runs the full
+health-gate/rollback path):
+
+```bash
+sudo systemctl start gumptionchain-update.service
+journalctl -u gumptionchain-update.service -f
+```
+
+---
+
+## 9. Troubleshooting
+
+**Follow live logs for the miller:**
+
+```bash
+journalctl -u gumptionchain-miller -f
+```
+
+**Check recent update runs:**
+
+```bash
+journalctl -u gumptionchain-update.service --no-pager
+```
+
+**Check service status:**
+
+```bash
+systemctl status gumptionchain-miller
+systemctl status gumptionchain-update.timer
+```
+
+**Re-sync from scratch** (if the local chain is corrupt or the node is on
+a fork with no path forward): stop the miller, delete the database, restart.
+The miller will re-poll the hub and rebuild from its current tip.
+
+```bash
+sudo systemctl stop gumptionchain-miller
+rm ~/gumptionchain/gumptionchain.db
+sudo systemctl start gumptionchain-miller
+journalctl -u gumptionchain-miller -f
+```
+
+The database path must match `FLASK_SQLALCHEMY_DATABASE_URI` in `.env`.
+If you used a different absolute path, delete that file instead.
+
+**The update skip file** — if a bad tag was detected and rolled back, the
+tag is appended to `~gc/.gumptionchain-skip-tags` (one tag per line). The
+updater will never re-attempt a listed tag. To clear it (for example, after
+a patched re-tag is published):
+
+```bash
+# inspect
+cat ~/.gumptionchain-skip-tags
+
+# clear entirely (next timer run will attempt the highest available tag)
+rm ~/.gumptionchain-skip-tags
+```
+
+**Hub connectivity** — if the miller is running but not submitting blocks,
+confirm the hub is reachable and your address is allowlisted:
+
+```bash
+curl -s https://hub.gumption.com/  # basic reachability
+```
+
+If the hub returns 403 on block submissions, your address is not in
+`GC_MILLER_ADDRESSES` — contact the hub operator.

--- a/docs/howto-miller-pi.md
+++ b/docs/howto-miller-pi.md
@@ -74,7 +74,7 @@ Unmount and boot the Pi. Confirm you can SSH in as `gc` before continuing.
 From a shell on the Pi (or over SSH as `gc`):
 
 ```bash
-sudo apt-get install -y git
+sudo apt-get update && sudo apt-get install -y git
 git clone https://github.com/gumptionthomas/gumptionchain.git ~/gumptionchain
 sudo bash ~/gumptionchain/deploy/pi/install.sh
 ```
@@ -88,6 +88,10 @@ sudo bash ~/gumptionchain/deploy/pi/install.sh
 4. Runs `uv sync --frozen` to install Python dependencies.
 5. Copies the systemd unit files to `/etc/systemd/system/`, reloads the
    daemon, and enables the update timer.
+
+`uv` is installed into `~/.local/bin/uv`. That directory is added to your
+`PATH` on login, so **log out and back in** (or prefix commands with
+`~/.local/bin/uv`) before continuing.
 
 If `.env` and `deploy.env` are not yet present, the installer prints the
 remaining steps and exits cleanly — it will not attempt `gumptionchain init`
@@ -104,13 +108,19 @@ sudo systemctl enable --now gumptionchain-miller
 From the repo directory as the `gc` user:
 
 ```bash
+mkdir -p /home/gc/wallets
 cd ~/gumptionchain
 uv run gumptionchain wallet create -d /home/gc/wallets
 ```
 
-The `-d` / `--walletdir` option sets the directory where the `.pem` is
-written. If omitted, it falls back to the `GC_WALLET_DIR` value in your
-`.env` (which must exist first). Using an explicit path here is safe.
+The `-d` / `--walletdir` option is `click.Path(exists=True)` — the directory
+**must exist before you run the command** (hence `mkdir -p` above). If
+omitted, it falls back to the `GC_WALLET_DIR` value in your `.env` (which
+must exist first). Using an explicit path here is safe.
+
+Running the command before `.env` exists will log a `SQLALCHEMY_DATABASE_URI`
+ERROR line, but the wallet is still created and the command still prints
+`Created /home/gc/wallets/<address>.pem` — this is normal.
 
 The command prints the path to the created file, e.g.
 `/home/gc/wallets/GCabc123...GC.pem`. The file name is the wallet address.
@@ -167,12 +177,15 @@ A relative path resolves from within the installed package directory
 
 ```
 GC_MILL_ADDRESS=<your-address>
-GC_MILL_PEER=https://hub.gumption.com
+GC_MILL_PEER=https://<your-address>@hub.gumption.com
 GC_UPDATE_CHANNEL=tags
 ```
 
 `GC_MILL_ADDRESS` is the wallet address that receives coinbase rewards.
-`GC_MILL_PEER` is the URL the miller polls before each round.
+`GC_MILL_PEER` is the URL the miller polls before each round. **This value
+must exactly match the corresponding entry in `GC_PEERS` (including the
+`<your-address>@` username prefix)** — the miller looks up the peer in
+`app.clients` by the literal string, and a mismatch causes a crash-loop.
 `GC_UPDATE_CHANNEL=tags` means the updater follows the highest semver
 `v*` release tag (the standard appliance channel).
 
@@ -199,15 +212,28 @@ Watch the live log:
 journalctl -u gumptionchain-miller -f
 ```
 
-Healthy milling output looks like: repeated lines showing proof-of-work
-rounds progressing, periodic "Polling peer" messages, and eventually
-"Block accepted" when a block is mined and the hub accepts it.
+Healthy milling output looks like:
 
-**First-sync expectations:** on first start the node has no chain history.
-The miller polls the hub for the current tip and begins milling from
-genesis — this is correct behavior. It does not need a full chain copy to
-mine; it only needs the current tip from the peer, which it fetches each
-round. There is no explicit sync step for a miller-only node.
+1. **First-sync phase** — a `Synchronizing with peer <peer>` rule prints,
+   followed by a two-panel progress display: "Finding Blocks" (backward
+   walk counting ancestors from the hub's tip) then "Loading Blocks" (forward
+   apply with a progress bar). This downloads and applies every ancestor block
+   from the hub's current chain tip all the way to genesis — a full local
+   chain copy, automatically, with no separate sync command. Expected duration
+   grows with chain length.
+
+2. **Milling phase** — a `Milling as address <address>` rule prints, then
+   for each block attempt: a borderless start table (Block index, Chain hash,
+   Target, Started timestamp) followed by a spinner while hashing, then a
+   stop table (Stopped, Elapsed, Hashes). The stop table's `POW` row reads
+   the proof-of-work value when **this node wins the block**, or `SCOOPED`
+   (styled dimly) when another miller extends the chain first. A very close
+   race prints `SCOOPED (but so close)`.
+
+**First-sync expectations:** on an empty database the full first-sync
+download runs automatically before the first milling round begins — there
+is no separate `gumptionchain sync` step needed. The time this takes scales
+with chain length.
 
 Check service status at any time:
 
@@ -298,6 +324,7 @@ The miller will re-poll the hub and rebuild from its current tip.
 ```bash
 sudo systemctl stop gumptionchain-miller
 rm ~/gumptionchain/gumptionchain.db
+cd ~/gumptionchain && uv run gumptionchain init
 sudo systemctl start gumptionchain-miller
 journalctl -u gumptionchain-miller -f
 ```
@@ -315,7 +342,8 @@ a patched re-tag is published):
 cat ~/.gumptionchain-skip-tags
 
 # clear entirely (next timer run will attempt the highest available tag)
-rm ~/.gumptionchain-skip-tags
+# (sudo required: update.sh runs as root and owns this file)
+sudo rm ~/.gumptionchain-skip-tags
 ```
 
 **Hub connectivity** — if the miller is running but not submitting blocks,

--- a/docs/pi-appliance-runbook.md
+++ b/docs/pi-appliance-runbook.md
@@ -28,8 +28,9 @@ Column notes:
   generated filename before the rename to `gcm-NN.pem`.
 - **Shipped** — the date the appliance left the bench. Leave `(canary)` for
   gcm-01; it never ships.
-- Wallet address and location are sensitive; keep this file in your private
-  operator notes or a secrets store, not in the public repo.
+- Wallet address and location are sensitive; the table above is a
+  template. Keep the **filled-in copy** in your private operator notes or
+  a secrets store (e.g. `~/gc-fleet/roster.md`), not in the public repo.
 
 ---
 

--- a/docs/pi-appliance-runbook.md
+++ b/docs/pi-appliance-runbook.md
@@ -1,0 +1,470 @@
+# GumptionChain Pi Appliance Runbook
+
+Operator reference for building "plug it in and forget it" miller appliances
+for EGU members. Covers wallet ceremony, bench provisioning, soak testing,
+shipping, release discipline, and recovery.
+
+The public roll-your-own path is in `docs/howto-miller-pi.md`. Cross-
+references below point to HOWTO sections for shared mechanics rather than
+duplicating them.
+
+---
+
+## 1. Fleet Roster
+
+Update this table every time an appliance is built, shipped, or recovered.
+
+| Hostname | Hardware  | Location          | Wallet address        | Channel | Shipped    |
+|----------|-----------|-------------------|-----------------------|---------|------------|
+| gcm-01   | Pi 3B+    | *(record here)*   | *(record here)*       | main    | *(canary)* |
+
+**gcm-01** is the canary. It tracks `GC_UPDATE_CHANNEL=main` and auto-
+updates nightly to the tip of `main`. A commit soaks on gcm-01 before it
+receives a `v*` tag and rolls to the member fleet.
+
+Column notes:
+- **Channel** — `main` for gcm-01 (canary); `tags` for all member appliances.
+- **Wallet address** — the `.pem` filename without the `.pem` extension.
+- **Shipped** — the date the appliance left the bench. Leave `(canary)` for
+  gcm-01; it never ships.
+- Wallet address and location are sensitive; keep this file in your private
+  operator notes or a secrets store, not in the public repo.
+
+---
+
+## 2. Wallet Ceremony
+
+**Generate the wallet on the bench workstation, never on the Pi.**
+
+### 2a. Generate
+
+```bash
+mkdir -p ~/gc-fleet/gcm-NN
+cd ~/gumptionchain
+uv run gumptionchain wallet create -d ~/gc-fleet/gcm-NN
+```
+
+The `-d` flag requires the directory to exist (it is a `click.Path(exists=True)`
+argument). The command prints the full path of the created file, e.g.:
+`Created /home/you/gc-fleet/gcm-NN/GCabc123...GC.pem`. The filename is the
+wallet address.
+
+Record the address in the fleet roster table above.
+
+### 2b. Encrypted backup
+
+Encrypt the `.pem` before storing it anywhere. Keep the encrypted backup
+with your other operator secrets (e.g. a password manager vault, an
+encrypted USB, or a self-hosted secrets store). The pattern below uses the
+device hostname as the archive name:
+
+**GPG symmetric (AES-256):**
+
+```bash
+gpg --symmetric --cipher-algo AES256 ~/gc-fleet/gcm-NN/gcm-NN.pem
+# produces: ~/gc-fleet/gcm-NN/gcm-NN.pem.gpg
+# store gcm-NN.pem.gpg in your secrets store; delete the plaintext .pem
+# from any unsecured location after confirming the backup decrypts
+```
+
+**age (preferred if you have age installed):**
+
+```bash
+age -p -o ~/gc-fleet/gcm-NN/gcm-NN.pem.age ~/gc-fleet/gcm-NN/gcm-NN.pem
+# -p prompts for a passphrase; the .age file is your backup
+```
+
+Verify the backup decrypts before proceeding:
+
+```bash
+# gpg
+gpg -d ~/gc-fleet/gcm-NN/gcm-NN.pem.gpg | diff - ~/gc-fleet/gcm-NN/gcm-NN.pem
+
+# age
+age -d ~/gc-fleet/gcm-NN/gcm-NN.pem.age | diff - ~/gc-fleet/gcm-NN/gcm-NN.pem
+```
+
+### 2c. Hub allowlist
+
+Add the address to the hub's `GC_MILLER_ADDRESSES` configuration and restart
+the hub. The MILLER role covers TRANSACTOR — one allowlist entry is sufficient
+for both block submission and faucet transactions from the member's game
+backend.
+
+```bash
+# On the hub: add the address to GC_MILLER_ADDRESSES in the hub's env,
+# then restart the hub process (exact mechanism depends on the hub's
+# deployment; see the gumption-hub runbook).
+```
+
+The hub will reject blocks from the device until this step is complete.
+Do it before provisioning so the bench soak actually exercises acceptance.
+
+### 2d. Deliver a key copy to the member
+
+Once allowlisted, deliver a copy of the `.pem` to the member over a
+**pre-agreed secure channel** (Signal, Bitwarden Send, age-encrypted email,
+or hand-off in person). The member's game backend signs faucet transactions
+with the same wallet — they need the private key to authorize those
+transactions. Confirm receipt before shipping the appliance.
+
+---
+
+## 3. Bench Provisioning
+
+### 3a. Per-device secrets layout
+
+Keep per-device secrets on the bench workstation at:
+
+```
+~/gc-fleet/gcm-NN/
+    gcm-NN.pem           # wallet private key (plaintext only during bench work)
+    gcm-NN.pem.gpg       # encrypted backup (always retained)
+    env                  # the device's .env file
+    deploy.env           # the device's deploy.env file
+```
+
+### 3b. Write the config files
+
+**`~/gc-fleet/gcm-NN/env`** (becomes `.env` on the device):
+
+```
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:////home/gc/gumptionchain/gumptionchain.db
+FLASK_SECRET_KEY=<random-string-at-least-32-chars>
+
+GC_NODE_HOST=http://localhost:5000
+GC_WALLET_DIR=/home/gc/wallets
+
+# The username portion of each GC_PEERS entry is the LOCAL wallet address
+# this node signs outgoing API requests as when talking to that peer.
+# That wallet's .pem must be in GC_WALLET_DIR.
+GC_PEERS=["https://<device-address>@hub.gumption.com"]
+```
+
+Use `sqlite:////` (four slashes). A relative path resolves inside
+`src/instance/`, not the repo root.
+
+**`~/gc-fleet/gcm-NN/deploy.env`** (read by systemd at unit start):
+
+```
+GC_MILL_ADDRESS=<device-address>
+GC_MILL_PEER=https://<device-address>@hub.gumption.com
+GC_UPDATE_CHANNEL=tags
+```
+
+`GC_MILL_PEER` **must exactly match the corresponding entry in `GC_PEERS`**,
+including the `<device-address>@` username prefix. The miller looks up the
+peer in `app.clients` by the literal string; a mismatch causes a crash-loop.
+Both `GC_PEERS` in `.env` and `GC_MILL_PEER` in `deploy.env` must carry the
+same `<device-address>@hub.gumption.com` value.
+
+For the canary (gcm-01) use `GC_UPDATE_CHANNEL=main` instead of `tags`.
+
+### 3c. Flash the SD card
+
+Flash **Raspberry Pi OS Lite (64-bit)** to the SD card. After flashing,
+mount the boot partition (the FAT32 partition, typically `/boot/firmware/`)
+and hand-write `custom.toml` there.
+
+Use `deploy/pi/custom.toml.example` as the template — fill in the device
+hostname from the roster and your operator SSH public key:
+
+```toml
+config_version = 1
+
+[system]
+hostname = "gcm-NN"
+
+[user]
+name = "gc"
+# generate with: openssl passwd -6
+password = "$6$replace$me"
+
+[ssh]
+enabled = true
+# bench access only; unreachable behind member's NAT once shipped
+authorized_keys = ["ssh-ed25519 AAAA... operator@bench"]
+
+[wlan]
+# leave commented for ethernet-only appliances
+# ssid = "member-network"
+# password = "member-psk"
+# country = "US"
+```
+
+**Warning:** The rpi-imager snap (Linux Snap Store) silently drops GUI
+customization. Do not rely on "Advanced options" if you installed via snap.
+Always hand-write `custom.toml` directly onto the boot partition.
+
+Unmount the SD card, insert into the Pi, boot on the bench LAN. Confirm SSH
+as `gc` works before running the provisioner.
+
+### 3d. Run the provisioner
+
+```bash
+cd ~/gumptionchain
+deploy/pi/provision-appliance.sh \
+    gcm-NN.local \
+    ~/gc-fleet/gcm-NN/gcm-NN.pem \
+    ~/gc-fleet/gcm-NN/env \
+    ~/gc-fleet/gcm-NN/deploy.env
+```
+
+The provisioner runs in three stages:
+
+1. **Base packages + repo** — installs `unattended-upgrades`, clones the
+   repo on the device (if absent).
+2. **Secrets + config** — `scp`s the wallet `.pem`, `.env`, and `deploy.env`
+   to the device and sets `chmod 600`. This happens **before** `install.sh`
+   runs, so `install.sh` always finds the config files in place and can
+   proceed to `gumptionchain init` and start the services in a single pass.
+3. **Install + start** — runs `sudo bash deploy/pi/install.sh` on the device.
+   Because `.env` and `deploy.env` already exist, `install.sh` runs
+   `gumptionchain init` to create the database, then enables and starts both
+   `gumptionchain-update.timer` and `gumptionchain-miller`.
+
+The script ends with `systemctl is-active gumptionchain-miller` and the last
+20 lines of the miller journal. A successful run prints:
+`==> gcm-NN.local: provisioned. Begin the 24h bench soak (see runbook).`
+
+---
+
+## 4. 24-Hour Bench Soak Checklist
+
+**Do not ship until every item below is checked.**
+
+- [ ] `systemctl is-active gumptionchain-miller` returns `active` on the device.
+- [ ] The miller journal shows the first-sync phase completing:
+      `journalctl -u gumptionchain-miller -n 50 --no-pager`
+      Look for "Finding Blocks" / "Loading Blocks" completing, then
+      "Milling as address ..." appearing. The full chain downloads
+      from the hub on first start — allow time proportional to chain
+      length (potentially many minutes on a long chain).
+- [ ] At least one block accepted by the hub is visible on the hub explorer.
+      A `SCOOPED` result is normal (another miller won the race); the node
+      is healthy regardless. A successful `POW` result is the gold standard.
+- [ ] One forced update-timer run completes cleanly:
+      ```bash
+      ssh gc@gcm-NN.local sudo systemctl start gumptionchain-update.service
+      ssh gc@gcm-NN.local journalctl -u gumptionchain-update.service --no-pager
+      ```
+      Expected: either "no release target" / "already current" (exit 0), or
+      "updated to vX.Y.Z" (exit 0). No rollback, no skip-file entry.
+- [ ] Reboot test — services come back unattended:
+      ```bash
+      ssh gc@gcm-NN.local sudo reboot
+      # wait ~60 s
+      ssh gc@gcm-NN.local systemctl is-active gumptionchain-miller
+      ```
+      Expected: `active`.
+- [ ] No errors in the miller journal from the last 4 hours:
+      ```bash
+      ssh gc@gcm-NN.local journalctl -u gumptionchain-miller --since "4h ago" --no-pager
+      ```
+
+Only after all items are checked: proceed to shipping.
+
+---
+
+## 5. Ship Checklist
+
+### What to include
+
+- [ ] Raspberry Pi (SD card inserted, kit provisioned and soaked).
+- [ ] Official Pi power supply (5V 3A USB-C for Pi 4; 5.1V 2.5A micro-USB
+      for Pi 3B+). Do not substitute; under-voltage causes SD corruption.
+- [ ] Short ethernet cable (recommended — but see note below).
+- [ ] Brief "what your Pi does" card (see talking points below).
+
+### Ethernet expectation
+
+The appliance is ethernet-first. If the member's placement requires Wi-Fi,
+bake the SSID and PSK into `custom.toml` at flash time and test the
+connection on the bench before shipping. **Wi-Fi is the exception, not the
+default.**
+
+### What to tell the member
+
+- Plug into power and a router port. Nothing else to do.
+- The box mines GRIT blocks and credits your wallet automatically.
+- It updates itself nightly. You will never need to log in.
+- If it stops working: mail it back. Do not attempt to debug it yourself.
+- Keep the private key copy you received — you will need it if the device
+  is ever re-flashed (your GRIT balance is safe on the chain; the key
+  is required to spend it).
+
+---
+
+## 6. Release Discipline
+
+**Tagging is the fleet deploy trigger.** Every member appliance running
+`GC_UPDATE_CHANNEL=tags` will pick up the new tag on its next nightly
+update window (within 28 hours, given the 4-hour jitter).
+
+### Canary-first rule
+
+1. Land commits on `main`.
+2. gcm-01 (`GC_UPDATE_CHANNEL=main`) auto-updates nightly. Let it soak for
+   at least one full update cycle (24+ hours) before tagging.
+3. Confirm gcm-01 is still milling and its update journal is clean.
+4. Only then cut the release tag.
+
+### Tagging
+
+Use **annotated tags** (`-a`). The annotation is the release audience:
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z — brief description"
+git push origin vX.Y.Z
+```
+
+Member appliances will pick it up on their next nightly timer run.
+
+### Forward-only migration rule
+
+Never tag a release whose schema migration breaks the *previous* tag's code.
+Rollback in `update.sh` reverts code only — it does NOT downgrade the
+database. If a rollback fires, the device runs the previous code against the
+post-migration schema. The release is safe only when the previous code
+remains compatible with the new schema. At EGU's current scale this
+constraint is easy to honor: additive-only schema changes (new nullable
+columns, new tables) satisfy it automatically.
+
+### Bad tag handling
+
+A bad tag costs one failed nightly update per device. The health gate
+detects the failure, rolls back the code, appends the tag to the skip file
+(`/home/gc/.gumptionchain-skip-tags`, root-owned), and exits non-zero (visible
+in the journal). The device stays on its previous tag and continues milling.
+The fleet waits for the next tag — no manual intervention is needed per
+device. Publish a corrected tag once the issue is fixed; devices will pick
+it up on the next timer run.
+
+---
+
+## 7. Recovery Flow
+
+Use when a device is unresponsive, corrupted, or physically returned.
+
+### 7a. Re-flash and re-provision
+
+The wallet address and its on-chain balance are permanent. Re-flashing
+gives the device a fresh SD with the same identity.
+
+- [ ] Retrieve the encrypted wallet backup:
+      `gpg -d ~/gc-fleet/gcm-NN/gcm-NN.pem.gpg > ~/gc-fleet/gcm-NN/gcm-NN.pem`
+      (or `age -d ~/gc-fleet/gcm-NN/gcm-NN.pem.age > ~/gc-fleet/gcm-NN/gcm-NN.pem`)
+- [ ] Flash a fresh Raspberry Pi OS Lite SD. Hand-write `custom.toml` with
+      the **same hostname** from the roster (same address, same identity).
+- [ ] Boot on the bench LAN. Confirm SSH.
+- [ ] Re-run the provisioner with the **same secrets files** — no wallet
+      ceremony needed:
+      ```bash
+      deploy/pi/provision-appliance.sh \
+          gcm-NN.local \
+          ~/gc-fleet/gcm-NN/gcm-NN.pem \
+          ~/gc-fleet/gcm-NN/env \
+          ~/gc-fleet/gcm-NN/deploy.env
+      ```
+- [ ] The chain database is empty after a re-flash. `gumptionchain init`
+      (run by `install.sh`) creates a fresh DB; the miller syncs the full
+      chain from the hub on first start. Budget soak time for the sync
+      (see Section 4 checklist item 2).
+- [ ] Hub allowlist entry does **not** need to change — the address is
+      unchanged.
+- [ ] Run the 24-hour bench soak (Section 4) before re-shipping.
+- [ ] Update the roster: note the recovery date in the Shipped column.
+- [ ] Shred the plaintext `.pem` from the workstation once provisioning
+      confirms the device is milling:
+      `shred -u ~/gc-fleet/gcm-NN/gcm-NN.pem`
+
+### 7b. If the device is permanently lost (hardware failure)
+
+If the Pi hardware itself is dead and cannot be re-flashed:
+
+- [ ] Provision a new Pi through the full ceremony (Sections 2–4) with a
+      new wallet and a new `gcm-NN` hostname.
+- [ ] Deliver the new key to the member.
+- [ ] Mark the old roster entry retired (old address, old hostname).
+- [ ] The old address's on-chain balance is inaccessible without the key.
+      If the member's key copy survived, they can still spend from it on
+      any node; the lost Pi's mining simply stops.
+
+---
+
+## 8. First Execution: Re-Provision gcm-01
+
+gcm-01 currently runs an ad-hoc rsync setup. This section migrates it to
+the new kit. Complete these steps before building the first member appliance.
+
+- [ ] **Generate gcm-01's deploy.env on the bench workstation.**
+      gcm-01's wallet already exists. Locate the `.pem` and note the address.
+      Write `~/gc-fleet/gcm-01/env` and `~/gc-fleet/gcm-01/deploy.env` using
+      the address and the real hub URL. Set `GC_UPDATE_CHANNEL=main`:
+
+      ```
+      # deploy.env for gcm-01 (canary)
+      GC_MILL_ADDRESS=<gcm-01-address>
+      GC_MILL_PEER=https://<gcm-01-address>@hub.gumption.com
+      GC_UPDATE_CHANNEL=main
+      ```
+
+      `GC_MILL_PEER` must exactly match the `GC_PEERS` entry in `.env`
+      including the `<gcm-01-address>@` prefix.
+
+- [ ] **Verify gcm-01's address is in the hub's `GC_MILLER_ADDRESSES`.**
+      It should already be there from the existing setup. Confirm before
+      proceeding.
+
+- [ ] **Stop the old ad-hoc rsync/service setup on gcm-01.** This varies by
+      whatever is currently running; the goal is a clean slate for the new
+      unit files. Stop and disable any existing gumptionchain service units,
+      then remove them from `/etc/systemd/system/` so the new installer
+      takes full ownership.
+
+- [ ] **Copy the existing wallet** to `~/gc-fleet/gcm-01/` on the bench (or
+      confirm it is already there with an encrypted backup). No new wallet
+      ceremony — same key, same address.
+
+- [ ] **Flash a fresh SD or re-provision in-place.**
+      - *Fresh flash (recommended for a clean baseline):* Flash Pi OS Lite,
+        hand-write `custom.toml` for `gcm-01`, boot, confirm SSH, then:
+        ```bash
+        deploy/pi/provision-appliance.sh \
+            gcm-01.local \
+            ~/gc-fleet/gcm-01/<address>.pem \
+            ~/gc-fleet/gcm-01/env \
+            ~/gc-fleet/gcm-01/deploy.env
+        ```
+      - *In-place (if re-flashing is inconvenient):* `scp` the secrets to the
+        device and run `sudo bash ~/gumptionchain/deploy/pi/install.sh` manually
+        from an SSH session. Confirm `GC_UPDATE_CHANNEL=main` is in `deploy.env`
+        before running.
+
+- [ ] **Confirm provisioning succeeded:**
+      ```bash
+      ssh gc@gcm-01.local systemctl is-active gumptionchain-miller
+      ssh gc@gcm-01.local journalctl -u gumptionchain-miller -n 30 --no-pager
+      ```
+      The journal should show the first-sync phase (or fast-start if the DB
+      was preserved), then "Milling as address ...".
+
+- [ ] **Run the bench soak (Section 4) for gcm-01.** At minimum: miller
+      active, one block attempt visible, forced update-timer run clean,
+      reboot test.
+
+- [ ] **Cut the first `v*` release tag** once gcm-01 has soaked at least one
+      full nightly update cycle cleanly (24+ hours, update journal shows
+      "updated to main tip" or "already current", no rollback):
+      ```bash
+      git tag -a v0.1.0 -m "v0.1.0 — initial managed appliance release"
+      git push origin v0.1.0
+      ```
+      Member appliances (once built) will auto-update to this tag on their
+      first nightly timer run.
+
+- [ ] **Update the fleet roster** with gcm-01's address and the migration
+      date. Mark channel `main`.
+
+Only after the first tag cycle soaks on gcm-01 cleanly: proceed to building
+the first member appliance.

--- a/docs/pi-appliance-runbook.md
+++ b/docs/pi-appliance-runbook.md
@@ -24,7 +24,8 @@ receives a `v*` tag and rolls to the member fleet.
 
 Column notes:
 - **Channel** — `main` for gcm-01 (canary); `tags` for all member appliances.
-- **Wallet address** — the `.pem` filename without the `.pem` extension.
+- **Wallet address** — derived from the key content; matches the original
+  generated filename before the rename to `gcm-NN.pem`.
 - **Shipped** — the date the appliance left the bench. Leave `(canary)` for
   gcm-01; it never ships.
 - Wallet address and location are sensitive; keep this file in your private
@@ -48,6 +49,17 @@ The `-d` flag requires the directory to exist (it is a `click.Path(exists=True)`
 argument). The command prints the full path of the created file, e.g.:
 `Created /home/you/gc-fleet/gcm-NN/GCabc123...GC.pem`. The filename is the
 wallet address.
+
+Rename the file to the device hostname so all per-device secrets share a
+consistent naming convention:
+
+```bash
+mv ~/gc-fleet/gcm-NN/GCabc123...GC.pem ~/gc-fleet/gcm-NN/gcm-NN.pem
+```
+
+The wallet loader keys wallets by the address derived from the key's content,
+not by filename — the rename is safe and keeps per-device files predictably
+named.
 
 Record the address in the fleet roster table above.
 
@@ -248,8 +260,10 @@ The script ends with `systemctl is-active gumptionchain-miller` and the last
       ssh gc@gcm-NN.local sudo systemctl start gumptionchain-update.service
       ssh gc@gcm-NN.local journalctl -u gumptionchain-update.service --no-pager
       ```
-      Expected: either "no release target" / "already current" (exit 0), or
-      "updated to vX.Y.Z" (exit 0). No rollback, no skip-file entry.
+      Expected: either a silent exit 0 when already current (check
+      `systemctl status gumptionchain-update.service` shows
+      `status=0/SUCCESS`), or `updated to vX.Y.Z` (tags channel) / `updated
+      to <commit-sha>` (branch channel). No rollback, no skip-file entry.
 - [ ] Reboot test — services come back unattended:
       ```bash
       ssh gc@gcm-NN.local sudo reboot
@@ -432,7 +446,7 @@ the new kit. Complete these steps before building the first member appliance.
         ```bash
         deploy/pi/provision-appliance.sh \
             gcm-01.local \
-            ~/gc-fleet/gcm-01/<address>.pem \
+            ~/gc-fleet/gcm-01/gcm-01.pem \
             ~/gc-fleet/gcm-01/env \
             ~/gc-fleet/gcm-01/deploy.env
         ```
@@ -455,7 +469,8 @@ the new kit. Complete these steps before building the first member appliance.
 
 - [ ] **Cut the first `v*` release tag** once gcm-01 has soaked at least one
       full nightly update cycle cleanly (24+ hours, update journal shows
-      "updated to main tip" or "already current", no rollback):
+      a silent exit 0 when already current or `updated to <commit-sha>`
+      (branch channel), no rollback):
       ```bash
       git tag -a v0.1.0 -m "v0.1.0 — initial managed appliance release"
       git push origin v0.1.0

--- a/tests/test_deploy_pi.py
+++ b/tests/test_deploy_pi.py
@@ -99,6 +99,9 @@ def kit(tmp_path):
     env = os.environ | {
         'REPO_DIR': str(repo),
         'AS_GC': '',
+        # update.sh defaults UV to the gc user's absolute ~/.local/bin/uv
+        # (root's systemd PATH lacks it); tests point it at the stub.
+        'UV': str(uv),
         'SKIP_FILE': str(tmp_path / 'skip'),
         'UNIT_DIR': str(tmp_path / 'units'),
         'HEALTH_SETTLE': '0',

--- a/tests/test_deploy_pi.py
+++ b/tests/test_deploy_pi.py
@@ -54,7 +54,7 @@ def _git(cwd, *args):
 
 @pytest.fixture
 def kit(tmp_path):
-    """A fixture 'origin' with tags v0.1.0/v0.2.0, a clone on v0.1.0,
+    """A fixture 'origin' with tags v0.1.0/v0.2.0/v0.10.0, a clone on v0.1.0,
     and stubbed seams (uv, systemctl) that log their invocations."""
     origin = tmp_path / 'origin.git'
     work = tmp_path / 'seed'
@@ -76,6 +76,11 @@ def kit(tmp_path):
     (work / 'f.txt').write_text('two\n')
     _git(work, 'commit', '-aqm', 'two')
     _git(work, 'tag', 'v0.2.0')
+    # v0.10.0 is intentionally after v0.2.0: lexical sort ('1' < '2') would
+    # wrongly pick v0.2.0; --sort=-version:refname must win with v0.10.0.
+    (work / 'f.txt').write_text('ten\n')
+    _git(work, 'commit', '-aqm', 'ten')
+    _git(work, 'tag', 'v0.10.0')
     _git(work, 'clone', '-q', '--bare', '.', str(origin))
     repo = tmp_path / 'repo'
     _git(tmp_path, 'clone', '-q', str(origin), str(repo))
@@ -127,7 +132,7 @@ def _run_update(kit, **extra):
 def test_update_follows_highest_tag(kit):
     result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
     assert result.returncode == 0, result.stderr
-    assert _head_tag(kit['repo']) == 'v0.2.0'
+    assert _head_tag(kit['repo']) == 'v0.10.0'
     calls = kit['log'].read_text()
     assert 'uv sync --frozen' in calls
     assert 'gumptionchain db upgrade' in calls
@@ -154,7 +159,7 @@ def test_update_rolls_back_and_skips_bad_tag(kit):
     assert result.returncode != 0
     assert _head_tag(kit['repo']) == 'v0.1.0'
     skip = (kit['tmp'] / 'skip').read_text()
-    assert 'v0.2.0' in skip
+    assert 'v0.10.0' in skip
     # next run: bad tag is skipped, exit 0, still on v0.1.0
     sysctl.write_text(
         f'#!/bin/sh\necho "systemctl $@" >> {kit["log"]}\nexit 0\n'

--- a/tests/test_deploy_pi.py
+++ b/tests/test_deploy_pi.py
@@ -1,6 +1,11 @@
 """Sanity checks for the deploy/pi kit (string-level; no systemd in CI)."""
 
+import os
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 DEPLOY = Path(__file__).parent.parent / 'deploy' / 'pi'
 
@@ -32,3 +37,156 @@ def test_kit_scripts_are_executable():
         path = DEPLOY / name
         assert path.exists(), name
         assert path.stat().st_mode & 0o111, f'{name} not executable'
+
+
+UPDATE_SH = DEPLOY / 'update.sh'
+
+
+def _git(cwd, *args):
+    subprocess.run(  # noqa: S603
+        ['git', *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def kit(tmp_path):
+    """A fixture 'origin' with tags v0.1.0/v0.2.0, a clone on v0.1.0,
+    and stubbed seams (uv, systemctl) that log their invocations."""
+    origin = tmp_path / 'origin.git'
+    work = tmp_path / 'seed'
+    work.mkdir()
+    _git(work, 'init', '-q', '-b', 'main')
+    _git(work, 'config', 'user.email', 't@example.com')
+    _git(work, 'config', 'user.name', 't')
+    (work / 'deploy' / 'pi').mkdir(parents=True)
+    for unit in (
+        'gumptionchain-miller.service',
+        'gumptionchain-update.service',
+        'gumptionchain-update.timer',
+    ):
+        shutil.copy(DEPLOY / unit, work / 'deploy' / 'pi' / unit)
+    (work / 'f.txt').write_text('one\n')
+    _git(work, 'add', '-A')
+    _git(work, 'commit', '-qm', 'one')
+    _git(work, 'tag', 'v0.1.0')
+    (work / 'f.txt').write_text('two\n')
+    _git(work, 'commit', '-aqm', 'two')
+    _git(work, 'tag', 'v0.2.0')
+    _git(work, 'clone', '-q', '--bare', '.', str(origin))
+    repo = tmp_path / 'repo'
+    _git(tmp_path, 'clone', '-q', str(origin), str(repo))
+    _git(repo, 'checkout', '-q', 'v0.1.0')
+
+    log = tmp_path / 'calls.log'
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    uv = bin_dir / 'uv'
+    uv.write_text(f'#!/bin/sh\necho "uv $@" >> {log}\nexit 0\n')
+    uv.chmod(0o755)
+    sysctl = bin_dir / 'systemctl'
+    sysctl.write_text(f'#!/bin/sh\necho "systemctl $@" >> {log}\nexit 0\n')
+    sysctl.chmod(0o755)
+
+    env = os.environ | {
+        'REPO_DIR': str(repo),
+        'AS_GC': '',
+        'SKIP_FILE': str(tmp_path / 'skip'),
+        'UNIT_DIR': str(tmp_path / 'units'),
+        'HEALTH_SETTLE': '0',
+        'PATH': f'{bin_dir}:{os.environ["PATH"]}',
+    }
+    (tmp_path / 'units').mkdir()
+    return {'repo': repo, 'env': env, 'log': log, 'tmp': tmp_path}
+
+
+def _head_tag(repo):
+    out = subprocess.run(
+        ['git', 'describe', '--tags', '--exact-match'],  # noqa: S607
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def _run_update(kit, **extra):
+    return subprocess.run(  # noqa: S603
+        [str(UPDATE_SH)],
+        env=kit['env'] | {k: str(v) for k, v in extra.items()},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_update_follows_highest_tag(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0, result.stderr
+    assert _head_tag(kit['repo']) == 'v0.2.0'
+    calls = kit['log'].read_text()
+    assert 'uv sync --frozen' in calls
+    assert 'gumptionchain db upgrade' in calls
+    assert 'systemctl restart gumptionchain-miller' in calls
+    assert 'systemctl is-active' in calls
+
+
+def test_update_noop_when_current(kit):
+    _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    kit['log'].write_text('')
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0
+    assert 'restart' not in kit['log'].read_text()
+
+
+def test_update_rolls_back_and_skips_bad_tag(kit):
+    # health gate fails (is-active exits 1) -> rollback to v0.1.0 + skip
+    sysctl = kit['tmp'] / 'bin' / 'systemctl'
+    sysctl.write_text(
+        f'#!/bin/sh\necho "systemctl $@" >> {kit["log"]}\n'
+        'case "$1" in is-active) exit 1;; esac\nexit 0\n'
+    )
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode != 0
+    assert _head_tag(kit['repo']) == 'v0.1.0'
+    skip = (kit['tmp'] / 'skip').read_text()
+    assert 'v0.2.0' in skip
+    # next run: bad tag is skipped, exit 0, still on v0.1.0
+    sysctl.write_text(
+        f'#!/bin/sh\necho "systemctl $@" >> {kit["log"]}\nexit 0\n'
+    )
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0
+    assert _head_tag(kit['repo']) == 'v0.1.0'
+
+
+def test_update_branch_channel_follows_main(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='main')
+    assert result.returncode == 0, result.stderr
+    head = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],  # noqa: S607
+        cwd=kit['repo'],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    main = subprocess.run(
+        ['git', 'rev-parse', 'origin/main'],  # noqa: S607
+        cwd=kit['repo'],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert head == main
+
+
+def test_update_syncs_changed_unit_files(kit):
+    result = _run_update(kit, GC_UPDATE_CHANNEL='tags')
+    assert result.returncode == 0, result.stderr
+    units = kit['tmp'] / 'units'
+    assert (units / 'gumptionchain-miller.service').exists()
+    assert 'systemctl daemon-reload' in kit['log'].read_text()

--- a/tests/test_deploy_pi.py
+++ b/tests/test_deploy_pi.py
@@ -1,0 +1,34 @@
+"""Sanity checks for the deploy/pi kit (string-level; no systemd in CI)."""
+
+from pathlib import Path
+
+DEPLOY = Path(__file__).parent.parent / 'deploy' / 'pi'
+
+
+def test_unit_files_exist_and_are_consistent():
+    miller = (DEPLOY / 'gumptionchain-miller.service').read_text()
+    update = (DEPLOY / 'gumptionchain-update.service').read_text()
+    timer = (DEPLOY / 'gumptionchain-update.timer').read_text()
+    # the miller runs as the gc user from the repo checkout
+    assert 'User=gc' in miller
+    assert 'WorkingDirectory=/home/gc/gumptionchain' in miller
+    assert 'mill --peer ${GC_MILL_PEER} ${GC_MILL_ADDRESS}' in miller
+    assert 'Restart=always' in miller
+    # the updater is root (it restarts units and writes /etc) and points
+    # at a script that exists in the kit
+    assert 'update.sh' in update
+    assert 'User=' not in update  # root
+    script = update.split('ExecStart=')[1].splitlines()[0].strip()
+    assert script == '/home/gc/gumptionchain/deploy/pi/update.sh'
+    assert (DEPLOY / 'update.sh').name in script
+    # timer fires daily with jitter and catches up after downtime
+    assert 'OnCalendar=daily' in timer
+    assert 'RandomizedDelaySec=' in timer
+    assert 'Persistent=true' in timer
+
+
+def test_kit_scripts_are_executable():
+    for name in ('update.sh', 'install.sh', 'provision-appliance.sh'):
+        path = DEPLOY / name
+        assert path.exists(), name
+        assert path.stat().st_mode & 0o111, f'{name} not executable'


### PR DESCRIPTION
Closes #254. Implements the approved design (`docs/superpowers/specs/2026-06-10-egu-254-pi-miller-distribution-design.md`, PR #255): one runtime kit, two wrappers — the public roll-your-own path and the operator's "plug it in and forget it" appliance process.

## What ships

- **`deploy/pi/` kit**: miller service (`mill --peer` as `gc`, `Restart=always`, `MemoryMax` for 1GB Pi 3s), daily update timer (jittered, `Persistent=true`), `update.sh` (channel follower: highest semver `v*` tag or a branch; `git checkout → uv sync --frozen → db upgrade → unit re-sync → restart → 60s health gate`; rollback + bad-tag skip file on failure; soft-fails transient fetch errors), idempotent `install.sh` (shared by both tiers), ssh-driven `provision-appliance.sh` (bench), and `custom.toml.example` (hand-written imager config — the rpi-imager snap drops GUI customization).
- **7 tests** (`tests/test_deploy_pi.py`): unit-file sanity + five updater behavior tests against a local fixture origin with stubbed `uv`/`systemctl` seams — tag-follow (with a `v0.10.0` semver-vs-lexical trap), no-op, rollback + skip + re-skip, branch channel, unit re-sync.
- **`docs/howto-miller-pi.md`** (public) and **`docs/pi-appliance-runbook.md`** (operator: wallet ceremony with encrypted backup, bench provisioning, 24h soak, ship + recovery checklists, release discipline).
- **shellcheck pre-commit hook** for `deploy/pi/*.sh`. (The spec's literal "`bash -n` + shellcheck" is satisfied by shellcheck alone — it subsumes `bash -n` syntax checking; `bash -n` was run manually throughout.)

## Review pipeline highlights (per-task spec + quality reviews; all fixed in-branch)

- `nullglob` landmines in `update.sh`/`install.sh` unit-copy loops (a missing unit type would have stranded an unattended device mid-update).
- `apt-get update` before install on fresh Pi OS images (stale indexes abort under `set -e`).
- **`GC_MILL_PEER` crash-loop class**: `app.clients` is keyed by the literal `GC_PEERS` string including the `<address>@` prefix — both docs now state the exact-match requirement and all examples carry it.
- HOWTO accuracy pass by execution: every CLI flag verified against `--help` (`wallet create -d` needs `mkdir -p` first), fabricated journal strings replaced with the real `Synchronizing with peer` / `Milling as address` / `POW` / `SCOOPED` output, resync recipe gained the required `gumptionchain init`.
- Runbook: pem naming convention unified (`gcm-NN.pem` with an explicit safe rename — wallets are keyed by key content), updater output expectations corrected to what `update.sh` actually prints.

## Gates

Full suite **556 passed, 1 skipped** (SAWarning gate active); ruff + format + mypy clean; shellcheck clean; final integration review READY (cross-artifact consistency table + four end-to-end story walkthroughs).

Pre-existing `app.py` ruff findings under `pre-commit --all-files` are untouched and tracked as #256.

## Not in this PR (operational follow-through)

Re-provision gcm-01 with the kit (`GC_UPDATE_CHANNEL=main`), cut the first `v*` tag, watch one auto-update cycle — then build the first member appliance. The runbook's §8 is that checklist.

## How to test

```bash
uv run pytest tests/test_deploy_pi.py -q
bash -n deploy/pi/*.sh && uv run pre-commit run shellcheck --all-files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)