### PR TITLE
feat(node-proxy): POST /txn/transfer build route

### DIFF
--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -11,6 +11,7 @@ from flask import Blueprint, Request, Response, jsonify, request
 from gumptionchain.api_client import ApiClient
 from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.payload import encode_subject, validate_raw_subject
+from gumptionchain.schema import validate_address_format
 
 
 class _ProxyError(Exception):
@@ -169,6 +170,32 @@ def node_proxy_blueprint(
     @bp.post('/txn/oppose')
     def txn_oppose() -> Response:
         return _build('get_opposition_transaction')
+
+    @bp.post('/txn/transfer')
+    def txn_transfer() -> Response:
+        # Build an unsigned player->address GRIT transfer. Same shape as the
+        # support/oppose build, but the destination is an address (validated
+        # here for a clean 400; the node validates it as AddressType too).
+        data = request.get_json(silent=True) or {}
+        public_key = data.get('public_key')
+        if not isinstance(public_key, str) or not public_key:
+            raise _ProxyError(400, 'public_key required')
+        to_address = data.get('to_address')
+        if not isinstance(to_address, str) or not validate_address_format(
+            to_address
+        ):
+            raise _ProxyError(400, 'invalid to_address')
+        grains = _grit_to_grains(data.get('amount_grit'))
+        return jsonify(
+            _ok(
+                _call(
+                    make_client().get_transfer_transaction,
+                    public_key,
+                    grains,
+                    to_address,
+                )
+            ).json()
+        )
 
     @bp.post('/txn/submit')
     def txn_submit() -> Response:

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -53,6 +53,11 @@ class FakeClient:
     ):
         return self._resp('build_oppose', pk, amount, subject)
 
+    def get_transfer_transaction(
+        self, pk, amount, address, *, raise_for_status=True
+    ):
+        return self._resp('build_transfer', pk, amount, address)
+
     def get(self, path, *, raise_for_status=True):
         return self._resp('status', path)
 
@@ -160,6 +165,30 @@ def test_build_support_converts_grit_and_passes_raw_subject():
     name, args, _ = client.calls[0]
     assert name == 'build_support'
     assert args == ('PUB', 700, 'goblins')
+
+
+def test_build_transfer_converts_grit_and_passes_address():
+    addr = 'GCB9JajrPayCVUqRU7RrDAVfZ1QPj135moCyrKkNwMwEtRGC'
+    unsigned = {'txid': 't2', 'outflows': [{'amount': 2000, 'address': addr}]}
+    client = FakeClient(build_transfer=FakeResponse(200, unsigned))
+    resp = _app(client).post(
+        '/api/node/txn/transfer',
+        json={'public_key': 'PUB', 'amount_grit': 20, 'to_address': addr},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == unsigned
+    name, args, _ = client.calls[0]
+    assert name == 'build_transfer'
+    assert args == ('PUB', 2000, addr)
+
+
+def test_build_transfer_rejects_bad_address():
+    client = FakeClient()
+    resp = _app(client).post(
+        '/api/node/txn/transfer',
+        json={'public_key': 'P', 'amount_grit': 20, 'to_address': 'nope'},
+    )
+    assert resp.status_code == 400
 
 
 def test_build_rejects_non_positive_and_sub_grain_amounts():


### PR DESCRIPTION
## Summary
Adds the missing **transfer-build** route to `node_proxy_blueprint`. The proxy had `txn/support`, `txn/oppose`, and `txn/submit` but no way to build a plain GRIT **transfer** — so a client couldn't construct a player→address payment to sign. gumptactoe needs this for its house-payment flow (e.g. a 20-GRIT reset).

```
POST /api/node/txn/transfer
  { "public_key": "...", "amount_grit": 20, "to_address": "GC…GC" }
→ 200  <unsigned transfer txn JSON>   # client signs it, then POSTs /api/node/txn/submit
```

- Mirrors the existing `txn/support`/`txn/oppose` build routes; the destination is an **address** instead of a subject.
- Validation: `public_key` non-empty; `to_address` via `validate_address_format` (clean 400; the node also validates it as `AddressType`); `amount_grit` via the shared `_grit_to_grains` (>0, ≤0.01 GRIT precision).
- Relays to `ApiClient.get_transfer_transaction(public_key, grains, to_address)` and returns the unsigned txn verbatim. **No node/API change** — the node's `/api/transaction/transfer` build already exists; this just exposes it through the browser-facing proxy.
- Purely additive: one route + `FakeClient` stub + 2 tests.

## Report-back for gumptactoe
Request field is **`to_address`** (symmetry with the stake routes' `subject`). Response is the unsigned transfer txn — sign it with `signUnsignedTxn` and submit via the existing `/api/node/txn/submit`. Pin base at this PR's squash-merge SHA (posted after merge).

## Test plan
- [x] `uv run pytest` → 614 passed, 1 skipped
- [x] New tests: grit→grains + address passthrough; bad/missing `to_address` → 400 (node-down → 502 covered by the shared `_call`/`_ok` path)
- [x] `ruff check` + `ruff format --check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)