### PR TITLE
docs(egu-262): transact signet flow — design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
+++ b/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
@@ -27,8 +27,9 @@ docs PR merges). Single implementation PR.
   the DOM-free `whichKeyControls({hasWallet, passkeySupported})`
   (~line 283) used by `renderKeyControls()` (~line 423), and
   `src/gumptionchain/static/js/transact-glue.test.mjs` exists and runs
-  in CI — read it first; it likely tests `whichKeyControls` and those
-  tests must be UPDATED, not deleted, when the function is replaced.
+  in CI — read it first; its `whichKeyControls` tests stay green
+  through Tasks 1-2 and are deleted in Task 3 along with the function
+  and `renderKeyControls` (the new state model replaces all three).
 - The keyring record's `address` is plaintext (no unlock needed):
   `store.get()` → `{version, address, wallet_ct, wraps}` or `null`
   (`clients/wallet/gc-keyring.mjs:18-21`). Create =

--- a/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
+++ b/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
@@ -1,0 +1,626 @@
+# EGU #262 — Transact Signet Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the `/transact` key UX as an explicit three-state signet
+panel (inline create / locked / unlocked) with markup-level action gating
+and the one-session key collapsed under an Advanced disclosure.
+
+**Architecture:** Per the approved spec
+(`docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md`).
+A pure decision function (`whichSignetPanel`) picks the visible state;
+the shared `_key_import.html` partial becomes the state-machine markup
+(so `/advanced` inherits it); `transact-glue.mjs` gains create/lock
+wiring and toggles the build buttons' `disabled`. No server-side changes.
+
+**Tech Stack:** Jinja templates, vanilla ESM (`transact-glue.mjs`),
+`node --test` for JS (CI already runs
+`node --test clients/wallet/*.test.mjs src/gumptionchain/static/js/*.test.mjs`),
+pytest for template markup.
+
+**Branch:** `feat/egu-262-transact-signet-flow` off `main` (after the
+docs PR merges). Single implementation PR.
+
+**Verified-in-code facts the implementer needs:**
+
+- `transact-glue.mjs` (`src/gumptionchain/static/js/`) already exports
+  the DOM-free `whichKeyControls({hasWallet, passkeySupported})`
+  (~line 283) used by `renderKeyControls()` (~line 423), and
+  `src/gumptionchain/static/js/transact-glue.test.mjs` exists and runs
+  in CI — read it first; it likely tests `whichKeyControls` and those
+  tests must be UPDATED, not deleted, when the function is replaced.
+- The keyring record's `address` is plaintext (no unlock needed):
+  `store.get()` → `{version, address, wallet_ct, wraps}` or `null`
+  (`clients/wallet/gc-keyring.mjs:18-21`). Create =
+  `keyring.enroll(wallet, {store}, {passphrase})` after
+  `Wallet.generate()` — exactly `wallet-glue.mjs:219-244`'s handler.
+- Trust acknowledgment helpers are EXPORTED from
+  `src/gumptionchain/static/js/wallet-glue.mjs:60-76`
+  (`TRUST_ACK_KEY`, `readTrustAck(storage)`, `writeTrustAck(storage)`),
+  and `wallet-glue.mjs` has no module-body side effects (its own node
+  test imports it) — `transact-glue.mjs` imports them directly.
+- The in-memory wallet lives in the injected `session`
+  (`wallet-session.mjs`): `session.setWallet(w)`, `session.getWallet()`,
+  `session.lock()`, `session.onLock(cb)` (the existing `onLock` callback
+  in transact-glue ~line 703 re-renders — repoint it), and
+  `session.installAutoLock(...)` stays untouched.
+- `unlockSaved({store, session, passphrase|passkey})` (~line 295) is the
+  saved-unlock path; the ephemeral import handler also ends in
+  `session.setWallet`. The new `unlockSource` module variable must be
+  set in BOTH paths ('saved' / 'session') and cleared in the `onLock`
+  callback.
+- `Wallet.generate()` and `wallet.address()` are async
+  (`clients/wallet/gc-wallet.mjs`).
+- Markup-pinning pytest to reconcile: `tests/test_transact_page.py:36-38`
+  (`id="saved-wallet"`, 'Unlock your saved wallet',
+  `id="unlock-passphrase"`), `tests/test_advanced_page.py:22-24`
+  (`id="saved-wallet"`, `id="key-b58"`, `id="import-key-btn"`).
+  `tests/test_wallet_page.py:31` pins `unlock-passphrase` on /wallet —
+  UNAFFECTED (different page, untouched).
+- Run JS tests: `node --test src/gumptionchain/static/js/*.test.mjs`
+  (or a single file: `node --test <path>`); node is available.
+- Style: templates use Bootstrap 5 classes; collapse idiom =
+  `data-bs-toggle="collapse" href="#id"` (see the broadcast section in
+  `advanced.html`). Python gates: ruff 80-col single quotes, mypy
+  strict (no Python changes expected beyond tests).
+
+## File structure
+
+```
+src/gumptionchain/static/js/transact-glue.mjs       # Tasks 1, 3
+src/gumptionchain/static/js/transact-glue.test.mjs  # Tasks 1, 3
+src/gumptionchain/templates/_key_import.html        # Task 2 (rewrite)
+src/gumptionchain/templates/transact.html           # Task 2
+tests/test_transact_page.py                         # Task 2
+tests/test_advanced_page.py                         # Task 2
+```
+
+---
+
+### Task 1: `whichSignetPanel` decision function (node TDD)
+
+**Files:**
+- Modify: `src/gumptionchain/static/js/transact-glue.mjs`
+- Modify: `src/gumptionchain/static/js/transact-glue.test.mjs`
+
+- [ ] **Step 1: Read the existing test file**, note any
+`whichKeyControls` tests. They stay green in this task (the old
+function and markup survive until Tasks 2-3); Task 3 deletes them with
+the function.
+
+- [ ] **Step 2: Write the failing tests** (append to
+`transact-glue.test.mjs`, matching its import style):
+
+```javascript
+test('whichSignetPanel: no record -> none, actions disabled', () => {
+  const c = whichSignetPanel({
+    hasRecord: false,
+    unlockedKind: null,
+    passkeySupported: true,
+  });
+  assert.equal(c.state, 'none');
+  assert.equal(c.actionsEnabled, false);
+  assert.equal(c.badge, null);
+  assert.equal(c.showUnlockPasskey, false);
+});
+
+test('whichSignetPanel: record + locked -> locked, passkey button per support', () => {
+  const locked = whichSignetPanel({
+    hasRecord: true,
+    unlockedKind: null,
+    passkeySupported: true,
+  });
+  assert.equal(locked.state, 'locked');
+  assert.equal(locked.actionsEnabled, false);
+  assert.equal(locked.showUnlockPasskey, true);
+  const noPasskey = whichSignetPanel({
+    hasRecord: true,
+    unlockedKind: null,
+    passkeySupported: false,
+  });
+  assert.equal(noPasskey.showUnlockPasskey, false);
+});
+
+test('whichSignetPanel: unlocked saved -> unlocked, actions enabled, saved badge', () => {
+  const c = whichSignetPanel({
+    hasRecord: true,
+    unlockedKind: 'saved',
+    passkeySupported: true,
+  });
+  assert.equal(c.state, 'unlocked');
+  assert.equal(c.actionsEnabled, true);
+  assert.equal(c.badge, 'saved');
+});
+
+test('whichSignetPanel: session key -> unlocked even with no record', () => {
+  const c = whichSignetPanel({
+    hasRecord: false,
+    unlockedKind: 'session',
+    passkeySupported: false,
+  });
+  assert.equal(c.state, 'unlocked');
+  assert.equal(c.actionsEnabled, true);
+  assert.equal(c.badge, 'session');
+});
+```
+
+Add `whichSignetPanel` to the file's import list from
+`./transact-glue.mjs`.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `node --test src/gumptionchain/static/js/transact-glue.test.mjs`
+Expected: the new tests FAIL (whichSignetPanel not exported)
+
+- [ ] **Step 4: Implement** in `transact-glue.mjs`, ADDED ALONGSIDE
+`whichKeyControls` (which keeps serving the old markup until Task 3
+deletes it together with `renderKeyControls` and their tests — clean
+task boundary; both functions coexist after this task):
+
+```javascript
+// Pure state decision for the signet panel (#262). unlockedKind is
+// null (locked / no key), 'saved' (unlocked from the keyring), or
+// 'session' (one-session key imported under Advanced).
+export function whichSignetPanel({
+  hasRecord,
+  unlockedKind,
+  passkeySupported,
+}) {
+  if (unlockedKind) {
+    return {
+      state: 'unlocked',
+      badge: unlockedKind,
+      actionsEnabled: true,
+      showUnlockPasskey: false,
+    };
+  }
+  if (hasRecord) {
+    return {
+      state: 'locked',
+      badge: null,
+      actionsEnabled: false,
+      showUnlockPasskey: !!passkeySupported,
+    };
+  }
+  return {
+    state: 'none',
+    badge: null,
+    actionsEnabled: false,
+    showUnlockPasskey: false,
+  };
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `node --test src/gumptionchain/static/js/transact-glue.test.mjs`
+Expected: ALL pass (pre-existing whichKeyControls tests included —
+nothing replaced yet)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/static/js/transact-glue.mjs src/gumptionchain/static/js/transact-glue.test.mjs
+git commit -m "feat(transact): whichSignetPanel state decision (#262)"
+```
+
+---
+
+### Task 2: state-machine markup — partial + transact page (pytest TDD)
+
+**Files:**
+- Rewrite: `src/gumptionchain/templates/_key_import.html`
+- Modify: `src/gumptionchain/templates/transact.html`
+- Modify: `tests/test_transact_page.py`, `tests/test_advanced_page.py`
+
+- [ ] **Step 1: Write the failing tests.** In
+`tests/test_transact_page.py`, REPLACE
+`test_transact_page_has_saved_wallet_unlock_markup` with:
+
+```python
+def test_transact_page_signet_panel_states(app, test_client):
+    with app.app_context():
+        body = str(test_client.get('/transact').data)
+        # The three-state signet panel (#262): exactly one state is
+        # shown by JS; all ship in markup.
+        assert 'data-signet-state="none"' in body
+        assert 'data-signet-state="locked"' in body
+        assert 'data-signet-state="unlocked"' in body
+        # Inline mini-create (the conversion moment).
+        assert 'id="signet-create-passphrase"' in body
+        assert 'id="signet-trust-ack"' in body
+        assert 'id="signet-create-btn"' in body
+        assert 'Create your signet' in body
+        # Explicit unlock state.
+        assert 'id="unlock-passphrase"' in body
+        assert 'id="unlock-saved-btn"' in body
+        # Unlocked state: badge + explicit lock.
+        assert 'id="signet-badge"' in body
+        assert 'id="signet-lock-btn"' in body
+        # One-session key collapsed under Advanced.
+        assert 'id="session-key"' in body
+        assert 'class="collapse' in body
+        assert 'one-session key' in body
+        assert 'id="key-b58"' in body
+        assert 'id="import-key-btn"' in body
+        # Signet-first copy with the bridge parenthetical.
+        assert 'signing keypair' in body
+
+
+def test_transact_actions_disabled_until_unlocked(app, test_client):
+    with app.app_context():
+        body = str(test_client.get('/transact').data)
+        # Markup-level gating: build/confirm ship disabled; the glue
+        # enables them only in the unlocked state.
+        assert 'id="build-review-btn"' in body
+        assert 'disabled' in body.split('id="build-review-btn"')[1][:120]
+        assert 'disabled' in body.split('id="confirm-submit-btn"')[1][:120]
+```
+
+In `tests/test_advanced_page.py`, replace the three key-area
+assertions (lines ~22-24) with:
+
+```python
+        # The shared signet panel (#262) renders here too.
+        assert 'data-signet-state="none"' in body
+        assert 'data-signet-state="locked"' in body
+        assert 'id="key-b58"' in body
+        assert 'id="import-key-btn"' in body
+```
+
+(Keep the rest of that test untouched.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_transact_page.py tests/test_advanced_page.py -q`
+Expected: FAIL (new ids absent)
+
+- [ ] **Step 3: Rewrite `_key_import.html`** in full:
+
+```html
+{# Signet panel (#262): explicit three-state machine — no signet on
+   this device (inline create) / saved + locked (explicit unlock) /
+   unlocked (badge + Lock). Shared by transact.html and advanced.html;
+   transact-glue.mjs shows exactly one state container and gates the
+   page actions. The one-session key for power users is collapsed
+   under the Advanced disclosure in every state. #}
+<div id="signet-panel">
+  <div data-signet-state="none" hidden>
+    <div class="fw-semibold">Create your signet</div>
+    <p class="small text-muted mb-2">
+      Your signet (a signing keypair) marks your stakes as yours. It is
+      created in your browser and saved encrypted on this device &mdash;
+      it is never sent anywhere.
+    </p>
+    <label for="signet-create-passphrase" class="form-label">Passphrase</label>
+    <input id="signet-create-passphrase" type="password" autocomplete="off"
+           class="form-control" placeholder="choose a passphrase">
+    <div class="form-check mt-2">
+      <input id="signet-trust-ack" type="checkbox" class="form-check-input">
+      <label for="signet-trust-ack" class="form-check-label small">
+        Persist only on a node you trust: this saves your encrypted
+        signet in this browser, on this site.
+      </label>
+    </div>
+    <button id="signet-create-btn" class="btn btn-primary btn-sm mt-2">
+      Create your signet
+    </button>
+    <div id="signet-create-status" class="mt-2 small"></div>
+  </div>
+
+  <div data-signet-state="locked" hidden>
+    <div class="fw-semibold">
+      Your signet
+      <span class="badge text-bg-secondary">locked</span>
+    </div>
+    <p class="small text-muted mb-2">
+      Saved on this device as <code data-signet-address></code>.
+      Unlock it to sign.
+    </p>
+    <label for="unlock-passphrase" class="form-label">Passphrase</label>
+    <input id="unlock-passphrase" type="password" autocomplete="off"
+           class="form-control" placeholder="your signet passphrase">
+    <div class="mt-2">
+      <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
+        Unlock
+      </button>
+      <button id="unlock-saved-passkey-btn"
+              class="btn btn-outline-primary btn-sm" hidden>
+        Unlock with passkey
+      </button>
+    </div>
+    <div id="unlock-status" class="mt-2 small"></div>
+  </div>
+
+  <div data-signet-state="unlocked" hidden>
+    <span id="signet-badge" class="badge text-bg-success"></span>
+    <button id="signet-lock-btn" class="btn btn-outline-secondary btn-sm">
+      Lock
+    </button>
+    <div id="signet-backup-nudge" class="small text-muted mt-2" hidden>
+      Signet created. <a href="{{ url_for('browser.wallet_view') }}">Back
+      it up on the Wallet page</a> &mdash; the backup is your only
+      recovery.
+    </div>
+  </div>
+
+  <div class="mt-3">
+    <a class="small text-decoration-none" data-bs-toggle="collapse"
+       href="#session-key" role="button" aria-expanded="false"
+       aria-controls="session-key">
+      &#9656; Advanced: use a one-session key instead
+    </a>
+    <div id="session-key" class="collapse mt-2">
+      <label for="key-b58" class="form-label">
+        One-session key (base58 private key) &mdash; held in memory
+        only, nothing is saved
+      </label>
+      <textarea id="key-b58" class="form-control" rows="2"
+                placeholder="paste base58 private key"></textarea>
+      <div class="mt-2">
+        <label for="key-pem" class="form-label">or upload a .pem</label>
+        <input id="key-pem" type="file" accept=".pem" class="form-control">
+      </div>
+      <div class="mt-2">
+        <button id="import-key-btn" class="btn btn-secondary btn-sm">
+          Import key
+        </button>
+        <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
+          Forget key
+        </button>
+      </div>
+      <div id="key-status" class="mt-2 small"></div>
+    </div>
+  </div>
+</div>
+```
+
+(The old partial's `saved-wallet` container id and "or use a key just
+for this session" copy are gone by design.)
+
+- [ ] **Step 4: Restructure `transact.html`.** Three surgical changes
+(read the file; the form-fields block and the scripts block are
+untouched):
+
+(a) Replace the alert paragraph with one line:
+
+```html
+  <div class="row my-3"><div class="col">
+    <div class="alert alert-warning" role="alert">
+      <strong>Your private key never leaves your browser</strong> &mdash;
+      signing happens here, and only signatures are sent.
+    </div>
+  </div></div>
+```
+
+(b) The Build & sign card ends after the last `data-field-group` block
+(close the card right after the rescind-kind select's `</div>`); the
+`{% include "_key_import.html" %}` and the `<hr>` above it move OUT of
+the card. After the form card, add:
+
+```html
+  <!-- The signet gate (#262): filling the form is free; signing
+       requires the explicit unlock above the action. -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      {% include "_key_import.html" %}
+    </div></div>
+  </div></div>
+
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <button id="build-review-btn" class="btn btn-primary" disabled>
+        Build &amp; review
+      </button>
+      <button id="confirm-submit-btn" class="btn btn-success" hidden disabled>
+        Confirm &amp; submit
+      </button>
+      <div class="mt-3">
+        <pre id="confirm-area" class="small bg-light p-2"></pre>
+        <div id="build-result" class="mt-2"></div>
+      </div>
+    </div></div>
+  </div></div>
+```
+
+(the old in-card button/confirm-area block is removed — same ids, new
+location, plus `disabled` on both buttons).
+
+(c) Page copy: the card title stays `Build &amp; sign a transaction`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `uv run pytest tests/test_transact_page.py tests/test_advanced_page.py tests/test_ui_seam.py -q`
+Expected: ALL pass (seam tests assert copy that still exists — verify;
+if `test_consumer_base_html_reskins_transact_page` pinned removed copy,
+update its content assertion to `Build &amp; sign`-family text and
+report the change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/templates tests/test_transact_page.py tests/test_advanced_page.py tests/test_ui_seam.py
+git commit -m "feat(transact): three-state signet panel markup, gated actions (#262)"
+```
+
+---
+
+### Task 3: glue wiring — create, lock, state rendering, gating
+
+**Files:**
+- Modify: `src/gumptionchain/static/js/transact-glue.mjs`
+- Modify: `src/gumptionchain/static/js/transact-glue.test.mjs` (only if
+  pure helpers are added)
+
+- [ ] **Step 1: Imports + state.** Add to transact-glue.mjs imports:
+
+```javascript
+import { readTrustAck, writeTrustAck } from './wallet-glue.mjs';
+```
+
+Inside `init()`, add a module of new element lookups next to the
+existing ones, and the unlock-source tracker:
+
+```javascript
+  const createPassphrase = $('#signet-create-passphrase');
+  const createTrustAck = $('#signet-trust-ack');
+  const createBtn = $('#signet-create-btn');
+  const createStatus = $('#signet-create-status');
+  const signetBadge = $('#signet-badge');
+  const lockBtn = $('#signet-lock-btn');
+  const backupNudge = $('#signet-backup-nudge');
+  const storage = win ? win.localStorage : undefined;
+  // 'saved' | 'session' | null — which key source unlocked the page.
+  let unlockSource = null;
+```
+
+- [ ] **Step 2: Replace `renderKeyControls` with `renderSignetPanel`**
+(NOW delete `whichKeyControls`, `renderKeyControls`, and the old
+whichKeyControls tests — the new state containers from Task 2 are the
+only markup left; note the interim state between Tasks 2 and 3 renders
+an all-hidden panel, which is fine inside a single PR):
+
+```javascript
+  async function renderSignetPanel() {
+    let rec = null;
+    try {
+      rec = await store.get();
+    } catch {
+      // IDB unavailable: fall through to the no-signet state; the
+      // Advanced one-session key still works.
+      if (createStatus) {
+        setStatus(
+          createStatus,
+          'Saved signets are unavailable in this browser; use the ' +
+            'Advanced one-session key below.',
+          'error',
+        );
+      }
+    }
+    const c = whichSignetPanel({
+      hasRecord: rec !== null,
+      unlockedKind: session.getWallet() ? unlockSource : null,
+      passkeySupported: passkey != null,
+    });
+    for (const el of root.querySelectorAll('[data-signet-state]')) {
+      show(el, el.dataset.signetState === c.state);
+    }
+    show(unlockPasskeyBtn, c.showUnlockPasskey);
+    const addrEl = root.querySelector('[data-signet-address]');
+    if (addrEl && rec) addrEl.textContent = `${rec.address.slice(0, 12)}…`;
+    if (signetBadge && c.state === 'unlocked') {
+      const addr = await session.getWallet().address();
+      signetBadge.textContent =
+        c.badge === 'session'
+          ? `one-session key · ${addr.slice(0, 12)}…`
+          : `signing as ${addr.slice(0, 12)}…`;
+    }
+    if (backupNudge && c.state !== 'unlocked') show(backupNudge, false);
+    for (const btn of [buildBtn, confirmBtn]) {
+      if (btn) btn.disabled = !c.actionsEnabled;
+    }
+  }
+```
+
+Update every existing `renderKeyControls()` call site (unlock handlers,
+the `onLock` callback, the bootstrap IIFE) to `renderSignetPanel()`, and
+in the `onLock` callback also clear the source: `unlockSource = null;`.
+In the two saved-unlock handlers set `unlockSource = 'saved'` after a
+successful `unlockSaved(...)`; in the ephemeral import handler set
+`unlockSource = 'session'` after its `session.setWallet(...)`; in the
+forget handler clear it (`unlockSource = null`) before/with
+`session.lock()`.
+
+NOTE: `confirmBtn.disabled` interacts with the existing build flow —
+the build handler reveals `confirmBtn` (`confirmBtn.hidden = false`);
+verify it doesn't also need `confirmBtn.disabled = false` (it will be
+enabled already since building requires the unlocked state — but
+`resetPending()` hides it again; leave `disabled` driven ONLY by
+`renderSignetPanel` and `hidden` by the build flow, which composes
+correctly).
+
+- [ ] **Step 3: The create handler** (next to the unlock handlers):
+
+```javascript
+  if (createBtn) {
+    createBtn.addEventListener('click', async () => {
+      const passphrase = createPassphrase ? createPassphrase.value : '';
+      if (!passphrase) {
+        setStatus(createStatus, 'Set a passphrase first.', 'error');
+        return;
+      }
+      if (!readTrustAck(storage)) {
+        if (createTrustAck && createTrustAck.checked) {
+          writeTrustAck(storage);
+        } else {
+          setStatus(
+            createStatus,
+            'Acknowledge the trust note first: persist only on a node ' +
+              'you trust.',
+            'error',
+          );
+          return;
+        }
+      }
+      try {
+        const wallet = await Wallet.generate();
+        await keyring.enroll(wallet, { store }, { passphrase });
+        session.setWallet(wallet);
+        unlockSource = 'saved';
+        createPassphrase.value = '';
+        if (backupNudge) show(backupNudge, true);
+        await renderSignetPanel();
+      } catch (e) {
+        setStatus(createStatus, `Could not create: ${msgOf(e)}`, 'error');
+      }
+    });
+  }
+
+  if (lockBtn) {
+    lockBtn.addEventListener('click', () => {
+      session.lock();
+    });
+  }
+```
+
+(`session.lock()` fires the `onLock` callback, which clears
+`unlockSource` and re-renders — no direct render call needed here.)
+
+- [ ] **Step 4: Verify the JS suite + lint posture**
+
+Run: `node --test src/gumptionchain/static/js/*.test.mjs clients/wallet/*.test.mjs`
+Expected: ALL pass. If any existing transact-glue test stubbed the old
+`#saved-wallet` rendering, update it to the state-container model (and
+report the change).
+
+- [ ] **Step 5: Manual checklist on a dev node** (operator step —
+document the results in the PR body): fresh browser profile →
+`/transact` shows Create state, buttons disabled → create → unlocked
+badge + nudge, buttons enabled → build+submit a stake → Lock → locked
+state, buttons disabled → unlock → enabled; Advanced disclosure: import
+b58 → `one-session key` badge; Forget → back to locked/none;
+`/advanced` shows the same panel and its tools require the unlocked
+state's key.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/static/js
+git commit -m "feat(transact): signet panel controller — create, lock, gated actions (#262)"
+```
+
+---
+
+### Task 4: Gates + PR + sibling-sweep issue
+
+- [ ] `uv run pytest -q` (full suite)
+- [ ] `node --test clients/wallet/*.test.mjs src/gumptionchain/static/js/*.test.mjs`
+- [ ] `uv run ruff format --check src tests && uv run ruff check src tests && uv run mypy`
+- [ ] `uv run pre-commit run --all-files` (app.py findings are
+  pre-existing, tracked in #256 — ignore those two)
+- [ ] File the sibling issue: "Base browser signet copy sweep —
+  /wallet, /advanced, /verify" referencing #262's vocabulary section
+  and hub#30's scope-split comment (operator surfaces keep 'wallet').
+- [ ] PR `feat(browser): explicit signet states on /transact — inline
+  create, gated signing (#262)`; body includes the manual-checklist
+  results; subagent review; hold for author review.

--- a/docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md
+++ b/docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md
@@ -1,0 +1,158 @@
+# EGU #262 — transact flow: explicit signet states
+
+**Date:** 2026-06-11
+**Issue:** #262 (follows #260's /advanced split; coordinates with the
+signet vocabulary introduced on the hub landing — see hub#30's scope-split
+comment)
+**Status:** design approved (interactive brainstorm 2026-06-11; layout
+mockups in `.superpowers/brainstorm/`, layout B selected)
+
+## Goal
+
+Make `/transact` the conversion surface it actually is: **creating a
+transaction is one flow through which people create signets.** Three
+directives, verbatim from the brainstorm:
+
+1. A visitor with no signet can create one inline, without leaving the
+   flow.
+2. **Explicit unlock UI** — a visible locked/unlocked state that gates
+   signing, instead of discovering at click time that a key is missing.
+3. The per-session key (b58 paste / .pem upload) is a power-user tool:
+   collapsed under an "Advanced" disclosure.
+
+## Page composition (layout B: form first, gate at the action)
+
+`/transact` top to bottom:
+
+1. Security alert (one line, lighter than today's paragraph).
+2. **Build & sign form** — type/amount/destination/subject/rescind-kind
+   fields, unchanged ids and behavior. Filling the form requires nothing.
+3. **Signet panel** — the explicit state machine (below). Sits between
+   the form and the action: the literal gate.
+4. Action area — `Build & review` / `Confirm & submit`, **disabled at the
+   markup level** (`disabled` attribute) unless the panel is unlocked.
+   The state machine enables them; `requireWallet`'s click-time error
+   remains only as a backstop.
+5. "Advanced tools →" pointer (unchanged), `transact/extra.html` hook
+   (unchanged).
+
+No server-side changes: routes, context (`node_host`, `rp_name`), and
+the build/submit API are untouched.
+
+## The signet panel: a three-state machine
+
+Lives in the shared `_key_import.html` partial (so `/advanced` inherits
+it identically — its broadcast/attestation tools gate on the same
+states). Exactly one state is visible at a time; the JS controller picks
+it from `gc-keyring` store contents + in-memory unlock state.
+
+### State 1 — no signet on this device
+
+The panel is an inline **mini-create** (the conversion moment):
+
+- Heading: `Create your signet` with the one-time bridge parenthetical:
+  "your signet (a signing keypair) marks your stakes as yours."
+- Passphrase field + the same trust acknowledgment `/wallet` uses
+  (persisting writes the encrypted keypair to this origin's IndexedDB —
+  same checkbox copy).
+- `Create your signet` button → `gc-keyring` generate + save (the exact
+  machinery behind `/wallet`'s create-btn), then transition straight to
+  state 3 (unlocked), ready to sign the txn the visitor came to make.
+- Post-create nudge (in the state-3 panel): "Back up your signet on the
+  [Wallet] page" — backup download and passkey enrollment deliberately
+  stay on `/wallet`; no forced backup step blocks the flow.
+
+### State 2 — signet saved, locked
+
+- Heading: `Your signet` + `locked` badge; shows the saved address.
+- Passphrase field + `Unlock` button; `Unlock with passkey` button when
+  a passkey is enrolled (today's reveal logic).
+- Nothing else — the form above is fillable, the actions below are
+  disabled.
+
+### State 3 — unlocked
+
+- `Signing as <address>` badge (green) + `Lock` button.
+- Auto-lock behavior unchanged (idle / tab-hide / leave / Forget —
+  today's session handling); auto-lock returns the panel to state 2 and
+  re-disables the action buttons.
+- After an inline create, this state carries the backup nudge line.
+
+### The Advanced disclosure (all states)
+
+`▸ Advanced: use a one-session key instead` — a collapsed disclosure
+(Bootstrap collapse, like the broadcast section) wrapping today's
+ephemeral import markup (b58 textarea, .pem upload, Import/Forget
+buttons, status line). Importing a session key enters a variant of
+state 3 with a visually distinct badge — `one-session key · <address>` —
+so a session key is never mistaken for the saved signet. Forget returns
+to whichever of states 1/2 applies.
+
+## Vocabulary
+
+Signet-first copy throughout the partial and the transact page, with the
+bridge parenthetical once per page. This is **part 1 of the base browser
+signet sweep** (hub#30 scope split): `/wallet`, `/advanced`, and
+`/verify` copy follow as a **sibling PR** in this repo — this PR touches
+only the shared partial + `transact.html`, so the sweep PR has no
+overlap. Operator surfaces (CLI, `GC_*` config, Pi HOWTO/runbook,
+api-auth docs) keep "wallet" permanently — they document the
+never-renamed code identifiers.
+
+## Code shape
+
+- **`_key_import.html`** — rewritten as the state-machine markup: three
+  state containers (`data-signet-state="none|locked|unlocked"`), all
+  initially hidden, plus the Advanced disclosure. Ids the glue already
+  binds keep their names where the control survives (`unlock-passphrase`,
+  `unlock-saved-btn`, `unlock-saved-passkey-btn`, `key-b58`, `key-pem`,
+  `import-key-btn`, `forget-key-btn`, `key-status`); new controls get
+  new ids (`signet-create-passphrase`, `signet-trust-ack`,
+  `signet-create-btn`, `signet-lock-btn`, `signet-badge`).
+- **`transact-glue.mjs`** — gains a small state controller: computes the
+  state (store record present? unlocked wallet in memory? session key?),
+  shows exactly one state container, toggles the action buttons'
+  `disabled`. Create wires to the same keyring call `/wallet`'s glue
+  uses. The existing defensive `if (el)` binding style is preserved so
+  `/advanced` (no build buttons) and `/transact` share the module
+  unchanged.
+- **Factor for testability:** the pure state-decision function
+  (inputs: has-record / unlocked / session-key → outputs: visible state,
+  buttons enabled, badge text) lives where the wallet ESM's existing
+  node test infrastructure (`clients/wallet/*.test.mjs`) can exercise
+  it. The implementation plan verifies how those tests run and follows
+  the established pattern; if the glue is not under that harness today,
+  the decision function moves to a small `clients/wallet/` module that
+  is.
+- `/wallet`'s own page and glue are untouched in this PR.
+
+## Error/edge posture
+
+- Wrong passphrase fails closed with the keyring's existing error
+  message; state stays locked.
+- Creating when storage is unavailable (IDB blocked) shows the error in
+  the panel and falls back to suggesting the Advanced session key.
+- The action buttons' disabled state is belt-and-braces: the click-time
+  `requireWallet` guard stays.
+- `/advanced` renders the same panel; its tools already require-wallet
+  at click time and additionally benefit from the explicit state.
+
+## Testing
+
+- **Template (pytest):** the three state containers + Advanced
+  disclosure render on `/transact` AND `/advanced` (shared partial);
+  action buttons carry `disabled` in initial markup; signet copy +
+  bridge parenthetical present; existing transact/advanced/seam tests
+  reconciled where they pin old copy or structure.
+- **State logic (node, `*.test.mjs`):** the decision function's matrix —
+  no record → `none`; record + locked → `locked`; record + unlocked →
+  `unlocked` (saved badge); session key → `unlocked` (session badge);
+  forget/lock transitions; buttons-enabled only in unlocked states.
+- Manual pass on a dev node: create → sign → lock → unlock → sign;
+  session-key path under Advanced; `/advanced` tools gated the same way.
+
+## Out of scope
+
+- `/wallet`, `/advanced`, `/verify` copy sweep (sibling PR, this repo).
+- Backup/passkey enrollment inline on `/transact` (stays on `/wallet`).
+- Any change to the build/submit API or auth scheme.


### PR DESCRIPTION
Design checkpoint for #262 (docs only; implementation follows once this merges).

## What the spec locks

- **Layout B** from the mockups: form first, the signet panel as the literal gate between form and action, Build/Confirm `disabled` at markup level until unlocked.
- **Three-state panel** in the shared `_key_import.html` partial (so `/advanced` inherits it): inline mini-create (gc-keyring `enroll`, `/wallet`'s trust ack reused via the already-exported helpers, backup nudge, straight to unlocked), explicit locked state showing the saved address (plaintext in the keyring record — no unlock needed), unlocked with `signing as` badge + Lock.
- **One-session key** collapsed under "▸ Advanced" in every state, with a distinct `one-session key ·` badge so the two key sources can't be confused.
- **Vocabulary boundary**: signet-first browser copy as part 1 of the base sweep (hub#30 scope-split comment is the cross-repo record); operator surfaces keep "wallet" permanently; `/wallet`+`/advanced`+`/verify` copy is a sibling PR with zero file overlap.

## Plan notes

Four TDD tasks with all code verbatim. Verified facts baked in: the JS harness is CI's `node --test clients/wallet/*.test.mjs src/gumptionchain/static/js/*.test.mjs` (the `whichKeyControls` precedent gives the new `whichSignetPanel` its testable home), trust-ack helpers are importable from `wallet-glue.mjs` with no module side effects, and the task boundary keeps old and new state functions coexisting until the wiring task deletes the old pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)