### PR TITLE
feat(signing-key): gc-onboarding — reusable headless onboarding controller + static-mount helper

### DIFF
--- a/clients/signing-key/gc-onboarding.mjs
+++ b/clients/signing-key/gc-onboarding.mjs
@@ -65,7 +65,14 @@ export function makeOnboarding({
 
   async function notify() {
     const snapshot = await status();
-    for (const fn of listeners) fn(snapshot);
+    for (const fn of listeners) {
+      try {
+        fn(snapshot);
+      } catch {
+        // A consumer's onChange handler must not break the action or starve
+        // other listeners. Render errors are the app's problem, not ours.
+      }
+    }
   }
 
   function onChange(fn) {
@@ -110,12 +117,17 @@ export function makeOnboarding({
   }
 
   async function backup({ passphrase } = {}) {
-    if (!key) {
+    const wasLocked = !key;
+    if (wasLocked) {
       key = await keyring.unlock({ store }, { passphrase });
     }
     const artifact = await exportEncrypted(key, passphrase);
+    const filename = backupFilename(await key.address());
+    if (wasLocked) {
+      key = null; // a backup is a read; don't leave the key unlocked
+    }
     await notify();
-    return { artifact, filename: backupFilename(await key.address()) };
+    return { artifact, filename };
   }
 
   async function addPasskey({ passphrase, userName } = {}) {

--- a/clients/signing-key/gc-onboarding.mjs
+++ b/clients/signing-key/gc-onboarding.mjs
@@ -1,0 +1,154 @@
+// Headless, style-agnostic signing-key onboarding controller. Orchestrates the
+// low-level gc-* modules into create / back up / restore / unlock / sign-login
+// over a single in-memory unlocked-key holder. NO DOM, NO CSS, NO framework:
+// the consuming app owns all markup and renders from status() + onChange().
+import { SigningKey } from './gc-signing-key.mjs';
+import * as keyring from './gc-keyring.mjs';
+import { makeIdbStore } from './gc-store-idb.mjs';
+import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
+import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { signMessage } from './gc-message.mjs';
+import {
+  NoSigningKeyError,
+  UnsupportedError,
+  BadBackupError,
+  BadPassphraseError,
+} from './gc-errors.mjs';
+
+// Re-exported so consuming apps can catch by type and render their own copy.
+export {
+  NoSigningKeyError, UnsupportedError, BadBackupError, BadPassphraseError,
+};
+
+function backupFilename(address) {
+  const slug = (address || 'signing-key')
+    .replace(/[^A-Za-z0-9]/g, '')
+    .slice(0, 12);
+  return `gc-signing-key-backup-${slug || 'signing-key'}.json`;
+}
+
+export function makeOnboarding({
+  store = makeIdbStore(),
+  rpId,
+  rpName,
+  passkey = null,
+  window: win = globalThis.window,
+} = {}) {
+  // A passkey adapter is built from rpId/rpName unless one is injected; absent
+  // both, passkey features stay unavailable (status reports passkeySupported:false).
+  const pk = passkey ?? ((rpId && rpName) ? makeWebauthnPasskey({ rpId, rpName }) : null);
+
+  let key = null; // the in-memory unlocked SigningKey, or null when locked
+  const listeners = new Set();
+
+  const secureContext = () => Boolean(win && win.isSecureContext);
+
+  async function status() {
+    const rec = await store.get();
+    const address = key ? await key.address() : (rec ? rec.address : null);
+    let passkeySupported = false;
+    if (pk && secureContext()) {
+      try {
+        passkeySupported = await pk.isSupported();
+      } catch {
+        passkeySupported = false;
+      }
+    }
+    return {
+      hasKey: Boolean(rec),
+      unlocked: Boolean(key),
+      address,
+      passkeySupported,
+      secureContext: secureContext(),
+    };
+  }
+
+  async function notify() {
+    const snapshot = await status();
+    for (const fn of listeners) fn(snapshot);
+  }
+
+  function onChange(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }
+
+  function passkeyIds(userName, address) {
+    return { userId: address, userName: userName || address };
+  }
+
+  async function create({ passphrase, withPasskey = false, userName } = {}) {
+    const sk = await SigningKey.generate();
+    await keyring.enroll(sk, { store }, { passphrase });
+    const address = await sk.address();
+    if (withPasskey && pk) {
+      await keyring.addPasskey(
+        { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
+      );
+    }
+    key = sk;
+    await notify();
+    return { address };
+  }
+
+  async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    key = await keyring.unlock(
+      { store, passkey: usePasskey ? pk : undefined },
+      { passphrase },
+    );
+    await notify();
+    return { address: await key.address() };
+  }
+
+  async function restore({ backup, passphrase } = {}) {
+    const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
+    const sk = await importEncrypted(artifact, passphrase);
+    await keyring.enroll(sk, { store }, { passphrase });
+    key = sk;
+    await notify();
+    return { address: await sk.address() };
+  }
+
+  async function backup({ passphrase } = {}) {
+    if (!key) {
+      key = await keyring.unlock({ store }, { passphrase });
+    }
+    const artifact = await exportEncrypted(key, passphrase);
+    await notify();
+    return { artifact, filename: backupFilename(await key.address()) };
+  }
+
+  async function addPasskey({ passphrase, userName } = {}) {
+    const rec = await store.get();
+    const address = await keyring.addPasskey(
+      { store, passkey: pk },
+      { passphrase },
+      passkeyIds(userName, rec ? rec.address : undefined),
+    );
+    await notify();
+    return { address };
+  }
+
+  async function signLogin(challenge, { timestamp } = {}) {
+    if (!key) {
+      throw new NoSigningKeyError('locked: unlock before signing a login challenge');
+    }
+    return signMessage(key, challenge, { timestamp });
+  }
+
+  async function lock() {
+    key = null;
+    await notify();
+  }
+
+  async function forget() {
+    await keyring.clear(store);
+    key = null;
+    await notify();
+  }
+
+  return {
+    status, onChange, create, unlock, restore, backup, addPasskey,
+    signLogin, lock, forget,
+  };
+}

--- a/clients/signing-key/gc-onboarding.mjs
+++ b/clients/signing-key/gc-onboarding.mjs
@@ -43,22 +43,26 @@ export function makeOnboarding({
 
   const secureContext = () => Boolean(win && win.isSecureContext);
 
+  // Feature-detect passkey support: an adapter must exist, the context must be
+  // secure, and the adapter must report support (guarded — a throwing adapter
+  // counts as unsupported). Reused by status() and create().
+  async function passkeySupported() {
+    if (!(pk && secureContext())) return false;
+    try {
+      return await pk.isSupported();
+    } catch {
+      return false;
+    }
+  }
+
   async function status() {
     const rec = await store.get();
     const address = key ? await key.address() : (rec ? rec.address : null);
-    let passkeySupported = false;
-    if (pk && secureContext()) {
-      try {
-        passkeySupported = await pk.isSupported();
-      } catch {
-        passkeySupported = false;
-      }
-    }
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
       address,
-      passkeySupported,
+      passkeySupported: await passkeySupported(),
       secureContext: secureContext(),
     };
   }
@@ -88,7 +92,7 @@ export function makeOnboarding({
     const sk = await SigningKey.generate();
     await keyring.enroll(sk, { store }, { passphrase });
     const address = await sk.address();
-    if (withPasskey && pk) {
+    if (withPasskey && (await passkeySupported())) {
       await keyring.addPasskey(
         { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
       );

--- a/clients/signing-key/gc-onboarding.test.mjs
+++ b/clients/signing-key/gc-onboarding.test.mjs
@@ -78,6 +78,21 @@ test('passkey: create with passkey, unlock by passkey', async () => {
   assert.equal(r.address, address);
 });
 
+test('create with withPasskey silently skips the passkey when unsupported (no throw)', async () => {
+  // An adapter that reports unsupported must NOT be enrolled — create gates on
+  // the live support state, not merely the adapter's presence.
+  const passkey = {
+    isSupported: async () => false,
+    enroll: async () => { throw new Error('enroll must not run when unsupported'); },
+    unlock: async () => { throw new Error('unlock must not run when unsupported'); },
+  };
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey });
+  assert.equal((await onb.status()).passkeySupported, false);
+  const { address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+  assert.match(address, /^GC.*GC$/);
+  assert.equal((await onb.status()).unlocked, true);
+});
+
 test('backup yields an encrypted artifact (no raw key) + filename; restore into a fresh store recovers the same address', async () => {
   const onb1 = makeOnboarding({ store: fakeStore(), window: SECURE });
   const { address } = await onb1.create({ passphrase: 'pw' });

--- a/clients/signing-key/gc-onboarding.test.mjs
+++ b/clients/signing-key/gc-onboarding.test.mjs
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { makeOnboarding, NoSigningKeyError } from './gc-onboarding.mjs';
+import { verifyMessage } from './gc-message.mjs';
+
+function fakeStore() {
+  let rec = null;
+  return {
+    get: async () => rec,
+    put: async (r) => { rec = r; },
+    delete: async () => { rec = null; },
+  };
+}
+
+function fakePasskey(fill = 7, credentialId = 'cred1') {
+  const PRF = new Uint8Array(32).fill(fill);
+  return {
+    isSupported: async () => true,
+    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    unlock: async () => PRF,
+  };
+}
+
+const SECURE = { isSecureContext: true };
+
+test('empty store: status reports no key, passkey off without an adapter', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const s = await onb.status();
+  assert.equal(s.hasKey, false);
+  assert.equal(s.unlocked, false);
+  assert.equal(s.address, null);
+  assert.equal(s.passkeySupported, false);
+  assert.equal(s.secureContext, true);
+});
+
+test('create persists + holds unlocked, and onChange fires with fresh status', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  let last = null;
+  const off = onb.onChange((s) => { last = s; });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  assert.match(address, /^GC.*GC$/);
+  const s = await onb.status();
+  assert.equal(s.hasKey, true);
+  assert.equal(s.unlocked, true);
+  assert.equal(s.address, address);
+  assert.equal(last.unlocked, true);
+  off();
+});
+
+test('lock drops the in-memory key, keeps the record; address still readable', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  const s = await onb.status();
+  assert.equal(s.unlocked, false);
+  assert.equal(s.hasKey, true);
+  assert.equal(s.address, address);
+});
+
+test('unlock by passphrase re-holds the key; wrong passphrase rejects', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  const r = await onb.unlock({ passphrase: 'pw' });
+  assert.equal(r.address, address);
+  assert.equal((await onb.status()).unlocked, true);
+  await onb.lock();
+  await assert.rejects(() => onb.unlock({ passphrase: 'WRONG' }));
+});
+
+test('passkey: create with passkey, unlock by passkey', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  assert.equal((await onb.status()).passkeySupported, true);
+  const { address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+  await onb.lock();
+  const r = await onb.unlock({ passkey: true });
+  assert.equal(r.address, address);
+});
+
+test('backup yields an encrypted artifact (no raw key) + filename; restore into a fresh store recovers the same address', async () => {
+  const onb1 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb1.create({ passphrase: 'pw' });
+  const { artifact, filename } = await onb1.backup({ passphrase: 'pw' });
+  assert.equal(artifact.kind, 'gc-signing-key-backup');
+  assert.match(filename, /^gc-signing-key-backup-.*\.json$/);
+  assert.deepEqual(
+    Object.keys(artifact).sort(),
+    ['address', 'ciphertext', 'iv', 'kdf', 'kind', 'version'],
+  );
+
+  const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const r = await onb2.restore({ backup: JSON.stringify(artifact), passphrase: 'pw' });
+  assert.equal(r.address, address);
+  assert.equal((await onb2.status()).hasKey, true);
+});
+
+test('signLogin requires unlocked and produces a verifiable gc-msg-v1 proof', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  await assert.rejects(() => onb.signLogin('login:abc'), NoSigningKeyError);
+  await onb.unlock({ passphrase: 'pw' });
+  const proof = await onb.signLogin('login:abc');
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.message, 'login:abc');
+  const v = await verifyMessage(proof, { maxAge: Number.MAX_SAFE_INTEGER });
+  assert.equal(v.valid, true);
+});
+
+test('forget deletes the device record', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await onb.create({ passphrase: 'pw' });
+  await onb.forget();
+  const s = await onb.status();
+  assert.equal(s.hasKey, false);
+  assert.equal(s.unlocked, false);
+});

--- a/clients/signing-key/index.mjs
+++ b/clients/signing-key/index.mjs
@@ -10,6 +10,9 @@ export const version = '0.2.0';
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
 
+// Onboarding controller (headless create / back up / restore / unlock / sign-login)
+export { makeOnboarding } from './gc-onboarding.mjs';
+
 // API request signing (gc-sig-v1)
 export { canonical, signHeaders } from './gc-sig.mjs';
 

--- a/docs/key-onboarding-for-egu-apps.md
+++ b/docs/key-onboarding-for-egu-apps.md
@@ -126,13 +126,37 @@ Reusable building blocks (don't reinvent them):
 
 ---
 
-## Recommended follow-up
+## The reusable drop-in (shipped)
 
-Base should extract the hub's onboarding into a **reusable drop-in** — a base
-template/partial plus glue that an app can `include`/mount — so apps adopt the
-proper flow by inclusion rather than reimplementation, and improvements land
-once for everyone. Until then, treat the hub's `onboarding.html` as the
-reference to copy.
+Base ships **`gc-onboarding.mjs`** — a headless, style-agnostic controller that
+orchestrates the modules above into the full flow. The consuming app owns all
+DOM/CSS and drives the controller; logic and improvements land once for everyone.
+
+Served at `/static/gumptionchain/signing-key/gc-onboarding.mjs`. Non-node
+consumers that don't register the chain-explorer blueprint can mount the assets
+with `static_assets_blueprint()`:
+
+    from gumptionchain import static_assets_blueprint
+    app.register_blueprint(static_assets_blueprint())  # serves /static/gumptionchain/...
+
+Minimal use:
+
+    import { makeOnboarding } from '/static/gumptionchain/signing-key/gc-onboarding.mjs';
+    const onb = makeOnboarding({ rpId: location.hostname, rpName: 'My App' });
+    onb.onChange(render);                       // app re-renders its own DOM
+    await onb.status();                         // { hasKey, unlocked, address, passkeySupported, secureContext }
+    await onb.create({ passphrase, withPasskey: true });
+    await onb.unlock({ passphrase });           // or { passkey: true }
+    const { artifact, filename } = await onb.backup({ passphrase });
+    await onb.restore({ backup, passphrase });
+    const proof = await onb.signLogin(challenge); // gc-msg-v1, POST to your server
+    onb.lock();
+
+Auto-lock is the app's policy — wire it to your own lifecycle, e.g.:
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) onb.lock();
+    });
 
 ---
 

--- a/docs/superpowers/plans/2026-06-15-gc-onboarding-reusable-controller.md
+++ b/docs/superpowers/plans/2026-06-15-gc-onboarding-reusable-controller.md
@@ -1,0 +1,547 @@
+# gc-onboarding Reusable Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a headless, style-agnostic signing-key onboarding controller (`gc-onboarding.mjs`) plus a Python static-mount helper so any EGU app adopts the create → back up → restore → unlock → sign-login flow by inclusion.
+
+**Architecture:** A pure ES module orchestrates the existing low-level `gc-*` modules over a single in-memory unlocked-key holder; the app owns all DOM and renders from `status()` + `onChange()`. A static-only Flask blueprint serves base's assets to consumers that don't register the chain explorer.
+
+**Tech Stack:** Vanilla ES modules (no bundler), `node --test`; Flask Blueprint + `importlib.resources`; pytest.
+
+Spec: `docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md`.
+
+---
+
+## File Structure
+
+- `src/gumptionchain/static_assets.py` — **new**: the `static_assets_blueprint()` helper.
+- `src/gumptionchain/__init__.py` — **modify**: re-export `static_assets_blueprint`.
+- `tests/test_static_assets.py` — **new**: pytest for the helper.
+- `clients/signing-key/gc-onboarding.mjs` — **new**: the controller (source of truth).
+- `clients/signing-key/gc-onboarding.test.mjs` — **new**: node tests.
+- `src/gumptionchain/static/signing-key/gc-onboarding.mjs` — **generated** by `scripts/sync_signing_key.py` (do not hand-edit).
+- `docs/key-onboarding-for-egu-apps.md` — **modify**: flip "Recommended follow-up" → Shipped.
+
+---
+
+## Task 1: Python static-mount helper
+
+**Files:**
+- Create: `src/gumptionchain/static_assets.py`
+- Modify: `src/gumptionchain/__init__.py` (add a re-export with the other top-level imports)
+- Test: `tests/test_static_assets.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_static_assets.py`:
+
+```python
+from flask import Flask
+
+from gumptionchain import static_assets_blueprint
+
+
+def test_static_assets_blueprint_serves_a_signing_key_module():
+    # A consumer that embeds the package but does NOT register the full
+    # browser blueprint can still serve base's ESM modules.
+    app = Flask(__name__)
+    app.register_blueprint(static_assets_blueprint())
+    client = app.test_client()
+
+    resp = client.get('/static/gumptionchain/signing-key/gc-keyring.mjs')
+    assert resp.status_code == 200
+    assert b'export' in resp.data  # it served the real module, not a 404 page
+
+
+def test_static_assets_blueprint_url_path_is_overridable():
+    app = Flask(__name__)
+    app.register_blueprint(static_assets_blueprint(url_path='/assets/gc'))
+    client = app.test_client()
+
+    assert client.get('/assets/gc/signing-key/gc-keyring.mjs').status_code == 200
+    assert client.get('/static/gumptionchain/signing-key/gc-keyring.mjs').status_code == 404
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_static_assets.py -q`
+Expected: FAIL with `ImportError: cannot import name 'static_assets_blueprint' from 'gumptionchain'`.
+
+- [ ] **Step 3: Write the helper**
+
+Create `src/gumptionchain/static_assets.py`:
+
+```python
+from __future__ import annotations
+
+from importlib.resources import files
+
+from flask import Blueprint
+
+
+def static_assets_blueprint(
+    url_path: str = '/static/gumptionchain',
+    name: str = 'gumptionchain_static',
+) -> Blueprint:
+    """A static-only blueprint serving base's browser assets (the signing-key
+    ESM modules + JS glue) for consumers that embed the ``gumptionchain``
+    package but do NOT register the full ``browser`` blueprint (chain explorer
+    + DB).
+
+    The default ``url_path`` matches the ``browser`` blueprint's, so module
+    URLs are identical whether a consumer mounts the explorer or only assets.
+    """
+    static_folder = str(files('gumptionchain') / 'static')
+    return Blueprint(
+        name,
+        __name__,
+        static_folder=static_folder,
+        static_url_path=url_path,
+    )
+```
+
+- [ ] **Step 4: Re-export from the package root**
+
+In `src/gumptionchain/__init__.py`, add this import alongside the other top-level imports (just after `from flask_migrate import Migrate`):
+
+```python
+from gumptionchain.static_assets import static_assets_blueprint
+```
+
+If Ruff flags the import as unused (F401), add it to `__all__` or annotate it; simplest is to mark it re-exported:
+
+```python
+from gumptionchain.static_assets import static_assets_blueprint as static_assets_blueprint
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_static_assets.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Lint + type-check**
+
+Run: `uv run ruff check src tests app.py && uv run ruff format --check src tests app.py && uv run mypy`
+Expected: all clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gumptionchain/static_assets.py src/gumptionchain/__init__.py tests/test_static_assets.py
+git commit -m "feat(static): static_assets_blueprint for non-node consumers"
+```
+
+---
+
+## Task 2: The `gc-onboarding.mjs` controller (TDD)
+
+**Files:**
+- Create: `clients/signing-key/gc-onboarding.mjs`
+- Test: `clients/signing-key/gc-onboarding.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `clients/signing-key/gc-onboarding.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { makeOnboarding, NoSigningKeyError } from './gc-onboarding.mjs';
+import { verifyMessage } from './gc-message.mjs';
+
+function fakeStore() {
+  let rec = null;
+  return {
+    get: async () => rec,
+    put: async (r) => { rec = r; },
+    delete: async () => { rec = null; },
+  };
+}
+
+function fakePasskey(fill = 7, credentialId = 'cred1') {
+  const PRF = new Uint8Array(32).fill(fill);
+  return {
+    isSupported: async () => true,
+    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    unlock: async () => PRF,
+  };
+}
+
+const SECURE = { isSecureContext: true };
+
+test('empty store: status reports no key, passkey off without an adapter', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const s = await onb.status();
+  assert.equal(s.hasKey, false);
+  assert.equal(s.unlocked, false);
+  assert.equal(s.address, null);
+  assert.equal(s.passkeySupported, false);
+  assert.equal(s.secureContext, true);
+});
+
+test('create persists + holds unlocked, and onChange fires with fresh status', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  let last = null;
+  const off = onb.onChange((s) => { last = s; });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  assert.match(address, /^GC.*GC$/);
+  const s = await onb.status();
+  assert.equal(s.hasKey, true);
+  assert.equal(s.unlocked, true);
+  assert.equal(s.address, address);
+  assert.equal(last.unlocked, true);
+  off();
+});
+
+test('lock drops the in-memory key, keeps the record; address still readable', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  const s = await onb.status();
+  assert.equal(s.unlocked, false);
+  assert.equal(s.hasKey, true);
+  assert.equal(s.address, address); // welcome-back address from the record
+});
+
+test('unlock by passphrase re-holds the key; wrong passphrase rejects', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  const r = await onb.unlock({ passphrase: 'pw' });
+  assert.equal(r.address, address);
+  assert.equal((await onb.status()).unlocked, true);
+  await onb.lock();
+  await assert.rejects(() => onb.unlock({ passphrase: 'WRONG' }));
+});
+
+test('passkey: create with passkey, unlock by passkey', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  assert.equal((await onb.status()).passkeySupported, true);
+  const { address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+  await onb.lock();
+  const r = await onb.unlock({ passkey: true });
+  assert.equal(r.address, address);
+});
+
+test('backup yields an encrypted artifact (no raw key) + filename; restore into a fresh store recovers the same address', async () => {
+  const onb1 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { address } = await onb1.create({ passphrase: 'pw' });
+  const { artifact, filename } = await onb1.backup({ passphrase: 'pw' });
+  assert.equal(artifact.kind, 'gc-signing-key-backup');
+  assert.match(filename, /^gc-signing-key-backup-.*\.json$/);
+  // The artifact is encrypted: no private-key field, only the sealed envelope.
+  assert.deepEqual(
+    Object.keys(artifact).sort(),
+    ['address', 'ciphertext', 'iv', 'kdf', 'kind', 'version'],
+  );
+
+  // A different origin/store restores from the artifact (string form too).
+  const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const r = await onb2.restore({ backup: JSON.stringify(artifact), passphrase: 'pw' });
+  assert.equal(r.address, address);
+  assert.equal((await onb2.status()).hasKey, true);
+});
+
+test('signLogin requires unlocked and produces a verifiable gc-msg-v1 proof', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await onb.create({ passphrase: 'pw' });
+  await onb.lock();
+  await assert.rejects(() => onb.signLogin('login:abc'), NoSigningKeyError);
+  await onb.unlock({ passphrase: 'pw' });
+  const proof = await onb.signLogin('login:abc');
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.message, 'login:abc');
+  const v = await verifyMessage(proof, { maxAge: Number.MAX_SAFE_INTEGER });
+  assert.equal(v.valid, true);
+});
+
+test('forget deletes the device record', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await onb.create({ passphrase: 'pw' });
+  await onb.forget();
+  const s = await onb.status();
+  assert.equal(s.hasKey, false);
+  assert.equal(s.unlocked, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test clients/signing-key/gc-onboarding.test.mjs`
+Expected: FAIL — cannot find module `./gc-onboarding.mjs`.
+
+- [ ] **Step 3: Write the controller**
+
+Create `clients/signing-key/gc-onboarding.mjs`:
+
+```js
+// Headless, style-agnostic signing-key onboarding controller. Orchestrates the
+// low-level gc-* modules into create / back up / restore / unlock / sign-login
+// over a single in-memory unlocked-key holder. NO DOM, NO CSS, NO framework:
+// the consuming app owns all markup and renders from status() + onChange().
+import { SigningKey } from './gc-signing-key.mjs';
+import * as keyring from './gc-keyring.mjs';
+import { makeIdbStore } from './gc-store-idb.mjs';
+import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
+import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { signMessage } from './gc-message.mjs';
+import {
+  NoSigningKeyError,
+  UnsupportedError,
+  BadBackupError,
+  BadPassphraseError,
+} from './gc-errors.mjs';
+
+// Re-exported so consuming apps can catch by type and render their own copy.
+export {
+  NoSigningKeyError, UnsupportedError, BadBackupError, BadPassphraseError,
+};
+
+function backupFilename(address) {
+  const slug = (address || 'signing-key')
+    .replace(/[^A-Za-z0-9]/g, '')
+    .slice(0, 12);
+  return `gc-signing-key-backup-${slug || 'signing-key'}.json`;
+}
+
+export function makeOnboarding({
+  store = makeIdbStore(),
+  rpId,
+  rpName,
+  passkey = null,
+  window: win = globalThis.window,
+} = {}) {
+  // A passkey adapter is built from rpId/rpName unless one is injected; absent
+  // both, passkey features stay unavailable (status reports passkeySupported:false).
+  const pk = passkey ?? ((rpId && rpName) ? makeWebauthnPasskey({ rpId, rpName }) : null);
+
+  let key = null; // the in-memory unlocked SigningKey, or null when locked
+  const listeners = new Set();
+
+  const secureContext = () => Boolean(win && win.isSecureContext);
+
+  async function status() {
+    const rec = await store.get();
+    const address = key ? await key.address() : (rec ? rec.address : null);
+    let passkeySupported = false;
+    if (pk && secureContext()) {
+      try {
+        passkeySupported = await pk.isSupported();
+      } catch {
+        passkeySupported = false;
+      }
+    }
+    return {
+      hasKey: Boolean(rec),
+      unlocked: Boolean(key),
+      address,
+      passkeySupported,
+      secureContext: secureContext(),
+    };
+  }
+
+  async function notify() {
+    const snapshot = await status();
+    for (const fn of listeners) fn(snapshot);
+  }
+
+  function onChange(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }
+
+  function passkeyIds(userName, address) {
+    return { userId: address, userName: userName || address };
+  }
+
+  async function create({ passphrase, withPasskey = false, userName } = {}) {
+    const sk = await SigningKey.generate();
+    await keyring.enroll(sk, { store }, { passphrase });
+    const address = await sk.address();
+    if (withPasskey && pk) {
+      await keyring.addPasskey(
+        { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
+      );
+    }
+    key = sk;
+    await notify();
+    return { address };
+  }
+
+  async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    key = await keyring.unlock(
+      { store, passkey: usePasskey ? pk : undefined },
+      { passphrase },
+    );
+    await notify();
+    return { address: await key.address() };
+  }
+
+  async function restore({ backup, passphrase } = {}) {
+    const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
+    const sk = await importEncrypted(artifact, passphrase);
+    await keyring.enroll(sk, { store }, { passphrase });
+    key = sk;
+    await notify();
+    return { address: await sk.address() };
+  }
+
+  async function backup({ passphrase } = {}) {
+    if (!key) {
+      key = await keyring.unlock({ store }, { passphrase });
+    }
+    const artifact = await exportEncrypted(key, passphrase);
+    await notify();
+    return { artifact, filename: backupFilename(await key.address()) };
+  }
+
+  async function addPasskey({ passphrase, userName } = {}) {
+    const rec = await store.get();
+    const address = await keyring.addPasskey(
+      { store, passkey: pk },
+      { passphrase },
+      passkeyIds(userName, rec ? rec.address : undefined),
+    );
+    await notify();
+    return { address };
+  }
+
+  async function signLogin(challenge, { timestamp } = {}) {
+    if (!key) {
+      throw new NoSigningKeyError('locked: unlock before signing a login challenge');
+    }
+    return signMessage(key, challenge, { timestamp });
+  }
+
+  async function lock() {
+    key = null;
+    await notify();
+  }
+
+  async function forget() {
+    await keyring.clear(store);
+    key = null;
+    await notify();
+  }
+
+  return {
+    status, onChange, create, unlock, restore, backup, addPasskey,
+    signLogin, lock, forget,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test clients/signing-key/gc-onboarding.test.mjs`
+Expected: PASS (8 tests).
+
+> If `verifyMessage` reports `valid:false` with reason `expired`, the `maxAge`
+> override in the test is wrong — confirm `verifyMessage`'s `maxAge` unit
+> (seconds) and pass a large value; the proof itself is valid.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/signing-key/gc-onboarding.mjs clients/signing-key/gc-onboarding.test.mjs
+git commit -m "feat(signing-key): gc-onboarding headless controller"
+```
+
+---
+
+## Task 3: Vendor to static + full-suite verification
+
+**Files:**
+- Generated: `src/gumptionchain/static/signing-key/gc-onboarding.mjs` (via the sync script)
+
+- [ ] **Step 1: Sync the module into the served static tree**
+
+Run: `python3 scripts/sync_signing_key.py`
+Expected: output includes `vendored gc-onboarding.mjs`. (The `.test.mjs` is intentionally NOT vendored.)
+
+- [ ] **Step 2: Confirm the vendored copy matches source**
+
+Run: `git diff --no-index clients/signing-key/gc-onboarding.mjs src/gumptionchain/static/signing-key/gc-onboarding.mjs`
+Expected: no diff (identical).
+
+- [ ] **Step 3: Run the JS suite as CI does**
+
+Run: `node --test clients/signing-key/*.test.mjs src/gumptionchain/static/js/*.test.mjs`
+Expected: all pass (including the new 8).
+
+- [ ] **Step 4: Run the Python suite (incl. the vendored-parity gate + static helper)**
+
+Run: `uv run pytest tests/test_signing_key_vendored.py tests/test_static_assets.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit the vendored module**
+
+```bash
+git add src/gumptionchain/static/signing-key/gc-onboarding.mjs
+git commit -m "build(signing-key): vendor gc-onboarding.mjs into static"
+```
+
+---
+
+## Task 4: Docs — flip "Recommended follow-up" to Shipped
+
+**Files:**
+- Modify: `docs/key-onboarding-for-egu-apps.md`
+
+- [ ] **Step 1: Replace the "Recommended follow-up" section**
+
+In `docs/key-onboarding-for-egu-apps.md`, replace the `## Recommended follow-up` section body with:
+
+```markdown
+## The reusable drop-in (shipped)
+
+Base ships **`gc-onboarding.mjs`** — a headless, style-agnostic controller that
+orchestrates the modules above into the full flow. The consuming app owns all
+DOM/CSS and drives the controller; logic and improvements land once for everyone.
+
+Served at `/static/gumptionchain/signing-key/gc-onboarding.mjs`. Non-node
+consumers that don't register the chain-explorer blueprint can mount the assets
+with `static_assets_blueprint()`:
+
+    from gumptionchain import static_assets_blueprint
+    app.register_blueprint(static_assets_blueprint())  # serves /static/gumptionchain/...
+
+Minimal use:
+
+    import { makeOnboarding } from '/static/gumptionchain/signing-key/gc-onboarding.mjs';
+    const onb = makeOnboarding({ rpId: location.hostname, rpName: 'My App' });
+    onb.onChange(render);                       // app re-renders its own DOM
+    await onb.status();                         // { hasKey, unlocked, address, passkeySupported, secureContext }
+    await onb.create({ passphrase, withPasskey: true });
+    await onb.unlock({ passphrase });           // or { passkey: true }
+    const { artifact, filename } = await onb.backup({ passphrase });
+    await onb.restore({ backup, passphrase });
+    const proof = await onb.signLogin(challenge); // gc-msg-v1, POST to your server
+    onb.lock();
+
+Auto-lock is the app's policy — wire it to your own lifecycle, e.g.:
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) onb.lock();
+    });
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/key-onboarding-for-egu-apps.md
+git commit -m "docs: gc-onboarding drop-in shipped (key-onboarding guide)"
+```
+
+---
+
+## After all tasks
+
+- Run the **full** gates once more: `uv run pytest -q`, `node --test clients/signing-key/*.test.mjs src/gumptionchain/static/js/*.test.mjs`, `uv run ruff check src tests app.py`, `uv run ruff format --check src tests app.py`, `uv run mypy`.
+- Open the PR. **Report back to the gumptactoe session** in the PR body + summary:
+  the module path (`/static/gumptionchain/signing-key/gc-onboarding.mjs`), the
+  `makeOnboarding` API (options + the method table above), the
+  `static_assets_blueprint()` mount snippet, and the **merge commit SHA** to pin.
+- The **hub refactor** (consume the controller in gumption-hub) is a separate
+  follow-up PR in that repo.

--- a/docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md
+++ b/docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md
@@ -1,0 +1,193 @@
+# gc-onboarding: a reusable, style-agnostic signing-key onboarding controller
+
+**Date:** 2026-06-15
+**Status:** design approved
+**Consumers:** gumption-hub (refactor, separate PR), gumptactoe (first external
+consumer), future EGU games/tools.
+
+## Goal
+
+Extract the hub's onboarding flow into a **reusable, framework- and
+style-agnostic drop-in** that base `gumptionchain` ships, so every EGU app
+adopts the proper *create → back up → restore → unlock → sign-login* flow **by
+inclusion** rather than hand-rolling the glue. This is the "Recommended
+follow-up" in `docs/key-onboarding-for-egu-apps.md`.
+
+The deliverable is **logic, not markup**: a headless ES-module controller that
+orchestrates the existing low-level signing modules. The consuming app owns all
+DOM and CSS — a Bootstrap app and a CRT/green-phosphor terminal game must both
+consume it unchanged.
+
+This spec also ships a small **Python static-mount helper** so non-node
+consumers (apps that embed the package but don't register the chain-explorer
+blueprint) stop rediscovering how to serve base's static modules.
+
+## Background — what already exists (and stays unchanged)
+
+The low-level browser modules are owned by base at
+`src/gumptionchain/static/signing-key/*.mjs` (source of truth in
+`clients/signing-key/`, synced to static via `scripts/sync_signing_key.py`):
+
+| Module | Relevant exports |
+|---|---|
+| `gc-signing-key.mjs` | `SigningKey.generate()`, `.fromPrivateKeyB58()`, `.address()`, `.sign()` |
+| `gc-store-idb.mjs` | `makeIdbStore({dbName='gc-signing-key'})` → `{get,put,delete}` |
+| `gc-keyring.mjs` | `hasSigningKey(store)`, `enroll(sk,{store},{passphrase})`, `unlock({store,passkey},{passphrase})`, `addPasskey({store,passkey},{passphrase},ids)`, `clear(store)`; record stores `address` cleartext; typed `NoSigningKeyError`/`UnsupportedError` |
+| `gc-backup.mjs` | `exportEncrypted(sk,passphrase)` → `gc-signing-key-backup` artifact, `importEncrypted(backup,passphrase)` → `SigningKey`; `BadBackupError`/`BadPassphraseError` |
+| `gc-passkey-webauthn.mjs` | `makeWebauthnPasskey({rpId,rpName})` → `{isSupported,enroll,unlock}` |
+| `gc-message.mjs` | `signMessage(sk,message,{timestamp})` → `gc-msg-v1` proof |
+
+The current orchestration (`static/js/signing-key-glue.mjs`,
+`transact-glue.mjs`) is **DOM/Bootstrap-coupled** (queries `#ids`, toggles
+`.hidden`, writes status divs). That coupling is exactly what this controller
+extracts away from. The low-level modules above are **not modified** — this is
+additive.
+
+## What we build
+
+### 1. `gc-onboarding.mjs` — the headless controller
+
+New module `clients/signing-key/gc-onboarding.mjs` (synced to
+`static/signing-key/`, served at
+`/static/gumptionchain/signing-key/gc-onboarding.mjs`). No DOM, no CSS, no
+framework; pure ESM, no bundler.
+
+**Boundary:** the controller owns **identity state only** (has-key / unlocked /
+address). It does **not** own the onboarding *wizard* (which screen is shown,
+"create → backup → name → done") — that staging is the app's DOM/flow concern.
+This boundary is what keeps it style-agnostic.
+
+**Factory:**
+
+```js
+import { makeOnboarding } from '.../gc-onboarding.mjs';
+
+const onb = makeOnboarding({
+  store,          // optional; default makeIdbStore() (the gc-signing-key IDB)
+  rpId, rpName,   // optional; enables passkey via makeWebauthnPasskey. Omit → passkey disabled
+  passkey,        // optional explicit adapter (tests inject a fake); else built from rpId/rpName
+  window,         // optional; default globalThis.window (secureContext detection)
+});
+```
+
+**Status + subscription:**
+
+```js
+await onb.status();
+// → { hasKey, unlocked, address|null, passkeySupported, secureContext }
+const off = onb.onChange(status => render(status)); // fires after every transition; returns unsubscribe
+```
+
+- `hasKey` = `await keyring.hasSigningKey(store)`.
+- `unlocked` = controller holds an in-memory key.
+- `address` = the unlocked key's address, else the stored record's cleartext
+  `address` if a record exists, else `null` (lets the app show "welcome back
+  GC…" *before* unlock — no raw key, no re-paste).
+- `passkeySupported` = `secureContext && await passkey.isSupported()` (false
+  when no `rpId`/`rpName`/`passkey` provided).
+- `secureContext` = `window.isSecureContext`.
+
+**Actions (all async unless noted):**
+
+| Method | Behavior | Returns |
+|---|---|---|
+| `create({ passphrase, withPasskey=false, userName })` | `SigningKey.generate()` → `keyring.enroll(sk,{store},{passphrase})`; if `withPasskey && passkeySupported`, `keyring.addPasskey(...)`. Holds unlocked. | `{ address }` |
+| `unlock({ passphrase })` or `unlock({ passkey: true })` | `keyring.unlock({store,passkey?},{passphrase?})`. Holds unlocked. | `{ address }` |
+| `restore({ backup, passphrase })` | `importEncrypted(backup,passphrase)` → `keyring.enroll(...)`. `backup` is a parsed object or JSON string (the app reads the File). Holds unlocked. | `{ address }` |
+| `backup({ passphrase })` | If locked, unlock with `passphrase` first; then `exportEncrypted(heldKey, passphrase)`. The app downloads/copies the artifact — the raw key is never returned. | `{ artifact, filename }` |
+| `addPasskey({ passphrase, userName })` | `keyring.addPasskey({store,passkey},{passphrase},ids)` on an existing key. | `{ address }` |
+| `signLogin(challenge, { timestamp } = {})` | Requires unlocked (throws `NoSigningKeyError` if locked); `signMessage(heldKey, challenge, {timestamp})`. The app POSTs the proof to its server, which verifies `gc-msg-v1`. | `gc-msg-v1` proof |
+
+**Passkey identity (`ids`):** WebAuthn enrollment needs a `userId`/`userName`.
+The controller defaults both to the key's `address` (stable, no PII); an app may
+override the display `userName` via the `create`/`addPasskey` option above.
+| `lock()` (sync) | Drop the in-memory key; the stored record stays. Fires `onChange`. | — |
+| `forget()` | `keyring.clear(store)` + `lock()`. Deletes the device record. | — |
+
+**Errors:** the low-level typed errors (`NoSigningKeyError`, `BadBackupError`,
+`BadPassphraseError`, `UnsupportedError`) propagate unchanged and are
+**re-exported** from `gc-onboarding.mjs` so apps can `catch` by type and render
+their own copy.
+
+**`onChange`** fires after `create`/`unlock`/`restore`/`addPasskey`/`lock`/
+`forget`, invoking each listener with the fresh `status()` snapshot.
+
+**Lock policy:** holds the unlocked `SigningKey` in memory until `lock()`. The
+controller ships **no timers** — idle/`visibilitychange` auto-lock is the app's
+policy. The docs/PR include the recommended snippet apps can wire themselves.
+
+### 2. `static_assets_blueprint()` — the Python static-mount helper
+
+In base (e.g. `src/gumptionchain/__init__.py`):
+
+```python
+from gumptionchain import static_assets_blueprint
+app.register_blueprint(static_assets_blueprint())  # serves /static/gumptionchain/...
+```
+
+A static-only `Blueprint(static_folder=files('gumptionchain')/'static',
+static_url_path='/static/gumptionchain')` — the **same URL space** as the full
+`browser` blueprint, so module paths are identical whether a consumer mounts the
+explorer (hub) or only the assets (gumptactoe). For consumers that embed the
+package but do **not** want the chain explorer + DB. `url_for(
+'gumptionchain_static.static', filename='signing-key/gc-onboarding.mjs')`.
+
+## Testing
+
+- **JS** — `clients/signing-key/gc-onboarding.test.mjs` (`node --test`, the
+  existing harness): exercises create → backup → restore → unlock (passphrase
+  and passkey) → signLogin → lock → forget end-to-end with a **real**
+  `SigningKey` (Node webcrypto), `fakeStore`, and `fakePasskey`. Asserts: the
+  raw private key is never returned by any method; `restore` of a `backup`
+  artifact yields the same address; `signLogin` proof verifies via
+  `verifyMessage`; `status()` transitions are correct; passkey paths are skipped
+  when unsupported. Not vendored (tests excluded by `sync_signing_key.py`);
+  parity test continues to cover the synced `.mjs`.
+- **Python** — a pytest mounts `static_assets_blueprint()` on a throwaway Flask
+  app and asserts `GET /static/gumptionchain/signing-key/gc-onboarding.mjs`
+  returns 200 with a JavaScript content-type.
+- Full `node --test` + `pytest` + `ruff` + `mypy` gates stay green.
+
+## Docs / deliverable
+
+- Update `docs/key-onboarding-for-egu-apps.md`: flip "Recommended follow-up" to
+  **Shipped**, documenting `gc-onboarding.mjs` (the API above), the
+  `static_assets_blueprint()` mount, and the auto-lock snippet.
+- **Report back to the gumptactoe session** (in the PR + a summary): the served
+  module path, the `makeOnboarding` API + methods/options, the minimal mount
+  snippet, and the **merge commit SHA** to pin.
+
+## Scope
+
+**In:** `gc-onboarding.mjs` + node tests; `static_assets_blueprint()` + pytest;
+docs update; the report-back. One base branch → PR → merge.
+
+**Out (separate efforts):**
+- The **hub refactor** to consume the controller (separate gumption-hub PR;
+  proves reusability but is a different repo).
+- **gumptactoe** itself (the consumer; pins the merge SHA and builds its CRT DOM
+  against the API).
+- Transaction build/sign/submit (that's `transact-glue`; this controller is
+  identity + login only).
+- A shipped HTML template partial — markup stays the app's job (a
+  "style-agnostic partial" is a contradiction; YAGNI).
+
+## Invariants — what does NOT change
+
+- The low-level `gc-*.mjs` module APIs (additive only).
+- Protocol strings: `gc-msg-v1`, `gc-signing-key-backup`, the `gc-signing-key`
+  IndexedDB name, keyring record/backup `VERSION`s.
+- The `browser` blueprint and its `/static/gumptionchain` URL space (the helper
+  reuses the same path).
+
+## Risks
+
+- **API doesn't fit a real consumer.** Mitigation: comprehensive end-to-end node
+  test now; the hub refactor + gumptactoe are the ergonomics proof. Keep the
+  controller small so a follow-up additive tweak is cheap.
+- **Endpoint-name overlap** between `browser` (`'browser.static'`) and the
+  helper (`'gumptionchain_static.static'`): only an issue if a single app
+  registers both, which no consumer does (the hub uses `browser`; gumptactoe
+  uses the helper). Same URL path is intentional.
+- **Holding the unlocked key in memory** is inherent to "unlock to sign without
+  re-prompting"; auto-lock is delegated to the app with a documented snippet.

--- a/src/gumptionchain/__init__.py
+++ b/src/gumptionchain/__init__.py
@@ -26,6 +26,10 @@ from flask import Flask
 from flask.cli import FlaskGroup
 from flask_migrate import Migrate
 
+from gumptionchain.static_assets import (
+    static_assets_blueprint as static_assets_blueprint,
+)
+
 __version__ = _pkg_version('gumptionchain')
 
 # Package-relative migrations path so `gumptionchain init` / `gumptionchain db

--- a/src/gumptionchain/static/signing-key/gc-onboarding.mjs
+++ b/src/gumptionchain/static/signing-key/gc-onboarding.mjs
@@ -43,22 +43,26 @@ export function makeOnboarding({
 
   const secureContext = () => Boolean(win && win.isSecureContext);
 
+  // Feature-detect passkey support: an adapter must exist, the context must be
+  // secure, and the adapter must report support (guarded — a throwing adapter
+  // counts as unsupported). Reused by status() and create().
+  async function passkeySupported() {
+    if (!(pk && secureContext())) return false;
+    try {
+      return await pk.isSupported();
+    } catch {
+      return false;
+    }
+  }
+
   async function status() {
     const rec = await store.get();
     const address = key ? await key.address() : (rec ? rec.address : null);
-    let passkeySupported = false;
-    if (pk && secureContext()) {
-      try {
-        passkeySupported = await pk.isSupported();
-      } catch {
-        passkeySupported = false;
-      }
-    }
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
       address,
-      passkeySupported,
+      passkeySupported: await passkeySupported(),
       secureContext: secureContext(),
     };
   }
@@ -88,7 +92,7 @@ export function makeOnboarding({
     const sk = await SigningKey.generate();
     await keyring.enroll(sk, { store }, { passphrase });
     const address = await sk.address();
-    if (withPasskey && pk) {
+    if (withPasskey && (await passkeySupported())) {
       await keyring.addPasskey(
         { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
       );

--- a/src/gumptionchain/static/signing-key/gc-onboarding.mjs
+++ b/src/gumptionchain/static/signing-key/gc-onboarding.mjs
@@ -1,0 +1,166 @@
+// Headless, style-agnostic signing-key onboarding controller. Orchestrates the
+// low-level gc-* modules into create / back up / restore / unlock / sign-login
+// over a single in-memory unlocked-key holder. NO DOM, NO CSS, NO framework:
+// the consuming app owns all markup and renders from status() + onChange().
+import { SigningKey } from './gc-signing-key.mjs';
+import * as keyring from './gc-keyring.mjs';
+import { makeIdbStore } from './gc-store-idb.mjs';
+import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
+import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { signMessage } from './gc-message.mjs';
+import {
+  NoSigningKeyError,
+  UnsupportedError,
+  BadBackupError,
+  BadPassphraseError,
+} from './gc-errors.mjs';
+
+// Re-exported so consuming apps can catch by type and render their own copy.
+export {
+  NoSigningKeyError, UnsupportedError, BadBackupError, BadPassphraseError,
+};
+
+function backupFilename(address) {
+  const slug = (address || 'signing-key')
+    .replace(/[^A-Za-z0-9]/g, '')
+    .slice(0, 12);
+  return `gc-signing-key-backup-${slug || 'signing-key'}.json`;
+}
+
+export function makeOnboarding({
+  store = makeIdbStore(),
+  rpId,
+  rpName,
+  passkey = null,
+  window: win = globalThis.window,
+} = {}) {
+  // A passkey adapter is built from rpId/rpName unless one is injected; absent
+  // both, passkey features stay unavailable (status reports passkeySupported:false).
+  const pk = passkey ?? ((rpId && rpName) ? makeWebauthnPasskey({ rpId, rpName }) : null);
+
+  let key = null; // the in-memory unlocked SigningKey, or null when locked
+  const listeners = new Set();
+
+  const secureContext = () => Boolean(win && win.isSecureContext);
+
+  async function status() {
+    const rec = await store.get();
+    const address = key ? await key.address() : (rec ? rec.address : null);
+    let passkeySupported = false;
+    if (pk && secureContext()) {
+      try {
+        passkeySupported = await pk.isSupported();
+      } catch {
+        passkeySupported = false;
+      }
+    }
+    return {
+      hasKey: Boolean(rec),
+      unlocked: Boolean(key),
+      address,
+      passkeySupported,
+      secureContext: secureContext(),
+    };
+  }
+
+  async function notify() {
+    const snapshot = await status();
+    for (const fn of listeners) {
+      try {
+        fn(snapshot);
+      } catch {
+        // A consumer's onChange handler must not break the action or starve
+        // other listeners. Render errors are the app's problem, not ours.
+      }
+    }
+  }
+
+  function onChange(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }
+
+  function passkeyIds(userName, address) {
+    return { userId: address, userName: userName || address };
+  }
+
+  async function create({ passphrase, withPasskey = false, userName } = {}) {
+    const sk = await SigningKey.generate();
+    await keyring.enroll(sk, { store }, { passphrase });
+    const address = await sk.address();
+    if (withPasskey && pk) {
+      await keyring.addPasskey(
+        { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
+      );
+    }
+    key = sk;
+    await notify();
+    return { address };
+  }
+
+  async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    key = await keyring.unlock(
+      { store, passkey: usePasskey ? pk : undefined },
+      { passphrase },
+    );
+    await notify();
+    return { address: await key.address() };
+  }
+
+  async function restore({ backup, passphrase } = {}) {
+    const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
+    const sk = await importEncrypted(artifact, passphrase);
+    await keyring.enroll(sk, { store }, { passphrase });
+    key = sk;
+    await notify();
+    return { address: await sk.address() };
+  }
+
+  async function backup({ passphrase } = {}) {
+    const wasLocked = !key;
+    if (wasLocked) {
+      key = await keyring.unlock({ store }, { passphrase });
+    }
+    const artifact = await exportEncrypted(key, passphrase);
+    const filename = backupFilename(await key.address());
+    if (wasLocked) {
+      key = null; // a backup is a read; don't leave the key unlocked
+    }
+    await notify();
+    return { artifact, filename };
+  }
+
+  async function addPasskey({ passphrase, userName } = {}) {
+    const rec = await store.get();
+    const address = await keyring.addPasskey(
+      { store, passkey: pk },
+      { passphrase },
+      passkeyIds(userName, rec ? rec.address : undefined),
+    );
+    await notify();
+    return { address };
+  }
+
+  async function signLogin(challenge, { timestamp } = {}) {
+    if (!key) {
+      throw new NoSigningKeyError('locked: unlock before signing a login challenge');
+    }
+    return signMessage(key, challenge, { timestamp });
+  }
+
+  async function lock() {
+    key = null;
+    await notify();
+  }
+
+  async function forget() {
+    await keyring.clear(store);
+    key = null;
+    await notify();
+  }
+
+  return {
+    status, onChange, create, unlock, restore, backup, addPasskey,
+    signLogin, lock, forget,
+  };
+}

--- a/src/gumptionchain/static/signing-key/index.mjs
+++ b/src/gumptionchain/static/signing-key/index.mjs
@@ -10,6 +10,9 @@ export const version = '0.2.0';
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
 
+// Onboarding controller (headless create / back up / restore / unlock / sign-login)
+export { makeOnboarding } from './gc-onboarding.mjs';
+
 // API request signing (gc-sig-v1)
 export { canonical, signHeaders } from './gc-sig.mjs';
 

--- a/src/gumptionchain/static_assets.py
+++ b/src/gumptionchain/static_assets.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from importlib.resources import files
+
+from flask import Blueprint
+
+
+def static_assets_blueprint(
+    url_path: str = '/static/gumptionchain',
+    name: str = 'gumptionchain_static',
+) -> Blueprint:
+    """A static-only blueprint serving base's browser assets (the signing-key
+    ESM modules + JS glue) for consumers that embed the ``gumptionchain``
+    package but do NOT register the full ``browser`` blueprint (chain explorer
+    + DB).
+
+    The default ``url_path`` matches the ``browser`` blueprint's, so module
+    URLs are identical whether a consumer mounts the explorer or only assets.
+    """
+    static_folder = str(files('gumptionchain') / 'static')
+    return Blueprint(
+        name,
+        __name__,
+        static_folder=static_folder,
+        static_url_path=url_path,
+    )

--- a/tests/test_static_assets.py
+++ b/tests/test_static_assets.py
@@ -1,0 +1,26 @@
+from flask import Flask
+
+from gumptionchain import static_assets_blueprint
+
+
+def test_static_assets_blueprint_serves_a_signing_key_module():
+    # A consumer that embeds the package but does NOT register the full
+    # browser blueprint can still serve base's ESM modules.
+    app = Flask(__name__)
+    app.register_blueprint(static_assets_blueprint())
+    client = app.test_client()
+
+    resp = client.get('/static/gumptionchain/signing-key/gc-keyring.mjs')
+    assert resp.status_code == 200
+    assert b'export' in resp.data  # it served the real module, not a 404 page
+
+
+def test_static_assets_blueprint_url_path_is_overridable():
+    app = Flask(__name__)
+    app.register_blueprint(static_assets_blueprint(url_path='/assets/gc'))
+    client = app.test_client()
+
+    mounted = client.get('/assets/gc/signing-key/gc-keyring.mjs')
+    assert mounted.status_code == 200
+    default = client.get('/static/gumptionchain/signing-key/gc-keyring.mjs')
+    assert default.status_code == 404


### PR DESCRIPTION
## Summary

Ships the "Recommended follow-up" from `docs/key-onboarding-for-egu-apps.md`: a **headless, style-agnostic onboarding controller** that every EGU app (hub, gumptactoe, future games) can adopt by inclusion instead of hand-rolling key glue. Logic only — the app owns all DOM/CSS. Spec: `docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md`; plan alongside it.

- **`gc-onboarding.mjs`** (`clients/signing-key/`, vendored to `static/signing-key/`, on the `index.mjs` barrel): `makeOnboarding(...)` orchestrating the existing `gc-*` modules over a single in-memory unlocked-key holder. No DOM, no framework.
- **`static_assets_blueprint()`** (`gumptionchain.static_assets`, re-exported from the package root): a static-only Flask blueprint so consumers that embed the package but don't register the chain-explorer blueprint can still serve the modules at the same `/static/gumptionchain/...` URL space.
- Docs: `key-onboarding-for-egu-apps.md` "Recommended follow-up" → **shipped**, with the API + mount snippet.

Built subagent-driven (implementer + spec-review + code-quality review per task, plus a final whole-branch review). Two review findings were folded in: `onChange` listeners are guarded so a throwing handler can't break an action; `backup()` restores prior lock state; and `create({withPasskey})` gates on **live** passkey support (skips silently when unsupported) rather than mere adapter presence.

## Report-back for the gumptactoe session (build against this)

- **Module:** `/static/gumptionchain/signing-key/gc-onboarding.mjs` (or `import { makeOnboarding } from '.../signing-key/index.mjs'`)
- **Mount (non-node consumer):**
  ```python
  from gumptionchain import static_assets_blueprint
  app.register_blueprint(static_assets_blueprint())  # /static/gumptionchain/...
  ```
- **API:** `makeOnboarding({ store?, rpId?, rpName?, passkey?, window? })` →
  `status()→{hasKey,unlocked,address,passkeySupported,secureContext}`, `onChange(fn)→off`,
  `create({passphrase,withPasskey?,userName?})`, `unlock({passphrase}|{passkey:true})`,
  `restore({backup,passphrase})`, `backup({passphrase})→{artifact,filename}`,
  `addPasskey({passphrase,userName?})`, `signLogin(challenge,{timestamp?})→gc-msg-v1 proof`,
  `lock()`, `forget()`. Typed errors (`NoSigningKeyError`/`UnsupportedError`/`BadBackupError`/`BadPassphraseError`) re-exported. Raw key is never returned/rendered.
- **Merge SHA to pin:** *(will post once squash-merged)*

## Test Plan
- [x] `node --test` — 174 pass (9 new controller cases: create/lock/unlock/passkey/unsupported-skip/backup+restore/signLogin/forget)
- [x] `pytest` — 572 passed, 1 skipped (incl. `test_static_assets.py` + the vendored-parity gate)
- [x] `ruff check` + `format --check` (src/tests/app.py) + `mypy --strict` — all clean
- [x] vendored `static/` copies byte-identical to `clients/` sources
- [ ] Consumer smoke: gumptactoe mounts the helper + drives the controller from its CRT DOM

The **hub refactor** to consume this controller is a separate follow-up PR in gumption-hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)