### PR TITLE
feat(browser): explicit signing-key states on /transact — inline create, gated signing (#262)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
+++ b/docs/superpowers/plans/2026-06-11-egu-262-transact-signet-flow.md
@@ -1,14 +1,14 @@
-# EGU #262 — Transact Signet Flow Implementation Plan
+# EGU #262 — Transact Signing-Key Flow Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Rebuild the `/transact` key UX as an explicit three-state signet
+**Goal:** Rebuild the `/transact` key UX as an explicit three-state signing-key
 panel (inline create / locked / unlocked) with markup-level action gating
 and the one-session key collapsed under an Advanced disclosure.
 
 **Architecture:** Per the approved spec
 (`docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md`).
-A pure decision function (`whichSignetPanel`) picks the visible state;
+A pure decision function (`whichKeyPanel`) picks the visible state;
 the shared `_key_import.html` partial becomes the state-machine markup
 (so `/advanced` inherits it); `transact-glue.mjs` gains create/lock
 wiring and toggles the build buttons' `disabled`. No server-side changes.
@@ -78,7 +78,7 @@ tests/test_advanced_page.py                         # Task 2
 
 ---
 
-### Task 1: `whichSignetPanel` decision function (node TDD)
+### Task 1: `whichKeyPanel` decision function (node TDD)
 
 **Files:**
 - Modify: `src/gumptionchain/static/js/transact-glue.mjs`
@@ -93,8 +93,8 @@ the function.
 `transact-glue.test.mjs`, matching its import style):
 
 ```javascript
-test('whichSignetPanel: no record -> none, actions disabled', () => {
-  const c = whichSignetPanel({
+test('whichKeyPanel: no record -> none, actions disabled', () => {
+  const c = whichKeyPanel({
     hasRecord: false,
     unlockedKind: null,
     passkeySupported: true,
@@ -105,8 +105,8 @@ test('whichSignetPanel: no record -> none, actions disabled', () => {
   assert.equal(c.showUnlockPasskey, false);
 });
 
-test('whichSignetPanel: record + locked -> locked, passkey button per support', () => {
-  const locked = whichSignetPanel({
+test('whichKeyPanel: record + locked -> locked, passkey button per support', () => {
+  const locked = whichKeyPanel({
     hasRecord: true,
     unlockedKind: null,
     passkeySupported: true,
@@ -114,7 +114,7 @@ test('whichSignetPanel: record + locked -> locked, passkey button per support', 
   assert.equal(locked.state, 'locked');
   assert.equal(locked.actionsEnabled, false);
   assert.equal(locked.showUnlockPasskey, true);
-  const noPasskey = whichSignetPanel({
+  const noPasskey = whichKeyPanel({
     hasRecord: true,
     unlockedKind: null,
     passkeySupported: false,
@@ -122,8 +122,8 @@ test('whichSignetPanel: record + locked -> locked, passkey button per support', 
   assert.equal(noPasskey.showUnlockPasskey, false);
 });
 
-test('whichSignetPanel: unlocked saved -> unlocked, actions enabled, saved badge', () => {
-  const c = whichSignetPanel({
+test('whichKeyPanel: unlocked saved -> unlocked, actions enabled, saved badge', () => {
+  const c = whichKeyPanel({
     hasRecord: true,
     unlockedKind: 'saved',
     passkeySupported: true,
@@ -133,8 +133,8 @@ test('whichSignetPanel: unlocked saved -> unlocked, actions enabled, saved badge
   assert.equal(c.badge, 'saved');
 });
 
-test('whichSignetPanel: session key -> unlocked even with no record', () => {
-  const c = whichSignetPanel({
+test('whichKeyPanel: session key -> unlocked even with no record', () => {
+  const c = whichKeyPanel({
     hasRecord: false,
     unlockedKind: 'session',
     passkeySupported: false,
@@ -145,13 +145,13 @@ test('whichSignetPanel: session key -> unlocked even with no record', () => {
 });
 ```
 
-Add `whichSignetPanel` to the file's import list from
+Add `whichKeyPanel` to the file's import list from
 `./transact-glue.mjs`.
 
 - [ ] **Step 3: Run to verify failure**
 
 Run: `node --test src/gumptionchain/static/js/transact-glue.test.mjs`
-Expected: the new tests FAIL (whichSignetPanel not exported)
+Expected: the new tests FAIL (whichKeyPanel not exported)
 
 - [ ] **Step 4: Implement** in `transact-glue.mjs`, ADDED ALONGSIDE
 `whichKeyControls` (which keeps serving the old markup until Task 3
@@ -159,10 +159,10 @@ deletes it together with `renderKeyControls` and their tests — clean
 task boundary; both functions coexist after this task):
 
 ```javascript
-// Pure state decision for the signet panel (#262). unlockedKind is
+// Pure state decision for the key panel (#262). unlockedKind is
 // null (locked / no key), 'saved' (unlocked from the keyring), or
 // 'session' (one-session key imported under Advanced).
-export function whichSignetPanel({
+export function whichKeyPanel({
   hasRecord,
   unlockedKind,
   passkeySupported,
@@ -202,7 +202,7 @@ nothing replaced yet)
 
 ```bash
 git add src/gumptionchain/static/js/transact-glue.mjs src/gumptionchain/static/js/transact-glue.test.mjs
-git commit -m "feat(transact): whichSignetPanel state decision (#262)"
+git commit -m "feat(transact): whichKeyPanel state decision (#262)"
 ```
 
 ---
@@ -219,33 +219,33 @@ git commit -m "feat(transact): whichSignetPanel state decision (#262)"
 `test_transact_page_has_saved_wallet_unlock_markup` with:
 
 ```python
-def test_transact_page_signet_panel_states(app, test_client):
+def test_transact_page_key_panel_states(app, test_client):
     with app.app_context():
         body = str(test_client.get('/transact').data)
-        # The three-state signet panel (#262): exactly one state is
+        # The three-state key panel (#262): exactly one state is
         # shown by JS; all ship in markup.
-        assert 'data-signet-state="none"' in body
-        assert 'data-signet-state="locked"' in body
-        assert 'data-signet-state="unlocked"' in body
+        assert 'data-key-state="none"' in body
+        assert 'data-key-state="locked"' in body
+        assert 'data-key-state="unlocked"' in body
         # Inline mini-create (the conversion moment).
