### PR TITLE
fix(#256): app.py passes ruff (S104 intentional-bind, PLW1508 str default)

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,4 +6,8 @@ app = create_app()
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+    # Dev-only entrypoint: production serves via gunicorn (see Dockerfile).
+    # Binding all interfaces is intentional so the dev/container server is
+    # reachable from outside the container.
+    port = int(os.environ.get('PORT', '8080'))
+    app.run(debug=True, host='0.0.0.0', port=port)  # noqa: S104


### PR DESCRIPTION
## Summary

Closes #256. Root `app.py` tripped two ruff rules under `pre-commit --all-files`. It was pre-existing on main because CI's ruff scope is `src tests` (root `app.py` isn't checked).

```python
# before
app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
```

- **PLW1508** — `os.environ.get('PORT', 8080)` passed an `int` default where `str | None` is expected. Changed to `'8080'`: behaviour-identical (`int('8080') == 8080`) and matches the codebase's str/None env pattern (`config.py`).
- **S104** — `host='0.0.0.0'` is an *intentional* all-interfaces bind for the dev/container entrypoint (production serves via gunicorn — see Dockerfile). Acknowledged with `# noqa: S104` + a reason, rather than a blanket per-file-ignore.

```python
# after
if __name__ == '__main__':
    # Dev-only entrypoint: production serves via gunicorn (see Dockerfile).
    # Binding all interfaces is intentional so the dev/container server is
    # reachable from outside the container.
    port = int(os.environ.get('PORT', '8080'))
    app.run(debug=True, host='0.0.0.0', port=port)  # noqa: S104
```

Restructured the `__main__` block to fit the 80-col limit alongside the noqa. Behaviour unchanged.

## Verification
- [x] `ruff check app.py` — was 2 errors, now clean
- [x] `ruff format --check app.py` — clean
- [x] `pre-commit run ruff --all-files` **and** `ruff-format --all-files` — both **Pass** (app.py was the only offender)
- [x] CI scope (`ruff check src tests`) still clean
- [x] `python -m py_compile app.py` — compiles

## Optional follow-up (not in this PR)
The reason this was pre-existing is that **CI lints `src tests` but not root `app.py`** (pre-commit `--all-files` does). If you want CI to catch root-file lint drift going forward, a one-token change — `ruff check src tests app.py` in `.github/workflows/tests.yml` — would close that gap. Left out here to keep the fix to exactly what #256 prescribed; happy to add it (here or as a separate PR) if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)