### PR TITLE
feat(#287): subject-search primitive — node endpoint + proxy relay

### DIFF
--- a/docs/superpowers/plans/2026-06-16-subject-search.md
+++ b/docs/superpowers/plans/2026-06-16-subject-search.md
@@ -1,0 +1,629 @@
+# Subject Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a subject-search primitive to base gumptionchain so consumer web apps can offer a typeahead of on-chain subjects ranked by stake.
+
+**Architecture:** Four thin layers. A decoded-plaintext column pair on `OutflowDAO` (`subject_plain` canonical + `subject_lower` indexed) populated at the constructor choke point → a `search_subjects` query method on `ChainDAO` (prefix, case-insensitive, ranked by total stake) delegated from `Chain` → a READER node endpoint `GET /api/subjects/search` → an `ApiClient.get_subject_search` method + a `node_proxy_blueprint` relay route that converts grains→GRIT.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0 (`Mapped[]`), Flask-Migrate/Alembic, pytest, httpx, uv.
+
+---
+
+## Background the engineer needs
+
+- **Subjects are stored base64url-encoded** in `OutflowDAO.opposition` / `OutflowDAO.support` (`String(500)`, nullable; a row sets at most one). `encode_subject` / `decode_subject` live in `gumptionchain.payload`; `decode_subject` is bijective for valid subjects.
+- **The constructor is the single creation choke point.** `OutflowDAO.__init__` (`src/gumptionchain/models.py:146-167`) is where `opposition`/`support` get set; the only construction sites are that class and `src/gumptionchain/transaction.py:315`, both via `OutflowDAO(...)`. Populating the new columns there covers every write path.
+- **Query methods exist on BOTH `Chain` and `ChainDAO`.** `ChainDAO` (`models.py`) implements (`subject_leaderboard`, `opposition_balance`); `Chain` (`chain.py`) has thin delegating wrappers (`chain.py:558` → `self.to_dao().subject_leaderboard(limit)`). The API and browser call them on the `Chain`. The new `search_subjects` follows the same dual placement.
+- **`node_lc_dao()`** (`api.py:82`) returns `(node, lc, dao)` where `lc` is the `Chain` (or `None` for an empty chain). Existing read views (`OppositionBalanceView`, `api.py:746`) do `_, lc, _ = node_lc_dao()` then call methods on `lc`.
+- **Greenfield migrations:** per project practice, fold schema changes into the single baseline migration `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py` rather than stacking a new revision. There is no production data to back-fill. Tests build via `db.create_all()`. The `gumptionchain db check` CI gate enforces that `create_all()` (model metadata) matches the migration.
+- **Proxy conventions** (`src/gumptionchain/node_proxy.py`): `_grit(grains)` → `{'grit': grains/100, 'grains': grains}`; `_call(fn, *args)` invokes `fn(*args, raise_for_status=False)` and maps `httpx.RequestError`→502; `_ok(r)` maps node 4xx/5xx; routes are CSRF-exempt with a `rate_limit` hook.
+- **Run the full suite** with `uv run pytest`; lint `uv run ruff check src tests` + `uv run ruff format --check src tests`; types `uv run mypy`; schema gate `uv run gumptionchain db check`.
+
+---
+
+## Task 1: `OutflowDAO` plaintext columns + baseline migration
+
+**Files:**
+- Modify: `src/gumptionchain/models.py` (`OutflowDAO`: columns, index, `__init__`, new import)
+- Modify: `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py` (outflow table)
+- Test: `tests/test_subject_search.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_subject_search.py`:
+
+```python
+from gumptionchain.database import db
+from gumptionchain.models import OutflowDAO
+from gumptionchain.payload import encode_subject
+
+
+def test_outflow_populates_plaintext_columns_for_a_stake(app):
+    with app.app_context():
+        enc = encode_subject('Tabs > Spaces')
+        row = OutflowDAO('txid1', 0, 100, support=enc)
+        assert row.subject_plain == 'Tabs > Spaces'
+        assert row.subject_lower == 'tabs > spaces'
+
+
+def test_outflow_plaintext_columns_none_for_non_stake(app):
+    with app.app_context():
+        row = OutflowDAO('txid2', 0, 100, address='GCwhoeverGC')
+        assert row.subject_plain is None
+        assert row.subject_lower is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_subject_search.py -v`
+Expected: FAIL — `AttributeError: 'OutflowDAO' object has no attribute 'subject_plain'`.
+
+- [ ] **Step 3: Add the columns, index, and constructor population**
+
+In `src/gumptionchain/models.py`, add an import near the other `gumptionchain.payload` usage (top of file):
+
+```python
+from gumptionchain.payload import decode_subject
+```
+
+In `OutflowDAO`, add the two columns after `support` (around `models.py:125`):
+
+```python
+    subject_plain: Mapped[str | None] = mapped_column(String(500))
+    subject_lower: Mapped[str | None] = mapped_column(String(500))
+```
+
+Add the index to `__table_args__` (after `ix_outflow_support`):
+
+```python
+        db.Index('ix_outflow_subject_lower', 'subject_lower'),
+```
+
+Add a static helper and populate in `__init__` (inside the `with db.session.no_autoflush:` block, after `self.support = support`):
+
+```python
+    @staticmethod
+    def _derive_subject_plain(
+        opposition: str | None, support: str | None
+    ) -> str | None:
+        encoded = opposition if opposition is not None else support
+        if encoded is None:
+            return None
+        try:
+            return decode_subject(encoded)
+        except Exception:
+            # Subjects are validated upstream; a decode failure must never
+            # break row construction. Leave the searchable columns null.
+            return None
+```
+
+```python
+            plain = self._derive_subject_plain(opposition, support)
+            self.subject_plain = plain
+            self.subject_lower = plain.lower() if plain is not None else None
+```
+
+In `src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py`, add the two columns inside `op.create_table('outflow', ...)` after the `support` column (`63d32cd7621a_initial_schema.py:117`):
+
+```python
+    sa.Column('subject_plain', sa.String(length=500), nullable=True),
+    sa.Column('subject_lower', sa.String(length=500), nullable=True),
+```
+
+And add the index inside the `with op.batch_alter_table('outflow', ...)` block after `ix_outflow_support` (`63d32cd7621a_initial_schema.py:129`):
+
+```python
+        batch_op.create_index('ix_outflow_subject_lower', ['subject_lower'], unique=False)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_subject_search.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Verify the schema gate and types**
+
+Run: `uv run gumptionchain db check`
+Expected: no pending model/migration diff (exit 0). If it reports the new columns/index as a diff, the migration edit doesn't match the model — reconcile names/types until clean.
+
+Run: `uv run mypy`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/models.py src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py tests/test_subject_search.py
+git commit -m "feat(#287): OutflowDAO decoded-subject columns for search"
+```
+
+---
+
+## Task 2: `search_subjects` DAO query + `Chain` delegate
+
+**Files:**
+- Modify: `src/gumptionchain/models.py` (`ChainDAO`: module constants, helper, `search_subjects`)
+- Modify: `src/gumptionchain/chain.py` (`Chain.search_subjects` delegate)
+- Test: `tests/test_subject_search.py`
+
+Reuse the existing leaderboard test harness pattern (`tests/test_subject_leaderboard.py`): the `app, host, mill_block, requests_proxy, signing_key` fixtures, and a local `_stake` helper. Note `create_opposition` / `create_support` take an **encoded** subject.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_subject_search.py`:
+
+```python
+from gumptionchain.api_client import ApiClient
+
+
+def _stake(host, chain, signing_key, *, oppose=None, support=None):
+    if oppose is not None:
+        subject, amount = oppose
+        txn = chain.create_opposition(signing_key, amount, subject)
+    else:
+        subject, amount = support
+        txn = chain.create_support(signing_key, amount, subject)
+    txn.sign()
+    ApiClient(host, signing_key).post_transaction(txn)
+    return txn
+
+
+def test_search_prefix_is_case_insensitive_returns_canonical(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    tabs = encode_subject('Tabs')
+    table = encode_subject('TABLE')
+    zebra = encode_subject('Zebra')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 300))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, support=(table, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(zebra, 999))
+        mill_block(signing_key)
+
+        dao = m.longest_chain.to_dao()
+        rows = db.session.execute(dao.search_subjects('tab', 8)).all()
+        subjects = [r.subject for r in rows]
+        # prefix 'tab' matches 'Tabs' and 'TABLE' (case-insensitive), not 'Zebra'
+        assert set(subjects) == {'Tabs', 'TABLE'}
+        # canonical strings returned verbatim (not lowercased)
+        assert 'Tabs' in subjects
+        assert 'TABLE' in subjects
+
+
+def test_search_ranks_by_total_and_caps(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    ta = encode_subject('Tango')
+    tb = encode_subject('Tankard')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(ta, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tb, 500))
+        mill_block(signing_key)
+
+        dao = m.longest_chain.to_dao()
+        rows = db.session.execute(dao.search_subjects('tan', 8)).all()
+        assert [r.subject for r in rows] == ['Tankard', 'Tango']  # 500 before 100
+        top = db.session.execute(dao.search_subjects('tan', 1)).all()
+        assert [r.subject for r in top] == ['Tankard']
+
+
+def test_search_blank_query_returns_nothing(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    sub = encode_subject('Anything')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(sub, 100))
+        mill_block(signing_key)
+        dao = m.longest_chain.to_dao()
+        assert db.session.execute(dao.search_subjects('', 8)).all() == []
+        assert db.session.execute(dao.search_subjects('   ', 8)).all() == []
+
+
+def test_search_escapes_like_metacharacters(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    pct = encode_subject('50% off')
+    plain = encode_subject('500 dollars')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(pct, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(plain, 100))
+        mill_block(signing_key)
+        dao = m.longest_chain.to_dao()
+        # '50%' must match literally — the '%' is escaped, not a wildcard
+        rows = db.session.execute(dao.search_subjects('50%', 8)).all()
+        assert [r.subject for r in rows] == ['50% off']
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_subject_search.py -k search -v`
+Expected: FAIL — `AttributeError: 'ChainDAO' object has no attribute 'search_subjects'`.
+
+- [ ] **Step 3: Implement `search_subjects` on `ChainDAO`**
+
+In `src/gumptionchain/models.py`, add module-level constants and a helper near the top (after imports):
+
+```python
+_SEARCH_LIMIT_DEFAULT = 8
+_SEARCH_LIMIT_MAX = 50
+
+
+def _search_like_pattern(query: str) -> str:
+    """A left-anchored LIKE pattern with metacharacters escaped (escape '\\')."""
+    escaped = (
+        query.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    )
+    return f'{escaped}%'
+```
+
+Add `search_subjects` to `ChainDAO`, immediately after `subject_leaderboard` (`models.py:893`):
+
+```python
+    def search_subjects(
+        self, query: str, limit: int = _SEARCH_LIMIT_DEFAULT
+    ) -> Select[Any]:
+        q = (query or '').strip()
+        bounded = max(1, min(int(limit), _SEARCH_LIMIT_MAX))
+
+        def _leg(stake_col: Any, kind: StakeKind) -> Select[Any]:
+            stmt = self.outflows.where(stake_col.is_not(None))
+            stmt = stmt.where(self._unspent_clause())
+            if q:
+                stmt = stmt.where(
+                    OutflowDAO.subject_lower.like(
+                        _search_like_pattern(q.lower()), escape='\\'
+                    )
+                )
+            else:
+                # Blank query → match nothing; never dump the whole set.
+                stmt = stmt.where(db.literal(False))
+            stmt = stmt.with_only_columns(
+                OutflowDAO.subject_plain.label('subject'),
+                OutflowDAO.amount.label('amount'),
+                db.literal(kind).label('kind'),
+            )
+            return stmt.order_by(None)
+
+        opp = _leg(OutflowDAO.opposition, 'opposition')
+        sup = _leg(OutflowDAO.support, 'support')
+        union = opp.union_all(sup).subquery()
+        stmt = db.select(
+            union.c.subject,
+            db.func.sum(
+                db.case((union.c.kind == 'opposition', union.c.amount), else_=0)
+            ).label('opposition'),
+            db.func.sum(
+                db.case((union.c.kind == 'support', union.c.amount), else_=0)
+            ).label('support'),
+            db.func.sum(union.c.amount).label('total'),
+        )
+        stmt = stmt.group_by(union.c.subject)
+        stmt = stmt.order_by(db.desc('total'), union.c.subject)
+        stmt = stmt.limit(bounded)
+        return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
+```
+
+- [ ] **Step 4: Add the `Chain` delegate**
+
+In `src/gumptionchain/chain.py`, after `subject_leaderboard` (`chain.py:559`):
+
+```python
+    def search_subjects(self, query: str, limit: int = 8) -> Select[Any]:
+        return self.to_dao().search_subjects(query, limit)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_subject_search.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/models.py src/gumptionchain/chain.py tests/test_subject_search.py
+git commit -m "feat(#287): ChainDAO.search_subjects prefix query"
+```
+
+---
+
+## Task 3: node API endpoint `GET /api/subjects/search`
+
+**Files:**
+- Modify: `src/gumptionchain/api.py` (`SubjectSearchView` + route; ensure `db` import)
+- Test: `tests/test_subject_search.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+The repo's API tests sign requests as a configured signing key. Mirror the existing reader-endpoint test style. Append to `tests/test_subject_search.py`:
+
+```python
+def test_search_endpoint_returns_shape(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    tabs = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 250))
+        mill_block(signing_key)
+
+    client = ApiClient(host, reader_signing_key)
+    resp = client.get('/api/subjects/search', params={'q': 'tab', 'limit': '8'})
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body['subjects'] == [
+        {'subject': 'Tabs', 'opposition': 250, 'support': 0}
+    ]
+    assert 'as_of_block' in body
+
+
+def test_search_endpoint_blank_query_is_empty(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    sub = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(sub, 100))
+        mill_block(signing_key)
+    client = ApiClient(host, reader_signing_key)
+    resp = client.get('/api/subjects/search', params={'q': '', 'limit': '8'})
+    assert resp.status_code == 200
+    assert resp.json()['subjects'] == []
+```
+
+Confirm the reader-key fixture name against `tests/conftest.py` (the canonical READER key). If it is exposed under a different fixture name, use that name; do not invent a new fixture.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_subject_search.py -k endpoint -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Implement the view + route**
+
+In `src/gumptionchain/api.py`, ensure `db` is importable (add `from gumptionchain.database import db` with the other imports if not already present). Add the view alongside the other subject views (near `SubjectSupportView`, ~`api.py:775`):
+
+```python
+class SubjectSearchView(MethodView):
+    def get(self, **kwargs: Any) -> Response:
+        try:
+            _, lc, _ = node_lc_dao()
+            if lc is None:
+                raise EmptyChainError()
+            q = request.args.get('q', default='', type=str)
+            limit = request.args.get('limit', default=8, type=int)
+            if limit is None:
+                limit = 8
+            rows = db.session.execute(lc.search_subjects(q, limit)).all()
+            subjects = [
+                {
+                    'subject': r.subject,
+                    'opposition': int(r.opposition),
+                    'support': int(r.support),
+                }
+                for r in rows
+            ]
+            return make_json_response(
+                {'subjects': subjects, 'as_of_block': lc.block_hash}
+            )
+        except GCError as err:
+            return make_error_response(err)
+        except Exception as e:
+            exception_response(e)
+```
+
+Register the route (near the other subject `add_url_rule` calls):
+
+```python
+blueprint.add_url_rule(
+    '/subjects/search',
+    view_func=authorize_reader(
+        SubjectSearchView.as_view('subjects_search_reader')
+    ),
+    methods=['GET'],
+)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_subject_search.py -k endpoint -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gumptionchain/api.py tests/test_subject_search.py
+git commit -m "feat(#287): GET /api/subjects/search reader endpoint"
+```
+
+---
+
+## Task 4: `ApiClient.get_subject_search`
+
+**Files:**
+- Modify: `src/gumptionchain/api_client.py`
+- Test: `tests/test_subject_search.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_subject_search.py`:
+
+```python
+def test_api_client_get_subject_search_round_trips(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    tabs = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 75))
+        mill_block(signing_key)
+    resp = ApiClient(host, reader_signing_key).get_subject_search('tab', 8)
+    assert resp.status_code == 200
+    assert resp.json()['subjects'] == [
+        {'subject': 'Tabs', 'opposition': 75, 'support': 0}
+    ]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_subject_search.py -k api_client -v`
+Expected: FAIL — `AttributeError: 'ApiClient' object has no attribute 'get_subject_search'`.
+
+- [ ] **Step 3: Implement the method**
+
+In `src/gumptionchain/api_client.py`, after `get_support_balance` (`api_client.py:332`):
+
+```python
+    def get_subject_search(
+        self,
+        query: str,
+        limit: int = 8,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> httpx.Response:
+        return self.get(
+            '/api/subjects/search',
+            params={'q': query, 'limit': str(limit)},
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_subject_search.py -k api_client -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gumptionchain/api_client.py tests/test_subject_search.py
+git commit -m "feat(#287): ApiClient.get_subject_search"
+```
+
+---
+
+## Task 5: proxy route `GET /api/node/subject/search`
+
+**Files:**
+- Modify: `src/gumptionchain/node_proxy.py` (new route)
+- Test: `tests/test_node_proxy.py` (new test + `FakeClient` method)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_node_proxy.py`, add a `get_subject_search` method to `FakeClient` (after `get_opposition_balance`, ~line 41):
+
+```python
+    def get_subject_search(self, query, limit, *, raise_for_status=True):
+        return self._resp('search', query, limit)
+```
+
+Add a test (after `test_subject_balances_normalizes_and_converts`):
+
+```python
+def test_subject_search_converts_grains_to_grit():
+    client = FakeClient(
+        search=FakeResponse(200, {'subjects': [
+            {'subject': 'Tabs', 'opposition': 300, 'support': 150},
+            {'subject': 'Tango', 'opposition': 0, 'support': 50},
+        ], 'as_of_block': 'b1'})
+    )
+    resp = _app(client).get('/api/node/subject/search?q=ta&limit=8')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'subjects': [
+        {'subject': 'Tabs',
+         'support': {'grit': 1.5, 'grains': 150},
+         'opposition': {'grit': 3.0, 'grains': 300}},
+        {'subject': 'Tango',
+         'support': {'grit': 0.5, 'grains': 50},
+         'opposition': {'grit': 0.0, 'grains': 0}},
+    ]}
+    # q and limit are forwarded to the client
+    assert client.calls[0][1] == ('ta', '8')
+
+
+def test_subject_search_maps_node_down_to_502():
+    client = FakeClient(search=httpx.RequestError('boom'))
+    resp = _app(client).get('/api/node/subject/search?q=ta')
+    assert resp.status_code == 502
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_node_proxy.py -k subject_search -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Implement the proxy route**
+
+In `src/gumptionchain/node_proxy.py`, add after the `subject_balances` route (~line 138):
+
+```python
+    @bp.get('/subject/search')
+    def subject_search() -> Response:
+        q = request.args.get('q', '')
+        limit = request.args.get('limit', '8')
+        r = _ok(_call(make_client().get_subject_search, q, limit))
+        body = r.json()
+        subjects = [
+            {
+                'subject': row['subject'],
+                'support': _grit(int(row['support'])),
+                'opposition': _grit(int(row['opposition'])),
+            }
+            for row in body.get('subjects', [])
+        ]
+        return jsonify({'subjects': subjects})
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_node_proxy.py -k subject_search -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate sweep**
+
+Run: `uv run pytest`
+Expected: all pass (existing + new), no unexpected skips.
+
+Run: `uv run ruff check src tests && uv run ruff format --check src tests`
+Expected: clean.
+
+Run: `uv run mypy`
+Expected: no new errors.
+
+Run: `uv run gumptionchain db check`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gumptionchain/node_proxy.py tests/test_node_proxy.py
+git commit -m "feat(#287): node_proxy subject/search relay route"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Full sweep green: `uv run pytest`, `uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run mypy`, `uv run gumptionchain db check`.
+- [ ] Dispatch a final whole-branch code review.
+- [ ] Open the PR with the report-back for the gumptactoe session:
+  1. **Proxy route:** `GET /api/node/subject/search?q=&limit=8` → `{"subjects":[{"subject","support":{grit,grains},"opposition":{grit,grains}}]}`. Tallies are `{grit, grains}` objects (NOT whole-int — deviation from the issue sketch, chosen for consistency with the existing balance routes; consumer formats whole-GRIT itself).
+  2. **Match semantics:** prefix, case-insensitive (ASCII-fold via Python `.lower()`), index-accelerated; ranked by total stake desc; default limit 8, clamped 1–50; blank query → empty.
+  3. **Index added:** `OutflowDAO.subject_plain` (canonical) + `subject_lower` (indexed `ix_outflow_subject_lower`); folded into the baseline migration; no backfill (greenfield).
+  4. The **merge commit SHA** to pin in gumptactoe's `[tool.uv.sources]`.
+  5. **Deviation:** substring left as a future toggle; `subject_lower` column + plain index used instead of a `lower()` expression index (avoids `db check` reflection noise; Unicode-correct folding).
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** Layer 1 → Task 1; Layer 2 → Task 2; Layer 3 → Task 3; Layer 4 → Tasks 4–5. Match semantics (prefix, case-insensitive, ranked, capped, blank→empty, LIKE-escape) → Task 2 tests. `_grit()` tally shape → Task 5. READER auth → Task 3. Report-back → Final. No gaps.
+- **Type consistency:** `search_subjects(query: str, limit: int=8) -> Select[Any]` identical on `ChainDAO` and `Chain`; `get_subject_search(query, limit=8, ...)` matches the `FakeClient` stub `(query, limit, *, raise_for_status)` and the proxy call `_call(make_client().get_subject_search, q, limit)`; node JSON keys (`subject`/`opposition`/`support`/`as_of_block`) consistent across Tasks 3–5.
+- **Deviation from spec noted:** the spec's "`lower()` expression index" is implemented as a stored `subject_lower` column + plain index (same effect, lower CI risk) — recorded in the report-back.

--- a/docs/superpowers/specs/2026-06-16-subject-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-subject-search-design.md
@@ -69,13 +69,19 @@ In `OutflowDAO` (`models.py`):
 
 - Add `subject_plain: Mapped[str | None] = mapped_column(String(500))` — the
   **decoded canonical plaintext** of whichever stake column is set.
-- Populate it in `__init__`: when `opposition` or `support` is non-`None`, set
-  `self.subject_plain = decode_subject(opposition or support)`; otherwise
-  `None` (address / rescind outflows carry no searchable subject). Decode
-  defensively — subjects are validated upstream, but a decode failure must not
-  break row construction (fall back to `None`).
-- Add an expression index:
-  `db.Index('ix_outflow_subject_plain_lower', db.func.lower(subject_plain))`.
+- Add a sibling `subject_plain.lower()` column, `subject_lower` — the
+  matched-against form (the canonical `subject_plain` is what's returned).
+- Populate both in `__init__`: when `opposition` or `support` is non-`None`, set
+  `subject_plain = decode_subject(opposition or support)` and
+  `subject_lower = subject_plain.lower()`; otherwise `None` (address / rescind
+  outflows carry no searchable subject). Decode defensively — subjects are
+  validated upstream, but a decode failure must not break row construction (fall
+  back to `None`).
+- Add a **plain** index `db.Index('ix_outflow_subject_lower', 'subject_lower')`.
+  (Two columns + a plain index rather than one column + a `lower()` **expression
+  index**: SQLite reflects expression indexes imperfectly, so `gumptionchain db
+  check` reports a phantom diff; a stored lowercased column sidesteps that and
+  gives Unicode-correct folding via Python `.lower()`.)
 
 **Migration (greenfield):** fold the column + index into the **baseline**
 migration `63d32cd7621a_initial_schema.py` rather than stacking a new revision —
@@ -95,7 +101,8 @@ A leaderboard-shaped query, filtered by the plaintext prefix:
 
 - Same union shape as `subject_leaderboard`: unspent opposition leg + support
   leg (`_unspent_clause`), grouped by subject, `sum` per kind, `total`.
-- Add `WHERE lower(subject_plain) LIKE lower(:query) || '%'` on each leg.
+- Add `WHERE subject_lower LIKE :query_lower || '%'` (LIKE metacharacters in the
+  query escaped) on each leg.
 - Order by `total` desc (tiebreak by subject), `LIMIT :limit`.
 - Returns rows of `(subject_plain canonical, opposition_grains, support_grains,
   total_grains)` — **grains** (internal units).
@@ -186,7 +193,7 @@ browser typeahead (debounced)
   → GET /api/node/subject/search?q=tab&limit=8        (proxy, base or consumer app)
     → ApiClient.get_subject_search("tab", 8)          (signs gc-sig-v1, node host server-side)
       → GET /api/subjects/search?q=tab&limit=8         (node, authorize_reader)
-        → ChainDAO.search_subjects("tab", 8)           (SQL: lower(subject_plain) LIKE 'tab%')
+        → ChainDAO.search_subjects("tab", 8)           (SQL: subject_lower LIKE 'tab%')
         ← [{subject, opposition_grains, support_grains, total}]
       ← {subjects:[{subject, opposition, support}], as_of_block}   (grains)
     ← grains→GRIT via _grit()
@@ -222,8 +229,8 @@ On merge, report to the gumptactoe session (in the PR + a summary):
 2. **Match semantics shipped:** prefix, case-insensitive, index-accelerated;
    ranked by total stake desc; default limit 8 (clamped).
 3. **Index added:** `OutflowDAO.subject_plain` (decoded canonical) +
-   `ix_outflow_subject_plain_lower`; folded into baseline; no backfill
-   (greenfield).
+   `subject_lower` (indexed `ix_outflow_subject_lower`); folded into baseline;
+   no backfill (greenfield).
 4. The **merge commit SHA** to pin in gumptactoe's `[tool.uv.sources]`.
 5. Any deviations.
 

--- a/docs/superpowers/specs/2026-06-16-subject-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-subject-search-design.md
@@ -49,8 +49,10 @@ and a dedicated index table (over-built for now).
 
 ## Match semantics (shipped)
 
-- **Prefix, case-insensitive.** `lower(subject_plain) LIKE lower(:q) || '%'`.
-  Left-anchored, so the `lower()` expression index is used as a real seek.
+- **Prefix, case-insensitive.** `subject_lower LIKE :q_lower || '%'` (the query
+  lowercased in Python, LIKE metacharacters escaped). Left-anchored, so the
+  plain index on `subject_lower` (`ix_outflow_subject_lower`) is used as a real
+  seek.
 - Subjects are **case-sensitive literals** — `"Tabs > Spaces"` ≠
   `"tabs > spaces"` are distinct subjects. We match loosely (case-insensitive)
   but **return the exact canonical string**, never an altered one.
@@ -106,8 +108,9 @@ A leaderboard-shaped query, filtered by the plaintext prefix:
 - Order by `total` desc (tiebreak by subject), `LIMIT :limit`.
 - Returns rows of `(subject_plain canonical, opposition_grains, support_grains,
   total_grains)` — **grains** (internal units).
-- Guard: a query that is empty or whitespace-only after `strip()` returns an
-  empty result without touching the DB.
+- Guard: a query that is empty or whitespace-only after `strip()` matches
+  nothing — each leg's predicate becomes `false()`, so the statement executes
+  but returns no rows (never dumps the whole set).
 - `limit` is clamped to a sane ceiling (e.g. `1..50`) to bound result size.
 
 Returns canonical plaintext directly (grouping key is the subject), so no

--- a/docs/superpowers/specs/2026-06-16-subject-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-subject-search-design.md
@@ -1,0 +1,261 @@
+# Subject search: typeahead node method + proxy route (EGU primitive)
+
+**Date:** 2026-06-16
+**Status:** design approved
+**Issue:** gumptionchain#287
+**Consumers:** gumptactoe (first adopter), gumption-hub, future EGU apps.
+**Consumer spec:** `gumptactoe/docs/superpowers/specs/2026-06-16-subject-autocomplete-design.md`
+
+## Goal
+
+Give a consumer web app a **subject search** capability so it can offer a
+typeahead of subjects **already on the chain** as a user types. First adopter:
+gumptactoe. This extends the just-landed GRIT-spend rails
+(`node_proxy_blueprint` + `makeOnboarding.signTransaction`) and is built as a
+**shared EGU primitive**, not a gumptactoe one-off.
+
+**Product term:** "**Standing**" / "subject" — consistent with the GRIT-spend
+rails. The chain-API name for the underlying record stays *stake attestation*.
+
+## Boundary decision — this lives in **base**
+
+Subject search belongs in base `gumptionchain`, not the hub. It is a **stateless
+read primitive over chain-intrinsic data** (what subjects exist on the chain,
+ranked by stake), which base already computes (`subject_leaderboard`) and
+already surfaces in the reference browser (`/subjects`). The consumer
+(gumptactoe) embeds the `gumptionchain` package and mounts
+`node_proxy_blueprint` directly — it never depends on the hub — so the primitive
+must live where every EGU app can reach it: base. The hub gets it for free (it
+embeds base) and may layer a themed UI on top. The condition that would flip it
+to the hub — *curated/editorial* search (featured ranking, social-identity
+enrichment, cross-chain aggregation, persistent caches) — is out of scope.
+
+## Background — what already exists (and stays unchanged)
+
+| Element | Where | Relevant detail |
+|---|---|---|
+| Subject storage | `OutflowDAO.opposition` / `.support` (`models.py`) | `String(500)`, **base64url-encoded** (no padding); each indexed |
+| `encode_subject` / `decode_subject` | `payload.py` | base64url; `decode` is bijective for valid subjects |
+| `subject_leaderboard(limit)` | `ChainDAO` (`models.py`) | per-distinct-subject union of unspent opposition + support legs → `sum(opposition)`, `sum(support)`, `total`; ranked by `total` desc; keyed by the **encoded** subject. Consumed only by the browser `/subjects` view today |
+| Per-subject balance API | `api.py` | `GET /api/subject/<enc>/opposition` and `/support`, both `authorize_reader`, `block_hash`-keyed `cache`, return `{balance|support, as_of_block}` |
+| `node_proxy_blueprint(make_client, ...)` | `node_proxy.py` | browser-facing JSON relay over `ApiClient`; `_grit(grains)` → `{grit, grains}`; CSRF-exempt; `rate_limit` hook; `_ProxyError` mapping |
+| `OutflowDAO.__init__` | `models.py:146-167` | the single choke point where `opposition`/`support` are set on a row |
+
+**Core question resolved:** subjects are stored base64url-encoded, and base64
+prefixes do not map to plaintext prefixes, so search **cannot** run against the
+encoded column. We add a **decoded-plaintext column** to index and match
+against (see Layer 1). This was chosen over decode-in-Python (does not scale)
+and a dedicated index table (over-built for now).
+
+## Match semantics (shipped)
+
+- **Prefix, case-insensitive.** `lower(subject_plain) LIKE lower(:q) || '%'`.
+  Left-anchored, so the `lower()` expression index is used as a real seek.
+- Subjects are **case-sensitive literals** — `"Tabs > Spaces"` ≠
+  `"tabs > spaces"` are distinct subjects. We match loosely (case-insensitive)
+  but **return the exact canonical string**, never an altered one.
+- **Ranked by total GRIT at stake** (`support + opposition`), descending.
+- **Hard cap** via `limit` (default 8).
+- Empty / whitespace query → **empty result** (never dump the whole set).
+- Substring matching is a deliberate future toggle (swap `:q || '%'` for
+  `'%' || :q || '%'`); it would forgo the index seek and is left for a later
+  enhancement if broader recall is wanted.
+
+## What we build — four thin layers
+
+### Layer 1 — schema: a decoded-plaintext column
+
+In `OutflowDAO` (`models.py`):
+
+- Add `subject_plain: Mapped[str | None] = mapped_column(String(500))` — the
+  **decoded canonical plaintext** of whichever stake column is set.
+- Populate it in `__init__`: when `opposition` or `support` is non-`None`, set
+  `self.subject_plain = decode_subject(opposition or support)`; otherwise
+  `None` (address / rescind outflows carry no searchable subject). Decode
+  defensively — subjects are validated upstream, but a decode failure must not
+  break row construction (fall back to `None`).
+- Add an expression index:
+  `db.Index('ix_outflow_subject_plain_lower', db.func.lower(subject_plain))`.
+
+**Migration (greenfield):** fold the column + index into the **baseline**
+migration `63d32cd7621a_initial_schema.py` rather than stacking a new revision —
+no production data exists yet, so there is no backfill and no `alembic stamp`
+ceremony. Tests build via `db.create_all()` from the model, so they pick the
+column up automatically. The `gumptionchain db check` CI gate continues to
+enforce model/migration parity.
+
+**Note on existing data:** because we fold into baseline, this design assumes no
+deployed chain to backfill. If that assumption ever changes, populating
+`subject_plain` for existing rows would require a one-off backfill (decode each
+opposition/support outflow) — explicitly out of scope here.
+
+### Layer 2 — DAO: `ChainDAO.search_subjects(query, limit=8)`
+
+A leaderboard-shaped query, filtered by the plaintext prefix:
+
+- Same union shape as `subject_leaderboard`: unspent opposition leg + support
+  leg (`_unspent_clause`), grouped by subject, `sum` per kind, `total`.
+- Add `WHERE lower(subject_plain) LIKE lower(:query) || '%'` on each leg.
+- Order by `total` desc (tiebreak by subject), `LIMIT :limit`.
+- Returns rows of `(subject_plain canonical, opposition_grains, support_grains,
+  total_grains)` — **grains** (internal units).
+- Guard: a query that is empty or whitespace-only after `strip()` returns an
+  empty result without touching the DB.
+- `limit` is clamped to a sane ceiling (e.g. `1..50`) to bound result size.
+
+Returns canonical plaintext directly (grouping key is the subject), so no
+Python decode of results is needed. Lives beside `subject_leaderboard`; tested
+at the DAO layer against the temp SQLite DB.
+
+### Layer 3 — node API endpoint
+
+New read endpoint in `api.py`, mirroring the existing subject-read views:
+
+```
+GET /api/subjects/search?q=<query>&limit=<n>      (authorize_reader)
+→ 200 {
+    "subjects": [
+      { "subject": "<exact canonical string>",
+        "opposition": <grains:int>,
+        "support":    <grains:int> },
+      ...
+    ],
+    "as_of_block": "<block_hash>"
+  }
+```
+
+- `MethodView` + `authorize_reader`, same as `OppositionBalanceView` /
+  `SubjectSupportView`.
+- `q` missing/blank → `{"subjects": [], "as_of_block": <hash>}` (200, not an
+  error — the consumer degrades to an empty dropdown).
+- `limit` parsed as int, defaulted to 8, clamped (out-of-range/garbage → default
+  or clamped bound, not a 400).
+- Empty chain → `EmptyChainError` via the existing `make_error_response` path.
+- Grains stay internal (the proxy converts). Block-hash-keyed `cache` MAY be
+  used keyed on `f'{block_hash}.search.{lower(q)}.{limit}'`, consistent with the
+  balance endpoints; cache is optional for a first cut.
+
+### Layer 4 — `ApiClient` method + proxy route
+
+**`ApiClient.get_subject_search`** (`api_client.py`), following the existing
+read methods:
+
+```python
+def get_subject_search(
+    self, query: str, limit: int = 8, *, raise_for_status: bool = True,
+) -> httpx.Response:
+    return self.get(
+        '/api/subjects/search',
+        params={'q': query, 'limit': limit},
+        raise_for_status=raise_for_status,
+    )
+```
+
+**Proxy route** on `node_proxy_blueprint` (`node_proxy.py`):
+
+```
+GET /api/node/subject/search?q=<query>&limit=8
+→ 200 {
+    "subjects": [
+      { "subject": "<exact canonical string>",
+        "support":    { "grit": <float>, "grains": <int> },
+        "opposition": { "grit": <float>, "grains": <int> } },
+      ...
+    ]
+  }
+```
+
+- Reuses `_grit(grains)` for each tally — consistent with the existing
+  `/balance` and `/subject/balances` routes; no precision loss; the consumer
+  formats whole-GRIT itself. (Chosen over the issue's whole-int sketch for
+  consistency; trivially changeable.)
+- `limit` parsed/forwarded; `q` forwarded as-is (blank `q` relays through to the
+  node's empty-result path).
+- The node's `as_of_block` is **dropped** at the proxy — the typeahead doesn't
+  need it, and this matches the issue's response shape and the sibling
+  `/subject/balances` route (which also omits it). Only `/balance` surfaces it.
+- Same treatment as the other proxy routes: node host stays server-side,
+  CSRF-exempt, `rate_limit` hook applies, `_ok`/`_call` error mapping (node down
+  → 502; node 4xx → 400/404). Read-only relay — holds no key, builds no txn,
+  safe to expose to a browser.
+
+## Data flow
+
+```
+browser typeahead (debounced)
+  → GET /api/node/subject/search?q=tab&limit=8        (proxy, base or consumer app)
+    → ApiClient.get_subject_search("tab", 8)          (signs gc-sig-v1, node host server-side)
+      → GET /api/subjects/search?q=tab&limit=8         (node, authorize_reader)
+        → ChainDAO.search_subjects("tab", 8)           (SQL: lower(subject_plain) LIKE 'tab%')
+        ← [{subject, opposition_grains, support_grains, total}]
+      ← {subjects:[{subject, opposition, support}], as_of_block}   (grains)
+    ← grains→GRIT via _grit()
+  ← {subjects:[{subject, support:{grit,grains}, opposition:{grit,grains}}]}
+```
+
+## Testing
+
+- **DAO** (`tests/test_*.py`, temp SQLite): `search_subjects` — prefix match is
+  case-insensitive; returns exact canonical (mixed-case) strings; ranks by total
+  stake desc; respects `limit` and the clamp; empty/whitespace query → `[]`;
+  unspent filtering (a fully-rescinded subject does not appear); a subject set
+  by `support` vs `opposition` both searchable; `subject_plain` is populated by
+  the constructor for stake outflows and `None` for address/rescind.
+- **Node API** (Flask test client): `GET /api/subjects/search` returns the
+  documented shape; requires READER (401/403 without); blank `q` → empty list +
+  200; `limit` parsing/clamp; empty chain → error path.
+- **Proxy** (`tests/test_node_proxy.py`, `FakeClient`): `/subject/search`
+  relays, converts grains→GRIT via `_grit()`, forwards `q`/`limit`, maps node
+  errors (502 on transport failure, 404/400 passthrough), honors the
+  `rate_limit` hook and `max_body_bytes`.
+- **Migration parity:** `gumptionchain db check` stays green (baseline edited,
+  not stacked).
+- Full `pytest` + `ruff` + `mypy` + `node --test` gates stay green.
+
+## Docs / report-back
+
+On merge, report to the gumptactoe session (in the PR + a summary):
+
+1. **Proxy route:** `GET /api/node/subject/search?q=&limit=8`, method, and the
+   exact request/response JSON (tallies are `{grit, grains}` objects via
+   `_grit()`, **not** whole-int — note the deviation from the issue sketch).
+2. **Match semantics shipped:** prefix, case-insensitive, index-accelerated;
+   ranked by total stake desc; default limit 8 (clamped).
+3. **Index added:** `OutflowDAO.subject_plain` (decoded canonical) +
+   `ix_outflow_subject_plain_lower`; folded into baseline; no backfill
+   (greenfield).
+4. The **merge commit SHA** to pin in gumptactoe's `[tool.uv.sources]`.
+5. Any deviations.
+
+## Scope
+
+**In:** the four layers above + their tests; the report-back. One base branch →
+PR → review → squash-merge.
+
+**Out (separate efforts / YAGNI):**
+- Substring / fuzzy / trigram / FTS matching (prefix is the 80% UX; substring is
+  a one-line future toggle, indexed substring is a much bigger lift).
+- A backfill path for already-deployed chains (greenfield assumption).
+- gumptactoe's typeahead DOM (the consumer; pins the merge SHA).
+- The hub's themed search UI (consumes the base primitive later).
+- Caching beyond the optional block-hash key reuse.
+
+## Invariants — what does NOT change
+
+- The encoded-subject storage, `encode_subject`/`decode_subject`, and the
+  existing per-subject balance endpoints.
+- `node_proxy_blueprint`'s existing routes, `_grit()` shape, error mapping, and
+  CSRF/rate-limit treatment.
+- The permissioned read model (`authorize_reader`); search exposes only
+  already-public subject data.
+- `subject_leaderboard` and the browser `/subjects` view (search is additive).
+
+## Risks
+
+- **`subject_plain` drift from the encoded column.** Mitigation: populate at the
+  single constructor choke point from the encoded value; never hand-set. The
+  DAO test asserts population for stake outflows and `None` otherwise.
+- **Substring expectation.** The consumer (and hub) get prefix first; the
+  report-back states this explicitly so the typeahead is built around prefix.
+- **Index unused if we later switch to substring.** Accepted — the index earns
+  its keep for prefix now; a substring switch is a separate, deliberate change.

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -799,3 +799,40 @@ blueprint.add_url_rule(
     ),
     methods=['GET'],
 )
+
+
+class SubjectSearchView(MethodView):
+    def get(self, **kwargs: Any) -> Response:
+        try:
+            _, lc, _ = node_lc_dao()
+            if lc is None:
+                raise EmptyChainError()
+            q = request.args.get('q', default='', type=str)
+            limit = request.args.get('limit', default=8, type=int)
+            if limit is None:
+                limit = 8
+            rows = db.session.execute(lc.search_subjects(q, limit)).all()
+            subjects = [
+                {
+                    'subject': r.subject,
+                    'opposition': int(r.opposition),
+                    'support': int(r.support),
+                }
+                for r in rows
+            ]
+            return make_json_response(
+                {'subjects': subjects, 'as_of_block': lc.block_hash}
+            )
+        except GCError as err:
+            return make_error_response(err)
+        except Exception as e:
+            exception_response(e)
+
+
+blueprint.add_url_rule(
+    '/subjects/search',
+    view_func=authorize_reader(
+        SubjectSearchView.as_view('subjects_search_reader')
+    ),
+    methods=['GET'],
+)

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -808,9 +808,9 @@ class SubjectSearchView(MethodView):
             if lc is None:
                 raise EmptyChainError()
             q = request.args.get('q', default='', type=str)
-            limit = request.args.get('limit', default=8, type=int)
-            if limit is None:
-                limit = 8
+            # type=int yields None for a missing or non-integer value; the
+            # DAO normalizes None to its default and clamps the range.
+            limit = request.args.get('limit', type=int)
             rows = db.session.execute(lc.search_subjects(q, limit)).all()
             subjects = [
                 {

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -330,3 +330,17 @@ class ApiClient:
             timeout=timeout,
             raise_for_status=raise_for_status,
         )
+
+    def get_subject_search(
+        self,
+        query: str,
+        limit: int = 8,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> httpx.Response:
+        return self.get(
+            '/api/subjects/search',
+            params={'q': query, 'limit': str(limit)},
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -334,10 +334,13 @@ class ApiClient:
     def get_subject_search(
         self,
         query: str,
-        limit: int = 8,
+        limit: int | str = 8,
         timeout: int | float | None = None,
         raise_for_status: bool = True,  # noqa: FBT001
     ) -> httpx.Response:
+        # limit accepts a raw query-string value too: the node_proxy relay
+        # forwards the browser's `limit` param straight through; the node
+        # parses and clamps it.
         return self.get(
             '/api/subjects/search',
             params={'q': query, 'limit': str(limit)},

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -558,6 +558,9 @@ class Chain:
     def subject_leaderboard(self, limit: int | None = None) -> Select[Any]:
         return self.to_dao().subject_leaderboard(limit)
 
+    def search_subjects(self, query: str, limit: int = 8) -> Select[Any]:
+        return self.to_dao().search_subjects(query, limit)
+
     def recent_blocks(self, count: int = 10) -> list[Block]:
         q = BlockDAO.longest_chain_blocks_q().limit(count)
         return [Block.from_dao(b) for b in db.session.scalars(q)]

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -558,7 +558,9 @@ class Chain:
     def subject_leaderboard(self, limit: int | None = None) -> Select[Any]:
         return self.to_dao().subject_leaderboard(limit)
 
-    def search_subjects(self, query: str, limit: int = 8) -> Select[Any]:
+    def search_subjects(
+        self, query: str, limit: int | None = None
+    ) -> Select[Any]:
         return self.to_dao().search_subjects(query, limit)
 
     def recent_blocks(self, count: int = 10) -> list[Block]:

--- a/src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py
+++ b/src/gumptionchain/migrations/versions/63d32cd7621a_initial_schema.py
@@ -115,6 +115,8 @@ def upgrade():
     sa.Column('opposition', sa.String(length=500), nullable=True),
     sa.Column('rescind', sa.String(length=500), nullable=True),
     sa.Column('support', sa.String(length=500), nullable=True),
+    sa.Column('subject_plain', sa.String(length=500), nullable=True),
+    sa.Column('subject_lower', sa.String(length=500), nullable=True),
     sa.Column('rescind_kind', sa.String(length=16), nullable=True),
     sa.Column('transaction_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['transaction_id'], ['transaction.id'], name=op.f('fk_outflow_transaction_transaction_id')),
@@ -127,6 +129,7 @@ def upgrade():
         batch_op.create_index('ix_outflow_address', ['address'], unique=False)
         batch_op.create_index('ix_outflow_opposition', ['opposition'], unique=False)
         batch_op.create_index('ix_outflow_support', ['support'], unique=False)
+        batch_op.create_index('ix_outflow_subject_lower', ['subject_lower'], unique=False)
 
     op.create_table('inflow',
     sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
@@ -172,6 +175,7 @@ def downgrade():
 
     op.drop_table('inflow')
     with op.batch_alter_table('outflow', schema=None) as batch_op:
+        batch_op.drop_index('ix_outflow_subject_lower')
         batch_op.drop_index('ix_outflow_support')
         batch_op.drop_index('ix_outflow_opposition')
         batch_op.drop_index('ix_outflow_address')

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from gumptionchain.database import Base, db
-from gumptionchain.payload import StakeKind
+from gumptionchain.payload import StakeKind, decode_subject
 
 # Chain-factory returns below carry `# type: ignore[no-any-return]` because
 # Flask-SQLAlchemy's `db.select` / `db.aliased` / `db.desc` facade methods
