### PR TITLE
fix(browser): explorer UI punch-list (brand, nav, index polish)

### DIFF
--- a/src/gumptionchain/application.py
+++ b/src/gumptionchain/application.py
@@ -11,6 +11,7 @@ from werkzeug.routing import BaseConverter, ValidationError
 
 from gumptionchain import __version__, api, browser, command
 from gumptionchain.api_client import ApiClient
+from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.payload import decode_subject, validate_subject
 from gumptionchain.schema import validate_address_format, validate_base64
 from gumptionchain.signing_key import SigningKey
@@ -76,6 +77,11 @@ def init_app(
     @app.template_filter('human_subject')
     def human_subject(value: str | None) -> str | None:
         return decode_subject(value) if value is not None else None
+
+    @app.template_filter('grit')
+    def grit(grains: int | None) -> str:
+        # grains -> GRIT with a fixed 2 decimal places (1 GRIT = 100 grains).
+        return f'{(grains or 0) / GRAIN_PER_GRIT:.2f}'
 
     @app.after_request
     def set_security_headers(response: Response) -> Response:

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -84,8 +84,7 @@ def explorer_home_context() -> dict[str, Any]:
     lc = longest_chain()
     # stake_stats runs the leaderboard union-anti-join once, yielding both
     # the distinct subject count and the total live stake; the template
-    # reads lc.length / lc.transaction_count / lc.recent_blocks(10)
-    # directly.
+    # reads lc.length / lc.transaction_count / lc.last_block directly.
     subject_count = total_staked = 0
     if lc is not None:
         subject_count, total_staked = lc.stake_stats()

--- a/src/gumptionchain/templates/_explorer_home.html
+++ b/src/gumptionchain/templates/_explorer_home.html
@@ -2,10 +2,12 @@
   {%- if lc %}
   <div class="row my-3 g-3">
     <div class="col-6 col-md">
-      <div class="card h-100"><div class="card-body py-3">
-        <div class="text-uppercase small text-muted">Height</div>
-        <div class="fs-3 fw-bold">{{ lc.length }}</div>
-      </div></div>
+      <a href="{{ url_for('browser.chains_view') }}" class="text-reset text-decoration-none">
+        <div class="card h-100"><div class="card-body py-3">
+          <div class="text-uppercase small text-muted">Height</div>
+          <div class="fs-3 fw-bold">{{ lc.length }}</div>
+        </div></div>
+      </a>
     </div>
     <div class="col-6 col-md">
       <div class="card h-100"><div class="card-body py-3">
@@ -16,26 +18,33 @@
     <div class="col-6 col-md">
       <div class="card h-100"><div class="card-body py-3">
         <div class="text-uppercase small text-muted">Total staked</div>
-        <div class="fs-3 fw-bold">{{ total_staked }} <span class="small text-muted">grains</span></div>
+        <div class="fs-3 fw-bold">{{ total_staked | grit }} <span class="small text-muted">GRIT</span></div>
       </div></div>
     </div>
     <div class="col-6 col-md">
-      <div class="card h-100"><div class="card-body py-3">
-        <div class="text-uppercase small text-muted">Subjects</div>
-        <div class="fs-3 fw-bold">{{ subject_count }}</div>
-      </div></div>
+      <a href="{{ url_for('browser.subjects_view') }}" class="text-reset text-decoration-none">
+        <div class="card h-100"><div class="card-body py-3">
+          <div class="text-uppercase small text-muted">Subjects</div>
+          <div class="fs-3 fw-bold">{{ subject_count }}</div>
+        </div></div>
+      </a>
     </div>
     <div class="col-6 col-md">
-      <div class="card h-100"><div class="card-body py-3">
-        <div class="text-uppercase small text-muted">Pending</div>
-        <div class="fs-3 fw-bold">{{ pending_count }}</div>
-      </div></div>
+      <a href="{{ url_for('browser.mempool_view') }}" class="text-reset text-decoration-none">
+        <div class="card h-100"><div class="card-body py-3">
+          <div class="text-uppercase small text-muted">Pending</div>
+          <div class="fs-3 fw-bold">{{ pending_count }}</div>
+        </div></div>
+      </a>
     </div>
   </div>
 
   <div class="row my-3"><div class="col">
     <div class="card bg-light"><div class="card-body">
-      <div class="card-title h5">Chain tip</div>
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <div class="card-title h5 mb-0">Chain tip</div>
+        <a href="{{ url_for('browser.chains_view') }}">View chain &rarr;</a>
+      </div>
       <table class="table table-hover block" style="table-layout:fixed;">
         <tbody class="font-monospace">
           <tr>
@@ -50,33 +59,6 @@
             <th class="col-2"><i class="bi-clock"></i>&nbsp;Timestamp</th>
             <td>{{ lc.last_block.timestamp_dt | utc_datetime }}</td>
           </tr>
-        </tbody>
-      </table>
-    </div></div>
-  </div></div>
-
-  <div class="row my-3"><div class="col">
-    <div class="card bg-light"><div class="card-body">
-      <div class="d-flex justify-content-between align-items-center">
-        <div class="card-title h5 mb-0">Recent blocks</div>
-        <div>
-          <a href="{{ url_for('browser.blocks_view') }}">View all blocks</a>
-          &middot;
-          <a href="{{ url_for('browser.subjects_view') }}">Subjects</a>
-          &middot;
-          <a href="{{ url_for('browser.stats_view') }}">Submission stats</a>
-        </div>
-      </div>
-      <table class="table table-hover blocks mt-3">
-        <thead><tr><th>#</th><th>Hash</th><th>Timestamp</th></tr></thead>
-        <tbody class="font-monospace">
-        {%- for block in lc.recent_blocks(10) %}
-          <tr>
-            <td>{{ block.idx }}</td>
-            <td><a class="text-dark" href="{{ url_for('browser.block_view', block_hash=block.block_hash) }}">{{ block.block_hash }}</a></td>
-            <td>{{ block.timestamp_dt | utc_datetime }}</td>
-          </tr>
-        {%- endfor %}
         </tbody>
       </table>
     </div></div>

--- a/src/gumptionchain/templates/base.html
+++ b/src/gumptionchain/templates/base.html
@@ -22,12 +22,13 @@
 
 <body>
   <nav class="navbar border-bottom mb-3 px-3">
-    <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">Gumption<span class="text-muted fw-normal small"> · node</span></a>
+    <a class="navbar-brand" href="{{ url_for('browser.index_view') }}">GumptionChain<span class="text-muted fw-normal small"> · node</span></a>
     <div class="navbar-nav flex-row flex-wrap align-items-center">
       <a class="nav-link px-2" href="{{ url_for('browser.chains_view') }}">Chains</a>
       <a class="nav-link px-2" href="{{ url_for('browser.blocks_view') }}">Blocks</a>
       <a class="nav-link px-2" href="{{ url_for('browser.subjects_view') }}">Subjects</a>
       <a class="nav-link px-2" href="{{ url_for('browser.addresses_view') }}">Addresses</a>
+      <a class="nav-link px-2" href="{{ url_for('browser.stats_view') }}">Stats</a>
       <a class="nav-link px-2" href="{{ url_for('browser.mempool_view') }}">Mempool</a>
       <a class="nav-link px-2" href="{{ url_for('browser.transact_view') }}">Transact</a>
       <a class="nav-link px-2" href="{{ url_for('browser.signing_key_view') }}">Signing key</a>
@@ -46,7 +47,7 @@
 
   {% block footer -%}
   <div class="footer text-center">
-    Version {{ gc_version }} | <a href="https://gumption.com/chain" class="link-dark">gumption.com/chain</a>
+    Version {{ gc_version }} | <a href="https://github.com/gumptionthomas/gumptionchain" class="link-dark">github</a>
   </div>
   {%- endblock %}
 

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -64,7 +64,7 @@ def test_base_links_node_favicon(test_client):
     assert b'img/favicon-node.svg' in resp.data
 
 
-def test_home_shows_stats_and_recent_blocks(
+def test_home_shows_stats_and_chain_tip(
     app, host, mill_block, requests_proxy, subject, signing_key
 ):
     with app.app_context():
@@ -82,7 +82,7 @@ def test_home_shows_stats_and_recent_blocks(
         # links into the explorer
         assert b'/blocks' in body
         assert b'/subjects' in body
-        # the chain tip hash appears in the recent-blocks table
+        # the chain tip hash appears in the Chain tip pane
         assert tip.block_hash.encode() in body
 
 


### PR DESCRIPTION
A batch of small explorer/UI fixes from a walkthrough of the dev app.

- **Brand:** nav logo `Gumption · node` → `GumptionChain · node` (distinct from gumption.com / the hub); footer links to the GitHub repo (text "github") instead of `gumption.com/chain`.
- **Index:** removed the home "recent blocks" pane — it was a wall of opaque hashes *and* the source of a duplicate Subjects link; the Chain-tip pane already shows the one useful thing (tip index/hash/time).
- **Nav:** added a **Stats** entry (the removed pane held the only `/stats` link); ordered `… Subjects · Addresses · Stats · Mempool …`.
- **Chain-tip pane:** added a **"View chain →"** link to `/chains`.
- **Stat cards:** **Total staked** now shows **GRIT (2dp)** via a new reusable `grit` Jinja filter; **Height → /chains**, **Subjects → /subjects**, **Pending → /mempool** (whole card clickable). **Transactions** and **Total staked** intentionally left unlinked (no distinct destination — a Transactions page is tracked separately in #296).

## Test plan
- [x] `uv run pytest` (home/subjects/stats page tests updated + green)
- [x] `ruff check` + `ruff format --check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)