### PR TITLE
feat(browser): subject detail page links to Subjects index

### DIFF
--- a/src/gumptionchain/templates/subject.html
+++ b/src/gumptionchain/templates/subject.html
@@ -4,6 +4,7 @@
 {% block content -%}
 <div class="container-fluid">
   <div class="row my-3"><div class="col">
+    <p class="mb-1"><a href="{{ url_for('browser.subjects_view') }}">&larr; Subjects</a></p>
     <h3>{{ subject | human_subject }}</h3>
     <p class="h5">Net: {{ net_stance(opposition, support) }}</p>
   </div></div>

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -106,6 +106,8 @@ def test_subject_detail_shows_totals_and_links(
         assert b'150 opposed' in resp.data
         # link to the staking transaction
         assert f'/transaction/{txn.txid}'.encode() in resp.data
+        # explicit link back to the Subjects index (not the browser back button)
+        assert b'href="/subjects"' in resp.data
 
 
 def test_subject_detail_unknown_valid_subject_is_200_zeros(


### PR DESCRIPTION
## Summary

The subject detail page (`/subject/<subject>`) had no in-page link to the **Subjects** index. The only way back was the browser back button — which doesn't always return to Subjects (you can arrive via a direct link, a transaction page, the home explorer, etc.).

Adds a breadcrumb-style **← Subjects** link above the heading, pointing at `browser.subjects_view` (same target as the nav link).

## Test Plan
- [x] `test_subject_detail_shows_totals_and_links` extended to assert `href="/subjects"` is present
- [x] `pytest tests/test_subjects_page.py` — 6 passed
- [x] `ruff check` + `format --check` — clean
- [ ] Visual: open any `/subject/<x>` page, confirm the link sits above the title and lands on `/subjects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)