### PR TITLE
test/docs(gc-sig): Ed25519 auth support (#312 sub-2)

### DIFF
--- a/docs/api-auth-protocol.md
+++ b/docs/api-auth-protocol.md
@@ -32,9 +32,9 @@ Every signed request must include all five of the following headers.
 |---|---|
 | `GC-Sig-Version` | `1` |
 | `GC-Address` | Caller's GC address (e.g. `GC…GC`) |
-| `GC-Public-Key` | Caller's RSA public key, base64-encoded DER SubjectPublicKeyInfo |
+| `GC-Public-Key` | Caller's public key (RSA-2048 or Ed25519), base64-encoded DER SubjectPublicKeyInfo — the algorithm OID identifies the key type |
 | `GC-Timestamp` | Unix time of the request, decimal seconds (e.g. `1748736000`) |
-| `GC-Signature` | Base64 RSASSA-PKCS1-v1_5 / SHA-384 signature over the canonical string |
+| `GC-Signature` | Base64 signature over the canonical string, in the key's native scheme: RSASSA-PKCS1-v1_5 / SHA-384 (RSA) or Ed25519 / RFC 8032 |
 
 The `GC-Public-Key` is **self-certifying**: the server derives the GC address from
 the supplied public key and requires it to equal `GC-Address`. No prior key
@@ -118,19 +118,32 @@ cryptographic configuration, because the canonical strings differ.
 
 ## Signing algorithm
 
-The signature is produced using **RSASSA-PKCS1-v1_5 with SHA-384** over the
-canonical string bytes. The key is the signing_key's RSA-2048 private key. The resulting
-signature bytes are encoded with **standard base64** (not URL-safe base64, using
-`+` and `/`).
+The signature is produced over the canonical string bytes in the key's native
+scheme, then encoded with **standard base64** (not URL-safe, using `+` and `/`):
+
+- **RSA-2048:** RSASSA-PKCS1-v1_5 with SHA-384.
+- **Ed25519:** Ed25519 (RFC 8032; the scheme hashes with SHA-512 internally).
+
+The `GC-Public-Key` (DER SubjectPublicKeyInfo) is self-describing — its
+algorithm OID tells the verifier which scheme to use. Nodes **verify Ed25519
+signatures with GumptionChain's vendored, version-independent cofactored
+verifier** (`src/gumptionchain/ed25519.py`), not OpenSSL, for the same
+node-uniform determinism the chain's consensus path requires (see #316); RSA
+verification uses `cryptography`/OpenSSL as before.
 
 In Python using the `cryptography` library:
 
 ```python
+# RSA-2048
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from base64 import standard_b64encode
 
 signature_bytes = private_key.sign(canonical_bytes, padding.PKCS1v15(), hashes.SHA384())
+gc_signature = standard_b64encode(signature_bytes).decode()
+
+# Ed25519
+signature_bytes = ed25519_private_key.sign(canonical_bytes)  # RFC 8032
 gc_signature = standard_b64encode(signature_bytes).decode()
 ```
 
@@ -140,7 +153,7 @@ gc_signature = standard_b64encode(signature_bytes).decode()
 
 A GC address is derived from a public key as follows:
 
-1. Serialize the RSA public key to DER-encoded SubjectPublicKeyInfo bytes.
+1. Serialize the RSA-2048 or Ed25519 public key to DER-encoded SubjectPublicKeyInfo bytes.
 2. Compute `mill_hash` of those bytes: `sha256(sha512(der_bytes).digest()).digest()` — 32 bytes.
 3. Base58Check-encode the 32-byte hash.
 4. Wrap with the `GC` tag: `"GC" + base58check_str + "GC"`.
@@ -181,8 +194,8 @@ The server performs these checks in order. Any failure in steps 1–6 results in
    present and non-empty → `401`.
 3. `GC-Timestamp` must parse as a decimal integer → `401`.
 4. Freshness: `abs(now − ts) <= 300` → else `401`.
-5. `GC-Public-Key` must be a valid RSA-2048 public key in base64 DER format, and
-   it must derive to an address equal to `GC-Address` → else `401`.
+5. `GC-Public-Key` must be a valid RSA-2048 or Ed25519 public key in base64 DER
+   format, and it must derive to an address equal to `GC-Address` → else `401`.
 6. Reconstruct the canonical string from the live request (see above); verify the
    `GC-Signature` using the public key from step 5 → else `401`.
 7. Map `GC-Address` to a role via the server's live address allowlists. If no role
@@ -228,7 +241,7 @@ GC-Sig-Version: 1
 GC-Address:     GCAbcDef…XyzGC
 GC-Public-Key:  <base64 DER SubjectPublicKeyInfo — placeholder>
 GC-Timestamp:   1748736000
-GC-Signature:   <base64 RSASSA-PKCS1-v1_5/SHA-384 over canonical bytes — placeholder>
+GC-Signature:   <base64 signature over canonical bytes (RSA or Ed25519) — placeholder>
 ```
 
 ### POST `/api/block/<hash>`
@@ -265,7 +278,7 @@ GC-Sig-Version: 1
 GC-Address:     GCAbcDef…XyzGC
 GC-Public-Key:  <base64 DER SubjectPublicKeyInfo — placeholder>
 GC-Timestamp:   1748736001
-GC-Signature:   <base64 RSASSA-PKCS1-v1_5/SHA-384 over canonical bytes — placeholder>
+GC-Signature:   <base64 signature over canonical bytes (RSA or Ed25519) — placeholder>
 ```
 
 All placeholder values (`GCAbcDef…XyzGC`, the base64 keys, and the base64
@@ -278,8 +291,9 @@ signatures) are illustrative only and are not real cryptographic values.
 | Property | Value |
 |---|---|
 | RSA key size | 2048 bits |
-| Signature algorithm | RSASSA-PKCS1-v1_5 |
-| Signature hash | SHA-384 |
+| Ed25519 key size | 256 bits (RFC 8032) |
+| RSA signature algorithm | RSASSA-PKCS1-v1_5 / SHA-384 |
+| Ed25519 signature algorithm | Ed25519 (RFC 8032) |
 | Signature encoding | Standard base64 (RFC 4648, uses `+` and `/`) |
 | Public key encoding | Standard base64 of DER SubjectPublicKeyInfo |
 | Body digest algorithm | SHA-256 (hex digest, lowercase) |

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -14,8 +14,21 @@ REQ = {
 }
 
 
-def test_sign_then_verify_roundtrip():
-    w = SigningKey()
+@pytest.fixture(params=['rsa', 'ed25519'])
+def make_key(request):
+    """Factory for a fresh SigningKey of the parametrized type, so every test
+    runs for both RSA-2048 and Ed25519. Tests needing >1 key call it again."""
+
+    def _make() -> SigningKey:
+        if request.param == 'ed25519':
+            return SigningKey.generate_ed25519()
+        return SigningKey()
+
+    return _make
+
+
+def test_sign_then_verify_roundtrip(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     assert headers[signing.H_VERSION] == signing.SIG_VERSION
     assert headers[signing.H_ADDRESS] == w.address
@@ -23,54 +36,54 @@ def test_sign_then_verify_roundtrip():
     assert addr == w.address
 
 
-def test_verify_rejects_tampered_path():
-    w = SigningKey()
+def test_verify_rejects_tampered_path(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     bad = {**REQ, 'path': '/api/block/DIFFERENT'}
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **bad)
 
 
-def test_verify_rejects_tampered_query():
-    w = SigningKey()
+def test_verify_rejects_tampered_query(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     bad = {**REQ, 'query': 'earliest=999'}
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **bad)
 
 
-def test_verify_rejects_tampered_method():
-    w = SigningKey()
+def test_verify_rejects_tampered_method(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     bad = {**REQ, 'method': 'GET'}
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **bad)
 
 
-def test_verify_rejects_tampered_body():
-    w = SigningKey()
+def test_verify_rejects_tampered_body(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     bad = {**REQ, 'body': b'{"x":2}'}
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **bad)
 
 
-def test_verify_rejects_wrong_node():
-    w = SigningKey()
+def test_verify_rejects_wrong_node(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     bad = {**REQ, 'node_host': 'http://peer.node:8888'}
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **bad)
 
 
-def test_verify_rejects_stale_timestamp():
+def test_verify_rejects_stale_timestamp(make_key):
     # Pin a single `now` for both the signed timestamp and verify(): using
     # int(time.time()) independently on each side lets a 1-second tick land
     # between them, collapsing the boundary check (the just-past-boundary
     # offset + truncation can net to exactly FRESHNESS_SECONDS, which the
     # strict `>` does not reject) — a real flake. verify() exposes `now`
     # precisely for this.
-    w = SigningKey()
+    w = make_key()
     now = int(time.time())
     old = now - (signing.FRESHNESS_SECONDS + 1)
     headers = signing.sign_headers(w, timestamp=old, **REQ)
@@ -78,10 +91,10 @@ def test_verify_rejects_stale_timestamp():
         signing.verify(headers, now=now, **REQ)
 
 
-def test_verify_rejects_future_timestamp():
+def test_verify_rejects_future_timestamp(make_key):
     # See test_verify_rejects_stale_timestamp: pin one `now` for both sides
     # so the int(time.time()) truncation race cannot collapse the boundary.
-    w = SigningKey()
+    w = make_key()
     now = int(time.time())
     future = now + (signing.FRESHNESS_SECONDS + 1)
     headers = signing.sign_headers(w, timestamp=future, **REQ)
@@ -89,26 +102,48 @@ def test_verify_rejects_future_timestamp():
         signing.verify(headers, now=now, **REQ)
 
 
-def test_verify_rejects_pubkey_address_mismatch():
-    w = SigningKey()
-    other = SigningKey()
+def test_verify_rejects_pubkey_address_mismatch(make_key):
+    w = make_key()
+    other = make_key()
     headers = signing.sign_headers(w, **REQ)
     headers[signing.H_PUBKEY] = other.public_key_b64
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **REQ)
 
 
-def test_verify_rejects_missing_header():
-    w = SigningKey()
+def test_verify_rejects_missing_header(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     del headers[signing.H_SIGNATURE]
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **REQ)
 
 
-def test_verify_rejects_unknown_version():
-    w = SigningKey()
+def test_verify_rejects_unknown_version(make_key):
+    w = make_key()
     headers = signing.sign_headers(w, **REQ)
     headers[signing.H_VERSION] = '999'
+    with pytest.raises(signing.SignatureError):
+        signing.verify(headers, **REQ)
+
+
+def test_verify_rejects_signature_from_other_key(make_key):
+    # A signature made by a DIFFERENT key over the SAME canonical (claiming w's
+    # identity) must be rejected — the core auth guarantee, for both key types.
+    # _canonical is the same internal sign_headers/verify use; building it here
+    # lets `other` sign exactly the bytes verify will check under w's pubkey.
+    w = make_key()
+    other = make_key()
+    headers = signing.sign_headers(w, **REQ)
+    canonical = signing._canonical(
+        method=REQ['method'],
+        path=REQ['path'],
+        query=REQ['query'],
+        body=REQ['body'],
+        node_host=REQ['node_host'],
+        timestamp=headers[signing.H_TIMESTAMP],
+        address=w.address,
+    )
+    headers[signing.H_SIGNATURE] = other.sign(canonical)
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **REQ)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -147,3 +147,41 @@ def test_verify_rejects_signature_from_other_key(make_key):
     headers[signing.H_SIGNATURE] = other.sign(canonical)
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **REQ)
+
+
+def _canonical_for(signing_key, timestamp):
+    return signing._canonical(
+        method=REQ['method'],
+        path=REQ['path'],
+        query=REQ['query'],
+        body=REQ['body'],
+        node_host=REQ['node_host'],
+        timestamp=timestamp,
+        address=signing_key.address,
+    )
+
+
+def test_verify_rejects_cross_scheme_signature():
+    # Document that the OID-self-describing wire is safe: a signature of the
+    # WRONG scheme (over the exact canonical verify checks) is rejected by the
+    # scheme picked from the pubkey type. Not parametrized — inherently
+    # cross-type. Address self-cert passes; only the signature scheme is wrong.
+    rsa = SigningKey()
+    ed = SigningKey.generate_ed25519()
+
+    # RSA identity, but an Ed25519 (64-byte) signature -> RSA verify rejects.
+    headers = signing.sign_headers(rsa, **REQ)
+    headers[signing.H_SIGNATURE] = ed.sign(
+        _canonical_for(rsa, headers[signing.H_TIMESTAMP])
+    )
+    with pytest.raises(signing.SignatureError):
+        signing.verify(headers, **REQ)
+
+    # Ed25519 identity, but an RSA (256-byte) signature -> the vendored
+    # verifier's len(signature) != 64 check rejects.
+    headers = signing.sign_headers(ed, **REQ)
+    headers[signing.H_SIGNATURE] = rsa.sign(
+        _canonical_for(ed, headers[signing.H_TIMESTAMP])
+    )
+    with pytest.raises(signing.SignatureError):
+        signing.verify(headers, **REQ)


