### PR TITLE
feat(browser): /advanced tools page — relocate broadcast + attestation sign (#260)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -447,6 +447,20 @@ def verify_view() -> Any:
     return render_template('verify.html', title='Verify')
 
 
+@blueprint.route('/advanced')
+def advanced_view() -> Any:
+    # Static shell like /transact (#260): the relocated power tools
+    # (broadcast pre-signed, sign attestation) sign their own API
+    # requests client-side; gc-sig-v1 is node-bound so NODE_HOST must
+    # reach the page.
+    return render_template(
+        'advanced.html',
+        title='Advanced',
+        node_host=current_app.config['NODE_HOST'],
+        rp_name='GumptionChain',
+    )
+
+
 @blueprint.route('/transact')
 def transact_view() -> Any:
     # Static shell — no chain/DB work. The page's client JS calls the authed

--- a/src/gumptionchain/templates/_key_import.html
+++ b/src/gumptionchain/templates/_key_import.html
@@ -1,0 +1,55 @@
+{# Shared signing-key area (#260): saved-wallet unlock + ephemeral
+   session import. Included by transact.html and advanced.html; the
+   transact-glue module binds these ids defensively on both pages. #}
+      <!-- Key area: two ways to obtain a signing key for this page session.
+           Either is held in memory only and auto-locks (idle / tab-hide /
+           leave / Forget). -->
+
+      <!-- (a) Unlock the wallet saved on this node (gc-keyring / IndexedDB).
+           Hidden by JS unless a wallet is actually persisted on this origin. -->
+      <div id="saved-wallet" class="mb-3" hidden>
+        <div class="fw-semibold">Unlock your saved wallet</div>
+        <p class="small text-muted mb-2">
+          You saved a wallet on this node (on
+          <a href="{{ url_for('browser.wallet_view') }}">Wallet</a>). Unlock it
+          for this session &mdash; it stays in memory only and auto-locks.
+        </p>
+        <label for="unlock-passphrase" class="form-label">Passphrase</label>
+        <input id="unlock-passphrase" type="password" autocomplete="off"
+               class="form-control" placeholder="your wallet passphrase">
+        <div class="mt-2">
+          <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
+            Unlock
+          </button>
+          <button id="unlock-saved-passkey-btn"
+                  class="btn btn-outline-primary btn-sm" hidden>
+            Unlock with passkey
+          </button>
+        </div>
+        <div id="unlock-status" class="mt-2 small"></div>
+        <hr>
+        <div class="small text-muted">or use a key just for this session:</div>
+      </div>
+
+      <!-- (b) Ephemeral import: paste a key for THIS session only; nothing is
+           saved (the alternative to a saved-wallet unlock). -->
+      <div class="mb-3">
+        <label for="key-b58" class="form-label">
+          Use a key just for this session (base58 private key)
+        </label>
+        <textarea id="key-b58" class="form-control" rows="2"
+                  placeholder="paste base58 private key"></textarea>
+        <div class="mt-2">
+          <label for="key-pem" class="form-label">or upload a .pem</label>
+          <input id="key-pem" type="file" accept=".pem" class="form-control">
+        </div>
+        <div class="mt-2">
+          <button id="import-key-btn" class="btn btn-secondary btn-sm">
+            Import key
+          </button>
+          <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
+            Forget key
+          </button>
+        </div>
+        <div id="key-status" class="mt-2 small"></div>
+      </div>

--- a/src/gumptionchain/templates/advanced.html
+++ b/src/gumptionchain/templates/advanced.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% block title %}Advanced{% endblock %}
+
+{% block content -%}
+<div class="container-fluid" data-node-host="{{ node_host }}"
+     data-rp-name="{{ rp_name }}">
+
+  <div class="row my-3"><div class="col">
+    <div class="alert alert-warning" role="alert">
+      <strong>Your private key never leaves your browser.</strong>
+      This node does not store it, and reloading or closing this tab clears it.
+      Only your signature and public key are ever sent. Keys are imported into
+      memory for this session only &mdash; nothing is saved.
+    </div>
+  </div></div>
+
+  <!-- Signing key: both tools below sign with the key imported here. -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">Signing key</div>
+      {% include "_key_import.html" %}
+    </div></div>
+  </div></div>
+
+  <!-- Broadcast a pre-signed txn (relocated from /transact, #260) -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">
+        <a class="text-decoration-none" data-bs-toggle="collapse"
+           href="#broadcast" role="button" aria-expanded="false"
+           aria-controls="broadcast">
+          Broadcast a pre-signed transaction
+        </a>
+      </div>
+      <div id="broadcast" class="collapse">
+        <p class="small text-muted">
+          Paste an already-signed transaction JSON. The submit request itself is
+          still authed, so the imported key signs the request envelope.
+        </p>
+        <textarea id="broadcast-input" class="form-control" rows="6"
+                  placeholder='{"txid":"...","signature":"...", ...}'></textarea>
+        <button id="broadcast-btn" class="btn btn-primary mt-2">Submit</button>
+        <div id="broadcast-result" class="mt-2"></div>
+      </div>
+    </div></div>
+  </div></div>
+
+  <!-- Sign attestation (relocated from /transact, #260) -->
+  <div class="row my-3"><div class="col">
+    <section id="attestation" class="card"><div class="card-body">
+      <div class="card-title h5">Sign a stake attestation</div>
+      <p class="small text-muted">
+        Produce a signed <code>gc-msg-v1</code> proof that you staked on a
+        subject &mdash; the producer side of
+        <a href="{{ url_for('browser.verify_view') }}">Verify</a>. Reuses the
+        key you imported above. The subject is the same RAW subject you staked.
+      </p>
+
+      <div class="mb-3">
+        <label for="att-txid" class="form-label">Transaction id (txid)</label>
+        <input id="att-txid" type="text" class="form-control"
+               placeholder="64-char hex txid of your stake">
+      </div>
+
+      <div class="mb-3">
+        <label for="att-kind" class="form-label">Kind</label>
+        <select id="att-kind" class="form-select">
+          <option value="opposition">opposition</option>
+          <option value="support">support</option>
+        </select>
+      </div>
+
+      <div class="mb-3">
+        <label for="att-subject" class="form-label">Subject</label>
+        <input id="att-subject" type="text" class="form-control"
+               placeholder="goblins">
+      </div>
+
+      <div class="mb-3">
+        <label for="att-amount" class="form-label">Amount (grains)</label>
+        <input id="att-amount" type="number" min="1" step="1"
+               class="form-control" placeholder="300">
+      </div>
+
+      <button id="att-sign-btn" class="btn btn-primary">Sign attestation</button>
+      <button id="att-copy-btn" class="btn btn-outline-secondary" hidden>Copy</button>
+
+      <div class="mt-3">
+        <div id="att-result" class="mb-2"></div>
+        <pre id="att-proof" class="small bg-light p-2"></pre>
+        <p class="small text-muted">Paste this into /verify.</p>
+      </div>
+    </div></section>
+  </div></div>
+
+  <!-- Verify: its own page (proof cards deep-link it); presented here as
+       the consumer side of the attestation tool. -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">Verify a stake attestation</div>
+      <p class="small text-muted mb-0">
+        Check a proof someone shared with you against the chain on
+        <a href="{{ url_for('browser.verify_view') }}">Verify</a>.
+      </p>
+    </div></div>
+  </div></div>
+
+  {% include "advanced/extra.html" ignore missing %}
+</div>
+{%- endblock %}
+
+{% block scripts -%}
+{{ super() }}
+<script type="module">
+  import { init } from "{{ url_for('browser.static', filename='js/transact-glue.mjs') }}";
+  const root = document.querySelector('[data-node-host]');
+  init(root, {
+    nodeHost: root.dataset.nodeHost,
+    rpName: root.dataset.rpName,
+  });
+</script>
+{%- endblock %}

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -23,6 +23,7 @@
     <a class="navbar-nav" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
     <a class="navbar-nav" href="{{ url_for('browser.transact_view') }}">Transact</a>
     <a class="navbar-nav" href="{{ url_for('browser.wallet_view') }}">Wallet</a>
+    <a class="navbar-nav" href="{{ url_for('browser.advanced_view') }}">Advanced</a>
     {% block nav -%}
     {%- endblock %}
   </nav>

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -58,58 +58,7 @@
 
       <hr>
 
-      <!-- Key area: two ways to obtain a signing key for this page session.
-           Either is held in memory only and auto-locks (idle / tab-hide /
-           leave / Forget). -->
-
-      <!-- (a) Unlock the wallet saved on this node (gc-keyring / IndexedDB).
-           Hidden by JS unless a wallet is actually persisted on this origin. -->
-      <div id="saved-wallet" class="mb-3" hidden>
-        <div class="fw-semibold">Unlock your saved wallet</div>
-        <p class="small text-muted mb-2">
-          You saved a wallet on this node (on
-          <a href="{{ url_for('browser.wallet_view') }}">Wallet</a>). Unlock it
-          for this session &mdash; it stays in memory only and auto-locks.
-        </p>
-        <label for="unlock-passphrase" class="form-label">Passphrase</label>
-        <input id="unlock-passphrase" type="password" autocomplete="off"
-               class="form-control" placeholder="your wallet passphrase">
-        <div class="mt-2">
-          <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
-            Unlock
-          </button>
-          <button id="unlock-saved-passkey-btn"
-                  class="btn btn-outline-primary btn-sm" hidden>
-            Unlock with passkey
-          </button>
-        </div>
-        <div id="unlock-status" class="mt-2 small"></div>
-        <hr>
-        <div class="small text-muted">or use a key just for this session:</div>
-      </div>
-
-      <!-- (b) Ephemeral import: paste a key for THIS session only; nothing is
-           saved (the alternative to a saved-wallet unlock). -->
-      <div class="mb-3">
-        <label for="key-b58" class="form-label">
-          Use a key just for this session (base58 private key)
-        </label>
-        <textarea id="key-b58" class="form-control" rows="2"
-                  placeholder="paste base58 private key"></textarea>
-        <div class="mt-2">
-          <label for="key-pem" class="form-label">or upload a .pem</label>
-          <input id="key-pem" type="file" accept=".pem" class="form-control">
-        </div>
-        <div class="mt-2">
-          <button id="import-key-btn" class="btn btn-secondary btn-sm">
-            Import key
-          </button>
-          <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
-            Forget key
-          </button>
-        </div>
-        <div id="key-status" class="mt-2 small"></div>
-      </div>
+      {% include "_key_import.html" %}
 
       <button id="build-review-btn" class="btn btn-primary">Build &amp; review</button>
       <button id="confirm-submit-btn" class="btn btn-success" hidden>Confirm &amp; submit</button>
@@ -121,75 +70,12 @@
     </div></div>
   </div></div>
 
-  <!-- Section 2: Broadcast a pre-signed txn (advanced) -->
   <div class="row my-3"><div class="col">
-    <div class="card"><div class="card-body">
-      <div class="card-title h5">
-        <a class="text-decoration-none" data-bs-toggle="collapse"
-           href="#broadcast" role="button" aria-expanded="false"
-           aria-controls="broadcast">
-          Broadcast a pre-signed transaction (advanced)
-        </a>
-      </div>
-      <div id="broadcast" class="collapse">
-        <p class="small text-muted">
-          Paste an already-signed transaction JSON. The submit request itself is
-          still authed, so the imported key signs the request envelope.
-        </p>
-        <textarea id="broadcast-input" class="form-control" rows="6"
-                  placeholder='{"txid":"...","signature":"...", ...}'></textarea>
-        <button id="broadcast-btn" class="btn btn-primary mt-2">Submit</button>
-        <div id="broadcast-result" class="mt-2"></div>
-      </div>
-    </div></div>
-  </div></div>
-
-  <!-- Section 3: Sign attestation (PR 3) -->
-  <div class="row my-3"><div class="col">
-    <section id="attestation" class="card"><div class="card-body">
-      <div class="card-title h5">Sign a stake attestation</div>
-      <p class="small text-muted">
-        Produce a signed <code>gc-msg-v1</code> proof that you staked on a
-        subject &mdash; the producer side of
-        <a href="{{ url_for('browser.verify_view') }}">Verify</a>. Reuses the
-        key you imported above. The subject is the same RAW subject you staked.
-      </p>
-
-      <div class="mb-3">
-        <label for="att-txid" class="form-label">Transaction id (txid)</label>
-        <input id="att-txid" type="text" class="form-control"
-               placeholder="64-char hex txid of your stake">
-      </div>
-
-      <div class="mb-3">
-        <label for="att-kind" class="form-label">Kind</label>
-        <select id="att-kind" class="form-select">
-          <option value="opposition">opposition</option>
-          <option value="support">support</option>
-        </select>
-      </div>
-
-      <div class="mb-3">
-        <label for="att-subject" class="form-label">Subject</label>
-        <input id="att-subject" type="text" class="form-control"
-               placeholder="goblins">
-      </div>
-
-      <div class="mb-3">
-        <label for="att-amount" class="form-label">Amount (grains)</label>
-        <input id="att-amount" type="number" min="1" step="1"
-               class="form-control" placeholder="300">
-      </div>
-
-      <button id="att-sign-btn" class="btn btn-primary">Sign attestation</button>
-      <button id="att-copy-btn" class="btn btn-outline-secondary" hidden>Copy</button>
-
-      <div class="mt-3">
-        <div id="att-result" class="mb-2"></div>
-        <pre id="att-proof" class="small bg-light p-2"></pre>
-        <p class="small text-muted">Paste this into /verify.</p>
-      </div>
-    </div></section>
+    <p class="small text-muted">
+      Looking for the power tools? Broadcasting a pre-signed transaction
+      and signing stake attestations live on
+      <a href="{{ url_for('browser.advanced_view') }}">Advanced tools</a>.
+    </p>
   </div></div>
 
   {% include "transact/extra.html" ignore missing %}

--- a/tests/test_advanced_page.py
+++ b/tests/test_advanced_page.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import httpx
+
+
+def test_advanced_page_renders(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/advanced')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        # The two relocated power-user sections (#260).
+        assert 'id="broadcast"' in body
+        assert 'id="attestation"' in body
+        assert 'id="broadcast-input"' in body
+        assert 'id="broadcast-btn"' in body
+        assert 'id="att-txid"' in body
+        assert 'id="att-kind"' in body
+        assert 'id="att-subject"' in body
+        assert 'id="att-amount"' in body
+        assert 'id="att-sign-btn"' in body
+        # Both sections need a signing key: the shared key area is here.
+        assert 'id="saved-wallet"' in body
+        assert 'id="key-b58"' in body
+        assert 'id="import-key-btn"' in body
+        # The security framing travels with the key area.
+        assert 'never leaves your browser' in body
+        # Verify is presented as an advanced tool (link card, own route).
+        assert '/verify' in body
+        # gc-sig is node-bound; the glue signs for this node.
+        assert 'data-node-host' in body
+        assert 'js/transact-glue.mjs' in body
+        # super() in the scripts block keeps base's bundled JS.
+        assert 'bootstrap' in body
+
+
+def test_advanced_page_has_seam_hook():
+    # The hook is an optional include and base ships no such file, so
+    # the rendered page can't show it — assert via the template source.
+    template = (
+        Path(__file__).parent.parent
+        / 'src'
+        / 'gumptionchain'
+        / 'templates'
+        / 'advanced.html'
+    ).read_text()
+    assert '{% include "advanced/extra.html" ignore missing %}' in template
+
+
+def test_transact_page_no_longer_carries_advanced_sections(app, test_client):
+    with app.app_context():
+        body = str(test_client.get('/transact').data)
+        assert 'id="broadcast"' not in body
+        assert 'id="attestation"' not in body
+        assert 'id="att-sign-btn"' not in body
+        # The build & sign flow and its key area remain.
+        assert 'id="txn-type"' in body
+        assert 'id="key-b58"' in body
+        # A quiet pointer to the relocated tools.
+        assert '/advanced' in body
+        assert 'Advanced tools' in body
+
+
+def test_nav_links_advanced(app, test_client):
+    with app.app_context():
+        body = str(test_client.get('/advanced').data)
+        assert '>Advanced</a>' in body

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -14,18 +14,9 @@ def test_transact_page_renders(app, test_client):
         assert 'value="rescind"' in body
         # The security framing must be loud and present.
         assert 'never leaves your browser' in body
-        # Build & sign + broadcast + attestation sections.
-        assert 'id="broadcast"' in body
-        assert 'id="attestation"' in body
-        # The attestation section is wired (not a "coming soon" placeholder):
-        # it has its inputs and a Sign attestation button.
+        # The power tools live on /advanced now (#260) — covered by
+        # tests/test_advanced_page.py.
         assert 'Coming soon' not in body
-        assert 'id="att-txid"' in body
-        assert 'id="att-kind"' in body
-        assert 'id="att-subject"' in body
-        assert 'id="att-amount"' in body
-        assert 'id="att-sign-btn"' in body
-        assert 'Sign attestation' in body
         # The page exposes the node host (gc-sig is node-bound).
         assert 'data-node-host' in body
         # Glue module is wired in from the blueprint static js dir.

--- a/tests/test_ui_seam.py
+++ b/tests/test_ui_seam.py
@@ -250,3 +250,17 @@ def test_consumer_base_html_reskins_wallet_page(tmp_path):
         assert b'SKINNED' in resp.data  # consumer skin won over blueprint
         # base wallet content still rendered
         assert b'Persist only on a node you trust' in resp.data
+
+
+def test_consumer_base_html_reskins_advanced_page(tmp_path):
+    # Seam check for the /advanced power-tools page (static shell like
+    # /transact): consumer skin wins, base's advanced content renders.
+    app = _consumer_app(tmp_path)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/advanced')
+        assert resp.status_code == 200
+        assert b'SKINNED' in resp.data  # consumer skin won over blueprint
+        # base advanced content still rendered
+        assert b'Sign a stake attestation' in resp.data


### PR DESCRIPTION
Closes #260 — follow-on from the hub's Great Ledger session: the `/transact` page's power-user sections drowned the normie Build & sign flow.

## Changes

- **New `/advanced` page** (static shell like `/transact`): hosts the relocated **Broadcast a pre-signed transaction** and **Sign a stake attestation** sections, plus a link-card presenting `/verify` as the consumer-side tool (verify keeps its own route — proof cards deep-link it). Standard `advanced/extra.html` seam hook.
- **Shared key area** extracted to `_key_import.html` (saved-wallet unlock + ephemeral session import) — both relocated tools sign with the imported key, so the partial travels with them. The security framing ("never leaves your browser") renders on both pages.
- **One glue module serves both pages**: `transact-glue.mjs` already binds every section defensively (`if (broadcastBtn)` etc.), so no JS split was needed — verified by reading the bindings before designing.
- `/transact` slims to Build & sign + a quiet "Advanced tools →" pointer; vanilla nav gains **Advanced** after Wallet.

## Tests

New `test_advanced_page.py` (sections + key area + node-host wiring + seam hook + nav), `/transact` pinned to no longer carry the moved ids, old assertions reconciled. TDD: watched all four fail (404) first. Full suite 566 passed / 1 skipped; ruff + mypy clean.

Hub follow-up (separate small PR after gumption-hub#31 merges): Chain dropdown's Verify item → Advanced.

## How to test

```bash
uv run pytest tests/test_advanced_page.py tests/test_transact_page.py -q
```
Then on a dev node: /transact shows only Build & sign; /advanced has both tools and they sign with a key imported on that page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)