### PR TITLE
feat(browser): explorer IA polish — nav, breadcrumbs, stat tiles, clickable rows

### DIFF
--- a/src/gumptionchain/templates/_explorer_home.html
+++ b/src/gumptionchain/templates/_explorer_home.html
@@ -1,34 +1,34 @@
 <div class="container-fluid">
   {%- if lc %}
   <div class="row my-3 g-3">
-    <div class="col-6 col-md-3">
-      <div class="card bg-light h-100"><div class="card-body">
-        <div class="text-muted small">Height</div>
-        <div class="h4 mb-0">{{ lc.length }}</div>
+    <div class="col-6 col-md">
+      <div class="card h-100"><div class="card-body py-3">
+        <div class="text-uppercase small text-muted">Height</div>
+        <div class="fs-3 fw-bold">{{ lc.length }}</div>
       </div></div>
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card bg-light h-100"><div class="card-body">
-        <div class="text-muted small">Transactions</div>
-        <div class="h4 mb-0">{{ lc.transaction_count }}</div>
+    <div class="col-6 col-md">
+      <div class="card h-100"><div class="card-body py-3">
+        <div class="text-uppercase small text-muted">Transactions</div>
+        <div class="fs-3 fw-bold">{{ lc.transaction_count }}</div>
       </div></div>
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card bg-light h-100"><div class="card-body">
-        <div class="text-muted small">Total staked</div>
-        <div class="h4 mb-0">{{ total_staked }} <span class="small text-muted">grains</span></div>
+    <div class="col-6 col-md">
+      <div class="card h-100"><div class="card-body py-3">
+        <div class="text-uppercase small text-muted">Total staked</div>
+        <div class="fs-3 fw-bold">{{ total_staked }} <span class="small text-muted">grains</span></div>
       </div></div>
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card bg-light h-100"><div class="card-body">
-        <div class="text-muted small">Subjects</div>
-        <div class="h4 mb-0">{{ subject_count }}</div>
+    <div class="col-6 col-md">
+      <div class="card h-100"><div class="card-body py-3">
+        <div class="text-uppercase small text-muted">Subjects</div>
+        <div class="fs-3 fw-bold">{{ subject_count }}</div>
       </div></div>
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card bg-light h-100"><div class="card-body">
-        <div class="text-muted small">Pending</div>
-        <div class="h4 mb-0">{{ pending_count }}</div>
+    <div class="col-6 col-md">
+      <div class="card h-100"><div class="card-body py-3">
+        <div class="text-uppercase small text-muted">Pending</div>
+        <div class="fs-3 fw-bold">{{ pending_count }}</div>
       </div></div>
     </div>
   </div>

--- a/src/gumptionchain/templates/address.html
+++ b/src/gumptionchain/templates/address.html
@@ -4,6 +4,7 @@
 {% block content -%}
 <div class="container-fluid">
   <div class="row my-3"><div class="col">
+    <p class="mb-1"><a href="{{ url_for('browser.addresses_view') }}">&larr; Addresses</a></p>
     <h3 class="font-monospace">{{ address }}</h3>
     <p class="h4">{{ balance }} <small class="text-muted">grains</small></p>
   </div></div>

--- a/src/gumptionchain/templates/addresses.html
+++ b/src/gumptionchain/templates/addresses.html
@@ -12,7 +12,7 @@
         <thead><tr><th>#</th><th>Address</th><th>Balance</th></tr></thead>
         <tbody>
         {%- for row in addresses_page.items %}
-          <tr>
+          <tr class="clickable" style="cursor: pointer;" onclick="window.location='{{ url_for('browser.address_view', address=row.address) }}'">
             <td>{{ loop.index + (addresses_page.page - 1) * addresses_page.per_page }}</td>
             <td class="font-monospace"><a class="text-dark" href="{{ url_for('browser.address_view', address=row.address) }}">{{ row.address }}</a></td>
             <td>{{ row.ct }} <small class="text-muted">grains</small></td>

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -21,18 +21,19 @@
 </head>
 
 <body>
