### PR TITLE
docs: rewrite README + add repo-based API/CLI/config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # GumptionChain
 
-GumptionChain is an open-source python project that implements a custom blockchain ledger. The ledger protocol allows for the assigning of tokens to subjects (utf-8 strings of less than 80 characters) as indications of either opposition or support. Either kind of entry may be rescinded later.
+GumptionChain is an open-source Python project that implements a custom
+proof-of-work blockchain ledger. The ledger lets tokens be assigned to
+*subjects* (UTF-8 strings of 1–79 characters) as indications of either
+**opposition** or **support**. Either kind of stake can be rescinded later.
 
-- [Project Home Page](https://gumption.com/chain)
-- [Documentation](https://gumption.com/chain/docs)
-- [Blog](https://gumption.com/chain/blog)
+Tokens are denominated in **GRIT** (1 GRIT = 100 grains). GumptionChain runs as
+both a Flask web application (a browser explorer plus a JSON API) and a
+`gumptionchain` command-line tool. The network is **permissioned**: API access
+is gated by role (`READER` < `TRANSACTOR` < `MILLER` < `ADMIN`).
+
+## Documentation
+
+- **[HTTP API reference](docs/api-reference.md)** — endpoints, roles, payloads.
+- **[CLI reference](docs/cli-reference.md)** — the `gumptionchain` command tree.
+- **[Configuration reference](docs/configuration.md)** — `FLASK_*` / `GC_*`
+  settings and role allowlists.
+- **[API authentication protocol](docs/api-auth-protocol.md)** — the
+  `gc-sig-v1` per-request signing scheme.
+- Full index: [`docs/`](docs/README.md).
 
 ## Quick Start
 
@@ -20,9 +34,11 @@ Install GumptionChain using pip:
 $ pip install gumptionchain
 ```
 
-It is recommended that a [python virtual environment](https://docs.python.org/3/library/venv.html) is used for [all](https://realpython.com/python-virtual-environments-a-primer/#avoid-system-pollution) [the](https://realpython.com/python-virtual-environments-a-primer/#sidestep-dependency-conflicts) [usual](https://realpython.com/python-virtual-environments-a-primer/#minimize-reproducibility-issues) [reasons](https://realpython.com/python-virtual-environments-a-primer/#dodge-installation-privilege-lockouts).
+It is recommended that a [Python virtual environment](https://docs.python.org/3/library/venv.html)
+is used.
 
-For development on the project itself, use [uv](https://docs.astral.sh/uv/) to manage the environment and dependencies:
+For development on the project itself, use [uv](https://docs.astral.sh/uv/) to
+manage the environment and dependencies:
 
 ```console
 $ git clone https://github.com/gumptionthomas/gumptionchain.git
@@ -31,56 +47,62 @@ $ uv sync --group dev
 $ uv run gumptionchain --help
 ```
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and quality
+gates.
+
 ### Configure
 
-Create a [python-dotenv](https://pypi.org/project/python-dotenv/) `.env` file. The `gumptionchain` command loads a `.env` file in the current working directory by default. See [dotenv documentation](https://gumption.com/chain/docs/en/latest/usage.html#dotenv) to locate the file elsewhere. The following `gumptionchain` command examples assume that the `.env` file is loaded by default.
+Create a [python-dotenv](https://pypi.org/project/python-dotenv/) `.env` file
+in the working directory. A minimal configuration:
 
-A minimal `.env` configuration file:
-
-```console
+```ini
 # Flask Settings
 FLASK_APP=gumptionchain
-FLASK_SECRET_KEY=0b6ceaa3b10d3e7a5dc53194
+FLASK_SECRET_KEY=change-me-to-a-random-string
 
 # Flask-SQLAlchemy Settings
 FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///gc.sqlite
 ```
 
-The [FLASK_SECRET_KEY](https://gumption.com/chain/docs/en/latest/usage.html#SECRET_KEY) value should be a unique random string.
-
-See the [Configuration Documentation](https://gumption.com/chain/docs/en/latest/usage.html#configuration) for more configuration settings.
+`FLASK_SECRET_KEY` should be a unique random string. See the
+[configuration reference](docs/configuration.md) for all available settings.
 
 ### Initialize
 
-Create a local database by running the [init command](https://gumption.com/chain/docs/en/latest/usage.html#init):
+Create a local database (this applies all schema migrations):
 
 ```console
 $ gumptionchain init
 ```
 
-The [FLASK_SQLALCHEMY_DATABASE_URI](https://gumption.com/chain/docs/en/latest/usage.html#SQLALCHEMY_DATABASE_URI) value in the example configuration above specifies a [SQLite](https://sqlite.org/index.html) database called `gc.sqlite` with a file path relative to the `gumptionchain` [instance folder](https://flask.palletsprojects.com/en/2.2.x/config/#instance-folders).
+The example `FLASK_SQLALCHEMY_DATABASE_URI` above specifies a
+[SQLite](https://sqlite.org/index.html) database called `gc.sqlite`, relative
+to the `gumptionchain`
+[instance folder](https://flask.palletsprojects.com/en/stable/config/#instance-folders).
 
 ### Import
 
-The `import` command bulk-loads blocks from a [JSON Lines](https://jsonlines.org/) export — for example, a file produced by the `gumptionchain export` command on another node.
-
-Run the [import command](https://gumption.com/chain/docs/en/latest/usage.html#import), passing it the location of the export file:
+The `import` command bulk-loads blocks from a [JSON Lines](https://jsonlines.org/)
+export — for example, a file produced by `gumptionchain export` on another node:
 
 ```console
 $ gumptionchain import path/to/gumptionchain.jsonl
 ```
 
-This command could take a while to run depending on your computer and the number of blocks imported. A progress bar will display with estimated time remaining. You can run the `import` command multiple times and it will only import new blocks that are not yet in the database.
+This can take a while depending on your machine and the number of blocks; a
+progress bar shows estimated time remaining. The command is idempotent — run it
+again and only new blocks are imported.
 
 ### Run
 
-Run the `gumptionchain` application by issuing the `run` command:
+Run the application with the `run` command:
 
 ```console
 $ gumptionchain run
 ```
 
-Open [http://localhost:5000](http://localhost:5000) in a browser to explore the local copy of the blockchain.
+Open [http://localhost:5000](http://localhost:5000) in a browser to explore the
+local copy of the blockchain.
 
 #### Home Page (Current Chain)
 
@@ -94,38 +116,52 @@ Open [http://localhost:5000](http://localhost:5000) in a browser to explore the 
 
 <img src="https://github.com/gumptionthomas/gumptionchain/blob/7a4fab66dfe6026e56c79df3e147b1ecbdbb6158/readme-assets/browser-txn.png?raw=true" width="500">
 
-Running the `gumptionchain` application also exposes a set of web service endpoints that comprise the communications layer of the blockchain. See the [API Documentation](https://gumption.com/chain/docs/en/latest/api.html) for more information.
+Running the application also exposes the JSON API that forms the communications
+layer of the blockchain — see the [API reference](docs/api-reference.md). For
+the other commands, see the [CLI reference](docs/cli-reference.md) or run
+`gumptionchain --help`.
 
-There are other `gumptionchain` commands for interacting with the blockchain. See the [Command Line Interface Documentation](https://gumption.com/chain/docs/en/latest/usage.html#command-line-interface) for more information or run `gumptionchain --help`.
+## Joining the GumptionChain Network
 
-## Joining The GumptionChain Network
+GumptionChain is run by a permissioned network of nodes. To have locally milled
+blocks or submitted transactions propagate to the official chain, a node needs
+[miller](docs/configuration.md#role-allowlists) or
+[transactor](docs/configuration.md#role-allowlists) role access to a node in
+the network.
 
-The GumptionChain is run by a permissioned network of nodes. A GumptionChain instance requires [miller](https://gumption.com/chain/docs/en/latest/api.html#miller) or [transactor](https://gumption.com/chain/docs/en/latest/api.html#transactor) role [API access](https://gumption.com/chain/docs/en/latest/api.html#api-roles) to a node in the network in order to have locally milled blocks or submitted transactions propagate to the official GumptionChain.
+API access is granted by a node's operator. Once your signing-key address is on
+a node's role allowlist, configure that node as a peer. Replace
+`GCYourAddressGC` with your signing-key address, `peer.example.com` with the
+node's host, and `/path/to/signing_keys` with the directory containing your key
+([PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail)) file:
 
-[API access](https://gumption.com/chain/docs/en/latest/api.html#api-roles) to a node is granted by that node's operator. Once your signing_key address is on a node's role allowlist (see below to request access), configure your instance to use that node as a peer. Replace `GCYourSigningKeyAddressGC` with your signing_key address, `peer.example.com` with the host of the node you've been granted access to, and `/path/to/signing_keys` with the path to a directory containing your key ([PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail)) file:
-
-```console
+```ini
 # GumptionChain Settings
-GC_NODE_HOST=http://GCYourSigningKeyAddressGC@localhost:5000
-GC_PEERS=["https://GCYourSigningKeyAddressGC@peer.example.com"]
-GC_DEFAULT_COMMAND_HOST=https://GCYourSigningKeyAddressGC@peer.example.com
+GC_NODE_HOST=http://GCYourAddressGC@localhost:5000
+GC_PEERS=["https://GCYourAddressGC@peer.example.com"]
+GC_DEFAULT_COMMAND_HOST=https://GCYourAddressGC@peer.example.com
 GC_SIGNING_KEY_DIR=/path/to/signing_keys
 ```
 
-Restart to load the new configuration.
+Restart to load the new configuration. See the
+[configuration reference](docs/configuration.md) for details.
 
-See [Configuration Documentation](https://gumption.com/chain/docs/en/latest/usage.html#configuration) for more detailed information about these settings.
-
-The [reader](https://gumption.com/chain/docs/en/latest/api.html#reader) role [API access](https://gumption.com/chain/docs/en/latest/api.html#api-roles) allows the [sync command](https://gumption.com/chain/docs/en/latest/usage.html#sync) to update to the most recent peer block data:
+With `READER` access, the [`sync` command](docs/cli-reference.md) updates your
+chain to the most recent peer block data:
 
 ```console
 $ gumptionchain sync
 ```
 
-This command could take a while to run depending on your computer, internet access, and the number of blocks synchronized. A progress bar will display with estimated time remaining. You can run the `sync command` multiple times and it will only synchronize new blocks that are not yet in the database.
+Like `import`, `sync` is idempotent and only fetches blocks you don't yet have.
+Reader access also allows querying data (subject totals and balances) via the
+CLI.
 
-Reader access also allows querying data (i.e. subject counts and balances) using the CLI. See [Command Line Interface Documentation](https://gumption.com/chain/docs/en/latest/usage.html#command-line-interface) for more information.
+To request access to a node in the GumptionChain network, email
+**thomas@gumption.com** with the role you'd like (reader, transactor, or
+miller) and how you intend to use it (e.g. research, business, non-profit,
+hobby).
 
-If you would like to be granted other [API access](https://gumption.com/chain/docs/en/latest/api.html#api-roles) to a node in the GumptionChain network, send an email to contact@gumption.com including what kind of role you'd like (e.g. [reader](https://gumption.com/chain/docs/en/latest/api.html#reader), [transactor](https://gumption.com/chain/docs/en/latest/api.html#transactor), or [miller](https://gumption.com/chain/docs/en/latest/api.html#miller)) and how you intend to use it (e.g. research, business, non-profit, hobby).
+## License
 
-See the [documentation](https://gumption.com/chain/docs) for some potential development ideas.
+GumptionChain is released under the [MIT License](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,17 @@
 In-repo documentation for running, extending, and integrating a GumptionChain
 node.
 
-## Protocol & API
+## Reference
+
+- [HTTP API reference](api-reference.md) — every `/api` endpoint, the role it
+  requires, and its request/response shapes.
+- [CLI reference](cli-reference.md) — the `gumptionchain` command tree
+  (`gc` alias): node lifecycle, milling, migrations, keys, subjects, and
+  transactions.
+- [Configuration reference](configuration.md) — `FLASK_*` and `GC_*` settings,
+  role allowlists, and joining a network.
+
+## Protocol & auth
 
 - [API authentication protocol (`gc-sig-v1`)](api-auth-protocol.md) — the
   per-request signing-key signature scheme every authenticated API request
@@ -16,6 +26,9 @@ node.
 
 ## Building on a node (app / extension developers)
 
+- [Browser-facing node proxy](node-proxy.md) — the embeddable blueprint that
+  lets a web app build, sign, and submit transactions from the browser without
+  exposing the node host or relay key.
 - [Base ↔ extension UI seam](ui-extension-seam.md) — how an extension re-skins
   and extends a vanilla node's browser pages through the template-override seam
   and block contract.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,143 @@
+# HTTP API Reference
+
+Every GumptionChain node exposes a JSON API under the `/api` prefix. This
+document lists the endpoints, the role each requires, and their request and
+response shapes.
+
+- **Authentication** for every endpoint is a per-request signing-key signature
+  (`gc-sig-v1`). The full protocol — canonical string, headers, algorithm, and
+  a worked example — is specified in
+  [api-auth-protocol.md](api-auth-protocol.md). In practice you sign requests
+  with [`ApiClient`](../src/gumptionchain/api_client.py), which sets the
+  `GC-*` headers for you.
+- **Roles** form a hierarchy: `READER` < `TRANSACTOR` < `MILLER` < `ADMIN`. An
+  endpoint's "Role" column is the *minimum*; a higher role also passes. Roles
+  are resolved from the `*_ADDRESSES` allowlists (see
+  [configuration.md](configuration.md)) and re-checked on every request, so
+  revocations take effect immediately.
+- **Errors** are returned as `{"error": "<message>"}` with an appropriate HTTP
+  status: `401` (signature invalid/expired), `403` (role insufficient), `404`
+  (not found), `429` (per-transactor quota exceeded), `503` (mempool full).
+- **Units:** all amounts in API request/response bodies are in **grains**
+  (1 GRIT = 100 grains). The CLI and the browser-facing proxy relay accept
+  GRIT and convert; the raw node API does not.
+
+## Endpoint summary
+
+| Method | Path | Role | Purpose |
+| --- | --- | --- | --- |
+| GET | `/api/block` | READER | Fetch the longest-chain tip block |
+| GET | `/api/block/<block_hash>` | READER | Fetch a block by hash |
+| POST | `/api/block/<block_hash>` | MILLER | Submit a block (peer gossip) |
+| POST | `/api/block/<block_hash>/<process>` | MILLER | Submit a block, forcing sync processing |
+| GET | `/api/blocks?from_idx=&limit=` | READER | Range of longest-chain blocks |
+| POST | `/api/transaction/<txid>` | TRANSACTOR | Submit a signed transaction |
+| POST | `/api/transaction/<txid>/<process>` | TRANSACTOR | Submit, forcing sync processing |
+| GET | `/api/transaction/<txid>` | READER | Transaction provenance / status |
+| GET | `/api/transaction/transfer` | TRANSACTOR | Build an unsigned transfer txn |
+| GET | `/api/transaction/split` | TRANSACTOR | Build an unsigned self-split txn |
+| GET | `/api/transaction/opposition` | TRANSACTOR | Build an unsigned opposition txn |
+| GET | `/api/transaction/support` | TRANSACTOR | Build an unsigned support txn |
+| GET | `/api/transaction/rescind` | TRANSACTOR | Build an unsigned rescind txn |
+| GET | `/api/transaction/pending` | READER | List pending (mempool) transactions |
+| GET | `/api/signing-key/<address>/balance` | READER | Address balance |
+| GET | `/api/subject/<subject>/opposition` | READER | Subject opposition total |
+| GET | `/api/subject/<subject>/support` | READER | Subject support total |
+| GET | `/api/subjects/search?q=&limit=` | READER | Prefix-search subjects |
+| GET | `/api/stats/transactors` | READER | Per-relay submission leaderboard |
+
+## Blocks
+
+### `GET /api/block` · `GET /api/block/<block_hash>`
+
+Returns a block as JSON. Without a hash, returns the current longest-chain
+tip. `<block_hash>` is a 64-hex-character mill hash.
+
+### `POST /api/block/<block_hash>[/<process>]` — MILLER
+
+Submits a block to the node, used for peer-to-peer gossip. The body is the
+block JSON. Response status: `201` if the block was newly applied, `202` if
+accepted for asynchronous processing (`GC_API_ASYNC_PROCESSING=true`), `200`
+if already known. Appending `/process` forces synchronous processing of a
+block that was previously queued.
+
+### `GET /api/blocks?from_idx=<n>&limit=<n>`
+
+Returns an array of longest-chain blocks starting at height `from_idx`
+(`>= 0`), up to `limit` blocks (`>= 1`, server-clamped to `SYNC_BATCH_SIZE`).
+Used by `gumptionchain sync`.
+
+## Transactions
+
+### `POST /api/transaction/<txid>[/<process>]` — TRANSACTOR
+
+Submits a signed transaction. The body is the signed transaction JSON; `txid`
+is its mill hash. Response status mirrors block submission (`201`/`202`/`200`).
+A `429` is returned if the submitting TRANSACTOR is over its
+`MAX_PENDING_PER_TRANSACTOR` in-flight quota; a `503` if the global mempool
+(`MAX_PENDING_TXNS`) is full.
+
+### `GET /api/transaction/<txid>` — READER
+
+Returns the provenance and confirmation status of a transaction, whether it is
+canonical (mined into the longest chain) or still pending.
+
+### Transaction builders — TRANSACTOR
+
+These endpoints **build and return an unsigned transaction** for the supplied
+public key. The caller signs it with the corresponding private key and submits
+it via `POST /api/transaction/<txid>`. They never move funds themselves. All
+take the signer's `public_key` (base64 SubjectPublicKeyInfo) as a query
+parameter; amounts are in grains.
+
+| Endpoint | Extra query params | Builds |
+| --- | --- | --- |
+| `GET /api/transaction/transfer` | `amount`, `address` | Transfer `amount` to another address |
+| `GET /api/transaction/split` | `denomination`, `count` (1–49) | Mint `count` same-address chips of `denomination` each |
+| `GET /api/transaction/opposition` | `amount`, `subject` (raw) | Stake `amount` of opposition on `subject` |
+| `GET /api/transaction/support` | `amount`, `subject` (raw) | Stake `amount` of support on `subject` |
+| `GET /api/transaction/rescind` | `amount`, `subject` (raw), `kind` (`opposition`\|`support`) | Rescind a prior stake |
+
+The `subject` parameter is the raw (unencoded) UTF-8 string (1–79 chars); the
+node encodes it.
+
+### `GET /api/transaction/pending?earliest=<iso8601>` — READER
+
+Returns the current mempool as an array of pending transactions, excluding any
+already confirmed or expired. The optional `earliest` filter returns only
+transactions submitted at or after the given ISO-8601 timestamp.
+
+## Balances and subjects — READER
+
+### `GET /api/signing-key/<address>/balance`
+
+Returns `{"balance": <grains>, "as_of_block": <hash>}` for an address.
+
+### `GET /api/subject/<subject>/opposition` · `.../support`
+
+Returns `{"opposition": <grains>, "as_of_block": <hash>}` (or `"support"`) for
+a subject. `<subject>` is URL-path-encoded.
+
+### `GET /api/subjects/search?q=<prefix>&limit=<n>`
+
+Case-insensitive prefix search over subjects, ranked by total GRIT at stake.
+`limit` is clamped by the node to 1–50 (default 8). Returns
+`{"subjects": [{"subject", "opposition", "support"}, ...], "as_of_block": <hash>}`
+with amounts in grains.
+
+## Stats — READER
+
+### `GET /api/stats/transactors`
+
+Returns `{"transactors": [{"address", "count", "last_submit_at"}, ...]}` — a
+per-relay leaderboard of how many transactions each submitter has been
+attributed (node-local accounting, first-submitter-wins; **not** consensus
+data).
+
+## Browser-facing proxy relay
+
+For consumer web apps that want to let a browser build, sign, and submit
+transactions without exposing the node host or holding a relay key
+client-side, GumptionChain ships an **embeddable** Flask blueprint,
+`node_proxy_blueprint` (see [node-proxy.md](node-proxy.md)). It is a library
+helper an app mounts itself — it is **not** part of a node's default surface.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,87 @@
+# CLI Reference
+
+GumptionChain installs a `gumptionchain` command (with a shorter `gc` alias).
+It is a Flask-aware CLI: it loads your application via `FLASK_APP` and reads
+configuration from the environment and `.env` (see
+[configuration.md](configuration.md)).
+
+Run `gumptionchain --help` for the live command tree, or
+`gumptionchain <command> --help` for any command's options. This document
+summarizes the commands and their arguments.
+
+Global options (before the command): `-e/--env-file FILE`, `-A/--app
+IMPORT`, `--debug/--no-debug`, `--version`.
+
+## Node lifecycle
+
+| Command | Description |
+| --- | --- |
+| `gumptionchain init` | Initialize the database (applies all migrations). |
+| `gumptionchain run` | Run the Flask development server (`:5000`). |
+| `gumptionchain validate` | Validate the node's block chain. |
+| `gumptionchain export FILE` | Export the chain to a JSON Lines file (appends if it exists). |
+| `gumptionchain import FILE` | Bulk-load blocks from a JSON Lines export (idempotent). |
+| `gumptionchain sync` | Synchronize the chain from configured peers (READER access). |
+| `gumptionchain routes` | Show the app's registered routes. |
+| `gumptionchain shell` | Open a Python shell in the app context. |
+
+### `gumptionchain mill ADDRESS`
+
+Start a milling (proof-of-work) process, paying coinbase rewards to `ADDRESS`.
+
+| Option | Description |
+| --- | --- |
+| `-m, --multi` | Use multiprocessing across CPUs when hashing. |
+| `-r, --rounds N` | Rounds of milling between new-block checks (default 1). |
+| `-s, --size N` | Hashes per round, per CPU when multiprocessing (default 100000). |
+| `-w, --signing_key PATH` | Signing-key file for coinbase rewards. |
+| `-p, --peer TEXT` | Peer to poll before checking for new blocks/transactions. |
+| `-b, --blocks N` | Stop after N blocks (default 0 = run forever). |
+
+## `gumptionchain db` — migrations
+
+A passthrough to Flask-Migrate / Alembic. Common subcommands:
+
+| Command | Description |
+| --- | --- |
+| `db upgrade` | Apply migrations (also run by `init`). |
+| `db migrate -m "msg"` | Autogenerate a new revision (hand-review before committing). |
+| `db check` | Fail if models drift from the migration history (CI gate). |
+| `db current` | Show the current revision. |
+| `db history` | List revisions chronologically. |
+
+## `gumptionchain signing-key`
+
+| Command | Description |
+| --- | --- |
+| `signing-key create [-d DIR]` | Create a new signing-key PEM file (defaults to the configured key dir). |
+| `signing-key balance ADDRESS` | Print an address's balance in GRIT. |
+
+## `gumptionchain subject`
+
+Query subject stakes. `SUBJECT` is always the raw (unencoded) string.
+
+| Command | Description |
+| --- | --- |
+| `subject opposition SUBJECT` | Opposition total (opposition minus rescinds), in GRIT. |
+| `subject support SUBJECT` | Support total, in GRIT. |
+| `subject search QUERY [-n LIMIT]` | Prefix-search subjects ranked by total GRIT at stake (limit clamped to 1–50, default 8). |
+
+## `gumptionchain txn` — create transactions
+
+All `txn` commands build, sign, and post a transaction. Amounts are GRIT
+(floats accepted). Common options: `-t/--txn-signing_key PATH` (source key),
+`-h/--host TEXT` (API host), `-w/--signing_key PATH` (API-auth key),
+`-y/--yes` (non-interactive).
+
+| Command | Arguments | Description |
+| --- | --- | --- |
+| `txn transfer` | `FROM_ADDRESS AMOUNT TO_ADDRESS` | Transfer GRIT to another address. |
+| `txn split` | `FROM_ADDRESS COUNT DENOMINATION_GRIT` | Split a balance into `COUNT` same-address chips (1–49) of `DENOMINATION_GRIT` each. |
+| `txn opposition` | `ADDRESS AMOUNT SUBJECT` | Stake opposition on a subject. |
+| `txn support` | `ADDRESS AMOUNT SUBJECT` | Stake support on a subject. |
+| `txn rescind` | `ADDRESS AMOUNT SUBJECT --kind {opposition,support}` | Rescind a prior stake. |
+
+The `split` command mints fixed-size "chips" so a busy key can spend without
+waiting on change confirmations — a key's spend concurrency equals its number
+of unspent outputs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,81 @@
+# Configuration Reference
+
+GumptionChain reads configuration from environment variables, conventionally
+placed in a `.env` file in the working directory (loaded automatically via
+[python-dotenv](https://pypi.org/project/python-dotenv/)). There are two
+layers:
+
+1. **`FLASK_*`** variables are injected into `app.config` with the `FLASK_`
+   prefix stripped (Flask's `from_prefixed_env`). This is how Flask and
+   extension settings such as `SECRET_KEY` and `SQLALCHEMY_DATABASE_URI` are
+   set.
+2. **`GC_*`** variables are parsed into the node's own settings. Values are
+   **JSON-parsed when possible**, so list and boolean settings must be valid
+   JSON strings (e.g. `GC_PEERS='["https://..."]'`,
+   `GC_API_ASYNC_PROCESSING=true`).
+
+## Flask settings
+
+| Variable | Description |
+| --- | --- |
+| `FLASK_APP` | The application import name. Set to `gumptionchain`. |
+| `FLASK_SECRET_KEY` | A unique random string. Required by Flask for session/CSRF infrastructure. |
+| `FLASK_SQLALCHEMY_DATABASE_URI` | SQLAlchemy database URL (e.g. `sqlite:///gc.sqlite`, or a `postgresql+pg8000://…` URL). |
+
+A minimal `.env`:
+
+```ini
+FLASK_APP=gumptionchain
+FLASK_SECRET_KEY=change-me-to-a-random-string
+FLASK_SQLALCHEMY_DATABASE_URI=sqlite:///gc.sqlite
+```
+
+## Node settings (`GC_*`)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GC_NODE_HOST` | — | This node's own host URL, `http(s)://<address>@host`. The `<address>` is the local signing-key address this node signs *as*; auth signatures are bound to this host. |
+| `GC_PEERS` | `[]` | JSON list of peer URLs `http(s)://<address>@host`. `host` is the peer; `<address>` is the **local** signing-key address this node signs as when talking to that peer. |
+| `GC_DEFAULT_COMMAND_HOST` | — | Default API host for CLI commands. |
+| `GC_SIGNING_KEY_DIR` | — | Directory walked at startup; every `*.pem` is loaded as an in-memory signing key, keyed by address. |
+| `GC_API_CLIENT_TIMEOUT` | `10` | Per-request timeout (seconds) for outgoing peer calls. |
+| `GC_API_ASYNC_PROCESSING` | `false` | When `true`, block/txn POSTs return `202` and finish gossip work via a Celery task. |
+| `GC_MAX_CHAIN_FILL_DEPTH` | `50000` | Caps a single `fill_chain` ancestor walk. |
+| `GC_FORK_PRUNE_DEPTH` | `100` | Depth bound for fork pruning. |
+| `GC_SYNC_BATCH_SIZE` | `256` | Max blocks returned by `/api/blocks` and pulled per sync batch. |
+| `GC_MAX_PENDING_TXNS` | `10000` | Global mempool admission cap. A full pool returns HTTP `503`. |
+| `GC_MAX_PENDING_PER_TRANSACTOR` | `100` | Per-TRANSACTOR in-flight (unconfirmed) txn cap. Over-cap returns HTTP `429`. MILLER/ADMIN are exempt. |
+
+## Role allowlists
+
+Roles form the hierarchy `READER` < `TRANSACTOR` < `MILLER` < `ADMIN`. Each
+variable is a JSON list of exact signing-key addresses. An address may appear
+in several lists; the highest matching role wins. Roles are re-checked on
+every request, so changes take effect immediately (after a config reload).
+
+| Variable | Notes |
+| --- | --- |
+| `GC_READER_ADDRESSES` | May contain the literal `"*"` to grant READER to any authenticated key. |
+| `GC_TRANSACTOR_ADDRESSES` | May contain `"*"` (open submission), but an **exact allowlist of relay addresses is the recommended posture** — the wildcard reopens the spam frontier. Gating exposes load, not theft. |
+| `GC_MILLER_ADDRESSES` | Exact addresses only. Required for peer block gossip. |
+| `GC_ADMIN_ADDRESSES` | Exact addresses only. |
+
+Invalid configurations are rejected at startup: a non-address entry, or a
+`"*"` outside `READER_ADDRESSES`/`TRANSACTOR_ADDRESSES`, raises an
+`InvalidRoleConfigError`.
+
+## Joining a network
+
+To participate in an existing network, your instance needs MILLER or
+TRANSACTOR access to a node, granted by that node's operator listing your
+address in its allowlist. Configure that node as a peer:
+
+```ini
+GC_NODE_HOST=http://GCYourAddressGC@localhost:5000
+GC_PEERS=["https://GCYourAddressGC@peer.example.com"]
+GC_DEFAULT_COMMAND_HOST=https://GCYourAddressGC@peer.example.com
+GC_SIGNING_KEY_DIR=/path/to/signing_keys
+```
+
+`GCYourAddressGC` is your signing-key address; the directory holds your key's
+PEM file. Restart to load the new configuration.

--- a/docs/node-proxy.md
+++ b/docs/node-proxy.md
@@ -1,0 +1,65 @@
+# Browser-Facing Node Proxy
+
+`node_proxy_blueprint` (in
+[`node_proxy.py`](../src/gumptionchain/node_proxy.py)) is an **embeddable Flask
+blueprint** for consumer web apps. It lets a browser build, sign, and submit
+GumptionChain transactions without exposing the node host or holding a relay
+key in client-side code.
+
+It is a **library helper an app mounts itself** — it is not part of a
+GumptionChain node's default API surface. The relay holds no signing key
+itself; the app supplies a configured `ApiClient` (node host + a
+TRANSACTOR/READER key), and the relay converts GRIT↔grains, validates
+subjects, and maps node errors to clean JSON.
+
+## Mounting
+
+```python
+from gumptionchain import node_proxy_blueprint
+
+app.register_blueprint(
+    node_proxy_blueprint(
+        make_client,            # () -> configured ApiClient (node host + key)
+        url_path='/api/node',   # mount prefix (default)
+        rate_limit=my_limiter,  # optional: (request) -> bool
+        max_body_bytes=65536,   # optional request-size guard
+    )
+)
+```
+
+`make_client` is called per request, so it can pick a key based on app state
+(e.g. a per-game house key). Requests exceeding `max_body_bytes` get `413`; a
+`rate_limit` returning `False` gets `429`.
+
+## Routes (relative to `url_path`)
+
+Unlike the raw node API, **amounts here are in GRIT** — the relay converts to
+grains before calling the node.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/balance/<address>` | Address balance, in GRIT. |
+| GET | `/subject/balances?subject=<raw>` | A subject's support and opposition, in GRIT. |
+| GET | `/subject/search?q=<prefix>&limit=<n>` | Prefix-search subjects (amounts in GRIT). |
+| POST | `/txn/support` | Build an unsigned support txn. |
+| POST | `/txn/oppose` | Build an unsigned opposition txn. |
+| POST | `/txn/transfer` | Build an unsigned transfer txn. |
+| POST | `/txn/split` | Build an unsigned self-split txn. |
+| POST | `/txn/submit` | Submit a client-signed transaction. |
+| GET | `/txn/<txid>/status` | Report `pending` or `milled` (with block + confirmations). |
+
+### Build request bodies (JSON)
+
+- **support / oppose:** `{"public_key", "subject", "amount_grit"}`
+- **transfer:** `{"public_key", "to_address", "amount_grit"}`
+- **split:** `{"public_key", "denomination_grit", "count"}` (`count` a positive integer)
+
+Each build endpoint returns the **unsigned** transaction JSON. The client signs
+it locally and submits it back via `POST /txn/submit` with
+`{"signed": {<the signed txn, including txid and signature>}}`.
+
+This server-builds / client-signs split keeps private keys in the browser
+(never on the relay) while keeping the node host and relay credentials on the
+server. See the
+[transact UI extension seam](ui-extension-seam.md) for how the base explorer
+and a themed host app layer on top of this.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,11 @@ gumptionchain = "gumptionchain:cli"
 gc = "gumptionchain:cli"
 
 [project.urls]
-Homepage = "https://gumption.com/chain"
-Documentation = "https://gumption.com/chain/docs"
+Homepage = "https://github.com/gumptionthomas/gumptionchain"
+Documentation = "https://github.com/gumptionthomas/gumptionchain/blob/main/docs/README.md"
 Source = "https://github.com/gumptionthomas/gumptionchain"
 Tracker = "https://github.com/gumptionthomas/gumptionchain/issues"
+Changelog = "https://github.com/gumptionthomas/gumptionchain/blob/main/CHANGELOG.md"
 
 # DEPENDENCY GROUPS (PEP 735)
 [dependency-groups]


### PR DESCRIPTION
## Summary

Workstreams **B** + **C** of the pre-1.0 release prep: replace the stale
cancelchain-lineage documentation links with in-repo markdown reference docs.

> **Depends on #302** — the new README links to `CONTRIBUTING.md` and the
> canonical `MIT LICENSE`, both of which land in #302. Merge #302 first; then
> these repo-relative links resolve on `main`.

## Changes

- **README rewrite** — drops the 14 dead
  `gumption.com/chain/docs/en/latest/*.html` Sphinx links and the
  home/docs/blog links (the cancelchain cruft), links to the new in-repo docs,
  standardizes the access contact to `thomas@gumption.com`, and adds a License
  section.
- **`docs/api-reference.md`** — every `/api` endpoint, its minimum role, and
  request/response shapes; links to `api-auth-protocol.md` for signing.
- **`docs/cli-reference.md`** — the full `gumptionchain` command tree (captured
  from `--help`): lifecycle, `mill`, `db`, `signing-key`, `subject`, `txn`.
- **`docs/configuration.md`** — `FLASK_*` and `GC_*` settings, role allowlists,
  joining a network.
- **`docs/node-proxy.md`** — the embeddable browser-facing relay blueprint for
  app builders (documented as a library helper, not a default node endpoint).
- **`docs/README.md`** — indexes the new reference docs.
- **`pyproject.toml` `[project.urls]`** — Homepage/Documentation now point at
  the repo and in-repo docs (were dead `gumption.com/chain` URLs); adds a
  Changelog URL.

## Accuracy

API paths/roles read from `src/gumptionchain/api.py`; CLI usage captured
directly from `gumptionchain <cmd> --help`; config from
`src/gumptionchain/config.py`. No source code changed.

## How to test

```console
$ uv run pytest tests/test_no_legacy_key_vocabulary.py   # README is gate-scanned
$ git grep -nE "gumption\.com/chain|cancelchain" -- . ':!docs/superpowers'
```

(The only remaining `cancelchain` match is the historical commit comment in
`.git-blame-ignore-revs`, which is correct to keep.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)