### PR TITLE
feat(sdk): cross-origin passkey discovery (discover())

### DIFF
--- a/clients/sdk/MANUAL-VERIFICATION.md
+++ b/clients/sdk/MANUAL-VERIFICATION.md
@@ -124,3 +124,18 @@ sets `READER_ADDRESSES=["*"]`).
   authenticator (a platform passkey in recent Chrome/Safari, a phone passkey
   via hybrid, or a hardware key with `hmac-secret`). Note the Bitwarden
   extension does **not** export PRF to external RPs.
+
+## Cross-origin discovery
+
+`discover()` is unit-tested with a faked `navigator`; verify the real WebAuthn
+path by hand:
+
+1. Enroll a passkey on the demo page (creates a discoverable credential).
+2. Reload (or open a second tab on the same `rpId`) and call
+   `makeWebauthnPasskey({ rpId }).discover()` from the console.
+3. Confirm it resolves to `{ credentialId, prfOutput }` after one ceremony, with
+   the same `credentialId` as enrollment.
+4. Call `discover()` and **cancel** the prompt — confirm it resolves to `null`
+   (not a throw).
+5. On a browser exposing `PublicKeyCredential.isConditionalMediationAvailable`,
+   confirm `isConditionalAvailable()` resolves `true`; on one without it, `false`.

--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -107,7 +107,7 @@ const result = await verifyMessage(fromArmored(armored));
 | `SigningKey` | keygen, key import/export, address, sign, verify-only via `fromPublicKeyB64` |
 | `canonical`, `signHeaders` | `gc-sig-v1` request signing |
 | `enroll`, `unlock`, `hasSigningKey`, `clear` | passkey-anchored storage orchestration |
-| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters |
+| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters; the passkey adapter also exposes `discover({ mediation })` / `isConditionalAvailable()` |
 | `exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain` | backup/recovery |
 | `signMessage`, `verifyMessage`, `toArmored`, `fromArmored` | `gc-msg-v1` message signing |
 | `UnsupportedError`, `NoSigningKeyError`, `BadBackupError`, `BadPassphraseError`, `BadProofError` | typed errors |
@@ -115,9 +115,24 @@ const result = await verifyMessage(fromArmored(armored));
 
 Anything not listed is internal/unstable.
 
+### Cross-origin passkey discovery
+
+`makeWebauthnPasskey({ rpId }).discover({ mediation })` finds an **existing**
+discoverable passkey for `rpId` on a fresh origin (no prior local state) and
+returns `{ credentialId, prfOutput }`, or `null` if none is found or the user
+dismisses. `mediation: 'optional'` (default) is a modal prompt; `'conditional'`
+is passkey autofill — for which the **consumer** supplies the
+`<input autocomplete="webauthn">` (the SDK stays DOM-free). Feature-detect with
+`isConditionalAvailable()`. `makeOnboarding(...)` exposes the same `discover()`.
+
+This is the base primitive for hub-brokered "Sign in with Gumption" recognition.
+**It yields recognition + unlock authority (the PRF), not the key bytes** — the
+encrypted key blob is origin-scoped and not re-derivable from the PRF, so the
+material itself still comes from the hub-served store or a user backup.
+
 ## Versioning
 
