### PR TITLE
docs: add docs/README.md index so in-repo docs are discoverable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# GumptionChain docs
+
+In-repo documentation for running, extending, and integrating a GumptionChain
+node. (The hosted, rendered docs live at <https://gumption.com/chain/docs>.)
+
+## Protocol & API
+
+- [API authentication protocol (`gc-sig-v1`)](api-auth-protocol.md) — the
+  per-request signing-key signature scheme every authenticated API request
+  uses: canonical string, `GC-*` headers, algorithm, and a worked example.
+- [Social binding envelope (`gc-msg-v1`)](social-binding-envelope.md) — the
+  bidirectional, Keybase-style proof that binds a signing key to an external
+  handle.
+
+## Running a node (operators)
+
+- [Roll your own miller Pi](howto-miller-pi.md) — step-by-step setup of an
+  outbound-only milling node on a Raspberry Pi.
+- [Pi appliance runbook](pi-appliance-runbook.md) — operator reference for
+  building "plug it in and forget it" miller appliances and provisioning a
+  fleet.
+
+## Building on a node (app / extension developers)
+
+- [Base ↔ extension UI seam](ui-extension-seam.md) — how an extension re-skins
+  and extends a vanilla node's browser pages through the template-override seam
+  and block contract.
+- [Key onboarding for EGU apps](key-onboarding-for-egu-apps.md) — the contract
+  every EGU app follows to bring a user's signing key into being safely
+  (reference implementation: the hub's `/onboarding` flow).
+
+## Internal
+
+- `superpowers/` — dated design specs, implementation plans, audits, and the
+  roadmap. Historical records of how features were built; not user-facing and
+  intentionally preserved as written.


### PR DESCRIPTION
## Summary

Checked discoverability of the new onboarding guide (#276) and found the root issue: there's **no docs index**, and the active `docs/*.md` are reachable only by knowing the path. Three were referenced **nowhere** — `key-onboarding-for-egu-apps.md` (the new one), `pi-appliance-runbook.md`, `ui-extension-seam.md` — and `README.md` links only to the hosted docs site, never to in-repo files.

Adds **`docs/README.md`**, a short index grouped by audience:
- **Protocol & API** — api-auth-protocol, social-binding-envelope
- **Running a node (operators)** — howto-miller-pi, pi-appliance-runbook
- **Building on a node (app/extension devs)** — ui-extension-seam, key-onboarding-for-egu-apps
- **Internal** — a note on `superpowers/` (dated design records)

GitHub auto-renders `docs/README.md` when browsing the `docs/` folder, so this fixes discoverability for the whole directory in one move, not just the new file.

## Verification
- [x] All six linked targets exist; **zero orphans** remain
- [x] Vocabulary gate passes (it scans `docs/*.md`, including the new index)
- [x] pre-commit hygiene hooks pass

## Note
I left root `README.md` untouched: it doubles as the PyPI long-description (`pyproject.readme`), where a relative `docs/` link wouldn't resolve. If you'd like a contributor-facing pointer to `docs/`, `CLAUDE.md` is a better home — happy to add it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)