### PR TITLE
feat(sdk): discover() returns the credential userHandle (#313)

### DIFF
--- a/clients/sdk/MANUAL-VERIFICATION.md
+++ b/clients/sdk/MANUAL-VERIFICATION.md
@@ -133,8 +133,10 @@ path by hand:
 1. Enroll a passkey on the demo page (creates a discoverable credential).
 2. Reload (or open a second tab on the same `rpId`) and call
    `makeWebauthnPasskey({ rpId }).discover()` from the console.
-3. Confirm it resolves to `{ credentialId, prfOutput }` after one ceremony, with
-   the same `credentialId` as enrollment.
+3. Confirm it resolves to `{ credentialId, prfOutput, userHandle }` after one
+   ceremony, with the same `credentialId` as enrollment, and `userHandle` equal
+   to the enrolled `user.id` (the GC address in EGU apps) — or `null` if the
+   credential was enrolled without one.
 4. Call `discover()` and **cancel** the prompt — confirm it resolves to `null`
    (not a throw).
 5. On a browser exposing `PublicKeyCredential.isConditionalMediationAvailable`,

--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -119,8 +119,11 @@ Anything not listed is internal/unstable.
 
 `makeWebauthnPasskey({ rpId }).discover({ mediation })` finds an **existing**
 discoverable passkey for `rpId` on a fresh origin (no prior local state) and
-returns `{ credentialId, prfOutput }`, or `null` if none is found or the user
-dismisses. `mediation: 'optional'` (default) is a modal prompt; `'conditional'`
+returns `{ credentialId, prfOutput, userHandle }`, or `null` if none is found or
+the user dismisses. `userHandle` is the credential's enrolled `user.id` decoded
+as a string (in EGU apps that's the signer's address), or `null` if the
+assertion carries none — so a member can learn *which* identity returned with no
+key material. `mediation: 'optional'` (default) is a modal prompt; `'conditional'`
 is passkey autofill — for which the **consumer** supplies the
 `<input autocomplete="webauthn">` (the SDK stays DOM-free). Feature-detect with
 `isConditionalAvailable()`. For conditional mediation in a single-page app, pass a `signal` from an `AbortController` and abort it on route changes to cancel the autofill session. `makeOnboarding(...)` exposes the same `discover()`

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -32,7 +32,9 @@ function fakeAssertion({
   return {
     rawId,
     response: {
-      userHandle: userHandle == null ? null : new TextEncoder().encode(userHandle),
+      // Real browsers expose userHandle as ArrayBuffer | null — use .buffer so
+      // the mock matches that shape (TextDecoder handles either).
+      userHandle: userHandle == null ? null : new TextEncoder().encode(userHandle).buffer,
     },
     getClientExtensionResults: () => (prf ? { prf: { results: { first: prf } } } : {}),
   };

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -24,9 +24,16 @@ test('idb store adapter exposes the store interface', () => {
 // enough logic — empty allowCredentials, PRF extraction, null-on-dismissal,
 // mediation forwarding — to warrant a unit test.)
 
-function fakeAssertion({ rawId = new Uint8Array([1, 2, 3]), prf = new Uint8Array(32).fill(9) } = {}) {
+function fakeAssertion({
+  rawId = new Uint8Array([1, 2, 3]),
+  prf = new Uint8Array(32).fill(9),
+  userHandle = 'GCdemoaddrGC',
+} = {}) {
   return {
     rawId,
+    response: {
+      userHandle: userHandle == null ? null : new TextEncoder().encode(userHandle),
+    },
     getClientExtensionResults: () => (prf ? { prf: { results: { first: prf } } } : {}),
   };
 }
@@ -74,6 +81,22 @@ test('discover() returns {credentialId, prfOutput}; empty allowCredentials + PRF
     assert.deepEqual(calls[0].publicKey.allowCredentials, []);
     assert.ok(calls[0].publicKey.extensions.prf.eval.first);
     assert.equal(calls[0].mediation, 'conditional');
+  });
+});
+
+test('discover() returns the credential userHandle (the enrolled GC address)', async () => {
+  await withFakeWebauthn({ getImpl: async () => fakeAssertion({ userHandle: 'GCalice123GC' }) }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    const r = await pk.discover();
+    assert.equal(r.userHandle, 'GCalice123GC');
+  });
+});
+
+test('discover() userHandle is null when the assertion carries none', async () => {
+  await withFakeWebauthn({ getImpl: async () => fakeAssertion({ userHandle: null }) }, async () => {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    const r = await pk.discover();
+    assert.equal(r.userHandle, null);
   });
 });
 

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -77,9 +77,14 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     if (!out) {
       throw new UnsupportedError('passkey PRF not available on assertion');
     }
+    // userHandle carries the enrolled user.id — in EGU apps that's the GC
+    // address — so a cross-origin discovery yields *which* identity, with no
+    // key material. Generic at the SDK layer; the consumer interprets it.
+    const uh = assertion.response && assertion.response.userHandle;
     return {
       credentialId: b64urlEncode(new Uint8Array(assertion.rawId)),
       prfOutput: out,
+      userHandle: uh ? new TextDecoder().decode(uh) : null,
     };
   }
 

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.3.0';
+export const version = '0.4.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "GumptionChain browser SDK — gc-sig-v1 signing, passkey storage, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -77,9 +77,14 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     if (!out) {
       throw new UnsupportedError('passkey PRF not available on assertion');
     }
+    // userHandle carries the enrolled user.id — in EGU apps that's the GC
+    // address — so a cross-origin discovery yields *which* identity, with no
+    // key material. Generic at the SDK layer; the consumer interprets it.
+    const uh = assertion.response && assertion.response.userHandle;
     return {
       credentialId: b64urlEncode(new Uint8Array(assertion.rawId)),
       prfOutput: out,
+      userHandle: uh ? new TextDecoder().decode(uh) : null,
     };
   }
 

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.3.0';
+export const version = '0.4.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Implements **#313** — the last base primitive the hub "Sign in with Gumption" recognition MVP (gumption-hub#67) needs.

## What

`makeWebauthnPasskey(...).discover()` now returns `userHandle` alongside `{ credentialId, prfOutput }`. The passkey's `user.id` is set to the GC address at enrollment, so a cross-origin discovery assertion already carries the address — `discover()` just wasn't reading `assertion.response.userHandle`. Now it decodes it (null-guarded) and returns it, so a member sharing the hub RP ID can recognize *which* returning EGU identity it is, with **no key material**.

Kept generic at the SDK layer (it's "the enrolled `user.id`"); the consumer interprets the string as the address.

## Changes

- `discover()` return gains `userHandle: string | null` — additive, existing `{credentialId, prfOutput}` consumers unaffected.
- Tests: `userHandle` returned (decoded), and `null` when the assertion carries none.
- SDK `0.3.0 → 0.4.0`; vendored `static/sdk/` re-synced (parity green); README return-doc updated.

## Scope

Key-type-agnostic and **independent of the Ed25519 work (#312)** — unblocks recognition on RSA today.

## Testing

```
node --test clients/sdk/*.test.mjs   # 130 pass
uv run pytest tests/test_sdk_vendored.py tests/test_static_assets.py tests/test_no_legacy_key_vocabulary.py
```

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)