### PR TITLE
fix(api): subject /opposition balance returns symmetric "opposition" key (#283)

### DIFF
--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -755,7 +755,7 @@ class OppositionBalanceView(MethodView):
                 balance = lc.opposition_balance(subject)
                 cache.set(key, balance)
             return make_json_response(
-                {'balance': balance, 'as_of_block': block_hash}
+                {'opposition': balance, 'as_of_block': block_hash}
             )
         except GCError as err:
             return make_error_response(err)

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -1070,7 +1070,7 @@ def opposition_balance(
     try:
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_opposition_balance(encode_subject(subject))
-        balance = r.json().get('balance')
+        balance = r.json().get('opposition')
         console.print(f'{human_grains(balance)} GRIT', style='success')
     except httpx.HTTPStatusError as e:
         console.print(

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -125,9 +125,8 @@ def node_proxy_blueprint(
         support = int(
             _ok(_call(client.get_support_balance, enc)).json()['support']
         )
-        # The node's /opposition endpoint returns grains under "balance" (#283).
         opp = int(
-            _ok(_call(client.get_opposition_balance, enc)).json()['balance']
+            _ok(_call(client.get_opposition_balance, enc)).json()['opposition']
         )
         return jsonify(
             {

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -78,14 +78,14 @@ def test_balance_converts_grains_to_grit():
 def test_subject_balances_normalizes_and_converts():
     client = FakeClient(
         support=FakeResponse(200, {'support': 500, 'as_of_block': 'b1'}),
-        opposition=FakeResponse(200, {'balance': 300, 'as_of_block': 'b1'}),
+        opposition=FakeResponse(200, {'opposition': 300, 'as_of_block': 'b1'}),
     )
     resp = _app(client).get(
         '/api/node/subject/balances?subject=Tabs %3E Spaces'
     )
     assert resp.status_code == 200
-    # Proves normalization: support.grains came from the node's "support" key
-    # while opposition.grains came from the node's "balance" key (#283).
+    # support.grains comes from the node's "support" key, opposition.grains
+    # from its now-symmetric "opposition" key (#283).
     assert resp.get_json() == {
         'subject': 'Tabs > Spaces',
         'support': {'grit': 5.0, 'grains': 500},

--- a/tests/test_subject_search.py
+++ b/tests/test_subject_search.py
@@ -79,6 +79,23 @@ def test_search_ranks_by_total_and_caps(
         assert [r.subject for r in top] == ['Tankard']
 
 
+def test_opposition_balance_endpoint_uses_symmetric_key(
+    app, host, mill_block, requests_proxy, signing_key, reader_signing_key
+):
+    # The /opposition balance endpoint returns grains under "opposition",
+    # symmetric with /support's "support" key (#283) — not the old "balance".
+    sub = encode_subject('loud chewing')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake(host, m.longest_chain, signing_key, oppose=(sub, 200))
+        mill_block(signing_key)
+    client = ApiClient(host, reader_signing_key)
+    body = client.get_opposition_balance(sub).json()
+    assert body['opposition'] == 200
+    assert 'balance' not in body
+    assert 'as_of_block' in body
+
+
 def test_search_blank_query_returns_nothing(
     app, host, mill_block, requests_proxy, signing_key
 ):


### PR DESCRIPTION
Closes #283.

## The fix
`GET /api/subject/<s>/opposition` returned grains under the generic `"balance"` key while `/support` used a purpose-named `"support"` key — asymmetric for no reason, forcing consumers to special-case per endpoint. Now:

```
GET /api/subject/<s>/opposition → {"opposition": <grains>, "as_of_block": ...}
GET /api/subject/<s>/support    → {"support":    <grains>, "as_of_block": ...}
```

## Consumers updated in lockstep (base)
- `api.py` `OppositionBalanceView` — returns `"opposition"`.
- `node_proxy.py` — reads `["opposition"]`; the grains→`balance` normalization shim is gone (the node is symmetric now).
- `command.py` `subject opposition` CLI — reads `["opposition"]`.
- `tests/test_node_proxy.py` fake + new `tests/test_subject_search.py::test_opposition_balance_endpoint_uses_symmetric_key` locking the contract.

The **address**-balance endpoints (`/signing-key/<addr>/balance`) intentionally keep the generic `"balance"` key — untouched.

## ⚠️ Breaking change — cross-repo
This is the node's public peer/browser API. Anything outside base that reads the opposition endpoint's `"balance"` key must update in lockstep — primarily **gumption-hub** if it consumes that endpoint. (Consumers are in a tidy state right now, which is why this is landing today.)

## Test plan
- [x] `uv run pytest` → 602 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] New endpoint test asserts `opposition` present, `balance` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)