-  <nav class="navbar mx-3" >
-    <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">Home</a>
-    <a class="navbar-nav" href="{{ url_for('browser.chains_view') }}">Chains</a>
-    <a class="navbar-nav" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
-    <a class="navbar-nav" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
-    <a class="navbar-nav" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
-    <a class="navbar-nav" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
-    <a class="navbar-nav" href="{{ url_for('browser.transact_view') }}">Transact</a>
-    <a class="navbar-nav" href="{{ url_for('browser.signing_key_view') }}">Signing key</a>
-    <a class="navbar-nav" href="{{ url_for('browser.advanced_view') }}">Advanced</a>
-    {% block nav -%}
-    {%- endblock %}
+  <nav class="navbar border-bottom mb-3 px-3">
+    <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">Gumption<span class="text-muted fw-normal small"> · node</span></a>
+    <div class="navbar-nav flex-row flex-wrap align-items-center">
+      <a class="nav-link px-2" href="{{ url_for('browser.chains_view') }}">Chains</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.transact_view') }}">Transact</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.signing_key_view') }}">Signing key</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.advanced_view') }}">Advanced</a>
+      {% block nav %}{% endblock %}
+    </div>
   </nav>
 
   {% block content -%}

--- a/src/gumptionchain/templates/block.html
+++ b/src/gumptionchain/templates/block.html
@@ -5,6 +5,7 @@
 {% block content -%}
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
+      <p class="mb-1"><a href="{{ url_for('browser.blocks_view') }}">&larr; Blocks</a></p>
       <div class="card bg-light"><div class="card-body">
         <div class="card-title h5">Block</div>
         <table class="table table-hover block" style="table-layout:fixed;">

--- a/src/gumptionchain/templates/blocks.html
+++ b/src/gumptionchain/templates/blocks.html
@@ -11,7 +11,7 @@
         <thead><tr><th>#</th><th>Hash</th><th>Timestamp</th><th>Txns</th></tr></thead>
         <tbody class="font-monospace">
         {%- for block in blocks_page.items %}
-          <tr>
+          <tr class="clickable" style="cursor: pointer;" onclick="window.location='{{ url_for('browser.block_view', block_hash=block.block_hash) }}'">
             <td>{{ block.idx }}</td>
             <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.block_hash) }}">{{ block.block_hash }}</a></td>
             <td>{{ block.timestamp | utc_datetime }}</td>

--- a/src/gumptionchain/templates/subjects.html
+++ b/src/gumptionchain/templates/subjects.html
@@ -13,7 +13,7 @@
         <thead><tr><th>#</th><th>Subject</th><th>Opposition</th><th>Support</th><th>Net</th><th>Total</th></tr></thead>
         <tbody>
         {%- for row in subjects_page.items %}
-          <tr>
+          <tr class="clickable" style="cursor: pointer;" onclick="window.location='{{ url_for('browser.subject_view', subject=row.subject) }}'">
             <td>{{ loop.index + (subjects_page.page - 1) * subjects_page.per_page }}</td>
             <td><a class="text-dark" href="{{ url_for('browser.subject_view', subject=row.subject) }}">{{ row.subject | human_subject }}</a></td>
             <td>{{ row.opposition }}</td>

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -4,6 +4,7 @@
 {% block content -%}
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
+      <p class="mb-1"><a href="{{ url_for('browser.blocks_view') }}">&larr; Blocks</a></p>
       <div class="card bg-light"><div class="card-body">
         <div class="h5">Transaction{% if transaction.is_coinbase %} <span class="badge bg-info text-dark">Coinbase</span>{% endif %}</div>
         <table class="table table-hover" style="table-layout:fixed;">