-        assert 'id="signet-create-passphrase"' in body
-        assert 'id="signet-trust-ack"' in body
-        assert 'id="signet-create-btn"' in body
-        assert 'Create your signet' in body
+        assert 'id="key-create-passphrase"' in body
+        assert 'id="key-trust-ack"' in body
+        assert 'id="key-create-btn"' in body
+        assert 'Create your signing key' in body  # noqa: dup-ok
         # Explicit unlock state.
         assert 'id="unlock-passphrase"' in body
         assert 'id="unlock-saved-btn"' in body
         # Unlocked state: badge + explicit lock.
-        assert 'id="signet-badge"' in body
-        assert 'id="signet-lock-btn"' in body
+        assert 'id="key-badge"' in body
+        assert 'id="key-lock-btn"' in body
         # One-session key collapsed under Advanced.
         assert 'id="session-key"' in body
         assert 'class="collapse' in body
         assert 'one-session key' in body
         assert 'id="key-b58"' in body
         assert 'id="import-key-btn"' in body
-        # Signet-first copy with the bridge parenthetical.
-        assert 'signing keypair' in body
+        # Key-first copy; self-explanatory, no glossary needed.
+        assert 'Create your signing key' in body
 
 
 def test_transact_actions_disabled_until_unlocked(app, test_client):
@@ -262,9 +262,9 @@ In `tests/test_advanced_page.py`, replace the three key-area
 assertions (lines ~22-24) with:
 
 ```python
-        # The shared signet panel (#262) renders here too.
-        assert 'data-signet-state="none"' in body
-        assert 'data-signet-state="locked"' in body
+        # The shared key panel (#262) renders here too.
+        assert 'data-key-state="none"' in body
+        assert 'data-key-state="locked"' in body
         assert 'id="key-b58"' in body
         assert 'id="import-key-btn"' in body
 ```
@@ -279,48 +279,48 @@ Expected: FAIL (new ids absent)
 - [ ] **Step 3: Rewrite `_key_import.html`** in full:
 
 ```html
-{# Signet panel (#262): explicit three-state machine — no signet on
+{# Key panel (#262): explicit three-state machine — no key on
    this device (inline create) / saved + locked (explicit unlock) /
    unlocked (badge + Lock). Shared by transact.html and advanced.html;
    transact-glue.mjs shows exactly one state container and gates the
    page actions. The one-session key for power users is collapsed
    under the Advanced disclosure in every state. #}
-<div id="signet-panel">
-  <div data-signet-state="none" hidden>
-    <div class="fw-semibold">Create your signet</div>
+<div id="key-panel">
+  <div data-key-state="none" hidden>
+    <div class="fw-semibold">Create your signing key</div>
     <p class="small text-muted mb-2">
-      Your signet (a signing keypair) marks your stakes as yours. It is
-      created in your browser and saved encrypted on this device &mdash;
-      it is never sent anywhere.
+      Your signing key marks your stakes as yours. It is created in
+      your browser and saved encrypted on this device &mdash; it is
+      never sent anywhere.
     </p>
-    <label for="signet-create-passphrase" class="form-label">Passphrase</label>
-    <input id="signet-create-passphrase" type="password" autocomplete="off"
+    <label for="key-create-passphrase" class="form-label">Passphrase</label>
+    <input id="key-create-passphrase" type="password" autocomplete="off"
            class="form-control" placeholder="choose a passphrase">
     <div class="form-check mt-2">
-      <input id="signet-trust-ack" type="checkbox" class="form-check-input">
-      <label for="signet-trust-ack" class="form-check-label small">
+      <input id="key-trust-ack" type="checkbox" class="form-check-input">
+      <label for="key-trust-ack" class="form-check-label small">
         Persist only on a node you trust: this saves your encrypted
-        signet in this browser, on this site.
+        key in this browser, on this site.
       </label>
     </div>
-    <button id="signet-create-btn" class="btn btn-primary btn-sm mt-2">
-      Create your signet
+    <button id="key-create-btn" class="btn btn-primary btn-sm mt-2">
+      Create your signing key
     </button>
-    <div id="signet-create-status" class="mt-2 small"></div>
+    <div id="key-create-status" class="mt-2 small"></div>
   </div>
 
-  <div data-signet-state="locked" hidden>
+  <div data-key-state="locked" hidden>
     <div class="fw-semibold">
-      Your signet
+      Your signing key
       <span class="badge text-bg-secondary">locked</span>
     </div>
     <p class="small text-muted mb-2">
-      Saved on this device as <code data-signet-address></code>.
+      Saved on this device as <code data-key-address></code>.
       Unlock it to sign.
     </p>
     <label for="unlock-passphrase" class="form-label">Passphrase</label>
     <input id="unlock-passphrase" type="password" autocomplete="off"
-           class="form-control" placeholder="your signet passphrase">
+           class="form-control" placeholder="your key passphrase">
     <div class="mt-2">
       <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
         Unlock
@@ -333,13 +333,13 @@ Expected: FAIL (new ids absent)
     <div id="unlock-status" class="mt-2 small"></div>
   </div>
 
-  <div data-signet-state="unlocked" hidden>
-    <span id="signet-badge" class="badge text-bg-success"></span>
-    <button id="signet-lock-btn" class="btn btn-outline-secondary btn-sm">
+  <div data-key-state="unlocked" hidden>
+    <span id="key-badge" class="badge text-bg-success"></span>
+    <button id="key-lock-btn" class="btn btn-outline-secondary btn-sm">
       Lock
     </button>
-    <div id="signet-backup-nudge" class="small text-muted mt-2" hidden>
-      Signet created. <a href="{{ url_for('browser.wallet_view') }}">Back
+    <div id="key-backup-nudge" class="small text-muted mt-2" hidden>
+      Key created. <a href="{{ url_for('browser.wallet_view') }}">Back
       it up on the Wallet page</a> &mdash; the backup is your only
       recovery.
     </div>
@@ -400,7 +400,7 @@ untouched):
 the card. After the form card, add:
 
 ```html