### PR DESCRIPTION
Implements **#312** sub-project 2: Ed25519 as a first-class `gc-sig-v1` auth key type.

## The YAGNI result: no auth code needed

gc-sig already works with Ed25519 — both `signing.sign_headers` and `signing.verify` route through `SigningKey`, which #1 (#316) made hybrid, and `signing.verify` is **fully key-type-agnostic** (version + freshness + pubkey/address self-cert + `validate_signature`, which dispatches Ed25519 → the vendored verifier). An Ed25519 node key already signs and verifies requests today. So this PR **locks the behavior with tests and updates the protocol doc** — zero production change.

## Changes

- **`tests/test_signing.py`** — parametrized over a `make_key` factory (`['rsa', 'ed25519']`), so the entire auth sign/verify/tamper matrix (roundtrip, tampered path/query/method/body, wrong-node, stale/future timestamp, pubkey-address mismatch, missing header, unknown version) now runs for **both** key types (24 cases). Plus a **foreign-signature rejection** test (a second key signs the exact canonical `verify` checks → rejected) — the core auth guarantee proven for both types, exercising the vendored verifier for Ed25519.
- **`docs/api-auth-protocol.md`** — `GC-Public-Key` (OID-self-identifying SPKI), `GC-Signature` (native scheme per type), the Signing-algorithm section (both schemes; Ed25519 *verification* uses the vendored verifier, not OpenSSL), and the worked examples / algorithm table generalized. **No `gc-sig` version bump** — the wire is self-describing.

## Scope

The JS `gc-sig.mjs` client signing Ed25519 is **#3** (separate). `authorize()` is `signing.verify` + address-based `Role.address_role` (both key-type-agnostic), so no e2e integration test was needed.

## Verification

```
uv run pytest          # 671 passed, 1 skipped
uv run ruff check/format src tests   # clean
uv run mypy            # clean
```
No `src/` change; gc-sig-v1 stays v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)