### PR TITLE
fix(#279): gc-keyring.unlock throws typed BadPassphraseError on wrong passphrase

### DIFF
--- a/clients/signing-key/gc-keyring.mjs
+++ b/clients/signing-key/gc-keyring.mjs
@@ -25,7 +25,11 @@
 //   store (single record): get()->record|null, put(record), delete().
 //   passkey: isSupported()->bool, enroll(ids)->{credentialId, prfOutput},
 //            unlock(credentialId)->prfOutput (Uint8Array).
-import { NoSigningKeyError, UnsupportedError } from './gc-errors.mjs';
+import {
+  NoSigningKeyError,
+  UnsupportedError,
+  BadPassphraseError,
+} from './gc-errors.mjs';
 import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
@@ -100,7 +104,14 @@ async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);
-    return new Uint8Array(await openWithKey(kek, w));
+    try {
+      return new Uint8Array(await openWithKey(kek, w));
+    } catch {
+      // Wrong passphrase -> GCM auth-tag failure. Surface a typed error (parity
+      // with gc-backup.importEncrypted) so consumers catch it uniformly; never
+      // leak the underlying WebCrypto OperationError.
+      throw new BadPassphraseError('wrong passphrase');
+    }
   }
   if (passkey && wraps.passkey) {
     const prfOutput = await passkey.unlock(wraps.passkey.credentialId);

--- a/clients/signing-key/gc-keyring.test.mjs
+++ b/clients/signing-key/gc-keyring.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { SigningKey } from './gc-signing-key.mjs';
 import * as keyring from './gc-keyring.mjs';
+import { BadPassphraseError } from './gc-errors.mjs';
 
 // In-memory single-record store mirroring the gc-store-idb contract.
 function fakeStore() {
@@ -40,10 +41,15 @@ test('enroll(passphrase) then unlock(passphrase) recovers the same signing_key',
   assert.equal(await unlocked.address(), addr);
 });
 
-test('wrong passphrase fails closed (unlock rejects)', async () => {
+test('wrong passphrase fails closed with a typed BadPassphraseError', async () => {
   const store = fakeStore();
   await keyring.enroll(await SigningKey.generate(), { store }, { passphrase: 'right' });
-  await assert.rejects(() => keyring.unlock({ store }, { passphrase: 'wrong' }));
+  // Parity with gc-backup.importEncrypted: a wrong passphrase must surface as
+  // BadPassphraseError, not a raw WebCrypto OperationError (#279).
+  await assert.rejects(
+    () => keyring.unlock({ store }, { passphrase: 'wrong' }),
+    BadPassphraseError,
+  );
 });
 
 test('the stored record is always ciphertext (no plaintext b58/DEK leaks)', async () => {

--- a/clients/signing-key/gc-onboarding.test.mjs
+++ b/clients/signing-key/gc-onboarding.test.mjs
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { makeOnboarding, NoSigningKeyError } from './gc-onboarding.mjs';
+import {
+  makeOnboarding, NoSigningKeyError, BadPassphraseError,
+} from './gc-onboarding.mjs';
 import { verifyMessage } from './gc-message.mjs';
 
 function fakeStore() {
@@ -66,7 +68,10 @@ test('unlock by passphrase re-holds the key; wrong passphrase rejects', async ()
   assert.equal(r.address, address);
   assert.equal((await onb.status()).unlocked, true);
   await onb.lock();
-  await assert.rejects(() => onb.unlock({ passphrase: 'WRONG' }));
+  await assert.rejects(
+    () => onb.unlock({ passphrase: 'WRONG' }),
+    BadPassphraseError, // typed + catchable through the controller (#279)
+  );
 });
 
 test('passkey: create with passkey, unlock by passkey', async () => {

--- a/src/gumptionchain/static/signing-key/gc-keyring.mjs
+++ b/src/gumptionchain/static/signing-key/gc-keyring.mjs
@@ -25,7 +25,11 @@
 //   store (single record): get()->record|null, put(record), delete().
 //   passkey: isSupported()->bool, enroll(ids)->{credentialId, prfOutput},
 //            unlock(credentialId)->prfOutput (Uint8Array).
-import { NoSigningKeyError, UnsupportedError } from './gc-errors.mjs';
+import {
+  NoSigningKeyError,
+  UnsupportedError,
+  BadPassphraseError,
+} from './gc-errors.mjs';
 import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
@@ -100,7 +104,14 @@ async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);
-    return new Uint8Array(await openWithKey(kek, w));
+    try {
+      return new Uint8Array(await openWithKey(kek, w));
+    } catch {
+      // Wrong passphrase -> GCM auth-tag failure. Surface a typed error (parity
+      // with gc-backup.importEncrypted) so consumers catch it uniformly; never
+      // leak the underlying WebCrypto OperationError.
+      throw new BadPassphraseError('wrong passphrase');
+    }
   }
   if (passkey && wraps.passkey) {
     const prfOutput = await passkey.unlock(wraps.passkey.credentialId);


### PR DESCRIPTION
## Summary

Closes #279 (surfaced from the hub onboarding refactor, gumption-hub#49 — the first real external consumer of `makeOnboarding`).

Wrong-passphrase failures weren't typed uniformly across the signing-key surface:
- `gc-backup.importEncrypted` (**restore**) threw the typed `BadPassphraseError`.
- `gc-keyring.unlock` (**unlock**, and `gc-onboarding.backup()`'s internal re-unlock) let a wrong passphrase surface as a raw WebCrypto `OperationError` (the GCM auth-tag failure from `openWithKey`).

So a consumer could `catch (e instanceof BadPassphraseError)` on `restore` but silently missed on `unlock`/`backup`.

## Fix (additive, non-breaking)

In `gc-keyring.mjs` `unwrapDek`, the passphrase branch now wraps `openWithKey` and rethrows `BadPassphraseError` (mirroring `gc-backup`), with a generic message and no crypto-internal leak. The passkey-unwrap path is unchanged. Because `gc-onboarding` delegates to `keyring.unlock`, its `unlock()` and `backup()` (locked re-unlock) now propagate the typed error too — `restore` / `unlock` / `backup` are catchable uniformly.

Existing callers that don't branch on the type are unaffected (it still rejects). As a bonus, the browser glue's generic `catch` now renders `'wrong passphrase'` instead of an opaque `OperationError`.

## Acceptance (all met)
- [x] `keyring.unlock` with a wrong passphrase throws `BadPassphraseError`, not a bare `OperationError` — keyring test strengthened to assert the type.
- [x] `gc-onboarding`'s `unlock()` propagates `BadPassphraseError` — controller test asserts it through `makeOnboarding`.
- [x] Node test covers the wrong-passphrase unlock case; existing tests stay green (full JS suite **174 pass**).
- [x] Vendored `static/` copy byte-identical (parity gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)