-  <!-- The signet gate (#262): filling the form is free; signing
+  <!-- The key gate (#262): filling the form is free; signing
        requires the explicit unlock above the action. -->
   <div class="row my-3"><div class="col">
     <div class="card"><div class="card-body">
@@ -441,7 +441,7 @@ report the change).
 
 ```bash
 git add src/gumptionchain/templates tests/test_transact_page.py tests/test_advanced_page.py tests/test_ui_seam.py
-git commit -m "feat(transact): three-state signet panel markup, gated actions (#262)"
+git commit -m "feat(transact): three-state key panel markup, gated actions (#262)"
 ```
 
 ---
@@ -463,55 +463,55 @@ Inside `init()`, add a module of new element lookups next to the
 existing ones, and the unlock-source tracker:
 
 ```javascript
-  const createPassphrase = $('#signet-create-passphrase');
-  const createTrustAck = $('#signet-trust-ack');
-  const createBtn = $('#signet-create-btn');
-  const createStatus = $('#signet-create-status');
-  const signetBadge = $('#signet-badge');
-  const lockBtn = $('#signet-lock-btn');
-  const backupNudge = $('#signet-backup-nudge');
+  const createPassphrase = $('#key-create-passphrase');
+  const createTrustAck = $('#key-trust-ack');
+  const createBtn = $('#key-create-btn');
+  const createStatus = $('#key-create-status');
+  const keyBadge = $('#key-badge');
+  const lockBtn = $('#key-lock-btn');
+  const backupNudge = $('#key-backup-nudge');
   const storage = win ? win.localStorage : undefined;
   // 'saved' | 'session' | null — which key source unlocked the page.
   let unlockSource = null;
 ```
 
-- [ ] **Step 2: Replace `renderKeyControls` with `renderSignetPanel`**
+- [ ] **Step 2: Replace `renderKeyControls` with `renderKeyPanel`**
 (NOW delete `whichKeyControls`, `renderKeyControls`, and the old
 whichKeyControls tests — the new state containers from Task 2 are the
 only markup left; note the interim state between Tasks 2 and 3 renders
 an all-hidden panel, which is fine inside a single PR):
 
 ```javascript
-  async function renderSignetPanel() {
+  async function renderKeyPanel() {
     let rec = null;
     try {
       rec = await store.get();
     } catch {
-      // IDB unavailable: fall through to the no-signet state; the
+      // IDB unavailable: fall through to the no-key state; the
       // Advanced one-session key still works.
       if (createStatus) {
         setStatus(
           createStatus,
-          'Saved signets are unavailable in this browser; use the ' +
+          'Saved keys are unavailable in this browser; use the ' +
             'Advanced one-session key below.',
           'error',
         );
       }
     }
-    const c = whichSignetPanel({
+    const c = whichKeyPanel({
       hasRecord: rec !== null,
       unlockedKind: session.getWallet() ? unlockSource : null,
       passkeySupported: passkey != null,
     });
-    for (const el of root.querySelectorAll('[data-signet-state]')) {
-      show(el, el.dataset.signetState === c.state);
+    for (const el of root.querySelectorAll('[data-key-state]')) {
+      show(el, el.dataset.keyState === c.state);
     }
     show(unlockPasskeyBtn, c.showUnlockPasskey);
-    const addrEl = root.querySelector('[data-signet-address]');
+    const addrEl = root.querySelector('[data-key-address]');
     if (addrEl && rec) addrEl.textContent = `${rec.address.slice(0, 12)}…`;
-    if (signetBadge && c.state === 'unlocked') {
+    if (keyBadge && c.state === 'unlocked') {
       const addr = await session.getWallet().address();
-      signetBadge.textContent =
+      keyBadge.textContent =
         c.badge === 'session'
           ? `one-session key · ${addr.slice(0, 12)}…`
           : `signing as ${addr.slice(0, 12)}…`;
@@ -524,7 +524,7 @@ an all-hidden panel, which is fine inside a single PR):
 ```
 
 Update every existing `renderKeyControls()` call site (unlock handlers,
-the `onLock` callback, the bootstrap IIFE) to `renderSignetPanel()`, and
+the `onLock` callback, the bootstrap IIFE) to `renderKeyPanel()`, and
 in the `onLock` callback also clear the source: `unlockSource = null;`.
 In the two saved-unlock handlers set `unlockSource = 'saved'` after a
 successful `unlockSaved(...)`; in the ephemeral import handler set
@@ -537,7 +537,7 @@ the build handler reveals `confirmBtn` (`confirmBtn.hidden = false`);
 verify it doesn't also need `confirmBtn.disabled = false` (it will be
 enabled already since building requires the unlocked state — but
 `resetPending()` hides it again; leave `disabled` driven ONLY by
-`renderSignetPanel` and `hidden` by the build flow, which composes
+`renderKeyPanel` and `hidden` by the build flow, which composes
 correctly).
 
 - [ ] **Step 3: The create handler** (next to the unlock handlers):
@@ -570,7 +570,7 @@ correctly).
         unlockSource = 'saved';
         createPassphrase.value = '';
         if (backupNudge) show(backupNudge, true);
-        await renderSignetPanel();
+        await renderKeyPanel();
       } catch (e) {
         setStatus(createStatus, `Could not create: ${msgOf(e)}`, 'error');
       }
@@ -607,7 +607,7 @@ state's key.
 
 ```bash
 git add src/gumptionchain/static/js
-git commit -m "feat(transact): signet panel controller — create, lock, gated actions (#262)"
+git commit -m "feat(transact): key panel controller — create, lock, gated actions (#262)"
 ```
 
 ---
