### PR TITLE
docs: soften internal roadmap jargon in consumer-facing surfaces

### DIFF
--- a/clients/signing-key/MANUAL-VERIFICATION.md
+++ b/clients/signing-key/MANUAL-VERIFICATION.md
@@ -47,7 +47,7 @@ Real behavior is verified by hand using `passkey-signing-key-demo.html`:
 
 6. **Clear.** Click **Clear** and confirm the record is removed from IndexedDB.
 
-## Backup / recovery (#2.3)
+## Backup / recovery
 
 The backup crypto (`gc-backup.mjs` — PBKDF2-SHA256 → AES-GCM-256, plus the
 raw-string path) is fully covered by `node --test`. Only the browser glue in the
@@ -68,7 +68,7 @@ demo page (file download/upload, passphrase prompt, clipboard) is manual:
 6. Click **Show raw key**, copy it; reload; paste into the import textarea and
    click **Import raw key** — confirm the address matches.
 
-## Message signing (#2.4)
+## Message signing
 
 The `gc-msg-v1` crypto (`gc-message.mjs` — canonical, sign/verify, armored) is
 fully covered by `node --test` and by JS↔Python parity + golden-vector tests.
@@ -87,7 +87,7 @@ manual:
 5. Tamper a character inside the JSON `message` field and verify; confirm
    `valid: false, reason: bad-signature`.
 
-## Stake attestation (#176b)
+## Stake attestation
 
 Composes gc-msg-v1 signing with on-chain provenance. Verification fetches
 `GET /api/transaction/<txid>` from the node, so point the demo at a node where

--- a/clients/signing-key/README.md
+++ b/clients/signing-key/README.md
@@ -135,8 +135,8 @@ IndexedDB) are covered by `MANUAL-VERIFICATION.md`.
 
 ## Extracting to its own repo / hosting
 
-The signing_key is packaged in place today. To move it to a dedicated repo or into
-the gumption.com hub (EGU #5):
+The signing_key is packaged in place today. To move it to a dedicated repo or
+embed it in a host web application:
 
 1. Copy `clients/signing-key/` to the new location. It is self-contained — the
    public surface has no imports outside this directory.

--- a/clients/signing-key/gc-attestation.mjs
+++ b/clients/signing-key/gc-attestation.mjs
@@ -206,7 +206,7 @@ function outflowMatches(outflows, claim) {
   );
 }
 
-// fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
+// fetchProvenance(txid) MUST resolve to the provenance object, or null
 // for an unknown txn. The verifier performs no transport itself; mapping a
 // 404 to null is the injected adapter's job. Genuine transport errors (e.g. a
 // network failure) propagate by design — they must NOT be misreported as

--- a/clients/signing-key/gc-attestation.test.mjs
+++ b/clients/signing-key/gc-attestation.test.mjs
@@ -12,7 +12,7 @@ const TS = '1700002000';
 const TX = '1'.repeat(64);
 const CLAIM = { txid: TX, kind: 'opposition', subject: 'goblins', amount: 300 };
 