@@ -123,6 +123,8 @@ class OutflowDAO(Base):
     opposition: Mapped[str | None] = mapped_column(String(500))
     rescind: Mapped[str | None] = mapped_column(String(500))
     support: Mapped[str | None] = mapped_column(String(500))
+    subject_plain: Mapped[str | None] = mapped_column(String(500))
+    subject_lower: Mapped[str | None] = mapped_column(String(500))
     rescind_kind: Mapped[str | None] = mapped_column(String(16))
     transaction_id: Mapped[int] = mapped_column(
         Integer, ForeignKey('transaction.id')
@@ -141,7 +143,22 @@ class OutflowDAO(Base):
         db.Index('ix_outflow_address', 'address'),
         db.Index('ix_outflow_opposition', 'opposition'),
         db.Index('ix_outflow_support', 'support'),
+        db.Index('ix_outflow_subject_lower', 'subject_lower'),
     )
+
+    @staticmethod
+    def _derive_subject_plain(
+        opposition: str | None, support: str | None
+    ) -> str | None:
+        encoded = opposition if opposition is not None else support
+        if encoded is None:
+            return None
+        try:
+            return decode_subject(encoded)
+        except Exception:
+            # Subjects are validated upstream; a decode failure must never
+            # break row construction. Leave the searchable columns null.
+            return None
 
     def __init__(
         self,
@@ -164,6 +181,9 @@ class OutflowDAO(Base):
             self.rescind = rescind
             self.support = support
             self.rescind_kind = rescind_kind
+            plain = self._derive_subject_plain(opposition, support)
+            self.subject_plain = plain
+            self.subject_lower = plain.lower() if plain is not None else None
             self.transaction = transaction_dao or None  # type: ignore[assignment]
 
     @classmethod

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -155,9 +155,10 @@ class OutflowDAO(Base):
             return None
         try:
             return decode_subject(encoded)
-        except Exception:
-            # Subjects are validated upstream; a decode failure must never
-            # break row construction. Leave the searchable columns null.
+        except (TypeError, ValueError):
+            # Subjects are validated upstream; a decode failure (bad padding
+            # → TypeError; bad base64/UTF-8 → ValueError subclasses) must
+            # never break row construction. Leave the searchable columns null.
             return None
 
     def __init__(

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -37,6 +37,18 @@ def rollback_session() -> None:
     db.session.rollback()
 
 
+_SEARCH_LIMIT_DEFAULT = 8
+_SEARCH_LIMIT_MAX = 50
+
+
+def _search_like_pattern(query: str) -> str:
+    """Left-anchored LIKE pattern with metacharacters escaped (escape '\\')."""
+    escaped = (
+        query.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    )
+    return f'{escaped}%'
+
+
 block_transactions = db.Table(
     'block_transaction',
     db.Column(
@@ -912,6 +924,48 @@ class ChainDAO(Base):
             stmt = stmt.limit(limit)
             return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
         return stmt  # type: ignore[no-any-return]
+
+    def search_subjects(
+        self, query: str, limit: int = _SEARCH_LIMIT_DEFAULT
+    ) -> Select[Any]:
+        q = (query or '').strip()
+        bounded = max(1, min(int(limit), _SEARCH_LIMIT_MAX))
+
+        def _leg(stake_col: Any, kind: StakeKind) -> Select[Any]:
+            stmt = self.outflows.where(stake_col.is_not(None))
+            stmt = stmt.where(self._unspent_clause())
+            if q:
+                stmt = stmt.where(
+                    OutflowDAO.subject_lower.like(
+                        _search_like_pattern(q.lower()), escape='\\'
+                    )
+                )
+            else:
+                stmt = stmt.where(false())
+            stmt = stmt.with_only_columns(
+                OutflowDAO.subject_plain.label('subject'),
+                OutflowDAO.amount.label('amount'),
+                db.literal(kind).label('kind'),
+            )
+            return stmt.order_by(None)
+
+        opp = _leg(OutflowDAO.opposition, 'opposition')
+        sup = _leg(OutflowDAO.support, 'support')
+        union = opp.union_all(sup).subquery()
+        stmt = db.select(
+            union.c.subject,
+            db.func.sum(
+                db.case((union.c.kind == 'opposition', union.c.amount), else_=0)
+            ).label('opposition'),
+            db.func.sum(
+                db.case((union.c.kind == 'support', union.c.amount), else_=0)
+            ).label('support'),
+            db.func.sum(union.c.amount).label('total'),
+        )
+        stmt = stmt.group_by(union.c.subject)
+        stmt = stmt.order_by(db.desc('total'), union.c.subject)
+        stmt = stmt.limit(bounded)
+        return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]
 
     def _is_longest(self) -> bool:
         """True iff this ChainDAO row is currently the longest chain.

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -926,10 +926,11 @@ class ChainDAO(Base):
         return stmt  # type: ignore[no-any-return]
 
     def search_subjects(
-        self, query: str, limit: int = _SEARCH_LIMIT_DEFAULT
+        self, query: str, limit: int | None = None
     ) -> Select[Any]:
         q = (query or '').strip()
-        bounded = max(1, min(int(limit), _SEARCH_LIMIT_MAX))
+        effective = _SEARCH_LIMIT_DEFAULT if limit is None else int(limit)
+        bounded = max(1, min(effective, _SEARCH_LIMIT_MAX))
 
         def _leg(stake_col: Any, kind: StakeKind) -> Select[Any]:
             stmt = self.outflows.where(stake_col.is_not(None))

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -137,6 +137,22 @@ def node_proxy_blueprint(
             }
         )
 
+    @bp.get('/subject/search')
+    def subject_search() -> Response:
+        q = request.args.get('q', '')
+        limit = request.args.get('limit', '8')
+        r = _ok(_call(make_client().get_subject_search, q, limit))
+        body = r.json()
+        subjects = [
+            {
+                'subject': row['subject'],
+                'support': _grit(int(row['support'])),
+                'opposition': _grit(int(row['opposition'])),
+            }
+            for row in body.get('subjects', [])
+        ]
+        return jsonify({'subjects': subjects})
+
     def _build(method_name: str) -> Response:
         data = request.get_json(silent=True) or {}
         public_key = data.get('public_key')

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -40,6 +40,9 @@ class FakeClient:
     def get_opposition_balance(self, subject, *, raise_for_status=True):
         return self._resp('opposition', subject)
 
+    def get_subject_search(self, query, limit, *, raise_for_status=True):
+        return self._resp('search', query, limit)
+
     def get_support_transaction(
         self, pk, amount, subject, *, raise_for_status=True
     ):
@@ -88,6 +91,44 @@ def test_subject_balances_normalizes_and_converts():
         'support': {'grit': 5.0, 'grains': 500},
         'opposition': {'grit': 3.0, 'grains': 300},
     }
+
+
+def test_subject_search_converts_grains_to_grit():
+    client = FakeClient(
+        search=FakeResponse(
+            200,
+            {
+                'subjects': [
+                    {'subject': 'Tabs', 'opposition': 300, 'support': 150},
+                    {'subject': 'Tango', 'opposition': 0, 'support': 50},
+                ],
+                'as_of_block': 'b1',
+            },
+        )
+    )
+    resp = _app(client).get('/api/node/subject/search?q=ta&limit=8')
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        'subjects': [
+            {
+                'subject': 'Tabs',
+                'support': {'grit': 1.5, 'grains': 150},
+                'opposition': {'grit': 3.0, 'grains': 300},
+            },
+            {
+                'subject': 'Tango',
+                'support': {'grit': 0.5, 'grains': 50},
+                'opposition': {'grit': 0.0, 'grains': 0},
+            },
+        ]
+    }
+    assert client.calls[0][1] == ('ta', '8')
+
+
+def test_subject_search_maps_node_down_to_502():
+    client = FakeClient(search=httpx.RequestError('boom'))
+    resp = _app(client).get('/api/node/subject/search?q=ta')
+    assert resp.status_code == 502
 
 
 def test_subject_balances_rejects_bad_subject():

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -131,6 +131,16 @@ def test_subject_search_maps_node_down_to_502():
     assert resp.status_code == 502
 
 
+def test_subject_search_blank_query_relays_empty():
+    # A blank q is forwarded as-is; the node returns no subjects and the
+    # proxy passes the empty list straight through (never dumps the set).
+    client = FakeClient(search=FakeResponse(200, {'subjects': []}))
+    resp = _app(client).get('/api/node/subject/search?q=')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'subjects': []}
+    assert client.calls[0][1] == ('', '8')
+
+
 def test_subject_balances_rejects_bad_subject():
     client = FakeClient()
     resp = _app(client).get('/api/node/subject/balances?subject=')

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -106,3 +106,36 @@ def test_search_escapes_like_metacharacters(
         dao = m.longest_chain.to_dao()
         rows = db.session.execute(dao.search_subjects('50%', 8)).all()
         assert [r.subject for r in rows] == ['50% off']
+
+
+def test_search_endpoint_returns_shape(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    tabs = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 250))
+        mill_block(signing_key)
+
+    client = ApiClient(host, reader_signing_key)
+    resp = client.get('/api/subjects/search', params={'q': 'tab', 'limit': '8'})
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body['subjects'] == [
+        {'subject': 'Tabs', 'opposition': 250, 'support': 0}
+    ]
+    assert 'as_of_block' in body
+
+
+def test_search_endpoint_blank_query_is_empty(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    sub = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(sub, 100))
+        mill_block(signing_key)
+    client = ApiClient(host, reader_signing_key)
+    resp = client.get('/api/subjects/search', params={'q': '', 'limit': '8'})
+    assert resp.status_code == 200
+    assert resp.json()['subjects'] == []

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -139,3 +139,18 @@ def test_search_endpoint_blank_query_is_empty(
     resp = client.get('/api/subjects/search', params={'q': '', 'limit': '8'})
     assert resp.status_code == 200
     assert resp.json()['subjects'] == []
+
+
+def test_api_client_get_subject_search_round_trips(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    tabs = encode_subject('Tabs')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 75))
+        mill_block(signing_key)
+    resp = ApiClient(host, reader_signing_key).get_subject_search('tab', 8)
+    assert resp.status_code == 200
+    assert resp.json()['subjects'] == [
+        {'subject': 'Tabs', 'opposition': 75, 'support': 0}
+    ]

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -10,6 +10,14 @@ def test_outflow_populates_plaintext_columns_for_a_stake(app):
         assert row.subject_lower == 'tabs > spaces'
 
 
+def test_outflow_populates_plaintext_columns_for_opposition(app):
+    with app.app_context():
+        enc = encode_subject('Loud Chewing')
+        row = OutflowDAO('txid_opp', 0, 100, opposition=enc)
+        assert row.subject_plain == 'Loud Chewing'
+        assert row.subject_lower == 'loud chewing'
+
+
 def test_outflow_plaintext_columns_none_for_non_stake(app):
     with app.app_context():
         row = OutflowDAO('txid2', 0, 100, address='GCwhoeverGC')

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -1,3 +1,5 @@
+from gumptionchain.api_client import ApiClient
+from gumptionchain.database import db
 from gumptionchain.models import OutflowDAO
 from gumptionchain.payload import encode_subject
 
@@ -23,3 +25,84 @@ def test_outflow_plaintext_columns_none_for_non_stake(app):
         row = OutflowDAO('txid2', 0, 100, address='GCwhoeverGC')
         assert row.subject_plain is None
         assert row.subject_lower is None
+
+
+def _stake(host, chain, signing_key, *, oppose=None, support=None):
+    if oppose is not None:
+        subject, amount = oppose
+        txn = chain.create_opposition(signing_key, amount, subject)
+    else:
+        subject, amount = support
+        txn = chain.create_support(signing_key, amount, subject)
+    txn.sign()
+    ApiClient(host, signing_key).post_transaction(txn)
+    return txn
+
+
+def test_search_prefix_is_case_insensitive_returns_canonical(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    tabs = encode_subject('Tabs')
+    table = encode_subject('TABLE')
+    zebra = encode_subject('Zebra')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tabs, 300))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, support=(table, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(zebra, 999))
+        mill_block(signing_key)
+
+        dao = m.longest_chain.to_dao()
+        rows = db.session.execute(dao.search_subjects('tab', 8)).all()
+        subjects = [r.subject for r in rows]
+        assert set(subjects) == {'Tabs', 'TABLE'}
+
+
+def test_search_ranks_by_total_and_caps(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    ta = encode_subject('Tango')
+    tb = encode_subject('Tankard')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(ta, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(tb, 500))
+        mill_block(signing_key)
+
+        dao = m.longest_chain.to_dao()
+        rows = db.session.execute(dao.search_subjects('tan', 8)).all()
+        assert [r.subject for r in rows] == ['Tankard', 'Tango']
+        top = db.session.execute(dao.search_subjects('tan', 1)).all()
+        assert [r.subject for r in top] == ['Tankard']
+
+
+def test_search_blank_query_returns_nothing(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    sub = encode_subject('Anything')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(sub, 100))
+        mill_block(signing_key)
+        dao = m.longest_chain.to_dao()
+        assert db.session.execute(dao.search_subjects('', 8)).all() == []
+        assert db.session.execute(dao.search_subjects('   ', 8)).all() == []
+
+
+def test_search_escapes_like_metacharacters(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    pct = encode_subject('50% off')
+    plain = encode_subject('500 dollars')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(pct, 100))
+        mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(plain, 100))
+        mill_block(signing_key)
+        dao = m.longest_chain.to_dao()
+        rows = db.session.execute(dao.search_subjects('50%', 8)).all()
+        assert [r.subject for r in rows] == ['50% off']

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -1,0 +1,17 @@
+from gumptionchain.models import OutflowDAO
+from gumptionchain.payload import encode_subject
+
+
+def test_outflow_populates_plaintext_columns_for_a_stake(app):
+    with app.app_context():
+        enc = encode_subject('Tabs > Spaces')
+        row = OutflowDAO('txid1', 0, 100, support=enc)
+        assert row.subject_plain == 'Tabs > Spaces'
+        assert row.subject_lower == 'tabs > spaces'
+
+
+def test_outflow_plaintext_columns_none_for_non_stake(app):
+    with app.app_context():
+        row = OutflowDAO('txid2', 0, 100, address='GCwhoeverGC')
+        assert row.subject_plain is None
+        assert row.subject_lower is None


### PR DESCRIPTION
Closes #287.

A **subject-search typeahead primitive** in base: consumer EGU apps (first adopter: gumptactoe) can query on-chain subjects by prefix, ranked by stake. Extends the GRIT-spend rails (`node_proxy_blueprint`). Base owns the primitive; gumptactoe/hub consume it.

## What changed (4 thin layers)
1. **Schema** — `OutflowDAO.subject_plain` (decoded canonical) + `subject_lower` (lowercased, indexed `ix_outflow_subject_lower`), populated at the constructor choke point. Folded into the **baseline** migration (`63d32cd7621a`); greenfield, no backfill.
2. **DAO** — `ChainDAO.search_subjects(query, limit=None)` + `Chain.search_subjects` delegate: prefix, case-insensitive, LIKE-metacharacter-escaped, ranked by total stake desc, limit clamped 1–50, blank query → empty.
3. **Node API** — `GET /api/subjects/search?q=&limit=` (READER-gated), grains internal.
4. **Client + proxy** — `ApiClient.get_subject_search` + `node_proxy_blueprint` route `GET /api/node/subject/search?q=&limit=8`, grains→GRIT via `_grit()`.

Spec: `docs/superpowers/specs/2026-06-16-subject-search-design.md` · Plan: `docs/superpowers/plans/2026-06-16-subject-search.md`

## Report-back for the gumptactoe consumer
1. **Proxy route:** `GET /api/node/subject/search?q=<query>&limit=8` →
   ```json
   {"subjects":[{"subject":"<exact canonical>","support":{"grit":1.5,"grains":150},"opposition":{"grit":3.0,"grains":300}}]}
   ```
   Tallies are `{grit, grains}` objects (**not** whole-int — deviation from the issue sketch, for consistency with the existing balance routes; format whole-GRIT client-side). `as_of_block` is intentionally dropped at the proxy.
2. **Match semantics:** prefix, case-insensitive (Python `.lower()` folding), index-accelerated; ranked by total stake desc; default limit 8, clamped 1–50; blank query → empty.
3. **Index added:** `OutflowDAO.subject_plain` + `subject_lower` (`ix_outflow_subject_lower`); folded into the baseline migration; no backfill (greenfield).
4. **Pin:** the squash-merge SHA (posted after merge) in gumptactoe's `[tool.uv.sources]`.
5. **Deviations:** substring left as a future toggle (prefix is the 80% UX); two columns + a plain index instead of a `lower()` expression index (avoids `db check` reflection noise + Unicode-correct folding).

## Test plan
- [x] `uv run pytest` → **599 passed, 1 skipped**
- [x] `uv run ruff check src tests` + `ruff format --check` → clean
- [x] `uv run mypy` → clean
- [x] Fresh-DB migration parity: `gumptionchain init` + `gumptionchain db check` → "No new upgrade operations detected"
- [x] Subagent-driven: per-task spec + code-quality reviews, plus a final whole-branch review (verdict: ready to merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)