### PR TITLE
refactor(browser): rename verify seal-dot class to verdict-mark

### DIFF
--- a/src/gumptionchain/templates/verify.html
+++ b/src/gumptionchain/templates/verify.html
@@ -12,7 +12,7 @@
                 placeholder='{"scheme":"gc-msg-v1", ...}'></textarea>
       <button id="verify-btn" class="btn btn-primary mt-2">Verify</button>
       <div id="verdict" class="mt-3" hidden>
-        <div id="verdict-seal" class="seal-dot">&#10003;</div>
+        <div id="verdict-seal" class="verdict-mark">&#10003;</div>
         <ul class="list-unstyled mt-2">
           <li data-check="signature">Signature</li>
           <li data-check="onchain">On-chain</li>

--- a/tests/test_verify_page.py
+++ b/tests/test_verify_page.py
@@ -13,6 +13,11 @@ def test_verify_page_renders(app, test_client):
         assert 'data-check="signature"' in body
         assert 'verdict-seal' in body
         assert 'verdict-reasons' in body
+        # The verdict mark uses a project-functional class, not a design-system
+        # one — base stays free of the proprietary hub vocabulary. The hub's CSS
+        # paints `.verdict-mark` (themed) at serve time via its seam.
+        assert 'verdict-mark' in body
+        assert 'seal-dot' not in body
         # super() in the scripts block must keep base's bundled JS (Bootstrap).
         assert 'bootstrap' in body
 


### PR DESCRIPTION
## Summary

Follow-up to #271. `verify.html` carried `class="seal-dot"` — a **design-system vocabulary** class — as the styling hook for the verdict ✓/✗ element. Since base must stay free of proprietary hub class names, rename it to the project-functional **`verdict-mark`** (fits the existing `verdict-seal` / `verdict-reasons` family).

Safe in base because:
- base has **no CSS** behind `seal-dot` (base is vanilla Bootstrap),
- base's JS (`verify-glue.mjs`) and tests key off the **`#verdict-seal` ID** and toggle a `.verified` class — never the renamed class.

Guard added: `test_verify_page` asserts `verdict-mark` is present and `seal-dot` is gone.

## ⚠ Requires a coordinated hub change
`gumption-hub` paints base's themed `/verify` page via `.theme-2b2f .seal-dot` (in its vendored CSS). After this merges, that selector must **also match `.verdict-mark`** — e.g.:

```css
.theme-2b2f .seal-dot,
.theme-2b2f .verdict-mark { /* gold wax-seal styling */ }
```

The hub keeps `seal-dot` for its **own** templates (`proof.html`, `onboarding.html`), so it's an additive selector, not a rename on the hub side. Until that hub PR lands, the gold seal on the *base verify page* falls back to plain — harmless, and base renders correctly as vanilla Bootstrap throughout.

## Test Plan
- [x] `test_verify_page` — passes (asserts new class, forbids `seal-dot`)
- [x] `node --test verify-glue.test.mjs` — 5 pass (keys off `#verdict-seal` ID, unaffected)
- [x] grep: `seal-dot` no longer in base (except the negative guard assertion)
- [x] `ruff` + hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)