### PR TITLE
feat(signing-key): gc-onboarding status() reports enrolled methods (passkeyEnrolled + methods)

### DIFF
--- a/clients/signing-key/gc-onboarding.mjs
+++ b/clients/signing-key/gc-onboarding.mjs
@@ -55,14 +55,26 @@ export function makeOnboarding({
     }
   }
 
+  // Which unlock methods the STORED record is enrolled under, read from its
+  // wraps without unlocking. Stable order: passphrase, then passkey.
+  function enrolledMethods(rec) {
+    const wraps = (rec && rec.wraps) || {};
+    return ['passphrase', 'passkey'].filter((m) => Boolean(wraps[m]));
+  }
+
   async function status() {
     const rec = await store.get();
     const address = key ? await key.address() : (rec ? rec.address : null);
+    const methods = enrolledMethods(rec);
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
       address,
+      // passkeySupported = device capability; passkeyEnrolled = stored state.
+      // Gate an "add a passkey" affordance on supported && !enrolled.
       passkeySupported: await passkeySupported(),
+      passkeyEnrolled: methods.includes('passkey'),
+      methods,
       secureContext: secureContext(),
     };
   }

--- a/clients/signing-key/gc-onboarding.test.mjs
+++ b/clients/signing-key/gc-onboarding.test.mjs
@@ -34,6 +34,28 @@ test('empty store: status reports no key, passkey off without an adapter', async
   assert.equal(s.address, null);
   assert.equal(s.passkeySupported, false);
   assert.equal(s.secureContext, true);
+  assert.deepEqual(s.methods, []);
+  assert.equal(s.passkeyEnrolled, false);
+});
+
+test('status reports enrolled methods (passphrase-only) from the record, no unlock', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await onb.create({ passphrase: 'pw' });
+  await onb.lock(); // prove it reads wraps from the record, not the held key
+  const s = await onb.status();
+  assert.deepEqual(s.methods, ['passphrase']);
+  assert.equal(s.passkeyEnrolled, false);
+});
+
+test('status reports passkeyEnrolled + both methods after create-with-passkey', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  await onb.create({ passphrase: 'pw', withPasskey: true });
+  await onb.lock();
+  const s = await onb.status();
+  assert.deepEqual(s.methods, ['passphrase', 'passkey']);
+  assert.equal(s.passkeyEnrolled, true);
+  // capability vs enrollment are distinct signals
+  assert.equal(s.passkeySupported, true);
 });
 
 test('create persists + holds unlocked, and onChange fires with fresh status', async () => {

--- a/docs/key-onboarding-for-egu-apps.md
+++ b/docs/key-onboarding-for-egu-apps.md
@@ -144,7 +144,11 @@ Minimal use:
     import { makeOnboarding } from '/static/gumptionchain/signing-key/gc-onboarding.mjs';
     const onb = makeOnboarding({ rpId: location.hostname, rpName: 'My App' });
     onb.onChange(render);                       // app re-renders its own DOM
-    await onb.status();                         // { hasKey, unlocked, address, passkeySupported, secureContext }
+    await onb.status();                         // { hasKey, unlocked, address, secureContext,
+                                                //   passkeySupported,  // device capability
+                                                //   passkeyEnrolled,   // stored key has a passkey wrap
+                                                //   methods }          // e.g. ['passphrase','passkey']
+    // Gate an "add a passkey" affordance on: passkeySupported && !passkeyEnrolled
     await onb.create({ passphrase, withPasskey: true });
     await onb.unlock({ passphrase });           // or { passkey: true }
     const { artifact, filename } = await onb.backup({ passphrase });

--- a/docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md
+++ b/docs/superpowers/specs/2026-06-15-gc-onboarding-reusable-controller-design.md
@@ -74,7 +74,10 @@ const onb = makeOnboarding({
 
 ```js
 await onb.status();
-// → { hasKey, unlocked, address|null, passkeySupported, secureContext }
+// → { hasKey, unlocked, address|null, secureContext,
+//     passkeySupported,   // device capability
+//     passkeyEnrolled,    // the stored record has a passkey wrap (added post-#280)
+//     methods }           // enrolled wrap names, e.g. ['passphrase','passkey']
 const off = onb.onChange(status => render(status)); // fires after every transition; returns unsubscribe
 ```
 

--- a/src/gumptionchain/static/signing-key/gc-onboarding.mjs
+++ b/src/gumptionchain/static/signing-key/gc-onboarding.mjs
@@ -55,14 +55,26 @@ export function makeOnboarding({
     }
   }
 
+  // Which unlock methods the STORED record is enrolled under, read from its
+  // wraps without unlocking. Stable order: passphrase, then passkey.
+  function enrolledMethods(rec) {
+    const wraps = (rec && rec.wraps) || {};
+    return ['passphrase', 'passkey'].filter((m) => Boolean(wraps[m]));
+  }
+
   async function status() {
     const rec = await store.get();
     const address = key ? await key.address() : (rec ? rec.address : null);
+    const methods = enrolledMethods(rec);
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
       address,
+      // passkeySupported = device capability; passkeyEnrolled = stored state.
+      // Gate an "add a passkey" affordance on supported && !enrolled.
       passkeySupported: await passkeySupported(),
+      passkeyEnrolled: methods.includes('passkey'),
+      methods,
       secureContext: secureContext(),
     };
   }


### PR DESCRIPTION
## Summary

Follow-up to #278/#280, requested from the hub onboarding refactor (gumption-hub#49). `status()` reported device **capability** (`passkeySupported`) but not **enrollment state**, so a consumer couldn't gate an "add a passkey" affordance — and `keyring.addPasskey()` silently *replaces* an existing passkey wrap (its own comment says the UI should gate on whether one is enrolled, but `status()` gave nothing to gate on).

Adds two fields to `status()`, derived from the stored record's `wraps` **without unlocking** (status already reads the record):

- **`methods`** — enrolled wrap names, e.g. `['passphrase','passkey']` (`[]` when no key). Source of truth; the keyring supports passphrase + passkey and has `removeMethod`, so a key can legitimately be passphrase-only.
- **`passkeyEnrolled`** — `methods.includes('passkey')`, the direct gate.

```js
await onb.status();
// { hasKey, unlocked, address, secureContext,
//   passkeySupported,   // device capability
//   passkeyEnrolled,    // stored key has a passkey wrap
//   methods }           // ['passphrase','passkey']
```

**Consumer gating rule:** show "add a passkey" when `passkeySupported && !passkeyEnrolled`.

Additive — existing fields and all other methods unchanged.

## Test Plan
- [x] `node --test` — 176 pass (3 new/extended: empty store → `methods: []`; passphrase-only → `['passphrase']`, `passkeyEnrolled:false`; create-with-passkey → `['passphrase','passkey']`, `passkeyEnrolled:true`; all asserted **while locked**, proving it reads the record not the held key)
- [x] vendored `static/` copy byte-identical (parity gate green)
- [x] vocabulary gate green (docs scanned)
- [ ] (separate, hub repo) the hub session wires `passkeySupported && !passkeyEnrolled` to gate its passkey UI

The **hub wiring** to actually use this is the hub session's follow-up (gumption-hub). I'll post the final `status()` shape + merge SHA for gumptactoe to pin once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)