-`version` is the **package** semver (currently `0.1.0`, pre-launch — the
+`version` is the **package** semver (pre-1.0, pre-launch — the
 embedder API is not yet frozen). It is **independent** of the wire scheme ids
 `gc-sig-v1` and `gc-msg-v1`, which are protocol identifiers bound into
 signatures and change only on a protocol revision.

--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -123,7 +123,7 @@ returns `{ credentialId, prfOutput }`, or `null` if none is found or the user
 dismisses. `mediation: 'optional'` (default) is a modal prompt; `'conditional'`
 is passkey autofill — for which the **consumer** supplies the
 `<input autocomplete="webauthn">` (the SDK stays DOM-free). Feature-detect with
-`isConditionalAvailable()`. `makeOnboarding(...)` exposes the same `discover()`.
+`isConditionalAvailable()`. For conditional mediation in a single-page app, pass a `signal` from an `AbortController` and abort it on route changes to cancel the autofill session. `makeOnboarding(...)` exposes the same `discover()`.
 
 This is the base primitive for hub-brokered "Sign in with Gumption" recognition.
 **It yields recognition + unlock authority (the PRF), not the key bytes** — the

--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -107,7 +107,7 @@ const result = await verifyMessage(fromArmored(armored));
 | `SigningKey` | keygen, key import/export, address, sign, verify-only via `fromPublicKeyB64` |
 | `canonical`, `signHeaders` | `gc-sig-v1` request signing |
 | `enroll`, `unlock`, `hasSigningKey`, `clear` | passkey-anchored storage orchestration |
-| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters; the passkey adapter also exposes `discover({ mediation })` / `isConditionalAvailable()` |
+| `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters; the passkey adapter also exposes `discover({ mediation, signal })` / `isConditionalAvailable()` |
 | `exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain` | backup/recovery |
 | `signMessage`, `verifyMessage`, `toArmored`, `fromArmored` | `gc-msg-v1` message signing |
 | `UnsupportedError`, `NoSigningKeyError`, `BadBackupError`, `BadPassphraseError`, `BadProofError` | typed errors |
@@ -123,7 +123,10 @@ returns `{ credentialId, prfOutput }`, or `null` if none is found or the user
 dismisses. `mediation: 'optional'` (default) is a modal prompt; `'conditional'`
 is passkey autofill — for which the **consumer** supplies the
 `<input autocomplete="webauthn">` (the SDK stays DOM-free). Feature-detect with
-`isConditionalAvailable()`. For conditional mediation in a single-page app, pass a `signal` from an `AbortController` and abort it on route changes to cancel the autofill session. `makeOnboarding(...)` exposes the same `discover()`.
+`isConditionalAvailable()`. For conditional mediation in a single-page app, pass a `signal` from an `AbortController` and abort it on route changes to cancel the autofill session. `makeOnboarding(...)` exposes the same `discover()`
+when it is configured with a passkey adapter (`rpId` + `rpName`, or an injected
+`passkey`); otherwise it returns `null`. Note `discover()` itself only needs
+`rpId` — `rpName` is required for enrollment, not discovery.
 
 This is the base primitive for hub-brokered "Sign in with Gumption" recognition.
 **It yields recognition + unlock authority (the PRF), not the key bytes** — the

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -18,3 +18,114 @@ test('idb store adapter exposes the store interface', () => {
     assert.equal(typeof store[m], 'function');
   }
 });
+
+// --- discover(): the real WebAuthn path, exercised via a minimal global fake.
+// (enroll/unlock remain manual per MANUAL-VERIFICATION.md; discover carries
+// enough logic — empty allowCredentials, PRF extraction, null-on-dismissal,
+// mediation forwarding — to warrant a unit test.)
+
+function fakeAssertion({ rawId = new Uint8Array([1, 2, 3]), prf = new Uint8Array(32).fill(9) } = {}) {
+  return {
+    rawId,
+    getClientExtensionResults: () => (prf ? { prf: { results: { first: prf } } } : {}),
+  };
+}
+
+// Use property descriptors, not plain assignment: Node 21+ defines `navigator`
+// as a non-writable global, so `globalThis.navigator = …` can throw.
+function setGlobal(name, value) {
+  const prev = Object.getOwnPropertyDescriptor(globalThis, name);
+  if (value === undefined) {
+    delete globalThis[name];
+  } else {
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  }
+  return () => {
+    if (prev) Object.defineProperty(globalThis, name, prev);
+    else delete globalThis[name];
+  };
+}
+
+async function withFakeWebauthn({ getImpl, conditional }, fn) {
+  const calls = [];
+  const restoreNav = setGlobal('navigator', {
+    credentials: { get: async (opts) => { calls.push(opts); return getImpl(opts); } },
+  });
+  let restoreWin = () => {};
+  if (conditional !== undefined) {
+    const PKC = function () {};
+    PKC.isConditionalMediationAvailable = async () => conditional;
+    restoreWin = setGlobal('window', { PublicKeyCredential: PKC });
+  }
+  try {
+    return await fn(calls);
+  } finally {
+    restoreWin();
+    restoreNav();
+  }
+}
+
+test('discover() returns {credentialId, prfOutput}; empty allowCredentials + PRF eval + forwarded mediation', async () => {
+  await withFakeWebauthn({ getImpl: async () => fakeAssertion() }, async (calls) => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    const r = await pk.discover({ mediation: 'conditional' });
+    assert.equal(typeof r.credentialId, 'string');
+    assert.ok(r.prfOutput instanceof Uint8Array);
+    assert.deepEqual(calls[0].publicKey.allowCredentials, []);
+    assert.ok(calls[0].publicKey.extensions.prf.eval.first);
+    assert.equal(calls[0].mediation, 'conditional');
+  });
+});
+
+test('discover() returns null when the user dismisses (NotAllowedError)', async () => {
+  await withFakeWebauthn({
+    getImpl: async () => { const e = new Error('dismissed'); e.name = 'NotAllowedError'; throw e; },
+  }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.discover(), null);
+  });
+});
+
+test('discover() returns null when aborted (AbortError)', async () => {
+  await withFakeWebauthn({
+    getImpl: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; },
+  }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.discover(), null);
+  });
+});
+
+test('discover() returns null when navigator is unavailable', async () => {
+  const restore = setGlobal('navigator', undefined);
+  try {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.discover(), null);
+  } finally {
+    restore();
+  }
+});
+
+test('discover() throws UnsupportedError when the assertion has no PRF', async () => {
+  await withFakeWebauthn({ getImpl: async () => fakeAssertion({ prf: null }) }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    await assert.rejects(() => pk.discover(), /PRF/);
+  });
+});
+
+test('isConditionalAvailable() reflects platform support and never throws', async () => {
+  await withFakeWebauthn({ getImpl: async () => null, conditional: true }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.isConditionalAvailable(), true);
+  });
+  await withFakeWebauthn({ getImpl: async () => null, conditional: false }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.isConditionalAvailable(), false);
+  });
+  const restore = setGlobal('window', undefined);
+  try {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.isConditionalAvailable(), false);
+  } finally {
+    restore();
+  }
+});

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -5,7 +5,7 @@ import { makeIdbStore } from './gc-store-idb.mjs';
 
 test('webauthn passkey adapter exposes the passkey interface', async () => {
   const pk = makeWebauthnPasskey({ rpId: 'example.com', rpName: 'Demo' });
-  for (const m of ['isSupported', 'enroll', 'unlock']) {
+  for (const m of ['isSupported', 'enroll', 'unlock', 'discover', 'isConditionalAvailable']) {
     assert.equal(typeof pk[m], 'function');
   }
   // In Node (no window) isSupported() must resolve false, not throw.
@@ -122,6 +122,44 @@ test('isConditionalAvailable() reflects platform support and never throws', asyn
     assert.equal(await pk.isConditionalAvailable(), false);
   });
   const restore = setGlobal('window', undefined);
+  try {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.isConditionalAvailable(), false);
+  } finally {
+    restore();
+  }
+});
+
+test('discover() returns null when navigator.credentials.get is missing', async () => {
+  const restore = setGlobal('navigator', { credentials: {} });
+  try {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.discover(), null);
+  } finally {
+    restore();
+  }
+});
+
+test('discover() returns null on SecurityError (insecure context)', async () => {
+  await withFakeWebauthn({
+    getImpl: async () => { const e = new Error('insecure'); e.name = 'SecurityError'; throw e; },
+  }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    assert.equal(await pk.discover(), null);
+  });
+});
+
+test('discover() omits signal when it is null or undefined', async () => {
+  await withFakeWebauthn({ getImpl: async () => fakeAssertion() }, async (calls) => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    await pk.discover({ signal: null });
+    assert.ok(!('signal' in calls[0]));
+  });
+});
+
+test('isConditionalAvailable() is false when isConditionalMediationAvailable is absent', async () => {
+  const PKC = function () {};
+  const restore = setGlobal('window', { PublicKeyCredential: PKC });
   try {
     const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
     assert.equal(await pk.isConditionalAvailable(), false);

--- a/clients/sdk/gc-onboarding.mjs
+++ b/clients/sdk/gc-onboarding.mjs
@@ -174,6 +174,13 @@ export function makeOnboarding({
     return signUnsignedTxn(unsigned, key);
   }
 
+  async function discover(opts) {
+    if (!pk || typeof pk.discover !== 'function') {
+      return null;
+    }
+    return pk.discover(opts);
+  }
+
   async function lock() {
     key = null;
     await notify();
@@ -186,7 +193,7 @@ export function makeOnboarding({
   }
 
   return {
-    status, onChange, create, unlock, restore, backup, addPasskey,
+    status, onChange, create, unlock, restore, backup, addPasskey, discover,
     signLogin, signTransaction, lock, forget,
   };
 }

--- a/clients/sdk/gc-onboarding.test.mjs
+++ b/clients/sdk/gc-onboarding.test.mjs
@@ -24,6 +24,7 @@ function fakePasskey(fill = 7, credentialId = 'cred1') {
     isSupported: async () => true,
     enroll: async () => ({ credentialId, prfOutput: PRF }),
     unlock: async () => PRF,
+    discover: async () => ({ credentialId, prfOutput: PRF }),
   };
 }
 
@@ -190,4 +191,16 @@ test('signTransaction: throws when locked; signs a node-built unsigned txn when 
   assert.equal(typeof signed.signature, 'string');
   // The signature is real: it verifies over the canonical signing data.
   assert.equal(await k.verify(signingData(signed), signed.signature), true);
+});
+
+test('discover() delegates to the passkey adapter', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  const r = await onb.discover();
+  assert.equal(r.credentialId, 'cred1');
+  assert.ok(r.prfOutput instanceof Uint8Array);
+});
+
+test('discover() returns null when no passkey adapter is configured', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  assert.equal(await onb.discover(), null);
 });

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -43,14 +43,16 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
   }
 
   async function discover({ mediation = 'optional', signal } = {}) {
-    if (typeof navigator === 'undefined' || !navigator.credentials) {
+    if (typeof navigator === 'undefined'
+        || !navigator.credentials
+        || typeof navigator.credentials.get !== 'function') {
       return null;
     }
     let assertion;
     try {
       assertion = await navigator.credentials.get({
         mediation,
-        ...(signal !== undefined && { signal }),
+        ...(signal != null && { signal }),
         publicKey: {
           rpId,
           challenge: crypto.getRandomValues(new Uint8Array(32)),
@@ -61,7 +63,9 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
       });
     } catch (e) {
       // Dismissal / abort are normal "no passkey selected" outcomes, not errors.
-      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) {
+      if (e && (e.name === 'NotAllowedError'
+          || e.name === 'AbortError'
+          || e.name === 'SecurityError')) {
         return null;
       }
       throw e;

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -42,6 +42,58 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     return out;
   }
 
+  async function discover({ mediation = 'optional', signal } = {}) {
+    if (typeof navigator === 'undefined' || !navigator.credentials) {
+      return null;
+    }
+    let assertion;
+    try {
+      assertion = await navigator.credentials.get({
+        mediation,
+        ...(signal !== undefined && { signal }),
+        publicKey: {
+          rpId,
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          allowCredentials: [],
+          userVerification,
+          extensions: { prf: { eval: { first: PRF_SALT } } },
+        },
+      });
+    } catch (e) {
+      // Dismissal / abort are normal "no passkey selected" outcomes, not errors.
+      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) {
+        return null;
+      }
+      throw e;
+    }
+    if (!assertion) {
+      return null;
+    }
+    const out = prfFirst(assertion);
+    if (!out) {
+      throw new UnsupportedError('passkey PRF not available on assertion');
+    }
+    return {
+      credentialId: b64urlEncode(new Uint8Array(assertion.rawId)),
+      prfOutput: out,
+    };
+  }
+
+  async function isConditionalAvailable() {
+    try {
+      if (typeof window === 'undefined' ||
+          typeof window.PublicKeyCredential !== 'function') {
+        return false;
+      }
+      const fn = window.PublicKeyCredential.isConditionalMediationAvailable;
+      return typeof fn === 'function'
+        ? Boolean(await fn.call(window.PublicKeyCredential))
+        : false;
+    } catch {
+      return false;
+    }
+  }
+
   return {
     async isSupported() {
       return (
@@ -79,5 +131,8 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     },
 
     unlock,
+
+    discover,
+    isConditionalAvailable,
   };
 }

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.2.0';
+export const version = '0.3.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GumptionChain browser SDK — gc-sig-v1 signing, passkey storage, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-onboarding.mjs
+++ b/src/gumptionchain/static/sdk/gc-onboarding.mjs
@@ -174,6 +174,13 @@ export function makeOnboarding({
     return signUnsignedTxn(unsigned, key);
   }
 
+  async function discover(opts) {
+    if (!pk || typeof pk.discover !== 'function') {
+      return null;
+    }
+    return pk.discover(opts);
+  }
+
   async function lock() {
     key = null;
     await notify();
@@ -186,7 +193,7 @@ export function makeOnboarding({
   }
 
   return {
-    status, onChange, create, unlock, restore, backup, addPasskey,
+    status, onChange, create, unlock, restore, backup, addPasskey, discover,
     signLogin, signTransaction, lock, forget,
   };
 }

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -43,14 +43,16 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
   }
 
   async function discover({ mediation = 'optional', signal } = {}) {
-    if (typeof navigator === 'undefined' || !navigator.credentials) {
+    if (typeof navigator === 'undefined'
+        || !navigator.credentials
+        || typeof navigator.credentials.get !== 'function') {
       return null;
     }
     let assertion;
     try {
       assertion = await navigator.credentials.get({
         mediation,
-        ...(signal !== undefined && { signal }),
+        ...(signal != null && { signal }),
         publicKey: {
           rpId,
           challenge: crypto.getRandomValues(new Uint8Array(32)),
@@ -61,7 +63,9 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
       });
     } catch (e) {
       // Dismissal / abort are normal "no passkey selected" outcomes, not errors.
-      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) {
+      if (e && (e.name === 'NotAllowedError'
+          || e.name === 'AbortError'
+          || e.name === 'SecurityError')) {
         return null;
       }
       throw e;

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -42,6 +42,58 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     return out;
   }
 
+  async function discover({ mediation = 'optional', signal } = {}) {
+    if (typeof navigator === 'undefined' || !navigator.credentials) {
+      return null;
+    }
+    let assertion;
+    try {
+      assertion = await navigator.credentials.get({
+        mediation,
+        ...(signal !== undefined && { signal }),
+        publicKey: {
+          rpId,
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          allowCredentials: [],
+          userVerification,
+          extensions: { prf: { eval: { first: PRF_SALT } } },
+        },
+      });
+    } catch (e) {
+      // Dismissal / abort are normal "no passkey selected" outcomes, not errors.
+      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) {
+        return null;
+      }
+      throw e;
+    }
+    if (!assertion) {
+      return null;
+    }
+    const out = prfFirst(assertion);
+    if (!out) {
+      throw new UnsupportedError('passkey PRF not available on assertion');
+    }
+    return {
+      credentialId: b64urlEncode(new Uint8Array(assertion.rawId)),
+      prfOutput: out,
+    };
+  }
+
+  async function isConditionalAvailable() {
+    try {
+      if (typeof window === 'undefined' ||
+          typeof window.PublicKeyCredential !== 'function') {
+        return false;
+      }
+      const fn = window.PublicKeyCredential.isConditionalMediationAvailable;
+      return typeof fn === 'function'
+        ? Boolean(await fn.call(window.PublicKeyCredential))
+        : false;
+    } catch {
+      return false;
+    }
+  }
+
   return {
     async isSupported() {
       return (
@@ -79,5 +131,8 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     },
 
     unlock,
+
+    discover,
+    isConditionalAvailable,
   };
 }

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.2.0';
+export const version = '0.3.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Implements **gumptionchain#310** — the base-SDK enabler for hub-brokered "Sign in with Gumption" recognition (gumption-hub#67).

## What

Adds a `discover()` primitive to the browser SDK that finds an **existing** discoverable passkey on a fresh origin (no prior local state) — the gap that blocked cross-member recognition.

- **`makeWebauthnPasskey({ rpId }).discover({ mediation, signal })`** → `navigator.credentials.get()` with **empty `allowCredentials`** + the shared PRF eval. Returns `{ credentialId, prfOutput }`, or `null` if none found / dismissed / aborted / insecure context. Missing PRF → `UnsupportedError`.
- **Both mediations:** `'optional'` (modal, default) and `'conditional'` (autofill — the consumer supplies the `<input autocomplete="webauthn">`; the SDK stays DOM-free). `isConditionalAvailable()` feature-detects.
- **`makeOnboarding(...).discover()`** thin pass-through.
- Version bump `0.2.0 → 0.3.0`; vendored `static/sdk/` re-synced (parity gate green); docs in the SDK README + `MANUAL-VERIFICATION.md`.

## The caveat (documented)

`discover()` yields **recognition + unlock authority (the PRF), not the key bytes**. The encrypted blob is origin-scoped and not re-derivable from the PRF, so the key material still comes from the hub-served store or a user backup. The README states this so callers don't assume a shared `rpId` moves the key.

## Scope

Discovery primitive only. **Deferred** (hub-driven, #67): `makeRemoteStore`, `unlockByDiscovery`, and Related Origin Requests `/.well-known/webauthn`. Their absence is intentional.

## Robustness (from final review)

`signal != null` (no `null` forwarded to `get()`), `SecurityError` treated as "none" on insecure origins, `navigator.credentials.get` presence guarded, interface-shape test extended, plus tests for each branch and an `AbortController`-lifecycle note for SPA conditional UI.

## Testing

```
node --test clients/sdk/*.test.mjs          # 128 pass
node --test src/gumptionchain/static/js/*.test.mjs   # 61 pass (glue imports ../sdk/)
uv run pytest tests/test_sdk_vendored.py tests/test_static_assets.py tests/test_no_legacy_key_vocabulary.py   # parity/assets/vocab
```

No real WebAuthn in CI (faked `navigator`); the live path is in `clients/sdk/MANUAL-VERIFICATION.md`.

Closes #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)