@@ -619,9 +619,9 @@ git commit -m "feat(transact): signet panel controller — create, lock, gated a
 - [ ] `uv run ruff format --check src tests && uv run ruff check src tests && uv run mypy`
 - [ ] `uv run pre-commit run --all-files` (app.py findings are
   pre-existing, tracked in #256 — ignore those two)
-- [ ] File the sibling issue: "Base browser signet copy sweep —
+- [ ] File the sibling issue: "Base browser key copy sweep —
   /wallet, /advanced, /verify" referencing #262's vocabulary section
   and hub#30's scope-split comment (operator surfaces keep 'wallet').
-- [ ] PR `feat(browser): explicit signet states on /transact — inline
+- [ ] PR `feat(browser): explicit signing-key states on /transact — inline
   create, gated signing (#262)`; body includes the manual-checklist
   results; subagent review; hold for author review.

--- a/docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md
+++ b/docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md
@@ -1,4 +1,4 @@
-# EGU #262 — transact flow: explicit signet states
+# EGU #262 — transact flow: explicit signing-key states
 
 **Date:** 2026-06-11
 **Issue:** #262 (follows #260's /advanced split; coordinates with the
@@ -156,3 +156,17 @@ never-renamed code identifiers.
 - `/wallet`, `/advanced`, `/verify` copy sweep (sibling PR, this repo).
 - Backup/passkey enrollment inline on `/transact` (stays on `/wallet`).
 - Any change to the build/submit API or auth scheme.
+
+## Vocabulary amendment (2026-06-11, post-approval)
+
+**Signet is retired** before reaching base (vocab tax, onboarding
+confusion, the Bitcoin Signet collision — recorded on hub#30). The
+panel ships **"signing key" / "your key"** copy instead: "Create your
+signing key", "Your signing key · locked", badges unchanged. The
+bridge parenthetical is unnecessary (the term self-explains) and is
+dropped. "Wallet" remains acceptable in balance contexts and on
+operator surfaces; it is simply not the onboarding word. Identifiers
+use a `key-` prefix (`data-key-state`, `key-create-btn`,
+`whichKeyPanel`) — the plan reflects this. The "sibling signet sweep"
+PR is cancelled: base pages already say wallet, which is acceptable
+outside onboarding.

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -3,15 +3,15 @@
 // pre-signed txn" mode. The active Wallet lives ONLY in the shared per-page
 // wallet-session holder — never persisted from here, never sent (only the
 // signature + public key leave the browser). Two ways to obtain that wallet:
-//   - "Unlock your saved wallet" — decrypt the gc-keyring record persisted on
+//   - Unlock the saved signing key — decrypt the gc-keyring record persisted on
 //     /wallet (passphrase or, on a secure origin, passkey), OR
-//   - "use a key just for this session" — paste a base58 private key (ephemeral
+//   - Advanced: use a one-session key — paste a base58 private key (ephemeral
 //     import; nothing is saved).
 // Either way the unlocked key is subject to the same auto-lock policy (idle /
-// tab-hide / page-unload / manual forget) via wallet-session.
+// tab-hide / page-unload / manual lock) via wallet-session.
 //
 // The pure helpers (buildQuery / submitPath / responseMessage / buildUnsigned /
-// signAndSubmit / whichKeyControls / unlockSaved) are exported and DOM-free so
+// signAndSubmit / whichKeyPanel / unlockSaved) are exported and DOM-free so
 // they can be unit-tested with fakes. The DOM wiring is in init().
 import { Wallet } from '../wallet/gc-wallet.mjs';
 import { signHeaders } from '../wallet/gc-sig.mjs';
@@ -25,6 +25,7 @@ import * as keyring from '../wallet/gc-keyring.mjs';
 import { makeIdbStore } from '../wallet/gc-store-idb.mjs';
 import { session as defaultSession } from './wallet-session.mjs';
 import { makePasskey } from './wallet-passkey.mjs';
+import { readTrustAck, writeTrustAck } from './wallet-glue.mjs';
 
 const API_PREFIX = '/api';
 
@@ -277,16 +278,6 @@ export async function signAttestation({
 
 // --- Saved-wallet unlock ----------------------------------------------------
 
-// Which saved-wallet unlock affordances to show, given the observable state.
-// The passphrase unlock shows whenever a wallet is persisted on this origin;
-// the passkey button shows only when a passkey is actually usable here.
-export function whichKeyControls({ hasWallet, passkeySupported }) {
-  return {
-    showUnlockSaved: !!hasWallet,
-    showUnlockPasskey: !!hasWallet && !!passkeySupported,
-  };
-}
-
 // Pure state decision for the key panel (#262). unlockedKind is
 // null (locked / no key), 'saved' (unlocked from the keyring), or
 // 'session' (one-session key imported under Advanced).
@@ -404,12 +395,23 @@ export function init(
     updateFields();
   }
 
-  // --- Saved-wallet unlock (gc-keyring record persisted on /wallet) ---
-  const savedSection = $('#saved-wallet');
+  // --- Key panel element lookups (three-state: none / locked / unlocked) ---
   const unlockPassphrase = $('#unlock-passphrase');
   const unlockBtn = $('#unlock-saved-btn');
   const unlockPasskeyBtn = $('#unlock-saved-passkey-btn');
   const unlockStatus = $('#unlock-status');
+
+  // Key panel new-state elements (#262).
+  const createPassphrase = $('#key-create-passphrase');
+  const createTrustAck = $('#key-trust-ack');
+  const createBtn = $('#key-create-btn');
+  const createStatus = $('#key-create-status');
+  const keyBadge = $('#key-badge');
+  const lockBtn = $('#key-lock-btn');
+  const backupNudge = $('#key-backup-nudge');
+  const storage = win ? win.localStorage : undefined;
+  // 'saved' | 'session' | null — which key source unlocked the page.
+  let unlockSource = null;
 
   // Key import (b58 textarea / .pem file) + forget.
   const keyStatus = $('#key-status');
@@ -422,7 +424,7 @@ export function init(
   // controls show, plus the passkey-unlock click.
   let passkey = null;
   // Whether a wallet was unlocked since the last lock — so an idle/hide lock
-  // only reports "locked" when there was actually a key to drop.
+  // only reports 'locked' when there was actually a key to drop.
   let wasUnlocked = false;
 
   function show(el, visible) {
@@ -439,7 +441,7 @@ export function init(
   // Is a wallet available for signing (from a saved-wallet unlock OR an
   // ephemeral import)? If not, surface the no-key message and return null.
   const NO_KEY_MSG =
-    'Unlock your saved wallet or import a key for this session first.';
+    'Unlock your signing key or import a one-session key first.';
   function requireWallet(statusEl) {
     const wallet = session.getWallet();
     if (!wallet) {
@@ -449,14 +451,46 @@ export function init(
     return wallet;
   }
 
-  // Re-render the saved-wallet unlock controls from the current state. Hidden
-  // entirely when no wallet is persisted on this origin (ephemeral import is
-  // then the only path).
-  async function renderKeyControls() {
-    const hasWallet = await keyring.hasWallet(store);
-    const c = whichKeyControls({ hasWallet, passkeySupported: passkey != null });
-    show(savedSection, c.showUnlockSaved);
+  // Render the key panel from the current state: show exactly one state
+  // container, update the badge, and gate the action buttons.
+  async function renderKeyPanel() {
+    let rec = null;
+    try {
+      rec = await store.get();
+    } catch {
+      // IDB unavailable: fall through to the no-key state; the
+      // Advanced one-session key still works.
+      if (createStatus) {
+        setStatus(
+          createStatus,
+          'Saved keys are unavailable in this browser; use the ' +
+            'Advanced one-session key below.',
+          'error',
+        );
+      }
+    }
+    const c = whichKeyPanel({
+      hasRecord: rec !== null,
+      unlockedKind: session.getWallet() ? unlockSource : null,
+      passkeySupported: passkey != null,
+    });
+    for (const el of root.querySelectorAll('[data-key-state]')) {
+      show(el, el.dataset.keyState === c.state);
+    }
     show(unlockPasskeyBtn, c.showUnlockPasskey);
+    const addrEl = root.querySelector('[data-key-address]');
+    if (addrEl && rec) addrEl.textContent = `${rec.address.slice(0, 12)}…`;
+    if (keyBadge && c.state === 'unlocked') {
+      const addr = await session.getWallet().address();
+      keyBadge.textContent =
+        c.badge === 'session'
+          ? `one-session key · ${addr.slice(0, 12)}…`
+          : `signing as ${addr.slice(0, 12)}…`;
+    }
+    if (backupNudge && c.state !== 'unlocked') show(backupNudge, false);
+    for (const btn of [buildBtn, confirmBtn]) {
+      if (btn) btn.disabled = !c.actionsEnabled;
+    }
   }
 
   // After any unlock/import, report the now-available address (in memory only).
@@ -479,11 +513,13 @@ export function init(
           return;
         }
         await unlockSaved({ store, session, passphrase });
+        unlockSource = 'saved';
         clearSecrets();
         await onUnlocked(
           unlockStatus,
-          'Unlocked your saved wallet for this session',
+          'Unlocked your signing key for this session',
         );
+        await renderKeyPanel();
       } catch {
         // Fixed message, no secret echo: a wrong passphrase fails closed in the
         // keyring (GCM auth tag), and the session is left locked.
@@ -504,10 +540,12 @@ export function init(
           return;
         }
         await unlockSaved({ store, session, passkey });
+        unlockSource = 'saved';
         await onUnlocked(
           unlockStatus,
-          'Unlocked your saved wallet with a passkey',
+          'Unlocked your signing key with a passkey',
         );
+        await renderKeyPanel();
       } catch (e) {
         setStatus(
           unlockStatus,
@@ -518,7 +556,48 @@ export function init(
     });
   }
 
-  // --- Ephemeral import (a key just for this session; nothing is saved) ---
+  // --- Create handler: generate a new wallet, enroll in keyring, set session.
+  if (createBtn) {
+    createBtn.addEventListener('click', async () => {
+      const passphrase = createPassphrase ? createPassphrase.value : '';
+      if (!passphrase) {
+        setStatus(createStatus, 'Set a passphrase first.', 'error');
+        return;
+      }
+      if (!readTrustAck(storage)) {
+        if (createTrustAck && createTrustAck.checked) {
+          writeTrustAck(storage);
+        } else {
+          setStatus(
+            createStatus,
+            'Acknowledge the trust note first: persist only on a node ' +
+              'you trust.',
+            'error',
+          );
+          return;
+        }
+      }
+      try {
+        const wallet = await Wallet.generate();
+        await keyring.enroll(wallet, { store }, { passphrase });
+        session.setWallet(wallet);
+        unlockSource = 'saved';
+        if (createPassphrase) createPassphrase.value = '';
+        if (backupNudge) show(backupNudge, true);
+        await renderKeyPanel();
+      } catch (e) {
+        setStatus(createStatus, `Could not create: ${msgOf(e)}`, 'error');
+      }
+    });
+  }
+
+  if (lockBtn) {
+    lockBtn.addEventListener('click', () => {
+      session.lock();
+    });
+  }
+
+  // --- Ephemeral import (a one-session key; nothing is saved) ---
   if (importBtn) {
     importBtn.addEventListener('click', async () => {
       try {
@@ -528,7 +607,9 @@ export function init(
           return;
         }
         session.setWallet(await importB58(b58));
+        unlockSource = 'session';
         await onUnlocked(keyStatus, 'Key imported');
+        await renderKeyPanel();
       } catch (e) {
         session.lock();
         setStatus(keyStatus, `Could not import key: ${msgOf(e)}`, 'error');
@@ -552,6 +633,7 @@ export function init(
     forgetBtn.addEventListener('click', () => {
       // Lock clears the session wallet (whether it came from a saved-wallet
       // unlock or an ephemeral import); the persisted ciphertext is untouched.
+      unlockSource = null;
       session.lock();
       if (b58Input) b58Input.value = '';
       clearSecrets();
@@ -726,10 +808,9 @@ export function init(
     });
   }
 
-  // Resolve passkey capability, reveal the saved-wallet controls if a wallet is
-  // persisted here, and install the shared auto-lock policy so an unlocked key
-  // (saved OR ephemeral) is dropped on idle / tab-hide / page-unload. A lock
-  // re-renders the controls (and surfaces it on the key status).
+  // Resolve passkey capability, render the initial key panel state, and install
+  // the shared auto-lock policy so an unlocked key (saved OR session) is dropped
+  // on idle / tab-hide / page-unload. A lock re-renders the panel.
   (async () => {
     passkey = await makePasskey({ window: win, rpName });
     session.onLock(() => {
@@ -737,12 +818,13 @@ export function init(
         setStatus(keyStatus, 'Key locked — cleared from memory.', 'info');
       }
       wasUnlocked = false;
-      renderKeyControls().catch(() => {});
+      unlockSource = null;
+      renderKeyPanel().catch(() => {});
     });
     if (doc && win) {
       session.installAutoLock({ document: doc, window: win });
     }
-    await renderKeyControls();
+    await renderKeyPanel();
   })().catch(() => {});
 }
 

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -577,16 +577,21 @@ export function init(
           return;
         }
       }
+      createBtn.disabled = true; // no double-submit while enrolling
       try {
         const wallet = await Wallet.generate();
         await keyring.enroll(wallet, { store }, { passphrase });
         session.setWallet(wallet);
         unlockSource = 'saved';
-        if (createPassphrase) createPassphrase.value = '';
         if (backupNudge) show(backupNudge, true);
         await renderKeyPanel();
       } catch (e) {
         setStatus(createStatus, `Could not create: ${msgOf(e)}`, 'error');
+      } finally {
+        // Wipe the chosen passphrase (and any other password input) on
+        // success AND failure; re-enable the button.
+        clearSecrets();
+        createBtn.disabled = false;
       }
     });
   }

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -287,6 +287,38 @@ export function whichKeyControls({ hasWallet, passkeySupported }) {
   };
 }
 
+// Pure state decision for the key panel (#262). unlockedKind is
+// null (locked / no key), 'saved' (unlocked from the keyring), or
+// 'session' (one-session key imported under Advanced).
+export function whichKeyPanel({
+  hasRecord,
+  unlockedKind,
+  passkeySupported,
+}) {
+  if (unlockedKind) {
+    return {
+      state: 'unlocked',
+      badge: unlockedKind,
+      actionsEnabled: true,
+      showUnlockPasskey: false,
+    };
+  }
+  if (hasRecord) {
+    return {
+      state: 'locked',
+      badge: null,
+      actionsEnabled: false,
+      showUnlockPasskey: !!passkeySupported,
+    };
+  }
+  return {
+    state: 'none',
+    badge: null,
+    actionsEnabled: false,
+    showUnlockPasskey: false,
+  };
+}
+
 // Unlock the saved (gc-keyring) wallet and hold it in the shared session for
 // this page's life (auto-locked like the ephemeral path). passphrase OR passkey
 // is supplied. A wrong secret rejects out of the keyring (GCM auth-tag failure)

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -9,7 +9,6 @@ import {
   submitSigned,
   encodeSubject,
   signAttestation,
-  whichKeyControls,
   whichKeyPanel,
   unlockSaved,
 } from './transact-glue.mjs';
@@ -362,28 +361,6 @@ test('signAttestation supports the support kind', async () => {
   const claim = parseStakeAttestation(proof);
   assert.equal(claim.kind, 'support');
   assert.equal(claim.subject, 'Y2FuY2VsIG1l');
-});
-
-// --- whichKeyControls: the saved-wallet unlock affordances show only when a
-// wallet exists; the passkey button shows only when a passkey is usable.
-
-test('whichKeyControls hides the unlock affordances when no saved wallet', () => {
-  const c = whichKeyControls({ hasWallet: false, passkeySupported: true });
-  assert.equal(c.showUnlockSaved, false);
-  assert.equal(c.showUnlockPasskey, false);
-});
-
-test('whichKeyControls shows unlock (passphrase) when a wallet exists', () => {
-  const c = whichKeyControls({ hasWallet: true, passkeySupported: false });
-  assert.equal(c.showUnlockSaved, true);
-  // No passkey support -> no passkey button even with a saved wallet.
-  assert.equal(c.showUnlockPasskey, false);
-});
-
-test('whichKeyControls shows the passkey button only when supported', () => {
-  const c = whichKeyControls({ hasWallet: true, passkeySupported: true });
-  assert.equal(c.showUnlockSaved, true);
-  assert.equal(c.showUnlockPasskey, true);
 });
 
 // --- unlockSaved: the seam between the keyring and the shared session. A fake

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -10,6 +10,7 @@ import {
   encodeSubject,
   signAttestation,
   whichKeyControls,
+  whichKeyPanel,
   unlockSaved,
 } from './transact-glue.mjs';
 import { Wallet } from '../wallet/gc-wallet.mjs';
@@ -500,4 +501,57 @@ test('submitSigned rejects a pasted object missing txid/signature', async () => 
     /signed transaction|txid or signature/i,
   );
   assert.equal(fetched, false); // never POSTed to /api/transaction/undefined
+});
+
+// --- whichKeyPanel: three-state signing-key panel decision function (#262).
+
+test('whichKeyPanel: no record -> none, actions disabled', () => {
+  const c = whichKeyPanel({
+    hasRecord: false,
+    unlockedKind: null,
+    passkeySupported: true,
+  });
+  assert.equal(c.state, 'none');
+  assert.equal(c.actionsEnabled, false);
+  assert.equal(c.badge, null);
+  assert.equal(c.showUnlockPasskey, false);
+});
+
+test('whichKeyPanel: record + locked -> locked, passkey button per support', () => {
+  const locked = whichKeyPanel({
+    hasRecord: true,
+    unlockedKind: null,
+    passkeySupported: true,
+  });
+  assert.equal(locked.state, 'locked');
+  assert.equal(locked.actionsEnabled, false);
+  assert.equal(locked.showUnlockPasskey, true);
+  const noPasskey = whichKeyPanel({
+    hasRecord: true,
+    unlockedKind: null,
+    passkeySupported: false,
+  });
+  assert.equal(noPasskey.showUnlockPasskey, false);
+});
+
+test('whichKeyPanel: unlocked saved -> unlocked, actions enabled, saved badge', () => {
+  const c = whichKeyPanel({
+    hasRecord: true,
+    unlockedKind: 'saved',
+    passkeySupported: true,
+  });
+  assert.equal(c.state, 'unlocked');
+  assert.equal(c.actionsEnabled, true);
+  assert.equal(c.badge, 'saved');
+});
+
+test('whichKeyPanel: session key -> unlocked even with no record', () => {
+  const c = whichKeyPanel({
+    hasRecord: false,
+    unlockedKind: 'session',
+    passkeySupported: false,
+  });
+  assert.equal(c.state, 'unlocked');
+  assert.equal(c.actionsEnabled, true);
+  assert.equal(c.badge, 'session');
 });

--- a/src/gumptionchain/templates/_key_import.html
+++ b/src/gumptionchain/templates/_key_import.html
@@ -1,55 +1,95 @@
-{# Shared signing-key area (#260): saved-wallet unlock + ephemeral
-   session import. Included by transact.html and advanced.html; the
-   transact-glue module binds these ids defensively on both pages. #}
-      <!-- Key area: two ways to obtain a signing key for this page session.
-           Either is held in memory only and auto-locks (idle / tab-hide /
-           leave / Forget). -->
+{# Key panel (#262): explicit three-state machine — no key on
+   this device (inline create) / saved + locked (explicit unlock) /
+   unlocked (badge + Lock). Shared by transact.html and advanced.html;
+   transact-glue.mjs shows exactly one state container and gates the
+   page actions. The one-session key for power users is collapsed
+   under the Advanced disclosure in every state. #}
+<div id="key-panel">
+  <div data-key-state="none" hidden>
+    <div class="fw-semibold">Create your signing key</div>
+    <p class="small text-muted mb-2">
+      Your signing key marks your stakes as yours. It is created in
+      your browser and saved encrypted on this device &mdash; it is
+      never sent anywhere.
+    </p>
+    <label for="key-create-passphrase" class="form-label">Passphrase</label>
+    <input id="key-create-passphrase" type="password" autocomplete="off"
+           class="form-control" placeholder="choose a passphrase">
+    <div class="form-check mt-2">
+      <input id="key-trust-ack" type="checkbox" class="form-check-input">
+      <label for="key-trust-ack" class="form-check-label small">
+        Persist only on a node you trust: this saves your encrypted
+        key in this browser, on this site.
+      </label>
+    </div>
+    <button id="key-create-btn" class="btn btn-primary btn-sm mt-2">
+      Create your signing key
+    </button>
+    <div id="key-create-status" class="mt-2 small"></div>
+  </div>
 
-      <!-- (a) Unlock the wallet saved on this node (gc-keyring / IndexedDB).
-           Hidden by JS unless a wallet is actually persisted on this origin. -->
-      <div id="saved-wallet" class="mb-3" hidden>
-        <div class="fw-semibold">Unlock your saved wallet</div>
-        <p class="small text-muted mb-2">
-          You saved a wallet on this node (on
-          <a href="{{ url_for('browser.wallet_view') }}">Wallet</a>). Unlock it
-          for this session &mdash; it stays in memory only and auto-locks.
-        </p>
-        <label for="unlock-passphrase" class="form-label">Passphrase</label>
-        <input id="unlock-passphrase" type="password" autocomplete="off"
-               class="form-control" placeholder="your wallet passphrase">
-        <div class="mt-2">
-          <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
-            Unlock
-          </button>
-          <button id="unlock-saved-passkey-btn"
-                  class="btn btn-outline-primary btn-sm" hidden>
-            Unlock with passkey
-          </button>
-        </div>
-        <div id="unlock-status" class="mt-2 small"></div>
-        <hr>
-        <div class="small text-muted">or use a key just for this session:</div>
-      </div>
+  <div data-key-state="locked" hidden>
+    <div class="fw-semibold">
+      Your signing key
+      <span class="badge text-bg-secondary">locked</span>
+    </div>
+    <p class="small text-muted mb-2">
+      Saved on this device as <code data-key-address></code>.
+      Unlock it to sign.
+    </p>
+    <label for="unlock-passphrase" class="form-label">Passphrase</label>
+    <input id="unlock-passphrase" type="password" autocomplete="off"
+           class="form-control" placeholder="your key passphrase">
+    <div class="mt-2">
+      <button id="unlock-saved-btn" class="btn btn-primary btn-sm">
+        Unlock
+      </button>
+      <button id="unlock-saved-passkey-btn"
+              class="btn btn-outline-primary btn-sm" hidden>
+        Unlock with passkey
+      </button>
+    </div>
+    <div id="unlock-status" class="mt-2 small"></div>
+  </div>
 
-      <!-- (b) Ephemeral import: paste a key for THIS session only; nothing is
-           saved (the alternative to a saved-wallet unlock). -->
-      <div class="mb-3">
-        <label for="key-b58" class="form-label">
-          Use a key just for this session (base58 private key)
-        </label>
-        <textarea id="key-b58" class="form-control" rows="2"
-                  placeholder="paste base58 private key"></textarea>
-        <div class="mt-2">
-          <label for="key-pem" class="form-label">or upload a .pem</label>
-          <input id="key-pem" type="file" accept=".pem" class="form-control">
-        </div>
-        <div class="mt-2">
-          <button id="import-key-btn" class="btn btn-secondary btn-sm">
-            Import key
-          </button>
-          <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
-            Forget key
-          </button>
-        </div>
-        <div id="key-status" class="mt-2 small"></div>
+  <div data-key-state="unlocked" hidden>
+    <span id="key-badge" class="badge text-bg-success"></span>
+    <button id="key-lock-btn" class="btn btn-outline-secondary btn-sm">
+      Lock
+    </button>
+    <div id="key-backup-nudge" class="small text-muted mt-2" hidden>
+      Key created. <a href="{{ url_for('browser.wallet_view') }}">Back
+      it up on the Wallet page</a> &mdash; the backup is your only
+      recovery.
+    </div>
+  </div>
+
+  <div class="mt-3">
+    <a class="small text-decoration-none" data-bs-toggle="collapse"
+       href="#session-key" role="button" aria-expanded="false"
+       aria-controls="session-key">
+      &#9656; Advanced: use a one-session key instead
+    </a>
+    <div id="session-key" class="collapse mt-2">
+      <label for="key-b58" class="form-label">
+        One-session key (base58 private key) &mdash; held in memory
+        only, nothing is saved
+      </label>
+      <textarea id="key-b58" class="form-control" rows="2"
+                placeholder="paste base58 private key"></textarea>
+      <div class="mt-2">
+        <label for="key-pem" class="form-label">or upload a .pem</label>
+        <input id="key-pem" type="file" accept=".pem" class="form-control">
       </div>
+      <div class="mt-2">
+        <button id="import-key-btn" class="btn btn-secondary btn-sm">
+          Import key
+        </button>
+        <button id="forget-key-btn" class="btn btn-outline-danger btn-sm">
+          Forget key
+        </button>
+      </div>
+      <div id="key-status" class="mt-2 small"></div>
+    </div>
+  </div>
+</div>

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -8,10 +8,8 @@
 
   <div class="row my-3"><div class="col">
     <div class="alert alert-warning" role="alert">
-      <strong>Your private key never leaves your browser.</strong>
-      This node does not store it, and reloading or closing this tab clears it.
-      Only your signature and public key are ever sent. Keys are imported into
-      memory for this session only &mdash; nothing is saved.
+      <strong>Your private key never leaves your browser</strong> &mdash;
+      signing happens here, and only signatures are sent.
     </div>
   </div></div>
 
@@ -55,14 +53,25 @@
           <option value="support">support</option>
         </select>
       </div>
+    </div></div>
+  </div></div>
 
-      <hr>
-
+  <!-- The key gate (#262): filling the form is free; signing
+       requires the explicit unlock above the action. -->
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
       {% include "_key_import.html" %}
+    </div></div>
+  </div></div>
 
-      <button id="build-review-btn" class="btn btn-primary">Build &amp; review</button>
-      <button id="confirm-submit-btn" class="btn btn-success" hidden>Confirm &amp; submit</button>
-
+  <div class="row my-3"><div class="col">
+    <div class="card"><div class="card-body">
+      <button id="build-review-btn" class="btn btn-primary" disabled>
+        Build &amp; review
+      </button>
+      <button id="confirm-submit-btn" class="btn btn-success" hidden disabled>
+        Confirm &amp; submit
+      </button>
       <div class="mt-3">
         <pre id="confirm-area" class="small bg-light p-2"></pre>
         <div id="build-result" class="mt-2"></div>

--- a/tests/test_advanced_page.py
+++ b/tests/test_advanced_page.py
@@ -18,8 +18,9 @@ def test_advanced_page_renders(app, test_client):
         assert 'id="att-subject"' in body
         assert 'id="att-amount"' in body
         assert 'id="att-sign-btn"' in body
-        # Both sections need a signing key: the shared key area is here.
-        assert 'id="saved-wallet"' in body
+        # The shared key panel (#262) renders here too.
+        assert 'data-key-state="none"' in body
+        assert 'data-key-state="locked"' in body
         assert 'id="key-b58"' in body
         assert 'id="import-key-btn"' in body
         # The security framing travels with the key area.

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -38,7 +38,7 @@ def test_transact_page_key_panel_states(app, test_client):
         assert 'id="key-create-passphrase"' in body
         assert 'id="key-trust-ack"' in body
         assert 'id="key-create-btn"' in body
-        assert 'Create your signing key' in body  # noqa: dup-ok
+        assert 'Create your signing key' in body
         # Explicit unlock state.
         assert 'id="unlock-passphrase"' in body
         assert 'id="unlock-saved-btn"' in body

--- a/tests/test_transact_page.py
+++ b/tests/test_transact_page.py
@@ -26,27 +26,43 @@ def test_transact_page_renders(app, test_client):
         assert 'bootstrap' in body
 
 
-def test_transact_page_has_saved_wallet_unlock_markup(app, test_client):
+def test_transact_page_key_panel_states(app, test_client):
     with app.app_context():
-        resp = test_client.get('/transact')
-        assert resp.status_code == httpx.codes.OK
-        body = str(resp.data)
-        # The "Unlock saved wallet" affordance is present (revealed by JS only
-        # when a wallet is actually persisted on this origin).
-        assert 'id="saved-wallet"' in body
-        assert 'Unlock your saved wallet' in body
+        body = str(test_client.get('/transact').data)
+        # The three-state key panel (#262): exactly one state is
+        # shown by JS; all ship in markup.
+        assert 'data-key-state="none"' in body
+        assert 'data-key-state="locked"' in body
+        assert 'data-key-state="unlocked"' in body
+        # Inline mini-create (the conversion moment).
+        assert 'id="key-create-passphrase"' in body
+        assert 'id="key-trust-ack"' in body
+        assert 'id="key-create-btn"' in body
+        assert 'Create your signing key' in body  # noqa: dup-ok
+        # Explicit unlock state.
         assert 'id="unlock-passphrase"' in body
         assert 'id="unlock-saved-btn"' in body
-        # The passkey unlock button is present (JS hides it off secure origins).
-        assert 'id="unlock-saved-passkey-btn"' in body
-        # The two options read clearly as distinct: a saved unlock vs an
-        # ephemeral, this-session-only key.
-        assert 'just for this session' in body
-        # The passphrase input is masked and never autofilled.
-        assert 'type="password"' in body
-        # The RP name reaches the page for the passkey adapter.
-        assert 'data-rp-name' in body
-        assert app.config.get('NODE_HOST') is not None
+        # Unlocked state: badge + explicit lock.
+        assert 'id="key-badge"' in body
+        assert 'id="key-lock-btn"' in body
+        # One-session key collapsed under Advanced.
+        assert 'id="session-key"' in body
+        assert 'class="collapse' in body
+        assert 'one-session key' in body
+        assert 'id="key-b58"' in body
+        assert 'id="import-key-btn"' in body
+        # Key-first copy; self-explanatory, no glossary needed.
+        assert 'Create your signing key' in body
+
+
+def test_transact_actions_disabled_until_unlocked(app, test_client):
+    with app.app_context():
+        body = str(test_client.get('/transact').data)
+        # Markup-level gating: build/confirm ship disabled; the glue
+        # enables them only in the unlocked state.
+        assert 'id="build-review-btn"' in body
+        assert 'disabled' in body.split('id="build-review-btn"')[1][:120]
+        assert 'disabled' in body.split('id="confirm-submit-btn"')[1][:120]
 
 
 def test_transact_page_carries_configured_node_host(app, test_client):


### PR DESCRIPTION
Closes #262. Implements the approved design (`docs/superpowers/specs/2026-06-11-egu-262-transact-signet-flow-design.md`) including its post-approval **vocabulary amendment** (signet retired → "signing key / your key"; recorded on hub#30).

## What ships

- **The key panel** — an explicit three-state machine in the shared `_key_import.html` partial (so `/advanced` inherits it):
  - **No key on this device** → inline mini-create: passphrase + the `/wallet` trust acknowledgment + `Create your signing key`, landing you unlocked and ready to sign the txn you came for, with a back-it-up nudge. *Creating a txn is now a flow that creates keys.*
  - **Locked** → explicit passphrase/passkey unlock showing the saved address (plaintext in the keyring record).
  - **Unlocked** → `signing as GC…` badge + Lock; auto-lock (idle/tab-hide) re-locks AND re-disables the actions.
- **Markup-level gating**: Build & review / Confirm & submit ship `disabled` and only the unlocked state enables them — the explicit-unlock contract, with the old click-time guard kept as backstop.
- **One-session key under "▸ Advanced"** (collapsed in every state) with a distinct `one-session key · GC…` badge so the two key sources can't be confused.
- Layout B: form first (filling is free), key panel as the literal gate, actions card last. One-line security alert. No server-side changes.
- `whichKeyPanel` pure decision function replaces `whichKeyControls`; `renderKeyPanel` + create/lock wiring; `unlockSource` tracking; `clearSecrets()` in `finally` + double-submit guard on create (review catches).

## Review pipeline (per-task spec + quality, then integration: READY)

Catches fixed in-branch: a plan noqa residue, the create passphrase lingering in the DOM on enroll failure, the unguarded create double-click (traced: couldn't desync session-vs-store, but wasteful), and full end-to-end traces of all five user stories including auto-lock → re-disable.

## Gates

pytest **568 passed / 1 skipped**; `node --test` **165/165**; ruff + format + mypy clean.

## Manual verification (the plan's Task 3 checklist — recommended before merge)

On a dev node, fresh browser profile: `/transact` shows Create + disabled buttons → create → badge + nudge + enabled → build/submit a stake → Lock → disabled → unlock → enabled; Advanced: import b58 → session badge; Forget → back to locked; `/advanced` shows the same panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)