### PR TITLE
feat(cli): subject search command

### DIFF
--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -1116,3 +1116,61 @@ def support_balance(
         )
     except Exception as e:
         console.print(f'Support balance failed: {e}', style='error')
+
+
+@subject_cli.command('search')
+@click.argument('query')
+@click.option(
+    '-h',
+    '--host',
+    default=None,
+    help='The API host to use (default from app config).',
+)
+@click.option(
+    '-w',
+    '--signing_key',
+    type=click.Path(exists=True),
+    default=None,
+    help='SigningKey file to use for API auth.',
+)
+@click.option(
+    '-n',
+    '--limit',
+    default=8,
+    show_default=True,
+    help='Maximum number of results (the node clamps to 1-50).',
+)
+@with_appcontext
+def subject_search(
+    query: str, host: str | None, signing_key: str | None, limit: int
+) -> None:
+    """Search subjects on the chain by case-insensitive prefix, ranked by
+       total GRIT at stake.
+
+    \b
+    QUERY is the raw (unencoded) subject prefix, e.g. "pine".
+    """
+    try:
+        client = host_api_client(host=host, signing_key_file=signing_key)
+        r = client.get_subject_search(query, limit)
+        subjects = r.json().get('subjects', [])
+        if not subjects:
+            console.print(f'No subjects matching {query!r}')
+            return
+        table = Table(title=f'Subjects matching {query!r}')
+        table.add_column('Subject')
+        table.add_column('Support', justify='right')
+        table.add_column('Opposition', justify='right')
+        for row in subjects:
+            table.add_row(
+                row['subject'],
+                f'{human_grains(row["support"])} GRIT',
+                f'{human_grains(row["opposition"])} GRIT',
+            )
+        console.print(table)
+    except httpx.HTTPStatusError as e:
+        console.print(
+            f'Subject search failed: {http_error_message(e)}', style='error'
+        )
+    except Exception as e:
+        console.print(f'Subject search failed: {e}', style='error')

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest.mock import patch
 
+from gumptionchain.api_client import ApiClient
 from gumptionchain.application import create_clients
 from gumptionchain.block import Block
 from gumptionchain.chain import GRAIN_PER_GRIT, REWARD
 from gumptionchain.database import db
 from gumptionchain.miller import Miller
 from gumptionchain.node import Node
+from gumptionchain.payload import encode_subject
 from gumptionchain.signing_key import SigningKey
 from gumptionchain.util import now
 
@@ -288,6 +290,33 @@ def test_empty_chain(app, runner, requests_proxy, subject_raw, signing_key):
         )
         result = run_txn_opposition(runner, subject_raw, txn_signing_key, txnwf)
         assert 'Opposition failed: EmptyChainError' in result.output
+
+
+def test_subject_search(
+    app, mill_block, runner, requests_proxy, host, signing_key
+):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        sub = encode_subject('pineapple on pizza')
+        txn = m.longest_chain.create_support(signing_key, 100, sub)
+        txn.sign()
+        ApiClient(host, signing_key).post_transaction(txn)
+        mill_block(signing_key)
+
+        result = runner.invoke(args=['subject', 'search', 'pine'])
+        assert result.exit_code == 0
+        assert 'pineapple' in result.output
+        assert 'GRIT' in result.output
+
+
+def test_subject_search_no_matches(
+    app, mill_block, runner, requests_proxy, signing_key
+):
+    with app.app_context():
+        mill_block(signing_key)
+        result = runner.invoke(args=['subject', 'search', 'zzznomatch'])
+        assert result.exit_code == 0
+        assert 'No subjects matching' in result.output
 
 
 def run_txn_rescind(


### PR DESCRIPTION
## Summary
Adds a terminal companion to the subject-search primitive (#287): there was no way to *discover* subjects from the CLI (only single-subject balance lookups). 

```
gumptionchain subject search QUERY [--limit N] [-h HOST] [-w KEY]
```

- Mirrors the existing `subject opposition` / `subject support` commands: signed client via `host_api_client`, calls `ApiClient.get_subject_search` against the authed node endpoint `/api/subjects/search`.
- Renders a `rich` table — **Subject | Support | Opposition** (GRIT, via `human_grains`), in the API's total-stake ranking.
- `--limit/-n` defaults to 8 (node clamps 1–50). Empty result → plain "No subjects matching …" line. Same two-arm error handling as the balance commands.

Purely additive — one command on `subject_cli` + two CLI tests. No API change.

## Test plan
- [x] `uv run pytest tests/test_command.py` → 23 passed (incl. `test_subject_search`, `test_subject_search_no_matches`)
- [x] `ruff check` + `ruff format --check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)