-// A provenance object shaped like #176a's GET /transaction/<txid> response.
+// A provenance object shaped like the GET /transaction/<txid> response.
 function provenanceFor(address, { status = 'canonical', confirmations = 3 } = {}) {
   return {
     txid: TX, address, status, confirmations,

--- a/clients/signing-key/gc-backup.mjs
+++ b/clients/signing-key/gc-backup.mjs
@@ -8,7 +8,7 @@ import { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
 import { sealWithKey, openWithKey } from './gc-envelope.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 
-// VERSION 2: the signing-key rename (EGU #265) changed BACKUP_KIND. Bumping
+// VERSION 2: the signing-key rename changed BACKUP_KIND. Bumping
 // the format version makes any pre-rename backup fail loudly on import rather
 // than decode ambiguously against the new kind string.
 const BACKUP_VERSION = 2;
@@ -107,7 +107,7 @@ export async function importEncrypted(backup, passphrase) {
 }
 
 // Raw-string backup: the b58 private key itself. At-rest protection is the
-// user's password manager. Thin, documented wrappers over the #2.1 key seam so
+// user's password manager. Thin, documented wrappers over the key seam so
 // all backup surface lives in one module.
 export async function exportPlain(signing_key) {
   return signing_key.exportPrivateKeyB58();

--- a/clients/signing-key/gc-keyring.mjs
+++ b/clients/signing-key/gc-keyring.mjs
@@ -34,8 +34,8 @@ import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 
-// VERSION 2: the encrypted-key field name changed in the signing-key rename
-// (EGU #265). Bumping the record version makes any pre-rename record fail
+// VERSION 2: the encrypted-key field name changed in the signing-key rename.
+// Bumping the record version makes any pre-rename record fail
 // loudly on read rather than silently miss the renamed field.
 const VERSION = 2;
 const SALT_BYTES = 16;

--- a/clients/signing-key/passkey-signing-key-demo.html
+++ b/clients/signing-key/passkey-signing-key-demo.html
@@ -73,7 +73,7 @@
       <button id="import-raw">Import raw key</button>
     </p>
 
-    <h2>Sign message (#2.4)</h2>
+    <h2>Sign message</h2>
     <p class="hint">
       Signs arbitrary text into a portable <code>gc-msg-v1</code> proof using
       <code>currentSigningKey</code>. Verifies off-chain in JS and Python.
@@ -96,7 +96,7 @@
                 readonly placeholder="armored proof appears here"></textarea>
     </p>
 
-    <h2>Verify message (#2.4)</h2>
+    <h2>Verify message</h2>
     <p class="hint">
       Paste either the JSON proof or the armored block; verification is
       self-contained (no signing_key required).
@@ -109,7 +109,7 @@
       <button id="verify-msg">Verify message</button>
     </p>
 
-    <h2>Stake attestation (#176b)</h2>
+    <h2>Stake attestation</h2>
     <p class="hint">
       Builds a "Verified on GumptionChain" stake claim, signs it with
       <code>currentSigningKey</code> into a <code>gc-msg-v1</code> proof, then

--- a/src/gumptionchain/attestation.py
+++ b/src/gumptionchain/attestation.py
@@ -237,7 +237,7 @@ def verify_stake(
     max_age: int | None = None,
     min_confirmations: int | None = None,
 ) -> dict[str, Any]:
-    # fetch_provenance(txid) MUST return the #176a provenance dict, or None for
+    # fetch_provenance(txid) MUST return the provenance dict, or None for
     # an unknown txn; mapping a 404 to None is the injected adapter's job.
     # Genuine transport errors propagate by design — they must NOT be
     # misreported as 'txn-not-found' (which would mark a real canonical stake

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -58,7 +58,8 @@ GENESIS_HASH = mill_hash_str('GENESIS')
 # too-hard floor would stall genesis. Re-derive with
 # scripts/benchmark_max_target.py if the baseline hardware changes.
 MAX_TARGET = '0' * 5 + 'F' * 59
-# EGU 1b: flat 5-GRIT non-halving reward, 5-min blocks, 24-block retarget.
+# Reward and timing: flat 5-GRIT non-halving reward, 5-min blocks,
+# 24-block retarget.
 REWARD = 5 * GRAIN_PER_GRIT
 TARGET_GOAL_SECONDS = 300
 TARGET_INTERVAL = 24

--- a/src/gumptionchain/provenance.py
+++ b/src/gumptionchain/provenance.py
@@ -11,7 +11,7 @@ from gumptionchain.node import Node
 def lookup_provenance(txid: str) -> dict[str, Any] | None:
     """Public, in-process provenance lookup — the same data the authed
     /api/transaction/<txid> view returns, minus authentication. Returns the
-    #176a provenance dict, or None if the txn is unknown.
+    provenance dict, or None if the txn is unknown.
 
     Resolves the longest chain via Node directly (mirroring
     browser.longest_chain) rather than the API layer, to avoid an upward

--- a/src/gumptionchain/static/signing-key/gc-attestation.mjs
+++ b/src/gumptionchain/static/signing-key/gc-attestation.mjs
@@ -206,7 +206,7 @@ function outflowMatches(outflows, claim) {
   );
 }
 
-// fetchProvenance(txid) MUST resolve to the #176a provenance object, or null
+// fetchProvenance(txid) MUST resolve to the provenance object, or null
 // for an unknown txn. The verifier performs no transport itself; mapping a
 // 404 to null is the injected adapter's job. Genuine transport errors (e.g. a
 // network failure) propagate by design — they must NOT be misreported as

--- a/src/gumptionchain/static/signing-key/gc-backup.mjs
+++ b/src/gumptionchain/static/signing-key/gc-backup.mjs
@@ -8,7 +8,7 @@ import { BadBackupError, BadPassphraseError } from './gc-errors.mjs';
 import { sealWithKey, openWithKey } from './gc-envelope.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 
-// VERSION 2: the signing-key rename (EGU #265) changed BACKUP_KIND. Bumping
+// VERSION 2: the signing-key rename changed BACKUP_KIND. Bumping
 // the format version makes any pre-rename backup fail loudly on import rather
 // than decode ambiguously against the new kind string.
 const BACKUP_VERSION = 2;
@@ -107,7 +107,7 @@ export async function importEncrypted(backup, passphrase) {
 }
 
 // Raw-string backup: the b58 private key itself. At-rest protection is the
-// user's password manager. Thin, documented wrappers over the #2.1 key seam so
+// user's password manager. Thin, documented wrappers over the key seam so
 // all backup surface lives in one module.
 export async function exportPlain(signing_key) {
   return signing_key.exportPrivateKeyB58();

--- a/src/gumptionchain/static/signing-key/gc-keyring.mjs
+++ b/src/gumptionchain/static/signing-key/gc-keyring.mjs
@@ -34,8 +34,8 @@ import { sealWithKey, openWithKey, deriveAesKey } from './gc-envelope.mjs';
 import { deriveKey } from './gc-backup.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 
-// VERSION 2: the encrypted-key field name changed in the signing-key rename
-// (EGU #265). Bumping the record version makes any pre-rename record fail
+// VERSION 2: the encrypted-key field name changed in the signing-key rename.
+// Bumping the record version makes any pre-rename record fail
 // loudly on read rather than silently miss the renamed field.
 const VERSION = 2;
 const SALT_BYTES = 16;


### PR DESCRIPTION
## Summary

Pre-1.0 cleanup: remove internal private-spec numbering from the surfaces a
public reader or a consumer of the signing-key client actually encounters,
keeping the surrounding meaning intact.

The guiding distinction: **GitHub issue numbers are plain integers** (`#208`,
`#262`). Anything with a decimal or letter suffix (`#2.1`, `#176b`) or an `EGU`
prefix is a reference into a *private* spec/tracker — meaningless to a public
reader — so it's removed. Three families:

| Family | Example | Action |
| --- | --- | --- |
| EGU tags | `(EGU #5)`, `(EGU #265)`, `EGU 1b:` | removed / rephrased |
| Decimal sub-tasks | `the #2.1 key seam`, `(#2.3)`, `(#2.4)` | removed |
| Integer+letter sub-tasks | `#176a`, `(#176b)` | removed |

### Files
- `clients/signing-key/`: `README.md`, `gc-backup.mjs`, `gc-keyring.mjs`,
  `gc-attestation.mjs`, `gc-attestation.test.mjs`, `MANUAL-VERIFICATION.md`,
  `passkey-signing-key-demo.html`.
- `src/gumptionchain/`: `chain.py`, `attestation.py`, `provenance.py`.
- `src/gumptionchain/static/signing-key/*`: re-synced vendored copies
  (byte-parity enforced by `tests/test_signing_key_vendored.py`).

## Kept deliberately

- **Plain-integer `#NNN`** references throughout `src/` and `tests/` — real
  links to this repo's public GitHub issues/PRs, standard OSS provenance.
- **`CLAUDE.md`** (internal contributor/dev guide) and test docstrings.

## How to test

```console
$ uv run pytest tests/test_signing_key_vendored.py
$ git grep -nIE "EGU|#[0-9]+\.[0-9]+|#[0-9]+[a-z]" -- clients src ':!docs/superpowers'
# -> only false positive is a #2f7d32 hex color in favicon-node.svg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)