### PR TITLE
feat: create_split UTXO chip-minting primitive

### DIFF
--- a/docs/superpowers/plans/2026-06-18-create-split.md
+++ b/docs/superpowers/plans/2026-06-18-create-split.md
@@ -1,0 +1,609 @@
+# create_split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `create_split` primitive that mints `count` same-address UTXO "chips" of `denomination` grains (+ change) in one transaction, exposed end-to-end (domain → node API → ApiClient → node-proxy → CLI).
+
+**Architecture:** Mirror `create_transfer` exactly — same input gather (`unspent_outflows(..., filter_pending=True)`) and `_funds_error`, differing only in the outputs (N self-addressed chips + change). Bounded by `MAX_FLOWS=50` (count ≤ 49, reserving one change slot). No new domain concepts; it's an ordinary regular transaction.
+
+**Tech Stack:** Python 3.12, Flask, SQLAlchemy 2.0, pydantic, click, pytest, uv.
+
+---
+
+## Background the engineer needs
+
+- **`Chain.create_transfer`** (`src/gumptionchain/chain.py:605`) is the exact template:
+  ```python
+  unspent = self.unspent_outflows(address, limit=amount, filter_pending=True)
+  for txid, index, outflow in unspent:
+      balance += outflow.amount or 0
+      t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
+  if balance < amount:
+      raise self._funds_error(address, amount)
+  t.add_outflow(Outflow(amount=amount, address=dest_address))
+  if balance - amount:
+      t.add_outflow(Outflow(amount=balance - amount, address=address))
+  t.set_signing_key(signing_key); t.seal(); return t
+  ```
+  `unspent_outflows(address, limit, filter_pending)` (chain.py:463) is a generator that yields confirmed-unspent (optionally pending-filtered) outflows until the accumulated amount ≥ `limit`. `Inflow`, `Outflow`, `Transaction`, `SigningKey` are already imported in chain.py.
+- **`_funds_error(address, amount)`** (chain.py:521): returns `PendingFundsError` if `balance(address) >= amount` (funds locked in pending), else `InsufficientFundsError`. Reuse unchanged.
+- **`MAX_FLOWS = 50`** (`src/gumptionchain/transaction.py:55`).
+- **Node build endpoint pattern** (`api.py`): `TransferTxnQueryModel` (`public_key: PublicKeyType`, `amount: int = Field(ge=1)`, `address: AddressType`) + `TransferTxnView.get` (validate model → `SigningKey(b64ks=public_key)` → `node_lc_dao()` → `lc.create_transfer(...)` → `make_json_response(txn.to_json())`; `except GCError → make_error_response`, `Exception → exception_response`) + `blueprint.add_url_rule('/transaction/transfer', authorize_transactor(TransferTxnView.as_view('txn_transfer_transactor')), methods=['GET'])`. `_pydantic_validation_error`, `node_lc_dao`, `EmptyChainError`, `SigningKey`, `make_json_response` are in api.py.
+- **`ApiClient.get_transfer_transaction(public_key, amount, address, ...)`** (`api_client.py:143`) → `self.get('/api/transaction/transfer', params={...str values...})`.
+- **node_proxy build routes** (`node_proxy.py`): `_grit_to_grains`, `_ok`, `_call`, `_ProxyError`; the `/txn/transfer` route reads `{public_key, amount_grit, to_address}`. (Added in #294.)
+- **CLI `txn transfer`** (`command.py:665-742`): `@txn_cli.command('transfer')` with args + `-t/--txn-signing_key`, `-h/--host`, `-w/--signing_key`, `-y/--yes`; body uses `address_signing_key(addr, signing_key_file=...)`, `host_api_client(...)`, `grit_to_grains(amount)`, `Transaction.from_json(r.text)`, confirm, `txn.set_signing_key/sign`, `client.post_transaction(txn)`. `grit_to_grains` (command.py:57), `address_signing_key` (command.py:117).
+- **Fixtures** (`tests/conftest.py`): `app`, `host`, `mill_block` (returns `(Miller, block)`; funds the key via coinbase `REWARD`), `requests_proxy`, `runner`, `signing_key`, `transactor_signing_key`. `tests/test_command.py` has `REWARD`, `run_txn_transfer`.
+- **Commands:** `uv run pytest <path>`, `uv run mypy`, `uv run ruff check src tests`, `uv run ruff format --check src tests`.
+
+---
+
+## Task 1: Domain — `Chain.create_split`
+
+**Files:**
+- Modify: `src/gumptionchain/chain.py`
+- Test: `tests/test_split.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_split.py`:
+
+```python
+import pytest
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.exceptions import (
+    InsufficientFundsError,
+    PendingFundsError,
+)
+
+
+def test_create_split_mints_chips_plus_change(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        txn = lc.create_split(signing_key, denomination=100, count=3)
+        chips = [o for o in txn.outflows if o.amount == 100]
+        change = [o for o in txn.outflows if o.amount != 100]
+        assert len(chips) == 3
+        assert all(o.address == signing_key.address for o in txn.outflows)
+        assert len(change) == 1  # leftover reward as one change UTXO
+        assert len(txn.outflows) <= 50
+
+
+def test_create_split_exact_has_no_change(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        txn = lc.create_split(signing_key, denomination=bal, count=1)
+        assert len(txn.outflows) == 1  # whole balance, no remainder
+        assert txn.outflows[0].amount == bal
+
+
+def test_create_split_49_chips_within_max_flows(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        txn = lc.create_split(signing_key, denomination=1, count=49)
+        assert sum(1 for o in txn.outflows if o.amount == 1) == 49
+        assert len(txn.outflows) <= 50  # 49 chips + 1 change
+
+
+def test_create_split_insufficient_funds(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        with pytest.raises(InsufficientFundsError):
+            lc.create_split(signing_key, denomination=bal, count=2)  # 2x balance
+
+
+def test_create_split_pending_funds(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        # Lock the only UTXO in a pending transfer, then split must see the
+        # confirmed balance but no spendable (non-pending) funds.
+        xfer = lc.create_transfer(signing_key, 1, signing_key.address)
+        xfer.sign()
+        ApiClient(host, signing_key).post_transaction(xfer)
+        with pytest.raises(PendingFundsError):
+            lc.create_split(signing_key, denomination=bal, count=1)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/test_split.py -v`
+Expected: FAIL — `AttributeError: 'Chain' object has no attribute 'create_split'`.
+
+- [ ] **Step 3: Implement `create_split`**
+
+In `src/gumptionchain/chain.py`, immediately after `create_transfer`:
+
+```python
+    def create_split(
+        self, signing_key: SigningKey, denomination: int, count: int
+    ) -> Transaction:
+        address = signing_key.address
+        total = denomination * count
+        t = Transaction()
+        balance = 0
+        unspent = self.unspent_outflows(
+            address, limit=total, filter_pending=True
+        )
+        for txid, index, outflow in unspent:
+            balance += outflow.amount or 0
+            t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
+        if balance < total:
+            raise self._funds_error(address, total)
+        for _ in range(count):
+            t.add_outflow(Outflow(amount=denomination, address=address))
+        if balance - total:
+            t.add_outflow(Outflow(amount=balance - total, address=address))
+        t.set_signing_key(signing_key)
+        t.seal()
+        return t
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/test_split.py -v`
+Expected: PASS (all 5).
+
+- [ ] **Step 5: Gates + commit**
+
+Run: `uv run mypy` (clean), `uv run ruff check src tests` + `uv run ruff format --check src tests` (clean).
+
+```bash
+git add src/gumptionchain/chain.py tests/test_split.py
+git commit -m "feat: Chain.create_split chip-minting primitive"
+```
+
+---
+
+## Task 2: Node endpoint — `GET /api/transaction/split`
+
+**Files:**
+- Modify: `src/gumptionchain/api.py` (model + view + route + `MAX_FLOWS` import)
+- Test: `tests/test_split.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_split.py`:
+
+```python
+def test_split_endpoint_returns_unsigned_txn(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    client = ApiClient(host, transactor_signing_key)
+    r = client.get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '100',
+            'count': '3',
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    chips = [o for o in body['outflows'] if o.get('amount') == 100]
+    assert len(chips) == 3
+
+
+def test_split_endpoint_rejects_count_over_49(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '1',
+            'count': '50',
+        },
+        raise_for_status=False,
+    )
+    assert r.status_code == 400
+
+
+def test_split_endpoint_rejects_zero_denomination(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '0',
+            'count': '3',
+        },
+        raise_for_status=False,
+    )
+    assert r.status_code == 400
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/test_split.py -k endpoint -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `src/gumptionchain/api.py`, add `MAX_FLOWS` to the transaction import (find the existing `from gumptionchain.transaction import ...`; if none, add `from gumptionchain.transaction import MAX_FLOWS`). Add the model + view next to `TransferTxnView`, and register the route next to the transfer rule:
+
+```python
+class SplitTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    public_key: PublicKeyType
+    denomination: int = Field(ge=1)
+    count: int = Field(ge=1, le=MAX_FLOWS - 1)
+
+
+class SplitTxnView(MethodView):
+    def get(self, **kwargs: Any) -> Response:
+        try:
+            model = SplitTxnQueryModel.model_validate(
+                request.args.to_dict(flat=True)
+            )
+        except ValidationError as e:
+            return make_error_response(_pydantic_validation_error(e))
+        try:
+            args = model.model_dump(exclude_none=True)
+            signing_key = SigningKey(b64ks=args['public_key'])
+            _, lc, _ = node_lc_dao()
+            if lc is None:
+                raise EmptyChainError()
+            return make_json_response(
+                lc.create_split(
+                    signing_key, args['denomination'], args['count']
+                ).to_json()
+            )
+        except GCError as err:
+            return make_error_response(err)
+        except Exception as e:
+            exception_response(e)
+
+
+blueprint.add_url_rule(
+    '/transaction/split',
+    view_func=authorize_transactor(
+        SplitTxnView.as_view('txn_split_transactor')
+    ),
+    methods=['GET'],
+)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/test_split.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Gates + commit**
+
+Run: `uv run mypy`, `uv run ruff check src tests`, `uv run ruff format --check src tests` (all clean).
+
+```bash
+git add src/gumptionchain/api.py tests/test_split.py
+git commit -m "feat: GET /api/transaction/split build endpoint"
+```
+
+---
+
+## Task 3: `ApiClient.get_split_transaction`
+
+**Files:**
+- Modify: `src/gumptionchain/api_client.py`
+- Test: `tests/test_split.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_split.py`:
+
+```python
+def test_api_client_get_split_transaction(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get_split_transaction(
+        transactor_signing_key.public_key_b64, 100, 4
+    )
+    assert r.status_code == 200
+    chips = [o for o in r.json()['outflows'] if o.get('amount') == 100]
+    assert len(chips) == 4
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_split.py -k api_client -v`
+Expected: FAIL — `AttributeError: 'ApiClient' object has no attribute 'get_split_transaction'`.
+
+- [ ] **Step 3: Implement the method**
+
+In `src/gumptionchain/api_client.py`, after `get_transfer_transaction`:
+
+```python
+    def get_split_transaction(
+        self,
+        public_key: str,
+        denomination: int,
+        count: int,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> httpx.Response:
+        return self.get(
+            '/api/transaction/split',
+            params={
+                'public_key': public_key,
+                'denomination': str(denomination),
+                'count': str(count),
+            },
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/test_split.py -k api_client -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+Run: `uv run mypy`, `uv run ruff check src tests`, `uv run ruff format --check src tests` (clean).
+
+```bash
+git add src/gumptionchain/api_client.py tests/test_split.py
+git commit -m "feat: ApiClient.get_split_transaction"
+```
+
+---
+
+## Task 4: node-proxy route — `POST /api/node/txn/split`
+
+**Files:**
+- Modify: `src/gumptionchain/node_proxy.py`
+- Test: `tests/test_node_proxy.py` (`FakeClient` stub + tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_node_proxy.py`, add to `FakeClient` (after `get_transfer_transaction`):
+
+```python
+    def get_split_transaction(
+        self, pk, denomination, count, *, raise_for_status=True
+    ):
+        return self._resp('build_split', pk, denomination, count)
+```
+
+Add tests (after the transfer-build tests):
+
+```python
+def test_build_split_converts_grit_and_passes_count():
+    unsigned = {'txid': 's1', 'outflows': [{'amount': 200, 'address': 'GCxGC'}]}
+    client = FakeClient(build_split=FakeResponse(200, unsigned))
+    resp = _app(client).post(
+        '/api/node/txn/split',
+        json={'public_key': 'PUB', 'denomination_grit': 2, 'count': 30},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == unsigned
+    name, args, _ = client.calls[0]
+    assert name == 'build_split'
+    assert args == ('PUB', 200, 30)   # 2 GRIT -> 200 grains; count passthrough
+
+
+def test_build_split_rejects_bad_amount():
+    client = FakeClient()
+    resp = _app(client).post(
+        '/api/node/txn/split',
+        json={'public_key': 'P', 'denomination_grit': 0, 'count': 5},
+    )
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/test_node_proxy.py -k split -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Implement the proxy route**
+
+In `src/gumptionchain/node_proxy.py`, after the `/txn/transfer` route:
+
+```python
+    @bp.post('/txn/split')
+    def txn_split() -> Response:
+        # Build an unsigned self-split: mint `count` chips of denomination_grit
+        # each (back to the signer's own address). Client signs + submits.
+        data = request.get_json(silent=True) or {}
+        public_key = data.get('public_key')
+        if not isinstance(public_key, str) or not public_key:
+            raise _ProxyError(400, 'public_key required')
+        denomination = _grit_to_grains(data.get('denomination_grit'))
+        count = data.get('count')
+        if not isinstance(count, int) or count < 1:
+            raise _ProxyError(400, 'count must be a positive integer')
+        return jsonify(
+            _ok(
+                _call(
+                    make_client().get_split_transaction,
+                    public_key,
+                    denomination,
+                    count,
+                )
+            ).json()
+        )
+```
+
+(Note: `count` upper-bound enforcement lives at the node endpoint via `SplitTxnQueryModel` — the proxy relays and the node returns the 400 if `count > 49`; the proxy only guards the obviously-bad `count < 1` for a clean early error.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/test_node_proxy.py -k split -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+Run: `uv run mypy`, `uv run ruff check src tests`, `uv run ruff format --check src tests` (clean).
+
+```bash
+git add src/gumptionchain/node_proxy.py tests/test_node_proxy.py
+git commit -m "feat: node_proxy /txn/split build relay route"
+```
+
+---
+
+## Task 5: CLI — `gc txn split`
+
+**Files:**
+- Modify: `src/gumptionchain/command.py`
+- Test: `tests/test_command.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_command.py`:
+
+```python
+def test_txn_split(app, mill_block, runner, requests_proxy, signing_key):
+    with app.app_context():
+        from_signing_key = SigningKey()
+        fwf = from_signing_key.to_file(
+            signing_keydir=app.config.get('SIGNING_KEY_DIR')
+        )
+        m, _ = mill_block(from_signing_key)
+        result = runner.invoke(
+            args=[
+                'txn', 'split', from_signing_key.address, '3', '1',
+                '--txn-signing_key', fwf, '-y',
+            ],
+        )
+        assert 'Split created.' in result.output
+        assert len(m.pending_txns) == 1
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_command.py::test_txn_split -v`
+Expected: FAIL — `Error: No such command 'split'` (nonzero exit).
+
+- [ ] **Step 3: Implement the command**
+
+In `src/gumptionchain/command.py`, add after the `create_transfer` command (mirroring its decorators + flow):
+
+```python
+@txn_cli.command('split')
+@click.argument('from_address')
+@click.argument('count', type=click.INT)
+@click.argument('denomination_grit', type=click.FLOAT)
+@click.option(
+    '-t',
+    '--txn-signing_key',
+    type=click.Path(exists=True),
+    default=None,
+    help='SigningKey file to use for transaction source.',
+)
+@click.option(
+    '-h',
+    '--host',
+    default=None,
+    help='The API host to use (default from app config).',
+)
+@click.option(
+    '-w',
+    '--signing_key',
+    type=click.Path(exists=True),
+    default=None,
+    help='SigningKey file to use for API auth.',
+)
+@click.option(
+    '-y',
+    '--yes',
+    is_flag=True,
+    default=False,
+    help='Assume "yes" as answer to all prompts and run non-interactively.',
+)
+@with_appcontext
+def create_split(
+    from_address: str,
+    count: int,
+    denomination_grit: float,
+    txn_signing_key: str | None,
+    host: str | None,
+    signing_key: str | None,
+    yes: bool,  # noqa: FBT001
+) -> None:
+    """Split your balance into COUNT same-address chips of DENOMINATION_GRIT each.
+
+    \b
+    FROM_ADDRESS is the key whose balance is sharded.
+    COUNT is how many chips to mint (1-49).
+    DENOMINATION_GRIT is each chip's size in GRIT.
+    """
+    try:
+        txn_signing_key_obj = address_signing_key(
+            from_address, signing_key_file=txn_signing_key
+        )
+        client = host_api_client(host=host, signing_key_file=signing_key)
+        r = client.get_split_transaction(
+            txn_signing_key_obj.public_key_b64,
+            grit_to_grains(denomination_grit),
+            count,
+        )
+        txn = Transaction.from_json(r.text)
+        if not (confirm := yes):
+            console.print(f'Split transaction created: {txn.txid}')
+            confirm = Confirm.ask(
+                'Do you want to sign and post the transaction?'
+            )
+        if confirm:
+            txn.set_signing_key(txn_signing_key_obj)
+            txn.sign()
+            client.post_transaction(txn)
+            console.print('Split created.', style='success')
+        else:
+            console.print('Split aborted.', style='error')
+    except httpx.HTTPStatusError as e:
+        console.print(f'Split failed: {http_error_message(e)}', style='error')
+    except Exception as e:
+        console.print(f'Split failed: {e}', style='error')
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/test_command.py::test_txn_split -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate sweep + commit**
+
+Run: `uv run pytest` (all pass), `uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run mypy` (clean).
+
+```bash
+git add src/gumptionchain/command.py tests/test_command.py
+git commit -m "feat(cli): gc txn split command"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `uv run pytest` → all pass; `ruff check` + `ruff format --check` + `mypy` clean.
+- [ ] Dispatch a final whole-branch code review.
+- [ ] Open the PR; report the merge SHA for gumptactoe to pin (the proxy `/txn/split` route + `denomination_grit`/`count` shape) so the house can pre-shard its balance into award-sized chips.
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** domain `create_split` → Task 1; `MAX_FLOWS` 49-cap + endpoint → Task 2; `ApiClient` → Task 3; proxy route → Task 4; CLI → Task 5. Validation (count 1..49, denomination ≥1) → Task 2 model + tests; funds errors (`PendingFundsError`/`InsufficientFundsError`) → Task 1 tests. All spec sections covered.
+- **Type consistency:** `create_split(signing_key, denomination, count)` identical across domain (Task 1), endpoint (`SplitTxnQueryModel` denomination/count, Task 2), `get_split_transaction(public_key, denomination, count)` (Task 3), proxy `get_split_transaction(public_key, grains, count)` (Task 4), CLI (Task 5). Grains everywhere except the proxy boundary (`denomination_grit`) and CLI (`DENOMINATION_GRIT`), converted via `_grit_to_grains`/`grit_to_grains`. `le=MAX_FLOWS - 1` (49) consistent with the 50-output bound.
+- **Placeholder scan:** none; complete code in every step.
+- **Minor refinement noted:** the CLI takes a leading `FROM_ADDRESS` (to locate the signing key, exactly like `txn transfer`) — the spec sketched `COUNT DENOMINATION_GRIT`; `FROM_ADDRESS` is required for `address_signing_key`, matching the transfer command.

--- a/docs/superpowers/specs/2026-06-18-create-split-design.md
+++ b/docs/superpowers/specs/2026-06-18-create-split-design.md
@@ -1,0 +1,218 @@
+# create_split — UTXO chip-minting primitive
+
+**Date:** 2026-06-18
+**Status:** design approved
+**Motivation:** A key's concurrent-spend capacity equals its number of
+independent UTXOs, and `create_transfer` *consolidates* (gathers inputs → one
+change output), so a busy payer collapses to a few big lumps and stalls on the
+"your previous transaction is still confirming" wall (observed live: a
+gumptactoe house key down to 2 UTXOs, both pending-locked, 46 GRIT unspendable).
+`create_split` lets a key pre-shard its balance into many small same-address
+UTXOs ("chips") so it can pay many times concurrently — and chips sized to the
+payment make those payments change-free, breaking the re-consolidation cycle.
+
+## Goal
+
+A new build primitive: in one transaction, mint **`count` outputs of
+`denomination` grains each, back to the key's own address**, plus one change
+output for any leftover. Exposed end-to-end (domain → node API → ApiClient →
+node-proxy → CLI), mirroring `create_transfer`. Player signing/custody and txn
+validation are untouched.
+
+## Background — what exists (and is reused)
+
+- `Chain.create_transfer(signing_key, amount, dest_address)` (`chain.py:605`):
+  gathers `unspent_outflows(address, limit=amount, filter_pending=True)` until
+  the running sum ≥ amount, raises `self._funds_error(address, amount)` on
+  shortfall, emits the dest outflow + a change outflow to self. `create_split`
+  mirrors this exactly, differing only in the outputs it builds.
+- `_funds_error` (`chain.py:521`): returns `PendingFundsError` when the confirmed
+  balance covers the amount but the pending-filtered gather fell short, else
+  `InsufficientFundsError`. Reused as-is.
+- `MAX_FLOWS = 50` (`transaction.py:55`): a regular transaction allows 0–50
+  inflows and 1–50 outflows (`RegularTransactionModel`). This bounds a split to
+  ≤ 50 outputs total.
+- Transfer's surfaces are the template: `TransferTxnQueryModel` + `TransferTxnView`
+  + `/api/transaction/transfer` (`api.py:503-540`, `authorize_transactor`);
+  `ApiClient.get_transfer_transaction` (`api_client.py:143`); the `node_proxy`
+  build routes (`node_proxy.py` `_build` + `/txn/transfer`); the `gc txn transfer`
+  CLI (`command.py:697`, build+sign+submit one-shot).
+
+## What we build — five layers
+
+### 1. Domain — `Chain.create_split(signing_key, denomination, count)`
+
+In `chain.py`, beside `create_transfer`:
+
+```python
+def create_split(
+    self, signing_key: SigningKey, denomination: int, count: int
+) -> Transaction:
+    address = signing_key.address
+    total = denomination * count
+    t = Transaction()
+    balance = 0
+    unspent = self.unspent_outflows(
+        address, limit=total, filter_pending=True
+    )
+    for txid, index, outflow in unspent:
+        balance += outflow.amount or 0
+        t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
+    if balance < total:
+        raise self._funds_error(address, total)
+    for _ in range(count):
+        t.add_outflow(Outflow(amount=denomination, address=address))
+    if balance - total:
+        t.add_outflow(Outflow(amount=balance - total, address=address))
+    t.set_signing_key(signing_key)
+    t.seal()
+    return t
+```
+
+- **Self-sharding:** every chip outflow goes to the key's **own** `address`;
+  there is no destination parameter.
+- **Outputs:** `count` chips (+ ≤1 change) = `count` or `count+1` outflows.
+
+### 2. The `MAX_FLOWS` bound
+
+`count` chips + 1 change ⇒ **`count` must be in `1..49`** (reserve one of the 50
+output slots for change). The domain method assumes a validated `count`; the
+node endpoint enforces it (below). Over 49 → a clean `400`. **No auto-tree**
+for bigger fan-outs in v1 — the consumer calls `split` again as the chips/change
+confirm.
+
+### 3. Node API — `/api/transaction/split`
+
+In `api.py`, mirroring `TransferTxnView`:
+
+```python
+class SplitTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    public_key: PublicKeyType
+    denomination: int = Field(ge=1)
+    count: int = Field(ge=1, le=MAX_FLOWS - 1)   # 1..49
+```
+
+A `SplitTxnView(MethodView)` GET that validates the query model, builds the
+unsigned txn via `lc.create_split(signing_key, denomination, count)`, and returns
+its `to_json()`. Registered at `/transaction/split` via `authorize_transactor`
+(same role gate as the other build endpoints). `MAX_FLOWS` is imported from
+`transaction`.
+
+### 4. `ApiClient.get_split_transaction`
+
+In `api_client.py`, mirroring `get_transfer_transaction`:
+
+```python
+def get_split_transaction(
+    self, public_key: str, denomination: int, count: int,
+    timeout: int | float | None = None,
+    raise_for_status: bool = True,  # noqa: FBT001
+) -> httpx.Response:
+    return self.get(
+        '/api/transaction/split',
+        params={
+            'public_key': public_key,
+            'denomination': str(denomination),
+            'count': str(count),
+        },
+        timeout=timeout, raise_for_status=raise_for_status,
+    )
+```
+
+### 5. node-proxy route + CLI
+
+**`node_proxy` `/txn/split`** (browser-facing build relay):
+
+```
+POST /api/node/txn/split
+  { "public_key": "...", "denomination_grit": 2, "count": 30 }
+→ 200  <unsigned split txn JSON>
+```
+
+- `public_key` non-empty string; `denomination_grit` → grains via the shared
+  `_grit_to_grains` (>0, ≤0.01 GRIT precision); `count` parsed as int.
+- Relays to `make_client().get_split_transaction(public_key, grains, count)`;
+  returns the unsigned txn. Client signs (`signUnsignedTxn`) + submits via the
+  existing `/api/node/txn/submit`. Same `_ok`/`_call` error mapping,
+  CSRF-exempt, rate-limit hook as the other proxy routes.
+
+**CLI `gc txn split COUNT DENOMINATION_GRIT`** in `command.py`, mirroring
+`txn transfer`: `host_api_client(...).get_split_transaction(...)` → sign →
+post_transaction → report the txid. (`COUNT` and `DENOMINATION_GRIT` as
+arguments; `-h/--host`, `--txn-signing_key` options like the siblings.)
+
+## Data flow
+
+```
+house/relay → POST /api/node/txn/split {public_key, denomination_grit, count}
+  → grit→grains → ApiClient.get_split_transaction → GET /api/transaction/split
+    → Chain.create_split → gather inputs (filter_pending) → count×denom + change
+  ← unsigned split txn
+  → signUnsignedTxn → POST /api/node/txn/submit → {txid}
+  → (mine a block) → chips confirm → N independent UTXOs ready for concurrent spends
+```
+
+## Validation & errors
+
+- `denomination ≥ 1`, `count ∈ 1..49` (pydantic on the endpoint; CLI/proxy parse
+  then rely on the endpoint). `count > 49` or `< 1`, `denomination < 1` → `400`.
+- `denomination × count` exceeds the spendable (non-pending) balance →
+  `_funds_error`: `PendingFundsError` if confirmed covers it (funds locked in
+  pending), else `InsufficientFundsError` — both `400` with their messages.
+- A split is **one** transaction → counts as 1 against the per-transactor
+  in-flight cap (`MAX_PENDING_PER_TRANSACTOR`).
+
+## Testing
+
+- **Domain** (`tests/`): `create_split` emits exactly `count` outflows of
+  `denomination` to the signer's own address + a change outflow for leftover;
+  total outflows ≤ `MAX_FLOWS`; an exact split (no remainder) emits no change;
+  insufficient non-pending funds → `PendingFundsError` (when confirmed covers)
+  / `InsufficientFundsError` (when it doesn't). Use the `mill_block` reward to
+  fund.
+- **Node endpoint**: `GET /api/transaction/split` returns the unsigned txn with
+  the right outflow shape; `count=50`/`count=0`/`denomination=0` → `400`
+  (validation); `authorize_transactor` gate.
+- **ApiClient**: `get_split_transaction` builds the right request.
+- **Proxy** (`tests/test_node_proxy.py`, `FakeClient`): `/txn/split` relays,
+  converts `denomination_grit`→grains, forwards `(public_key, grains, count)`;
+  bad amount → 400; node-down → 502.
+- **CLI** (`tests/test_command.py`): `txn split` builds+signs+submits; the
+  resulting pending txn carries `count` chip outflows.
+- Full `pytest` + `ruff` + `mypy` + `node --test` (unaffected) green.
+
+## Scope
+
+**In:** the domain method, node endpoint + query model, ApiClient method, proxy
+route, CLI command, and their tests. One base branch → PR.
+
+**Out / deferred:**
+- **Fill mode** (`create_split(key, denomination)` with no count → mint
+  `balance // denomination` chips). The consumer can compute `count` itself;
+  revisit if the ergonomic is wanted.
+- **Auto-tree** for >49 chips in one call (inter-level confirmation complexity).
+- **Auto-shard on receipt** (a node/app policy that splits incoming payments
+  automatically) — an app concern, not a base primitive.
+- **Spending unconfirmed change** (would remove the block-wait entirely but adds
+  reorg risk) — explicitly not pursued.
+
+## Invariants — what does NOT change
+
+- Transaction validation, the txid/signing path, `MAX_FLOWS`, and the
+  consensus/block rules. A split is an ordinary regular transaction.
+- `create_transfer`, the existing build endpoints, and the gather/`_funds_error`
+  helpers (reused, not modified).
+- Player signing/custody.
+
+## Risks
+
+- **Chips help concurrency only if payments match the denomination.** A payment
+  that isn't a single chip still combines chips + makes change (re-consolidating
+  a little). Mitigation: size chips to the common payment; documented, not
+  enforced. This is a usage guideline, not a code constraint.
+- **49-chip cap per txn** means sharding a large balance into many chips takes
+  several splits (each one txn, each needing its inputs confirmed before the next
+  can spend the change). Acceptable; the alternative (auto-tree) is deferred.
+- **Self-transfer outputs** must pass the existing outflow validation (address
+  outflow to self is already valid — `create_transfer` change does the same).

