### PR TITLE
feat(browser): node favicon + EGU voice/casing pass (stays vanilla)

### DIFF
--- a/src/gumptionchain/static/img/favicon-node.svg
+++ b/src/gumptionchain/static/img/favicon-node.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 140" role="img" aria-label="GumptionChain">
+  <rect x="4" y="4" width="132" height="132" rx="30" fill="#2f7d32"></rect>
+  <g fill="none" stroke="#fbf8f0" stroke-width="18" stroke-linecap="round">
+    <path d="M110 70 A40 40 0 1 1 98.28 41.72"></path>
+    <path d="M110 70 L70 70"></path>
+  </g>
+</svg>

--- a/src/gumptionchain/templates/_explorer_home.html
+++ b/src/gumptionchain/templates/_explorer_home.html
@@ -35,15 +35,15 @@
 
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">
-      <div class="card-title h5">Chain Tip</div>
+      <div class="card-title h5">Chain tip</div>
       <table class="table table-hover block" style="table-layout:fixed;">
         <tbody class="font-monospace">
           <tr>
-            <th class="col-2"><i class="bi-info"></i>&nbsp;Last Block Index</th>
+            <th class="col-2"><i class="bi-info"></i>&nbsp;Last block index</th>
             <td>{{ lc.last_block.idx }}</td>
           </tr>
           <tr>
-            <th class="col-2"><i class="bi-hash"></i>&nbsp;Last Block Hash</th>
+            <th class="col-2"><i class="bi-hash"></i>&nbsp;Last block hash</th>
             <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=lc.last_block.block_hash) }}">{{ lc.last_block.block_hash }}</a></td>
           </tr>
           <tr>
@@ -58,7 +58,7 @@
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">
       <div class="d-flex justify-content-between align-items-center">
-        <div class="card-title h5 mb-0">Recent Blocks</div>
+        <div class="card-title h5 mb-0">Recent blocks</div>
         <div>
           <a href="{{ url_for('browser.blocks_view') }}">View all blocks</a>
           &middot;
@@ -84,7 +84,7 @@
   {%- else %}
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">
-      <div class="card-title h5">Current Chain</div>
+      <div class="card-title h5">Current chain</div>
       <p>No chain</p>
     </div></div>
   </div></div>

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -7,6 +7,13 @@
 
   <title>{% block title %}{{ title }}{% endblock %}</title>
 
+  {# Node favicon: the green "G" node mark. The hub overrides this block (or
+     shadows base.html) to swap in its gold constellation favicon. #}
+  {% block favicon -%}
+  <link rel="icon" type="image/svg+xml"
+        href="{{ url_for('browser.static', filename='img/favicon-node.svg') }}">
+  {%- endblock %}
+
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
@@ -31,7 +38,7 @@
   {% block content -%}
   <div class="container-fluid">
     <div class="row"><div class="col">
-      This space (un)intentionally left blank.
+      Nothing to show here yet.
     </div></div>
   </div>
   {%- endblock %}

--- a/src/gumptionchain/templates/block.html
+++ b/src/gumptionchain/templates/block.html
@@ -30,19 +30,19 @@
               <td>{{ block.timestamp_dt | utc_datetime }}</td>
             </tr>
             <tr>
-              <th class="col-3"><i class="bi-bookmark-check"></i>&nbsp;Proof Of Work</th>
+              <th class="col-3"><i class="bi-bookmark-check"></i>&nbsp;Proof of work</th>
               <td>{{ block.proof_of_work }}</td>
             </tr>
             <tr>
-              <th class="col-3"><i class="bi-diagram-2"></i>&nbsp;Merkle Root</th>
+              <th class="col-3"><i class="bi-diagram-2"></i>&nbsp;Merkle root</th>
               <td>{{ block.merkle_root }}</td>
             </tr>
             <tr>
-              <th class="col-3"><i class="bi-box-arrow-in-left"></i>&nbsp;Previous Block Hash</th>
+              <th class="col-3"><i class="bi-box-arrow-in-left"></i>&nbsp;Previous block hash</th>
               <td>{% if block_dao.prev %}<a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.prev_hash) }}">{{ block.prev_hash }}</a>{% else %}<span class="text-muted">{{ block.prev_hash }} (genesis)</span>{% endif %}</td>
             </tr>
             <tr>