--- a/tests/test_address_pages.py
+++ b/tests/test_address_pages.py
@@ -64,6 +64,7 @@ def test_addresses_index_shows_milled_address(
         assert resp.status_code == 200
         assert signing_key.address.encode() in resp.data
         assert f'/address/{signing_key.address}'.encode() in resp.data
+        assert b'clickable' in resp.data  # rows clickable into address detail
         assert str(balance).encode() in resp.data
 
 
@@ -88,6 +89,8 @@ def test_address_detail_shows_balance_and_holdings(
         assert str(balance).encode() in resp.data
         # a holding links to its source transaction
         assert f'/transaction/{a_txid}'.encode() in resp.data
+        # breadcrumb back to the Addresses index
+        assert b'&larr; Addresses' in resp.data
 
 
 def test_address_detail_unknown_valid_address_is_200_zeros(

--- a/tests/test_block_view.py
+++ b/tests/test_block_view.py
@@ -22,6 +22,8 @@ def test_genesis_prev_hash_is_not_a_dead_link(
         )
         assert f'/block/{genesis.prev_hash}' not in page  # no dead link
         assert '(genesis)' in page
+        # breadcrumb back to the Blocks index
+        assert '&larr; Blocks' in page
 
 
 def test_non_genesis_prev_hash_links_to_parent(

--- a/tests/test_blocks_page.py
+++ b/tests/test_blocks_page.py
@@ -39,6 +39,8 @@ def test_blocks_list_shows_mined_blocks(
         assert resp.status_code == 200
         assert tip_hash.encode() in resp.data
         assert b'/block/' in resp.data
+        # rows are clickable into the block detail page
+        assert b'clickable' in resp.data
 
 
 def test_blocks_list_shows_transaction_count(

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -47,6 +47,7 @@ def test_subjects_index_shows_stakes(
         assert b'150 opposed' in resp.data
         # links to the detail page using the encoded subject
         assert f'/subject/{subject}'.encode() in resp.data
+        assert b'clickable' in resp.data  # rows clickable into subject detail
 
 
 def test_subjects_index_paginates_across_pages(

--- a/tests/test_transaction_view.py
+++ b/tests/test_transaction_view.py
@@ -33,6 +33,8 @@ def test_transaction_view_marks_coinbase(
         assert 'newly minted' in page  # the no-inputs message
         # a coinbase's reward outputs are address transfers
         assert 'transfer' in page
+        # breadcrumb back to the Blocks index
+        assert '&larr; Blocks' in page
 
 
 def test_transaction_view_labels_stake_and_rescind_kinds(


### PR DESCRIPTION
## Summary

Structural / information-architecture improvements to the chain explorer, implementing the prescriptive plain-Bootstrap brief. **Everything is stock Bootstrap 5** — no new CSS file, no webfonts, no design-system classes or brand artwork. The gold `gumption-hub` skin is added at serve time through its template-override seam; base is and stays vanilla.

> **Open-source / licensing boundary respected:** no `egu-design` skill, no `styles.css`/tokens, none of `theme-2b2f` / `egu-*` / `gc-card` / `gc-stat` / `seal-dot` / `ledger-*` / `kind-*`, no gold palette, GRIT mark, constellation, or hero. Verified by grep — the only matches are pre-existing seam hooks (`verify.html`'s bare `seal-dot` class, which base leaves unstyled for the hub to paint) and a doc-filename in a comment.

### Changes
1. **Nav** (`base.html`) — the old markup put `class="navbar-nav"` on *every* `<a>` (broken/cramped). Now a proper navbar with `nav-link`s; brand reads **Gumption · node**.
2. **Breadcrumbs** on every detail page — `block` / `transaction` → ← Blocks, `address` → ← Addresses (subject → ← Subjects already shipped in #267).
3. **Home stat tiles** — plain Bootstrap cards (`col-md` auto-fit, uppercase muted label, `fs-3` value). Same five metrics, cleaner markup.
4. **Clickable rows** on the Blocks / Subjects / Addresses lists, mirroring the existing transaction-inflows `cursor:pointer` + `onclick` pattern. (URL values are safe charsets — hex hashes, base58 addresses, encoded subjects — so no quote-injection in the inline handler.)

Content voice + the node favicon were already in place from #268; unchanged here.

## Test Plan
- [x] `pytest` — 570 passed, 1 skipped
- [x] new guards: breadcrumb assertions (block/transaction/address detail) + `clickable` assertions (3 list indexes)
- [x] `ruff` + pre-commit hooks pass
- [x] grep: **zero** design-system/hub CSS, fonts, classes, or artwork introduced
- [ ] Visual: nav wraps cleanly, breadcrumbs land on the right index, stat row + clickable rows feel right

🤖 Generated with [Claude Code](https://claude.com/claude-code)