--- a/docs/superpowers/specs/2026-06-18-create-split-design.md
+++ b/docs/superpowers/specs/2026-06-18-create-split-design.md
@@ -137,10 +137,13 @@ POST /api/node/txn/split
   existing `/api/node/txn/submit`. Same `_ok`/`_call` error mapping,
   CSRF-exempt, rate-limit hook as the other proxy routes.
 
-**CLI `gc txn split COUNT DENOMINATION_GRIT`** in `command.py`, mirroring
-`txn transfer`: `host_api_client(...).get_split_transaction(...)` → sign →
-post_transaction → report the txid. (`COUNT` and `DENOMINATION_GRIT` as
-arguments; `-h/--host`, `--txn-signing_key` options like the siblings.)
+**CLI `gc txn split FROM_ADDRESS COUNT DENOMINATION_GRIT`** in `command.py`,
+mirroring `txn transfer`: `address_signing_key(FROM_ADDRESS, ...)` →
+`host_api_client(...).get_split_transaction(...)` → sign → post_transaction →
+report the txid. `FROM_ADDRESS` (the key whose balance is sharded) leads —
+exactly as `txn transfer` takes its source address, and needed to locate the
+signing key; `-t/--txn-signing_key`, `-h/--host`, `-w/--signing_key`,
+`-y/--yes` options like the siblings.
 
 ## Data flow
 

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -56,6 +56,7 @@ from gumptionchain.schema import (
 from gumptionchain.signals import http_post as http_post_signal
 from gumptionchain.signing_key import SigningKey
 from gumptionchain.tasks import post_process
+from gumptionchain.transaction import MAX_FLOWS
 from gumptionchain.util import (
     ciso_2_dt,
     dt_2_iso,
@@ -561,6 +562,48 @@ blueprint.add_url_rule(
     '/transaction/transfer',
     view_func=authorize_transactor(
         TransferTxnView.as_view('txn_transfer_transactor')
+    ),
+    methods=['GET'],
+)
+
+
+class SplitTxnQueryModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    public_key: PublicKeyType
+    denomination: int = Field(ge=1)
+    count: int = Field(ge=1, le=MAX_FLOWS - 1)
+
+
+class SplitTxnView(MethodView):
+    def get(self, **kwargs: Any) -> Response:
+        try:
+            model = SplitTxnQueryModel.model_validate(
+                request.args.to_dict(flat=True)
+            )
+        except ValidationError as e:
+            return make_error_response(_pydantic_validation_error(e))
+        try:
+            args = model.model_dump(exclude_none=True)
+            signing_key = SigningKey(b64ks=args['public_key'])
+            _, lc, _ = node_lc_dao()
+            if lc is None:
+                raise EmptyChainError()
+            return make_json_response(
+                lc.create_split(
+                    signing_key, args['denomination'], args['count']
+                ).to_json()
+            )
+        except GCError as err:
+            return make_error_response(err)
+        except Exception as e:
+            exception_response(e)
+
+
+blueprint.add_url_rule(
+    '/transaction/split',
+    view_func=authorize_transactor(
+        SplitTxnView.as_view('txn_split_transactor')
     ),
     methods=['GET'],
 )

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -159,6 +159,25 @@ class ApiClient:
             raise_for_status=raise_for_status,
         )
 
+    def get_split_transaction(
+        self,
+        public_key: str,
+        denomination: int,
+        count: int,
+        timeout: int | float | None = None,
+        raise_for_status: bool = True,  # noqa: FBT001
+    ) -> httpx.Response:
+        return self.get(
+            '/api/transaction/split',
+            params={
+                'public_key': public_key,
+                'denomination': str(denomination),
+                'count': str(count),
+            },
+            timeout=timeout,
+            raise_for_status=raise_for_status,
+        )
+
     def get_opposition_transaction(
         self,
         public_key: str,

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -626,10 +626,14 @@ class Chain:
     def create_split(
         self, signing_key: SigningKey, denomination: int, count: int
     ) -> Transaction:
+        # Assumes validated inputs: count in 1..MAX_FLOWS-1 (so count chips +
+        # one change stay within the 50-outflow cap) and denomination >= 1.
+        # The build endpoint enforces this; a direct caller passing count > 49
+        # would build an over-cap txn that fails at seal/validation.
         address = signing_key.address
         total = denomination * count
-        t = Transaction()
         balance = 0
+        t = Transaction()
         unspent = self.unspent_outflows(
             address, limit=total, filter_pending=True
         )

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -626,10 +626,14 @@ class Chain:
     def create_split(
         self, signing_key: SigningKey, denomination: int, count: int
     ) -> Transaction:
-        # Assumes validated inputs: count in 1..MAX_FLOWS-1 (so count chips +
-        # one change stay within the 50-outflow cap) and denomination >= 1.
-        # The build endpoint enforces this; a direct caller passing count > 49
-        # would build an over-cap txn that fails at seal/validation.
+        # Assumes validated inputs: denomination >= 1, and count low enough
+        # that count chips + at most one change output stay within MAX_FLOWS
+        # (50) outflows. The build endpoint caps count at MAX_FLOWS-1 (49),
+        # conservatively reserving a change slot. The domain method is
+        # unguarded: an over-large count is rejected by the transaction
+        # model's outflow max_length=MAX_FLOWS on validation/submission
+        # (e.g. Transaction.from_json), not here — seal() only computes the
+        # txid.
         address = signing_key.address
         total = denomination * count
         balance = 0

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -623,6 +623,29 @@ class Chain:
         t.seal()
         return t
 
+    def create_split(
+        self, signing_key: SigningKey, denomination: int, count: int
+    ) -> Transaction:
+        address = signing_key.address
+        total = denomination * count
+        t = Transaction()
+        balance = 0
+        unspent = self.unspent_outflows(
+            address, limit=total, filter_pending=True
+        )
+        for txid, index, outflow in unspent:
+            balance += outflow.amount or 0
+            t.add_inflow(Inflow(outflow_txid=txid, outflow_idx=index))
+        if balance < total:
+            raise self._funds_error(address, total)
+        for _ in range(count):
+            t.add_outflow(Outflow(amount=denomination, address=address))
+        if balance - total:
+            t.add_outflow(Outflow(amount=balance - total, address=address))
+        t.set_signing_key(signing_key)
+        t.seal()
+        return t
+
     def create_opposition(
         self,
         signing_key: SigningKey,

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -741,6 +741,83 @@ def create_transfer(
         console.print(f'Transfer failed: {e}', style='error')
 
 
+@txn_cli.command('split')
+@click.argument('from_address')
+@click.argument('count', type=click.INT)
+@click.argument('denomination_grit', type=click.FLOAT)
+@click.option(
+    '-t',
+    '--txn-signing_key',
+    type=click.Path(exists=True),
+    default=None,
+    help='SigningKey file to use for transaction source.',
+)
+@click.option(
+    '-h',
+    '--host',
+    default=None,
+    help='The API host to use (default from app config).',
+)
+@click.option(
+    '-w',
+    '--signing_key',
+    type=click.Path(exists=True),
+    default=None,
+    help='SigningKey file to use for API auth.',
+)
+@click.option(
+    '-y',
+    '--yes',
+    is_flag=True,
+    default=False,
+    help='Assume "yes" as answer to all prompts and run non-interactively.',
+)
+@with_appcontext
+def create_split(
+    from_address: str,
+    count: int,
+    denomination_grit: float,
+    txn_signing_key: str | None,
+    host: str | None,
+    signing_key: str | None,
+    yes: bool,  # noqa: FBT001
+) -> None:
+    """Split balance into COUNT same-address chips of DENOMINATION_GRIT each.
+
+    \b
+    FROM_ADDRESS is the key whose balance is sharded.
+    COUNT is how many chips to mint (1-49).
+    DENOMINATION_GRIT is each chip's size in GRIT.
+    """
+    try:
+        txn_signing_key_obj = address_signing_key(
+            from_address, signing_key_file=txn_signing_key
+        )
+        client = host_api_client(host=host, signing_key_file=signing_key)
+        r = client.get_split_transaction(
+            txn_signing_key_obj.public_key_b64,
+            grit_to_grains(denomination_grit),
+            count,
+        )
+        txn = Transaction.from_json(r.text)
+        if not (confirm := yes):
+            console.print(f'Split transaction created: {txn.txid}')
+            confirm = Confirm.ask(
+                'Do you want to sign and post the transaction?'
+            )
+        if confirm:
+            txn.set_signing_key(txn_signing_key_obj)
+            txn.sign()
+            client.post_transaction(txn)
+            console.print('Split created.', style='success')
+        else:
+            console.print('Split aborted.', style='error')
+    except httpx.HTTPStatusError as e:
+        console.print(f'Split failed: {http_error_message(e)}', style='error')
+    except Exception as e:
+        console.print(f'Split failed: {e}', style='error')
+
+
 @txn_cli.command('opposition')
 @click.argument('address')
 @click.argument('amount', type=click.FLOAT)

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -207,7 +207,9 @@ def node_proxy_blueprint(
             raise _ProxyError(400, 'public_key required')
         denomination = _grit_to_grains(data.get('denomination_grit'))
         count = data.get('count')
-        if not isinstance(count, int) or count < 1:
+        # bool is an int subclass — reject it explicitly so a JSON `true`
+        # doesn't slip through as count == 1.
+        if not isinstance(count, int) or isinstance(count, bool) or count < 1:
             raise _ProxyError(400, 'count must be a positive integer')
         return jsonify(
             _ok(

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -197,6 +197,29 @@ def node_proxy_blueprint(
             ).json()
         )
 
+    @bp.post('/txn/split')
+    def txn_split() -> Response:
+        # Build an unsigned self-split: mint `count` chips of denomination_grit
+        # each (back to the signer's own address). Client signs + submits.
+        data = request.get_json(silent=True) or {}
+        public_key = data.get('public_key')
+        if not isinstance(public_key, str) or not public_key:
+            raise _ProxyError(400, 'public_key required')
+        denomination = _grit_to_grains(data.get('denomination_grit'))
+        count = data.get('count')
+        if not isinstance(count, int) or count < 1:
+            raise _ProxyError(400, 'count must be a positive integer')
+        return jsonify(
+            _ok(
+                _call(
+                    make_client().get_split_transaction,
+                    public_key,
+                    denomination,
+                    count,
+                )
+            ).json()
+        )
+
     @bp.post('/txn/submit')
     def txn_submit() -> Response:
         data = request.get_json(silent=True) or {}

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -61,16 +61,16 @@ def _require_subject(subject: object) -> str:
     return subject
 
 
-def _grit_to_grains(value: object) -> int:
+def _grit_to_grains(value: object, field: str = 'amount_grit') -> int:
     try:
         grit = Decimal(str(value))
     except (InvalidOperation, ValueError):
-        raise _ProxyError(400, 'amount_grit must be a number') from None
+        raise _ProxyError(400, f'{field} must be a number') from None
     if grit <= 0:
-        raise _ProxyError(400, 'amount_grit must be positive')
+        raise _ProxyError(400, f'{field} must be positive')
     grains = grit * GRAIN_PER_GRIT
     if grains != grains.to_integral_value():
-        raise _ProxyError(400, 'amount_grit precision exceeds 0.01 GRIT')
+        raise _ProxyError(400, f'{field} precision exceeds 0.01 GRIT')
     return int(grains)
 
 
@@ -205,7 +205,9 @@ def node_proxy_blueprint(
         public_key = data.get('public_key')
         if not isinstance(public_key, str) or not public_key:
             raise _ProxyError(400, 'public_key required')
-        denomination = _grit_to_grains(data.get('denomination_grit'))
+        denomination = _grit_to_grains(
+            data.get('denomination_grit'), field='denomination_grit'
+        )
         count = data.get('count')
         # bool is an int subclass — reject it explicitly so a JSON `true`
         # doesn't slip through as count == 1.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -576,3 +576,26 @@ def test_mill(app, runner, signing_key):
         )
         assert 'Block │ 2' in result.output
         assert 'Block │ 3' in result.output
+
+
+def test_txn_split(app, mill_block, runner, requests_proxy, signing_key):
+    with app.app_context():
+        from_signing_key = SigningKey()
+        fwf = from_signing_key.to_file(
+            signing_keydir=app.config.get('SIGNING_KEY_DIR')
+        )
+        m, _ = mill_block(from_signing_key)
+        result = runner.invoke(
+            args=[
+                'txn',
+                'split',
+                from_signing_key.address,
+                '3',
+                '1',
+                '--txn-signing_key',
+                fwf,
+                '-y',
+            ],
+        )
+        assert 'Split created.' in result.output
+        assert len(m.pending_txns) == 1

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -219,6 +219,17 @@ def test_build_split_rejects_bad_amount():
     assert resp.status_code == 400
 
 
+def test_build_split_rejects_non_positive_or_bool_count():
+    client = FakeClient()
+    c = _app(client)
+    for bad in (0, -1, True):  # bool is an int subclass; must be rejected
+        resp = c.post(
+            '/api/node/txn/split',
+            json={'public_key': 'P', 'denomination_grit': 2, 'count': bad},
+        )
+        assert resp.status_code == 400, bad
+
+
 def test_build_rejects_non_positive_and_sub_grain_amounts():
     client = FakeClient()
     c = _app(client)

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -58,6 +58,11 @@ class FakeClient:
     ):
         return self._resp('build_transfer', pk, amount, address)
 
+    def get_split_transaction(
+        self, pk, denomination, count, *, raise_for_status=True
+    ):
+        return self._resp('build_split', pk, denomination, count)
+
     def get(self, path, *, raise_for_status=True):
         return self._resp('status', path)
 
@@ -187,6 +192,29 @@ def test_build_transfer_rejects_bad_address():
     resp = _app(client).post(
         '/api/node/txn/transfer',
         json={'public_key': 'P', 'amount_grit': 20, 'to_address': 'nope'},
+    )
+    assert resp.status_code == 400
+
+
+def test_build_split_converts_grit_and_passes_count():
+    unsigned = {'txid': 's1', 'outflows': [{'amount': 200, 'address': 'GCxGC'}]}
+    client = FakeClient(build_split=FakeResponse(200, unsigned))
+    resp = _app(client).post(
+        '/api/node/txn/split',
+        json={'public_key': 'PUB', 'denomination_grit': 2, 'count': 30},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == unsigned
+    name, args, _ = client.calls[0]
+    assert name == 'build_split'
+    assert args == ('PUB', 200, 30)  # 2 GRIT -> 200 grains; count passthrough
+
+
+def test_build_split_rejects_bad_amount():
+    client = FakeClient()
+    resp = _app(client).post(
+        '/api/node/txn/split',
+        json={'public_key': 'P', 'denomination_grit': 0, 'count': 5},
     )
     assert resp.status_code == 400
 

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -217,6 +217,8 @@ def test_build_split_rejects_bad_amount():
         json={'public_key': 'P', 'denomination_grit': 0, 'count': 5},
     )
     assert resp.status_code == 400
+    # the error names the split field, not the transfer 'amount_grit'
+    assert 'denomination_grit' in resp.get_json()['error']
 
 
 def test_build_split_rejects_non_positive_or_bool_count():

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -11,6 +11,7 @@ def test_create_split_mints_chips_plus_change(app, mill_block, signing_key):
     with app.app_context():
         m, _ = mill_block(signing_key)
         lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
         txn = lc.create_split(signing_key, denomination=100, count=3)
         chips = [o for o in txn.outflows if o.amount == 100]
         change = [o for o in txn.outflows if o.amount != 100]
@@ -18,6 +19,8 @@ def test_create_split_mints_chips_plus_change(app, mill_block, signing_key):
         assert all(o.address == signing_key.address for o in txn.outflows)
         assert len(change) == 1  # leftover reward as one change UTXO
         assert len(txn.outflows) <= 50
+        # value conservation: chips + change == the whole spent balance
+        assert sum(o.amount for o in txn.outflows) == bal
 
 
 def test_create_split_exact_has_no_change(app, mill_block, signing_key):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -66,3 +66,57 @@ def test_create_split_pending_funds(
         ApiClient(host, signing_key).post_transaction(xfer)
         with pytest.raises(PendingFundsError):
             lc.create_split(signing_key, denomination=bal, count=1)
+
+
+def test_split_endpoint_returns_unsigned_txn(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    client = ApiClient(host, transactor_signing_key)
+    r = client.get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '100',
+            'count': '3',
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    chips = [o for o in body['outflows'] if o.get('amount') == 100]
+    assert len(chips) == 3
+
+
+def test_split_endpoint_rejects_count_over_49(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '1',
+            'count': '50',
+        },
+        raise_for_status=False,
+    )
+    assert r.status_code == 400
+
+
+def test_split_endpoint_rejects_zero_denomination(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get(
+        '/api/transaction/split',
+        params={
+            'public_key': transactor_signing_key.public_key_b64,
+            'denomination': '0',
+            'count': '3',
+        },
+        raise_for_status=False,
+    )
+    assert r.status_code == 400

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -120,3 +120,16 @@ def test_split_endpoint_rejects_zero_denomination(
         raise_for_status=False,
     )
     assert r.status_code == 400
+
+
+def test_api_client_get_split_transaction(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    with app.app_context():
+        mill_block(transactor_signing_key)
+    r = ApiClient(host, transactor_signing_key).get_split_transaction(
+        transactor_signing_key.public_key_b64, 100, 3
+    )
+    assert r.status_code == 200
+    chips = [o for o in r.json()['outflows'] if o.get('amount') == 100]
+    assert len(chips) == 3

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,65 @@
+import pytest
+
+from gumptionchain.api_client import ApiClient
+from gumptionchain.exceptions import (
+    InsufficientFundsError,
+    PendingFundsError,
+)
+
+
+def test_create_split_mints_chips_plus_change(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        txn = lc.create_split(signing_key, denomination=100, count=3)
+        chips = [o for o in txn.outflows if o.amount == 100]
+        change = [o for o in txn.outflows if o.amount != 100]
+        assert len(chips) == 3
+        assert all(o.address == signing_key.address for o in txn.outflows)
+        assert len(change) == 1  # leftover reward as one change UTXO
+        assert len(txn.outflows) <= 50
+
+
+def test_create_split_exact_has_no_change(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        txn = lc.create_split(signing_key, denomination=bal, count=1)
+        assert len(txn.outflows) == 1  # whole balance, no remainder
+        assert txn.outflows[0].amount == bal
+
+
+def test_create_split_49_chips_within_max_flows(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        txn = lc.create_split(signing_key, denomination=1, count=49)
+        assert sum(1 for o in txn.outflows if o.amount == 1) == 49
+        assert len(txn.outflows) <= 50  # 49 chips + 1 change
+
+
+def test_create_split_insufficient_funds(app, mill_block, signing_key):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        with pytest.raises(InsufficientFundsError):
+            # count=2 means 2x bal -- exceeds funds
+            lc.create_split(signing_key, denomination=bal, count=2)
+
+
+def test_create_split_pending_funds(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        m, _ = mill_block(signing_key)
+        lc = m.longest_chain
+        bal = lc.balance(signing_key.address)
+        # Lock the only UTXO in a pending transfer, then split must see the
+        # confirmed balance but no spendable (non-pending) funds.
+        xfer = lc.create_transfer(signing_key, 1, signing_key.address)
+        xfer.sign()
+        ApiClient(host, signing_key).post_transaction(xfer)
+        with pytest.raises(PendingFundsError):
+            lc.create_split(signing_key, denomination=bal, count=1)


### PR DESCRIPTION
Adds `create_split` — mint `count` same-address UTXO "chips" of `denomination` grains (+ change) in one transaction — so a busy payer can pre-shard its balance and pay concurrently instead of collapsing to a few big change lumps and stalling on the "previous transaction is still confirming" wall.

**Motivating diagnosis:** a gumptactoe house key was down to 2 UTXOs (a 20-GRIT + a 26-GRIT lump, 46 GRIT total), both pending-locked → 2-GRIT awards 400'd with `PendingFundsError`. `create_transfer` consolidates (gathers inputs → one change output), so spending keeps re-collapsing the balance. `create_split` breaks that cycle.

## What changed (5 thin layers, mirroring transfer)
1. **`Chain.create_split(signing_key, denomination, count)`** — `count` self-addressed chips + change, reusing the `create_transfer` gather + `_funds_error` (so `PendingFundsError`/`InsufficientFundsError` semantics come for free).
2. **`GET /api/transaction/split`** — `SplitTxnQueryModel` with `count: Field(ge=1, le=MAX_FLOWS-1)` (1..49; reserve a change slot under the 50-outflow cap), TRANSACTOR-gated.
3. **`ApiClient.get_split_transaction`**.
4. **`node_proxy POST /api/node/txn/split`** — `{public_key, denomination_grit, count}` → grit→grains, count guard (rejects non-int/bool/<1), relay.
5. **`gc txn split FROM_ADDRESS COUNT DENOMINATION_GRIT`** CLI (build+sign+submit one-shot).

Spec: `docs/superpowers/specs/2026-06-18-create-split-design.md` · Plan: `docs/superpowers/plans/2026-06-18-create-split.md`

## Notes
- **Self-sharding** (chips to your own address); a split is **one** txn (1 against the per-transactor in-flight cap).
- **Honest limit:** chips help concurrency only if payments match the denomination; a payment that isn't one chip still combines + makes change. Size chips to the common payment.
- **49-chip cap/txn** (no auto-tree); **deferred:** fill-mode, auto-tree, auto-shard-on-receipt, spending-unconfirmed-change.

## Report-back for gumptactoe
Pre-shard the house balance via the proxy: `POST /api/node/txn/split { public_key, denomination_grit, count }` → sign (`signUnsignedTxn`) → `POST /api/node/txn/submit`. Mint award-sized chips (e.g. `denomination_grit` = your common award) so each payout spends one chip with no change. Pin base at this PR's squash-merge SHA (posted after merge).

## Test plan
- [x] `uv run pytest` → 627 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] Subagent-driven: per-task spec + code-quality reviews + a final whole-branch review (verdict: ready to merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)