-              <th class="col-3"><i class="bi-box-arrow-in-right"></i>&nbsp;Next Block Hash</th>
+              <th class="col-3"><i class="bi-box-arrow-in-right"></i>&nbsp;Next block hash</th>
               <td>{% for next_block in block_dao.next %}<a class="text-dark" href="{{ url_for('browser.block_view', block_hash=next_block.block_hash) }}">{{ next_block.block_hash }}</a><br/>{% else %}None{% endfor %}</td>
             </tr>
           </tbody>

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -39,7 +39,7 @@
               <td>{{ transaction.address }}</td>
             </tr>
             <tr>
-              <th class="col-2"><i class="bi-key" />&nbsp;&nbsp;Public Key</th>
+              <th class="col-2"><i class="bi-key" />&nbsp;&nbsp;Public key</th>
               <td>{{ transaction.public_key or None }}</td>
             </tr>
             <tr>
@@ -57,8 +57,8 @@
         <table class="table table-hover" style="table-layout:fixed;">
           <thead>
             <tr>
-              <th class="col-8">Outflow Transaction ID</th>
-              <th class="col-1">Outflow Index</th>
+              <th class="col-8">Outflow transaction ID</th>
+              <th class="col-1">Outflow index</th>
               <th class="col-3">Amount</th>
             </tr>
           </thead>

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -56,6 +56,14 @@ def test_home_empty_chain(test_client):
     assert b'No chain' in resp.data
 
 
+def test_base_links_node_favicon(test_client):
+    # The base node ships the green "G" node favicon by default; the hub
+    # overrides the favicon block (or shadows base.html) for its own.
+    resp = test_client.get('/')
+    assert resp.status_code == 200
+    assert b'img/favicon-node.svg' in resp.data
+
+
 def test_home_shows_stats_and_recent_blocks(
     app, host, mill_block, requests_proxy, subject, signing_key
 ):


### PR DESCRIPTION
## Summary

Two small base-node changes from the egu-design brief. **Base stays stock Bootstrap 5** — the gold 2B2F skin is the hub's job (its template-override + CSS seam), never base's. No design-system CSS, no `theme-2b2f`, no gold classes were added here (verified by grep).

**1 · Node favicon.** The green "G" node mark (distinct from the hub's gold constellation), copied to `static/img/favicon-node.svg` and linked via a new `{% block favicon %}` in `base.html`. The hub already shadows `base.html` wholesale, so it controls its own favicon for hub pages; the new block also lets it override *just* the favicon if it ever extends rather than replaces.

**2 · Content voice (copy/casing pass, not a restyle).** Sentence-cased the Title Case headings and table labels to match the EGU "sentence case in body copy" rule:
- `Chain Tip → Chain tip`, `Recent Blocks → Recent blocks`, `Current Chain → Current chain`
- `Last Block Index/Hash`, `Merkle Root`, `Proof Of Work`, `Previous/Next Block Hash`, `Public Key`, `Outflow Index`, `Outflow Transaction ID` → sentence case (initialisms like `ID` and the proper name `Merkle` preserved)
- Replaced the jokey base content placeholder (`This space (un)intentionally left blank.`) with a plain civic line.

Vocabulary was already correct (grains / grit / stake / support / opposition / subject / block / signing key) — no off-vocabulary terms and no emoji found. No markup or CSS touched.

**3 · Visual parity.** Sanity-checked only: structure/markup unchanged, base renders as plain Bootstrap matching the kit's toggle-**OFF** state. Nothing gold leaked.

Note: the `egu-design` skill itself (installed under `.claude/skills/`) is intentionally **not** part of this PR — see the PR comment.

## Test Plan
- [x] new `test_base_links_node_favicon` asserts the node favicon link renders
- [x] `pytest` — 570 passed, 1 skipped
- [x] `ruff check` + `format --check` — clean
- [x] grep: no `theme-2b2f` / `egu-*` / `gc-card` / `btn-gold` / design-system CSS in base
- [ ] Visual: favicon shows in the tab; explorer screens look like plain Bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)