### PR TITLE
ci: include app.py in the ruff check + format scope

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
           enable-cache: true
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --group dev --python ${{ matrix.python-version }}
-      - run: uv run ruff check src tests
-      - run: uv run ruff format --check src tests
+      - run: uv run ruff check src tests app.py
+      - run: uv run ruff format --check src tests app.py
       # Node is needed on PATH for the live JS->Python gc-sig cross-verify in
       # tests/test_browser_signing_key_parity.py (it shells out to `node`). The
       # browser signing_key is pure Web Crypto + vanilla JS — zero npm packages.


### PR DESCRIPTION
## Summary

Follow-up to #274 / #256. CI ran `ruff check src tests` and `ruff format --check src tests` — root **`app.py` was out of lint scope**, which is exactly why the S104/PLW1508 errors fixed in #274 were pre-existing on main (only `pre-commit --all-files` caught them).

Add `app.py` to both ruff steps so CI guards the repo's one root module going forward, keeping CI consistent with pre-commit's coverage.

```diff
-      - run: uv run ruff check src tests
-      - run: uv run ruff format --check src tests
+      - run: uv run ruff check src tests app.py
+      - run: uv run ruff format --check src tests app.py
```

`app.py` is the only root-level `.py` and is already clean (#274), so both steps pass.

## Test Plan
- [x] `uv run ruff check src tests app.py` — clean
- [x] `uv run ruff format --check src tests app.py` — clean (90 files, app.py now included)
- [x] `tests.yml` is valid YAML
- [x] No untrusted-input interpolation (static command args only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)