### PR TITLE
refactor: self-certifying / v1 cleanup — drop redundant pubkey, revert gc-sig to v1

### DIFF
--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -2,7 +2,7 @@
 
 A dependency-free, vanilla-JS ([Web Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API))
 SDK for [GumptionChain](../../README.md): Ed25519 key management,
-`gc-sig-v2` authenticated API requests, passkey-anchored at-rest storage,
+`gc-sig-v1` authenticated API requests, passkey-anchored at-rest storage,
 passkey-PRF key **derivation** (self-custodial federated login),
 24-word BIP-39 recovery phrases, self-custody backup/recovery, and generic
 `gc-msg-v1` message signing.
@@ -41,7 +41,7 @@ files (`gc-crypto.mjs`, `gc-envelope.mjs`, …) are internal and may change.
 
 ## Quickstart
 
-### 1. Sign an authenticated API request (`gc-sig-v2`)
+### 1. Sign an authenticated API request (`gc-sig-v1`)
 
 ```js
 import { SigningKey, signHeaders } from './index.mjs';
@@ -145,7 +145,7 @@ mapping, *not* BIP-39's PBKDF2 seed-stretching — the words **are** the seed.)
 | Symbol | Purpose |
 | --- | --- |
 | `SigningKey` | Ed25519 keygen, `exportSecret`/`fromSecret` (`gcsec1…`), `mnemonic()`/`fromMnemonic` (24-word phrase), `gc1…` address, sign, verify-only via `fromPublicKeyB64` |
-| `canonical`, `signHeaders` | `gc-sig-v2` request signing |
+| `canonical`, `signHeaders` | `gc-sig-v1` request signing |
 | `enroll`, `unlock`, `hasSigningKey`, `clear` | passkey-anchored storage orchestration |
 | `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters; the passkey adapter also exposes `discover({ mediation, signal })` / `isConditionalAvailable()` |
 | `deriveSeed`, `deriveSigningKey` | passkey-PRF → 32-byte seed / `SigningKey` (no stored key; optional `passphrase` 2FA) |
@@ -227,7 +227,7 @@ key is preferred.
 
 `version` is the **package** semver (pre-1.0, pre-launch — the
 embedder API is not yet frozen). It is **independent** of the wire scheme ids
-`gc-sig-v2` and `gc-msg-v1`, which are protocol identifiers bound into
+`gc-sig-v1` and `gc-msg-v1`, which are protocol identifiers bound into
 signatures and change only on a protocol revision.
 
 ## Testing

--- a/clients/sdk/gc-message.mjs
+++ b/clients/sdk/gc-message.mjs
@@ -27,7 +27,6 @@ export async function signMessage(signing_key, message, { timestamp } = {}) {
     scheme: MSG_SCHEME,
     version: MSG_VERSION,
     address,
-    public_key: await signing_key.publicKeyB64(),
     timestamp: ts,
     message,
     signature: await signing_key.sign(bytes),
@@ -39,13 +38,12 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
     throw new BadProofError('not a proof object');
   }
   const {
-    scheme, version, address, public_key: publicKey, timestamp, message, signature,
+    scheme, version, address, timestamp, message, signature,
   } = proof;
   if (
     scheme !== MSG_SCHEME
     || version !== MSG_VERSION
     || typeof address !== 'string'
-    || typeof publicKey !== 'string'
     || typeof timestamp !== 'string'
     || !/^[0-9]+$/.test(timestamp)
     || typeof message !== 'string'
@@ -55,14 +53,11 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   }
   let verifier;
   try {
-    verifier = await SigningKey.fromPublicKeyB64(publicKey);
+    verifier = await SigningKey.fromAddress(address);
   } catch {
-    throw new BadProofError('invalid public key');
+    throw new BadProofError('invalid address');
   }
   const result = { address, timestamp, message };
-  if ((await verifier.address()) !== address) {
-    return { ...result, valid: false, reason: 'address-mismatch' };
-  }
   const bytes = await messageCanonical({ address, timestamp, message });
   let signatureOk;
   try {

--- a/clients/sdk/gc-message.mjs
+++ b/clients/sdk/gc-message.mjs
@@ -1,5 +1,5 @@
 // Generic gc-msg-v1 message signing: sign arbitrary text into a portable proof
-// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v2.
+// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v1.
 // Pure Web Crypto + vanilla JS. No dependencies. Knows nothing about the chain.
 import { sha256Hex, base64encode, base64decode } from './gc-crypto.mjs';
 import { BadProofError } from './gc-errors.mjs';
@@ -73,7 +73,7 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   if (maxAge !== undefined) {
     const current = now ?? Math.floor(Date.now() / 1000);
     // Symmetric window: reject stale AND future timestamps (mirrors the
-    // server-side gc-sig-v2 freshness check) so maxAge can't be defeated by a
+    // server-side gc-sig-v1 freshness check) so maxAge can't be defeated by a
     // far-future signed timestamp.
     if (Math.abs(current - Number(timestamp)) > maxAge) {
       return { ...result, valid: false, reason: 'expired' };

--- a/clients/sdk/gc-message.test.mjs
+++ b/clients/sdk/gc-message.test.mjs
@@ -29,13 +29,19 @@ test('a tampered message yields bad-signature', async () => {
   assert.equal(r.reason, 'bad-signature');
 });
 
-test('an address not matching the public key yields address-mismatch', async () => {
+test('a tampered address is invalid', async () => {
+  const w = await SigningKey.generate();
+  const other = await SigningKey.generate();
+  const proof = await signMessage(w, 'hi', { timestamp: TS });
+  proof.address = await other.address();   // sig now reconstructs a different key
+  assert.equal((await verifyMessage(proof)).valid, false);
+});
+
+test('proof has no public_key and verifies via address', async () => {
   const w = await SigningKey.generate();
   const proof = await signMessage(w, 'hi', { timestamp: TS });
-  proof.address = `${proof.address}X`;
-  const r = await verifyMessage(proof);
-  assert.equal(r.valid, false);
-  assert.equal(r.reason, 'address-mismatch');
+  assert.equal(proof.public_key, undefined);
+  assert.equal((await verifyMessage(proof)).valid, true);
 });
 
 test('wrong scheme/version/missing fields throw BadProofError', async () => {

--- a/clients/sdk/gc-sig.mjs
+++ b/clients/sdk/gc-sig.mjs
@@ -1,9 +1,9 @@
-// GumptionChain gc-sig-v2 canonical string + GC-* signing headers.
+// GumptionChain gc-sig-v1 canonical string + GC-* signing headers.
 // Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
 import { sha256Hex } from './gc-crypto.mjs';
 
-const SIG_SCHEME = 'gc-sig-v2';
-const SIG_VERSION = '2';
+const SIG_SCHEME = 'gc-sig-v1';
+const SIG_VERSION = '1';
 
 export async function canonical({
   method,

--- a/clients/sdk/gc-signing-key.mjs
+++ b/clients/sdk/gc-signing-key.mjs
@@ -2,7 +2,7 @@
 // address, gcsec secret, sign/verify. Pure Web Crypto + vanilla JS. No
 // dependencies. Browser + Node 20+.
 import { base64encode, base64decode, base64urlDecode } from './gc-crypto.mjs';
-import { encodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
+import { encodeAddress, decodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
 
 const ALG = 'Ed25519';
 // RFC 8410 Ed25519 PKCS8 prefix for a bare 32-byte seed (16 bytes); WebCrypto
@@ -82,6 +82,17 @@ export class SigningKey {
       true,
       ['verify'],
     );
+    return new SigningKey(null, pub);
+  }
+
+  static async fromAddress(address) {
+    const raw = decodeAddress(address);
+    if (raw === null) {
+      throw new Error('invalid gc1… address (bad checksum or HRP)');
+    }
+    const pub = await crypto.subtle.importKey('raw', raw, 'Ed25519', true, [
+      'verify',
+    ]);
     return new SigningKey(null, pub);
   }
 

--- a/clients/sdk/gc-signing-key.test.mjs
+++ b/clients/sdk/gc-signing-key.test.mjs
@@ -63,3 +63,19 @@ test('fromMnemonic rejects a corrupted phrase', async () => {
   words[23] = words[23] === 'zoo' ? 'zone' : 'zoo';
   await assert.rejects(() => SigningKey.fromMnemonic(words.join(' ')), /checksum/);
 });
+
+test('fromAddress yields a verify-only key that verifies the address owner', async () => {
+  const w = await SigningKey.generate();
+  const addr = await w.address();
+  const pub = await SigningKey.fromAddress(addr);
+  assert.equal(await pub.address(), addr);
+  const msg = new TextEncoder().encode('x');
+  assert.equal(await pub.verify(msg, await w.sign(msg)), true);
+  await assert.rejects(() => pub.sign(msg)); // verify-only, no private key
+});
+
+test('fromAddress rejects a corrupted address', async () => {
+  const addr = await (await SigningKey.generate()).address();
+  const bad = addr.slice(0, -1) + (addr.at(-1) === 'q' ? 'p' : 'q');
+  await assert.rejects(() => SigningKey.fromAddress(bad), /address/);
+});

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -4,8 +4,8 @@
 // is internal and may change without notice.
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
-// wire scheme ids gc-sig-v2 / gc-msg-v1 bound into signatures.
-export const version = '0.6.0';
+// wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
+export const version = '0.7.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -13,7 +13,7 @@ export { SigningKey } from './gc-signing-key.mjs';
 // Onboarding controller (headless create / back up / restore / unlock / sign-login)
 export { makeOnboarding } from './gc-onboarding.mjs';
 
-// API request signing (gc-sig-v2)
+// API request signing (gc-sig-v1)
 export { canonical, signHeaders } from './gc-sig.mjs';
 
 // Passkey-anchored storage

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.6.0",
-  "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v2), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
+  "version": "0.7.0",
+  "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {
     ".": "./index.mjs"

--- a/clients/sdk/sign-cli.mjs
+++ b/clients/sdk/sign-cli.mjs
@@ -1,4 +1,4 @@
-// GumptionChain gc-sig-v2 signing CLI (test harness, not a unit test).
+// GumptionChain gc-sig-v1 signing CLI (test harness, not a unit test).
 // Reads a JSON request from argv[2], signs it with the given gcsec secret,
 // and prints {address, signature} JSON to stdout. Used by the Python live
 // cross-verify test to prove byte-for-byte gc-sig parity without fixtures.

--- a/clients/sdk/testdata/gc-sig-vectors.json
+++ b/clients/sdk/testdata/gc-sig-vectors.json
@@ -10,8 +10,8 @@
       "body": "",
       "node_host": "node.example",
       "timestamp": "1700000000",
-      "canonical": "gc-sig-v2\nGET\n/api/blocks\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nnode.example\n1700000000\ngc10x64vt50ue20jsrckyfw32vt57gplpf6u62ma4lquwgshtgyjejqfua3x3",
-      "signature": "3ttw0SJnMf6qBcROaE4rcZskpH8HCN8XXGbAOX0vR4TaI00wsfShUWT5so/tLO39i44T1/iwIcOV1IPJ7R5QBg=="
+      "canonical": "gc-sig-v1\nGET\n/api/blocks\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nnode.example\n1700000000\ngc10x64vt50ue20jsrckyfw32vt57gplpf6u62ma4lquwgshtgyjejqfua3x3",
+      "signature": "moCXfWW1wPLQwIleu/X28cGZsDi06yxcy9bgdQqXSo+cBWHaNmIYdzhRMjX9IVrQeE9UHi7ueWdjLo+HgD5YDg=="
     },
     {
       "method": "POST",
@@ -20,8 +20,8 @@
       "body": "{\"hello\":\"world\"}",
       "node_host": "node.example",
       "timestamp": "1700000001",
-      "canonical": "gc-sig-v2\nPOST\n/api/transactions\nfoo=bar\n93a23971a914e5eacbf0a8d25154cda309c3c1c72fbb9914d47c60f3cb681588\nnode.example\n1700000001\ngc10x64vt50ue20jsrckyfw32vt57gplpf6u62ma4lquwgshtgyjejqfua3x3",
-      "signature": "TV6pF81x43ig+UWHnAOEFznpqcAXtXcgNLLfZrWG+aIRhzpoYiTJWy3Jf29WWG6vcF60SAFMpyCrIIh/Q1H2CA=="
+      "canonical": "gc-sig-v1\nPOST\n/api/transactions\nfoo=bar\n93a23971a914e5eacbf0a8d25154cda309c3c1c72fbb9914d47c60f3cb681588\nnode.example\n1700000001\ngc10x64vt50ue20jsrckyfw32vt57gplpf6u62ma4lquwgshtgyjejqfua3x3",
+      "signature": "PU/94Lk4dxbMofjI+/8cKKzJKG/tkMztSo7qKqkgCJpT+L9bjhfIvrExYkfAr1OoGO07o/0yvCR+kCopgb1HDg=="
     }
   ]
 }

--- a/docs/api-auth-protocol.md
+++ b/docs/api-auth-protocol.md
@@ -1,4 +1,4 @@
-# GumptionChain API Authentication Protocol: `gc-sig-v2`
+# GumptionChain API Authentication Protocol: `gc-sig-v1`
 
 Every GumptionChain API request (excluding the unauthenticated browser views) must
 be authenticated with a per-request signing_key signature. The server verifies the
@@ -12,21 +12,25 @@ the signature is verified.
 ## Versioning
 
 Authentication scheme selection is driven by the `GC-Sig-Version` request header.
-This document specifies **version `2`** — the `gc-sig-v2` scheme. The header value
-is the decimal string `"2"`.
+This document specifies **version `1`** — the `gc-sig-v1` scheme. The header value
+is the decimal string `"1"`.
 
 GumptionChain is Ed25519-only: every key is an Ed25519 key, and the GC address
 **is** the public key (a bech32m encoding of the raw 32-byte Ed25519 public key).
 The verifier therefore reconstructs the public key directly from `GC-Address`, so
-`v2` carries **no** `GC-Public-Key` header — the address is the credential, not a
-fingerprint of one.
+`gc-sig-v1` carries **no** `GC-Public-Key` header — the address is the credential,
+not a fingerprint of one.
 
-Future schemes (for example, an RFC 9421 HTTP Message Signatures-based scheme for
-broader third-party library interoperability) will be assigned new version numbers
-and accepted by the server side-by-side with existing versions — existing `v2`
-clients do not need to change when a new version is introduced. RFC 9421 support is
-deferred pending real third-party-client demand and a fuller Python library
-ecosystem; it is a planned additive scheme, not a current one.
+Pre-1.0, the scheme is **v1, redefined in place**: as the wire format evolves
+during development the single `gc-sig-v1` definition is edited rather than a new
+version stacked beside it (there are no deployed clients pinned to an older
+definition to stay compatible with). The `GC-Sig-Version` field nonetheless exists
+as a forward-looking dispatch hook: once the protocol is stable (post-1.0), a
+future incompatible change — for example, an RFC 9421 HTTP Message Signatures-based
+scheme for broader third-party library interoperability — can bump the version and
+be accepted side-by-side with `gc-sig-v1`. RFC 9421 support is deferred pending
+real third-party-client demand and a fuller Python library ecosystem; it is a
+planned additive scheme, not a current one.
 
 ---
 
@@ -36,12 +40,12 @@ Every signed request must include all four of the following headers.
 
 | Header | Value |
 |---|---|
-| `GC-Sig-Version` | `2` |
+| `GC-Sig-Version` | `1` |
 | `GC-Address` | Caller's GC address — a `gc1…` bech32m string that **is** the raw 32-byte Ed25519 public key |
 | `GC-Timestamp` | Unix time of the request, decimal seconds (e.g. `1748736000`) |
 | `GC-Signature` | Base64 Ed25519 signature (RFC 8032) over the canonical string |
 
-There is **no** `GC-Public-Key` header in `gc-sig-v2`. The address itself encodes
+There is **no** `GC-Public-Key` header in `gc-sig-v1`. The address itself encodes
 the public key, so the server **reconstructs** the Ed25519 verifying key by
 decoding `GC-Address` (validating its HRP and bech32m checksum) — see
 [Address derivation](#address-derivation). No prior key registration is needed;
@@ -50,14 +54,14 @@ authenticate.
 
 ---
 
-## Canonical string (`gc-sig-v2`)
+## Canonical string (`gc-sig-v1`)
 
 The client signs — and the server reconstructs — a canonical string formed by
 joining exactly these eight fields with newline (`\n`) characters, **in this
 order**, with no trailing newline:
 
 ```
-gc-sig-v2
+gc-sig-v1
 <METHOD>
 <path>
 <query>
@@ -71,7 +75,7 @@ Field-by-field rules:
 
 | Field | Value |
 |---|---|
-| `gc-sig-v2` | Literal scheme identifier, always this exact string |
+| `gc-sig-v1` | Literal scheme identifier, always this exact string |
 | `<METHOD>` | HTTP method, **uppercased** (e.g. `GET`, `POST`) |
 | `<path>` | The URL path, exactly as the server sees it (e.g. `/api/block`) |
 | `<query>` | The raw URL query string; empty string `""` when no query is present |
@@ -191,7 +195,7 @@ transport precondition assumed for all API communication).
 The server performs these checks in order. Any failure in steps 1–6 results in
 `401 Unauthorized`. Insufficient role in step 7 results in `403 Forbidden`.
 
-1. `GC-Sig-Version` must be present and equal to `"2"`. Unknown or missing version
+1. `GC-Sig-Version` must be present and equal to `"1"`. Unknown or missing version
    → `401`.
 2. `GC-Address`, `GC-Timestamp`, and `GC-Signature` must all be present and
    non-empty → `401`.
@@ -225,7 +229,7 @@ address:   gc1abc…xyz   ← placeholder
 **Canonical string** (fields separated by `\n`, shown here on separate lines):
 
 ```
-gc-sig-v2
+gc-sig-v1
 GET
 /api/block
 
@@ -240,7 +244,7 @@ gc1abc…xyz
 **Resulting request headers:**
 
 ```
-GC-Sig-Version: 2
+GC-Sig-Version: 1
 GC-Address:     gc1abc…xyz
 GC-Timestamp:   1748736000
 GC-Signature:   <base64 Ed25519 signature over canonical bytes — placeholder>
@@ -263,7 +267,7 @@ address:   gc1abc…xyz
 **Canonical string:**
 
 ```
-gc-sig-v2
+gc-sig-v1
 POST
 /api/block/0000ab12…ef34
 
@@ -276,7 +280,7 @@ gc1abc…xyz
 **Resulting request headers:**
 
 ```
-GC-Sig-Version: 2
+GC-Sig-Version: 1
 GC-Address:     gc1abc…xyz
 GC-Timestamp:   1748736001
 GC-Signature:   <base64 Ed25519 signature over canonical bytes — placeholder>
@@ -298,5 +302,5 @@ only and are not real cryptographic values.
 | Body digest algorithm | SHA-256 (hex digest, lowercase) |
 | Timestamp format | Decimal integer, Unix seconds |
 | Freshness window | ±300 seconds |
-| Scheme identifier | `gc-sig-v2` (first field of canonical string) |
-| Version header value | `2` |
+| Scheme identifier | `gc-sig-v1` (first field of canonical string) |
+| Version header value | `1` |

--- a/src/gumptionchain/api.py
+++ b/src/gumptionchain/api.py
@@ -48,7 +48,6 @@ from gumptionchain.payload import (
 )
 from gumptionchain.schema import (
     AddressType,
-    PublicKeyType,
     pydantic_errors_to_messages,
     truncate,
     validate_address_format,
@@ -527,7 +526,7 @@ blueprint.add_url_rule(
 class TransferTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    public_key: PublicKeyType
+    signer: AddressType
     amount: int = Field(ge=1)
     address: AddressType
 
@@ -542,10 +541,9 @@ class TransferTxnView(MethodView):
             return make_error_response(_pydantic_validation_error(e))
         try:
             args = model.model_dump(exclude_none=True)
-            public_key_b64 = args['public_key']
             amount = args['amount']
             dest_address = args['address']
-            signing_key = SigningKey(b64ks=public_key_b64)
+            signing_key = SigningKey.from_address(args['signer'])
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()
@@ -570,7 +568,7 @@ blueprint.add_url_rule(
 class SplitTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    public_key: PublicKeyType
+    signer: AddressType
     denomination: int = Field(ge=1)
     count: int = Field(ge=1, le=MAX_FLOWS - 1)
 
@@ -585,7 +583,7 @@ class SplitTxnView(MethodView):
             return make_error_response(_pydantic_validation_error(e))
         try:
             args = model.model_dump(exclude_none=True)
-            signing_key = SigningKey(b64ks=args['public_key'])
+            signing_key = SigningKey.from_address(args['signer'])
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()
@@ -622,7 +620,7 @@ _RawSubjectField = Annotated[str, AfterValidator(_check_raw_subject)]
 class SubjectTxnQueryModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    public_key: PublicKeyType
+    signer: AddressType
     amount: int = Field(ge=1)
     subject: _RawSubjectField
 
@@ -641,10 +639,9 @@ class OppositionTxnView(MethodView):
             return make_error_response(_pydantic_validation_error(e))
         try:
             args = model.model_dump(exclude_none=True)
-            public_key_b64 = args['public_key']
             amount = args['amount']
             subject = encode_subject(args['subject'])
-            signing_key = SigningKey(b64ks=public_key_b64)
+            signing_key = SigningKey.from_address(args['signer'])
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()
@@ -676,11 +673,10 @@ class RescindTxnView(MethodView):
             return make_error_response(_pydantic_validation_error(e))
         try:
             args = model.model_dump(exclude_none=True)
-            public_key_b64 = args['public_key']
             amount = args['amount']
             subject = encode_subject(args['subject'])
             kind = args['kind']
-            signing_key = SigningKey(b64ks=public_key_b64)
+            signing_key = SigningKey.from_address(args['signer'])
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()
@@ -712,10 +708,9 @@ class SupportTxnView(MethodView):
             return make_error_response(_pydantic_validation_error(e))
         try:
             args = model.model_dump(exclude_none=True)
-            public_key_b64 = args['public_key']
             amount = args['amount']
             subject = encode_subject(args['subject'])
-            signing_key = SigningKey(b64ks=public_key_b64)
+            signing_key = SigningKey.from_address(args['signer'])
             _, lc, _ = node_lc_dao()
             if lc is None:
                 raise EmptyChainError()

--- a/src/gumptionchain/api_client.py
+++ b/src/gumptionchain/api_client.py
@@ -142,7 +142,7 @@ class ApiClient:
 
     def get_transfer_transaction(
         self,
-        public_key: str,
+        signer: str,
         amount: int,
         address: str,
         timeout: int | float | None = None,
@@ -151,7 +151,7 @@ class ApiClient:
         return self.get(
             '/api/transaction/transfer',
             params={
-                'public_key': public_key,
+                'signer': signer,
                 'amount': str(amount),
                 'address': address,
             },
@@ -161,7 +161,7 @@ class ApiClient:
 
     def get_split_transaction(
         self,
-        public_key: str,
+        signer: str,
         denomination: int,
         count: int,
         timeout: int | float | None = None,
@@ -170,7 +170,7 @@ class ApiClient:
         return self.get(
             '/api/transaction/split',
             params={
-                'public_key': public_key,
+                'signer': signer,
                 'denomination': str(denomination),
                 'count': str(count),
             },
@@ -180,7 +180,7 @@ class ApiClient:
 
     def get_opposition_transaction(
         self,
-        public_key: str,
+        signer: str,
         amount: int,
         subject: str,
         timeout: int | float | None = None,
@@ -189,7 +189,7 @@ class ApiClient:
         return self.get(
             '/api/transaction/opposition',
             params={
-                'public_key': public_key,
+                'signer': signer,
                 'amount': str(amount),
                 'subject': subject,
             },
@@ -199,7 +199,7 @@ class ApiClient:
 
     def get_rescind_transaction(
         self,
-        public_key: str,
+        signer: str,
         amount: int,
         subject: str,
         kind: Literal['opposition', 'support'],
@@ -209,7 +209,7 @@ class ApiClient:
         return self.get(
             '/api/transaction/rescind',
             params={
-                'public_key': public_key,
+                'signer': signer,
                 'amount': str(amount),
                 'subject': subject,
                 'kind': kind,
@@ -220,7 +220,7 @@ class ApiClient:
 
     def get_support_transaction(
         self,
-        public_key: str,
+        signer: str,
         amount: int,
         subject: str,
         timeout: int | float | None = None,
@@ -229,7 +229,7 @@ class ApiClient:
         return self.get(
             '/api/transaction/support',
             params={
-                'public_key': public_key,
+                'signer': signer,
                 'amount': str(amount),
                 'subject': subject,
             },

--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -467,7 +467,7 @@ def verify_view() -> Any:
 def advanced_view() -> Any:
     # Static shell like /transact (#260): the relocated power tools
     # (broadcast pre-signed, sign attestation) sign their own API
-    # requests client-side; gc-sig-v2 is node-bound so NODE_HOST must
+    # requests client-side; gc-sig-v1 is node-bound so NODE_HOST must
     # reach the page.
     return render_template(
         'advanced.html',
@@ -481,7 +481,7 @@ def advanced_view() -> Any:
 def transact_view() -> Any:
     # Static shell — no chain/DB work. The page's client JS calls the authed
     # build/submit API itself, signing each request with the imported key.
-    # NODE_HOST must reach the page because gc-sig-v2 is node-bound: the
+    # NODE_HOST must reach the page because gc-sig-v1 is node-bound: the
     # signature canonical includes the node's host, so the glue has to sign for
     # *this* node.
     return render_template(

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -1072,18 +1072,11 @@ signing_key_cli = AppGroup(
     default=None,
     help='Parent directory for the signing-key file (default from app config).',
 )
-@click.option(
-    '--ed25519',
-    'ed25519',
-    is_flag=True,
-    default=False,
-    help='Create an Ed25519 signing key instead of RSA.',
-)
 @with_appcontext
-def create_signing_key(signing_keydir: str | None, ed25519: bool) -> None:  # noqa: FBT001
+def create_signing_key(signing_keydir: str | None) -> None:
     """Create a new signing_key file."""
     signing_keydir = signing_keydir or current_app.config.get('SIGNING_KEY_DIR')
-    w = SigningKey.generate_ed25519() if ed25519 else SigningKey()
+    w = SigningKey()
     filename = w.to_file(signing_keydir=signing_keydir)
     console.print(f'Created {filename}', style='success')
 

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -716,7 +716,7 @@ def create_transfer(
         )
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_transfer_transaction(
-            txn_signing_key_obj.public_key_b64,
+            txn_signing_key_obj.address,
             grit_to_grains(amount),
             to_address,
         )
@@ -795,7 +795,7 @@ def create_split(
         )
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_split_transaction(
-            txn_signing_key_obj.public_key_b64,
+            txn_signing_key_obj.address,
             grit_to_grains(denomination_grit),
             count,
         )
@@ -872,7 +872,7 @@ def create_opposition(
         )
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_opposition_transaction(
-            txn_signing_key_obj.public_key_b64,
+            txn_signing_key_obj.address,
             grit_to_grains(amount),
             subject,
         )
@@ -958,7 +958,7 @@ def create_rescind(
         )
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_rescind_transaction(
-            txn_signing_key_obj.public_key_b64,
+            txn_signing_key_obj.address,
             grit_to_grains(amount),
             subject,
             cast(StakeKind, kind),
@@ -1036,7 +1036,7 @@ def create_support(
         )
         client = host_api_client(host=host, signing_key_file=signing_key)
         r = client.get_support_transaction(
-            txn_signing_key_obj.public_key_b64,
+            txn_signing_key_obj.address,
             grit_to_grains(amount),
             subject,
         )

--- a/src/gumptionchain/message.py
+++ b/src/gumptionchain/message.py
@@ -41,7 +41,6 @@ def sign_message(
         'scheme': MSG_SCHEME,
         'version': MSG_VERSION,
         'address': signing_key.address,
-        'public_key': signing_key.public_key_b64,
         'timestamp': ts,
         'message': message,
         'signature': signing_key.sign(canonical),
@@ -57,21 +56,17 @@ def verify_message(
     scheme = proof.get('scheme')
     version = proof.get('version')
     address = proof.get('address')
-    pubkey = proof.get('public_key')
     ts = proof.get('timestamp')
     message = proof.get('message')
     sig = proof.get('signature')
     if (
         scheme != MSG_SCHEME
         or version != MSG_VERSION
-        or not all(
-            isinstance(v, str) for v in (address, pubkey, ts, message, sig)
-        )
+        or not all(isinstance(v, str) for v in (address, ts, message, sig))
     ):
         msg = 'malformed gc-msg-v1 proof'
         raise BadProofError(msg)
     assert isinstance(address, str)
-    assert isinstance(pubkey, str)
     assert isinstance(ts, str)
     assert isinstance(message, str)
     assert isinstance(sig, str)
@@ -81,17 +76,15 @@ def verify_message(
         msg = 'malformed gc-msg-v1 proof'
         raise BadProofError(msg)
     try:
-        signing_key = SigningKey(b64ks=pubkey)
+        signing_key = SigningKey.from_address(address)
     except InvalidKeyError as e:
-        msg = 'invalid public key'
+        msg = 'invalid address'
         raise BadProofError(msg) from e
     result: dict[str, Any] = {
         'address': address,
         'timestamp': ts,
         'message': message,
     }
-    if signing_key.address != address:
-        return {**result, 'valid': False, 'reason': 'address-mismatch'}
     canonical = _message_canonical(
         address=address, timestamp=ts, message=message
     )

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -153,15 +153,23 @@ def node_proxy_blueprint(
         ]
         return jsonify({'subjects': subjects})
 
+    def _signer(data: dict[str, object]) -> str:
+        # Self-certifying addresses: the build endpoints derive the signer's
+        # verify-only key straight from the address, so the relay forwards the
+        # signer address (not a carried public key). Validated here for a clean
+        # 400; the node re-validates it as AddressType.
+        signer = data.get('signer')
+        if not isinstance(signer, str) or not validate_address_format(signer):
+            raise _ProxyError(400, 'invalid signer')
+        return signer
+
     def _build(method_name: str) -> Response:
         data = request.get_json(silent=True) or {}
-        public_key = data.get('public_key')
-        if not isinstance(public_key, str) or not public_key:
-            raise _ProxyError(400, 'public_key required')
+        signer = _signer(data)
         subject = _require_subject(data.get('subject'))
         grains = _grit_to_grains(data.get('amount_grit'))
         method = getattr(make_client(), method_name)
-        return jsonify(_ok(_call(method, public_key, grains, subject)).json())
+        return jsonify(_ok(_call(method, signer, grains, subject)).json())
 
     @bp.post('/txn/support')
     def txn_support() -> Response:
@@ -177,9 +185,7 @@ def node_proxy_blueprint(
         # support/oppose build, but the destination is an address (validated
         # here for a clean 400; the node validates it as AddressType too).
         data = request.get_json(silent=True) or {}
-        public_key = data.get('public_key')
-        if not isinstance(public_key, str) or not public_key:
-            raise _ProxyError(400, 'public_key required')
+        signer = _signer(data)
         to_address = data.get('to_address')
         if not isinstance(to_address, str) or not validate_address_format(
             to_address
@@ -190,7 +196,7 @@ def node_proxy_blueprint(
             _ok(
                 _call(
                     make_client().get_transfer_transaction,
-                    public_key,
+                    signer,
                     grains,
                     to_address,
                 )
@@ -202,9 +208,7 @@ def node_proxy_blueprint(
         # Build an unsigned self-split: mint `count` chips of denomination_grit
         # each (back to the signer's own address). Client signs + submits.
         data = request.get_json(silent=True) or {}
-        public_key = data.get('public_key')
-        if not isinstance(public_key, str) or not public_key:
-            raise _ProxyError(400, 'public_key required')
+        signer = _signer(data)
         denomination = _grit_to_grains(
             data.get('denomination_grit'), field='denomination_grit'
         )
@@ -217,7 +221,7 @@ def node_proxy_blueprint(
             _ok(
                 _call(
                     make_client().get_split_transaction,
-                    public_key,
+                    signer,
                     denomination,
                     count,
                 )

--- a/src/gumptionchain/schema.py
+++ b/src/gumptionchain/schema.py
@@ -12,7 +12,6 @@ from pydantic_core import ErrorDetails
 from gumptionchain import ed25519 as gc_ed25519
 from gumptionchain.exceptions import InvalidKeyError
 from gumptionchain.signing_key import (
-    SigningKey,
     b64decode,
     b64encode,
     public_key_from_address,
@@ -42,14 +41,6 @@ def validate_base64(s: str) -> bool:
     except Exception:
         pass
     return False
-
-
-def validate_public_key(public_key_b64: str) -> bool:
-    try:
-        signing_key = SigningKey(b64ks=public_key_b64)
-    except InvalidKeyError:
-        return False
-    return signing_key is not None and signing_key.private_key is None
 
 
 def validate_signature(
@@ -128,18 +119,10 @@ def _check_timestamp(s: str) -> str:
     return s
 
 
-def _check_public_key(s: str) -> str:
-    if not validate_public_key(s):
-        msg = f'Invalid public key: {truncate(s)!r}'
-        raise ValueError(msg)
-    return s
-
-
 AddressType = Annotated[str, AfterValidator(_check_address_format)]
 Base64Type = Annotated[str, AfterValidator(_check_base64)]
 MillHashType = Annotated[str, AfterValidator(_check_mill_hash)]
 TimestampType = Annotated[str, AfterValidator(_check_timestamp)]
-PublicKeyType = Annotated[str, AfterValidator(_check_public_key)]
 
 
 class _ErrorsAware(Protocol):

--- a/src/gumptionchain/signing.py
+++ b/src/gumptionchain/signing.py
@@ -8,17 +8,17 @@ from typing import Any
 from gumptionchain.exceptions import InvalidKeyError
 from gumptionchain.signing_key import SigningKey
 
-SIG_VERSION = '2'  # GC-Sig-Version header value (dispatch key)
-SIG_SCHEME = 'gc-sig-v2'  # scheme id bound into the signed canonical
+SIG_VERSION = '1'  # GC-Sig-Version header value (dispatch key)
+SIG_SCHEME = 'gc-sig-v1'  # scheme id bound into the signed canonical
 FRESHNESS_SECONDS = 300
 
 H_VERSION = 'GC-Sig-Version'
 H_ADDRESS = 'GC-Address'
 H_TIMESTAMP = 'GC-Timestamp'
 H_SIGNATURE = 'GC-Signature'
-# gc-sig-v1's GC-Public-Key header is gone in v2 — the verifier reconstructs
-# the key from GC-Address. A lingering v1 header is ignored (the version gate
-# rejects v1 outright); v2 simply never reads or emits a public-key header.
+# gc-sig-v1 carries no GC-Public-Key header — the verifier reconstructs the key
+# from GC-Address. A stray public-key header (if any) is simply ignored; the
+# scheme never reads or emits one. Mismatched versions fail the version gate.
 
 
 class SignatureError(Exception):
@@ -88,7 +88,7 @@ def verify(
     node_host: str,
     now: int | None = None,
 ) -> str:
-    """Verify a `gc-sig-v2` signed request; return the authenticated
+    """Verify a `gc-sig-v1` signed request; return the authenticated
     address or raise SignatureError.
     """
     if headers.get(H_VERSION) != SIG_VERSION:

--- a/src/gumptionchain/static/js/signing-key-session.mjs
+++ b/src/gumptionchain/static/js/signing-key-session.mjs
@@ -8,7 +8,7 @@
 //   - an idle timeout (default ~15 min, reset on user activity via touch()),
 //   - the page being hidden (visibilitychange -> hidden) or unloaded (pagehide).
 //
-// On lock the reference is released. An RSA CryptoKey can't be zeroed in JS, so
+// On lock the reference is released. An Ed25519 CryptoKey can't be zeroed in JS, so
 // this is best-effort: dropping the reference is the strongest available
 // guarantee. The page reload that follows a navigation away clears it fully.
 //

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -127,7 +127,7 @@ async function readBody(resp) {
 // nowSeconds: gc-sig timestamps are epoch SECONDS (server allows +/-300s).
 const nowSeconds = () => Math.floor(Date.now() / 1000);
 
-// Send a gc-sig-v2 authed request. path/query are signed separately so the
+// Send a gc-sig-v1 authed request. path/query are signed separately so the
 // canonical matches what the server reconstructs from the actual request.
 async function authedFetch(
   fetchImpl,

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -29,9 +29,10 @@ import { readTrustAck, writeTrustAck } from './signing-key-glue.mjs';
 
 const API_PREFIX = '/api';
 
-// The fields each transaction type sends. public_key is always added from the
-// imported signing_key; the rest come from the form. (subject is the RAW UTF-8
-// subject — the server encodes it itself, so it must NOT be pre-encoded.)
+// The fields each transaction type sends. signer (the signing key's address) is
+// always added from the imported signing_key; the rest come from the form.
+// (subject is the RAW UTF-8 subject — the server encodes it itself, so it must
+// NOT be pre-encoded.)
 const TYPE_FIELDS = {
   transfer: ['amount', 'address'],
   opposition: ['amount', 'subject'],
@@ -47,10 +48,10 @@ export function buildQuery(type, fields) {
     throw new Error(`unknown transaction type: ${type}`);
   }
   const params = new URLSearchParams();
-  // public_key first by convention; order is irrelevant to the server (it
+  // signer first by convention; order is irrelevant to the server (it
   // reconstructs the canonical from the actual request), but stable for tests.
-  if (fields.publicKey != null) {
-    params.set('public_key', fields.publicKey);
+  if (fields.signer != null) {
+    params.set('signer', fields.signer);
   }
   for (const name of names) {
     const value = fields[name];
@@ -163,8 +164,8 @@ export async function buildUnsigned({
   fetchImpl = globalThis.fetch,
   timestamp = nowSeconds(),
 }) {
-  const publicKey = await signing_key.publicKeyB64();
-  const query = buildQuery(type, { ...fields, publicKey });
+  const signer = await signing_key.address();
+  const query = buildQuery(type, { ...fields, signer });
   const buildPath = `${API_PREFIX}/transaction/${type}`;
   const buildResp = await authedFetch(fetchImpl, {
     method: 'GET',

--- a/src/gumptionchain/static/js/transact-glue.test.mjs
+++ b/src/gumptionchain/static/js/transact-glue.test.mjs
@@ -21,28 +21,29 @@ import { makeSession } from './signing-key-session.mjs';
 // --- buildQuery: one query string, used for BOTH the fetch URL and the
 // gc-sig canonical, so it must round-trip exactly the fields the type needs.
 
-test('buildQuery transfer carries public_key, amount, address', () => {
+test('buildQuery transfer carries signer, amount, address', () => {
   const q = buildQuery('transfer', {
-    publicKey: 'PUB',
+    signer: 'gc1...sometestaddr',
     amount: '42',
     address: 'GCdestGC',
   });
   const p = new URLSearchParams(q);
-  assert.equal(p.get('public_key'), 'PUB');
+  assert.equal(p.get('signer'), 'gc1...sometestaddr');
+  assert.equal(p.get('public_key'), null);
   assert.equal(p.get('amount'), '42');
   assert.equal(p.get('address'), 'GCdestGC');
   assert.equal(p.has('subject'), false);
   assert.equal(p.has('kind'), false);
 });
 
-test('buildQuery opposition carries public_key, amount, subject (raw)', () => {
+test('buildQuery opposition carries signer, amount, subject (raw)', () => {
   const q = buildQuery('opposition', {
-    publicKey: 'PUB',
+    signer: 'gc1...sometestaddr',
     amount: '7',
     subject: 'goblins & orcs',
   });
   const p = new URLSearchParams(q);
-  assert.equal(p.get('public_key'), 'PUB');
+  assert.equal(p.get('signer'), 'gc1...sometestaddr');
   assert.equal(p.get('amount'), '7');
   // The server takes the RAW subject and encodes it itself — do NOT pre-encode.
   assert.equal(p.get('subject'), 'goblins & orcs');
@@ -52,7 +53,7 @@ test('buildQuery opposition carries public_key, amount, subject (raw)', () => {
 
 test('buildQuery support behaves like opposition', () => {
   const q = buildQuery('support', {
-    publicKey: 'PUB',
+    signer: 'gc1...sometestaddr',
     amount: '3',
     subject: 'dragons',
   });
@@ -63,7 +64,7 @@ test('buildQuery support behaves like opposition', () => {
 
 test('buildQuery rescind carries subject AND kind', () => {
   const q = buildQuery('rescind', {
-    publicKey: 'PUB',
+    signer: 'gc1...sometestaddr',
     amount: '5',
     subject: 'goblins',
     kind: 'support',
@@ -210,7 +211,7 @@ test('buildUnsigned: GET authed, verifies txid, does NOT sign or POST', async ()
   assert.equal(calls.length, 1);
   const get = calls[0];
   assert.match(get.url, /\/api\/transaction\/transfer\?/);
-  assert.match(get.url, /public_key=SIGNER_PUB/);
+  assert.match(get.url, /signer=GCsignerGC/);
   assert.equal(get.opts.headers['GC-Signature'], 'SIGNATURE_B64');
   assert.equal(got.txid, unsigned.txid);
 });

--- a/src/gumptionchain/static/sdk/gc-message.mjs
+++ b/src/gumptionchain/static/sdk/gc-message.mjs
@@ -1,5 +1,5 @@
 // Generic gc-msg-v1 message signing: sign arbitrary text into a portable proof
-// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v2.
+// that verifies off-chain in JS and Python. Domain-separated from gc-sig-v1.
 // Pure Web Crypto + vanilla JS. No dependencies. Knows nothing about the chain.
 import { sha256Hex, base64encode, base64decode } from './gc-crypto.mjs';
 import { BadProofError } from './gc-errors.mjs';
@@ -27,7 +27,6 @@ export async function signMessage(signing_key, message, { timestamp } = {}) {
     scheme: MSG_SCHEME,
     version: MSG_VERSION,
     address,
-    public_key: await signing_key.publicKeyB64(),
     timestamp: ts,
     message,
     signature: await signing_key.sign(bytes),
@@ -39,13 +38,12 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
     throw new BadProofError('not a proof object');
   }
   const {
-    scheme, version, address, public_key: publicKey, timestamp, message, signature,
+    scheme, version, address, timestamp, message, signature,
   } = proof;
   if (
     scheme !== MSG_SCHEME
     || version !== MSG_VERSION
     || typeof address !== 'string'
-    || typeof publicKey !== 'string'
     || typeof timestamp !== 'string'
     || !/^[0-9]+$/.test(timestamp)
     || typeof message !== 'string'
@@ -55,14 +53,11 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   }
   let verifier;
   try {
-    verifier = await SigningKey.fromPublicKeyB64(publicKey);
+    verifier = await SigningKey.fromAddress(address);
   } catch {
-    throw new BadProofError('invalid public key');
+    throw new BadProofError('invalid address');
   }
   const result = { address, timestamp, message };
-  if ((await verifier.address()) !== address) {
-    return { ...result, valid: false, reason: 'address-mismatch' };
-  }
   const bytes = await messageCanonical({ address, timestamp, message });
   let signatureOk;
   try {
@@ -78,7 +73,7 @@ export async function verifyMessage(proof, { maxAge, now } = {}) {
   if (maxAge !== undefined) {
     const current = now ?? Math.floor(Date.now() / 1000);
     // Symmetric window: reject stale AND future timestamps (mirrors the
-    // server-side gc-sig-v2 freshness check) so maxAge can't be defeated by a
+    // server-side gc-sig-v1 freshness check) so maxAge can't be defeated by a
     // far-future signed timestamp.
     if (Math.abs(current - Number(timestamp)) > maxAge) {
       return { ...result, valid: false, reason: 'expired' };

--- a/src/gumptionchain/static/sdk/gc-sig.mjs
+++ b/src/gumptionchain/static/sdk/gc-sig.mjs
@@ -1,9 +1,9 @@
-// GumptionChain gc-sig-v2 canonical string + GC-* signing headers.
+// GumptionChain gc-sig-v1 canonical string + GC-* signing headers.
 // Pure Web Crypto + vanilla JS. No dependencies. Browser + Node 20+.
 import { sha256Hex } from './gc-crypto.mjs';
 
-const SIG_SCHEME = 'gc-sig-v2';
-const SIG_VERSION = '2';
+const SIG_SCHEME = 'gc-sig-v1';
+const SIG_VERSION = '1';
 
 export async function canonical({
   method,

--- a/src/gumptionchain/static/sdk/gc-signing-key.mjs
+++ b/src/gumptionchain/static/sdk/gc-signing-key.mjs
@@ -2,7 +2,7 @@
 // address, gcsec secret, sign/verify. Pure Web Crypto + vanilla JS. No
 // dependencies. Browser + Node 20+.
 import { base64encode, base64decode, base64urlDecode } from './gc-crypto.mjs';
-import { encodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
+import { encodeAddress, decodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
 
 const ALG = 'Ed25519';
 // RFC 8410 Ed25519 PKCS8 prefix for a bare 32-byte seed (16 bytes); WebCrypto
@@ -82,6 +82,17 @@ export class SigningKey {
       true,
       ['verify'],
     );
+    return new SigningKey(null, pub);
+  }
+
+  static async fromAddress(address) {
+    const raw = decodeAddress(address);
+    if (raw === null) {
+      throw new Error('invalid gc1… address (bad checksum or HRP)');
+    }
+    const pub = await crypto.subtle.importKey('raw', raw, 'Ed25519', true, [
+      'verify',
+    ]);
     return new SigningKey(null, pub);
   }
 

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -4,8 +4,8 @@
 // is internal and may change without notice.
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
-// wire scheme ids gc-sig-v2 / gc-msg-v1 bound into signatures.
-export const version = '0.6.0';
+// wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
+export const version = '0.7.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -13,7 +13,7 @@ export { SigningKey } from './gc-signing-key.mjs';
 // Onboarding controller (headless create / back up / restore / unlock / sign-login)
 export { makeOnboarding } from './gc-onboarding.mjs';
 
-// API request signing (gc-sig-v2)
+// API request signing (gc-sig-v1)
 export { canonical, signHeaders } from './gc-sig.mjs';
 
 // Passkey-anchored storage

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,7 +662,7 @@ def test_rescind_missing_kind_returns_validation_error(
             client.get(
                 '/api/transaction/rescind',
                 params={
-                    'public_key': transactor_signing_key.public_key_b64,
+                    'signer': transactor_signing_key.address,
                     'amount': '1',
                     'subject': subject_raw,
                     # `kind` deliberately absent
@@ -681,12 +681,38 @@ def test_rescind_invalid_kind_returns_validation_error(
             client.get(
                 '/api/transaction/rescind',
                 params={
-                    'public_key': transactor_signing_key.public_key_b64,
+                    'signer': transactor_signing_key.address,
                     'amount': '1',
                     'subject': subject_raw,
                     'kind': 'invalid',
                 },
             )
+
+
+def test_transfer_build_accepts_signer_address(
+    app, host, mill_block, requests_proxy, transactor_signing_key
+):
+    """The transfer builder takes a `signer` address, not a `public_key`.
+
+    Mills a block to fund the transactor, then requests an unsigned transfer
+    keyed by the signer's gc1… address. The request SHAPE must be accepted
+    (no 400 on an unknown `public_key` field or a missing `signer`).
+    """
+    with app.app_context():
+        mill_block(transactor_signing_key)
+        dest = SigningKey().address
+        client = ApiClient(host, transactor_signing_key)
+        r = client.get(
+            '/api/transaction/transfer',
+            params={
+                'signer': transactor_signing_key.address,
+                'amount': '1',
+                'address': dest,
+            },
+        )
+        assert r.status_code == httpx.codes.OK
+        # The builder echoes the signer as the unsigned txn's `address`.
+        assert r.json()['address'] == transactor_signing_key.address
 
 
 def test_transaction_provenance_endpoint_canonical(

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -440,7 +440,7 @@ def test_verify_binding_malformed_envelope_raises() -> None:
     w = _signing_key()
     proof = sign_social_binding(w, BINDING_CLAIM, timestamp=TS_BINDING)
     bad = dict(proof)
-    del bad['public_key']
+    del bad['signature']
     with pytest.raises(BadAttestationError):
         verify_binding(bad)
 

--- a/tests/test_attestation_vectors.py
+++ b/tests/test_attestation_vectors.py
@@ -142,19 +142,17 @@ def test_binding_vectors_match() -> None:
 
 
 def test_binding_vectors_verify() -> None:
-    w = SigningKey(secret=VECTOR_SECRET)
     vectors = json.loads(_BINDING_VECTORS_PATH.read_text())
     for v in vectors:
         claim = v['claim']
         assert v['message'] == build_binding_message(claim)
-        # Reconstruct a full gc-msg-v1 proof from stored fields + the known
-        # public key (vectors store only the claim-side fields; the public key
-        # is derivable from the known vector signing_key).
+        # Reconstruct a full gc-msg-v1 proof from stored fields (vectors store
+        # only the claim-side fields; verify reconstructs the public key from
+        # the address).
         proof = {
             'scheme': 'gc-msg-v1',
             'version': '1',
             'address': v['address'],
-            'public_key': w.public_key_b64,
             'timestamp': v['timestamp'],
             'message': v['message'],
             'signature': v['signature'],

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -492,23 +492,8 @@ def test_create_signing_key(app, runner):
         pem_files = list(Path(signing_keydir).glob('*.pem'))
         assert len(pem_files) == 1
         assert SigningKey.from_file(str(pem_files[0])) is not None
-
-
-def test_signing_key_create_ed25519(app, runner):
-    with app.app_context(), TemporaryDirectory() as signing_keydir:
-        result = runner.invoke(
-            args=[
-                'signing-key',
-                'create',
-                '--ed25519',
-                '--signing_keydir',
-                signing_keydir,
-            ]
-        )
-        assert result.exit_code == 0
-        pems = list(Path(signing_keydir).glob('*.pem'))
-        assert len(pems) == 1
-        sk = SigningKey(ks=pems[0].read_bytes())
+        # The default (and only) key type is Ed25519 — RSA is gone.
+        sk = SigningKey(ks=pem_files[0].read_bytes())
         assert isinstance(sk.key, Ed25519PrivateKey)
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -41,12 +41,17 @@ def test_tampered_message_is_bad_signature() -> None:
     assert r['reason'] == 'bad-signature'
 
 
-def test_address_mismatch() -> None:
+def test_tampered_address_is_invalid() -> None:
     proof = sign_message(_signing_key(), 'hi', timestamp=int(TS))
-    proof['address'] = proof['address'] + 'X'
-    r = verify_message(proof)
-    assert r['valid'] is False
-    assert r['reason'] == 'address-mismatch'
+    other = SigningKey.from_ed25519_seed(bytes(range(40, 72)))
+    proof['address'] = other.address  # sig now verifies under a different key
+    assert verify_message(proof)['valid'] is False
+
+
+def test_proof_has_no_public_key() -> None:
+    proof = sign_message(_signing_key(), 'hi', timestamp=int(TS))
+    assert 'public_key' not in proof
+    assert verify_message(proof)['valid'] is True
 
 
 def test_malformed_proof_raises() -> None:

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -3,6 +3,10 @@ from flask import Flask
 
 from gumptionchain import node_proxy_blueprint
 
+# A valid bech32m gc1… address — the relay validates the `signer` field as an
+# address (self-certifying: the build endpoints derive the verify key from it).
+SIGNER = 'gc13sqcx509fwu3mkceq4hmll0xcufszhzajp8seuvdy22z872tn6sqxlqndc'
+
 
 class FakeResponse:
     def __init__(self, status_code, body=None, text=''):
@@ -44,24 +48,24 @@ class FakeClient:
         return self._resp('search', query, limit)
 
     def get_support_transaction(
-        self, pk, amount, subject, *, raise_for_status=True
+        self, signer, amount, subject, *, raise_for_status=True
     ):
-        return self._resp('build_support', pk, amount, subject)
+        return self._resp('build_support', signer, amount, subject)
 
     def get_opposition_transaction(
-        self, pk, amount, subject, *, raise_for_status=True
+        self, signer, amount, subject, *, raise_for_status=True
     ):
-        return self._resp('build_oppose', pk, amount, subject)
+        return self._resp('build_oppose', signer, amount, subject)
 
     def get_transfer_transaction(
-        self, pk, amount, address, *, raise_for_status=True
+        self, signer, amount, address, *, raise_for_status=True
     ):
-        return self._resp('build_transfer', pk, amount, address)
+        return self._resp('build_transfer', signer, amount, address)
 
     def get_split_transaction(
-        self, pk, denomination, count, *, raise_for_status=True
+        self, signer, denomination, count, *, raise_for_status=True
     ):
-        return self._resp('build_split', pk, denomination, count)
+        return self._resp('build_split', signer, denomination, count)
 
     def get(self, path, *, raise_for_status=True):
         return self._resp('status', path)
@@ -163,13 +167,28 @@ def test_build_support_converts_grit_and_passes_raw_subject():
     client = FakeClient(build_support=FakeResponse(200, unsigned))
     resp = _app(client).post(
         '/api/node/txn/support',
-        json={'public_key': 'PUB', 'amount_grit': 7, 'subject': 'goblins'},
+        json={'signer': SIGNER, 'amount_grit': 7, 'subject': 'goblins'},
     )
     assert resp.status_code == 200
     assert resp.get_json() == unsigned
     name, args, _ = client.calls[0]
     assert name == 'build_support'
-    assert args == ('PUB', 700, 'goblins')
+    assert args == (SIGNER, 700, 'goblins')
+
+
+def test_build_rejects_invalid_signer():
+    # The relay validates `signer` as a bech32m address (self-certifying) —
+    # a missing or malformed value is a clean 400 before the node is called.
+    client = FakeClient()
+    c = _app(client)
+    for bad in ({}, {'signer': ''}, {'signer': 'not-an-address'}):
+        resp = c.post(
+            '/api/node/txn/support',
+            json={**bad, 'amount_grit': 1, 'subject': 'x'},
+        )
+        assert resp.status_code == 400, bad
+        assert 'signer' in resp.get_json()['error']
+    assert client.calls == []
 
 
 def test_build_transfer_converts_grit_and_passes_address():
@@ -178,20 +197,20 @@ def test_build_transfer_converts_grit_and_passes_address():
     client = FakeClient(build_transfer=FakeResponse(200, unsigned))
     resp = _app(client).post(
         '/api/node/txn/transfer',
-        json={'public_key': 'PUB', 'amount_grit': 20, 'to_address': addr},
+        json={'signer': SIGNER, 'amount_grit': 20, 'to_address': addr},
     )
     assert resp.status_code == 200
     assert resp.get_json() == unsigned
     name, args, _ = client.calls[0]
     assert name == 'build_transfer'
-    assert args == ('PUB', 2000, addr)
+    assert args == (SIGNER, 2000, addr)
 
 
 def test_build_transfer_rejects_bad_address():
     client = FakeClient()
     resp = _app(client).post(
         '/api/node/txn/transfer',
-        json={'public_key': 'P', 'amount_grit': 20, 'to_address': 'nope'},
+        json={'signer': SIGNER, 'amount_grit': 20, 'to_address': 'nope'},
     )
     assert resp.status_code == 400
 
@@ -201,20 +220,20 @@ def test_build_split_converts_grit_and_passes_count():
     client = FakeClient(build_split=FakeResponse(200, unsigned))
     resp = _app(client).post(
         '/api/node/txn/split',
-        json={'public_key': 'PUB', 'denomination_grit': 2, 'count': 30},
+        json={'signer': SIGNER, 'denomination_grit': 2, 'count': 30},
     )
     assert resp.status_code == 200
     assert resp.get_json() == unsigned
     name, args, _ = client.calls[0]
     assert name == 'build_split'
-    assert args == ('PUB', 200, 30)  # 2 GRIT -> 200 grains; count passthrough
+    assert args == (SIGNER, 200, 30)  # 2 GRIT -> 200 grains; count passthrough
 
 
 def test_build_split_rejects_bad_amount():
     client = FakeClient()
     resp = _app(client).post(
         '/api/node/txn/split',
-        json={'public_key': 'P', 'denomination_grit': 0, 'count': 5},
+        json={'signer': SIGNER, 'denomination_grit': 0, 'count': 5},
     )
     assert resp.status_code == 400
     # the error names the split field, not the transfer 'amount_grit'
@@ -227,7 +246,7 @@ def test_build_split_rejects_non_positive_or_bool_count():
     for bad in (0, -1, True):  # bool is an int subclass; must be rejected
         resp = c.post(
             '/api/node/txn/split',
-            json={'public_key': 'P', 'denomination_grit': 2, 'count': bad},
+            json={'signer': SIGNER, 'denomination_grit': 2, 'count': bad},
         )
         assert resp.status_code == 400, bad
 
@@ -238,7 +257,7 @@ def test_build_rejects_non_positive_and_sub_grain_amounts():
     for bad in (0, -5, 0.001, 'x'):
         resp = c.post(
             '/api/node/txn/oppose',
-            json={'public_key': 'P', 'amount_grit': bad, 'subject': 'x'},
+            json={'signer': SIGNER, 'amount_grit': bad, 'subject': 'x'},
         )
         assert resp.status_code == 400, bad
 
@@ -310,7 +329,7 @@ def test_node_4xx_is_passed_through_as_400():
     )
     resp = _app(client).post(
         '/api/node/txn/support',
-        json={'public_key': 'P', 'amount_grit': 1, 'subject': 'x'},
+        json={'signer': SIGNER, 'amount_grit': 1, 'subject': 'x'},
     )
     assert resp.status_code == 400
     assert resp.get_json()['error'] == 'insufficient funds'
@@ -330,6 +349,6 @@ def test_oversized_body_is_413():
     c = _app(client, max_body_bytes=8)
     resp = c.post(
         '/api/node/txn/support',
-        json={'public_key': 'P', 'amount_grit': 1, 'subject': 'x'},
+        json={'signer': SIGNER, 'amount_grit': 1, 'subject': 'x'},
     )
     assert resp.status_code == 413

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,9 @@
 """Regression tests for the schema validator try/except guards.
 
-`validate_signature` reconstructs a key from an address and raises
-`InvalidKeyError` on malformed input. Without the try/except guards, that
-exception would propagate through the validation pipeline and surface as a
+`validate_signature` reconstructs a key from an address via
+`public_key_from_address`, which raises `InvalidKeyError` on a malformed
+address. The function guards that call and returns `False`; without the guard
+the exception would propagate through the validation pipeline and surface as a
 500 instead of a structured 400.
 """
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,9 +1,9 @@
 """Regression tests for the schema validator try/except guards.
 
-`validate_public_key` makes a `SigningKey(b64ks=...)` and `validate_signature`
-reconstructs a key from an address; both raise `InvalidKeyError` on malformed
-input. Without the try/except guards, that exception would propagate through
-the validation pipeline and surface as a 500 instead of a structured 400.
+`validate_signature` reconstructs a key from an address and raises
+`InvalidKeyError` on malformed input. Without the try/except guards, that
+exception would propagate through the validation pipeline and surface as a
+500 instead of a structured 400.
 """
 
 from base64 import b64encode
@@ -16,21 +16,11 @@ from gumptionchain.schema import (
     AddressType,
     Base64Type,
     MillHashType,
-    PublicKeyType,
     TimestampType,
     pydantic_errors_to_messages,
-    validate_public_key,
     validate_signature,
 )
 from gumptionchain.util import now_iso
-
-
-def test_validate_public_key_returns_false_on_malformed_key():
-    assert validate_public_key('not-a-valid-base64-key') is False
-
-
-def test_validate_public_key_returns_false_on_empty_key():
-    assert validate_public_key('') is False
 
 
 def test_validate_signature_returns_false_on_malformed_address():
@@ -229,22 +219,6 @@ def test_timestamp_type_rejects_invalid():
 
     with pytest.raises(PydanticValidationError):
         M(t='not-a-timestamp')
-
-
-def test_public_key_type_accepts_valid(signing_key):
-    class M(BaseModel):
-        pk: PublicKeyType
-
-    m = M(pk=signing_key.public_key_b64)
-    assert m.pk == signing_key.public_key_b64
-
-
-def test_public_key_type_rejects_invalid():
-    class M(BaseModel):
-        pk: PublicKeyType
-
-    with pytest.raises(PydanticValidationError):
-        M(pk='not-a-key')
 
 
 def test_base64_type_truncates_long_invalid_input_in_message():

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -135,17 +135,17 @@ def test_verify_rejects_signature_from_other_key(make_key):
         signing.verify(headers, **REQ)
 
 
-def test_sign_headers_v2_has_no_pubkey_header(make_key):
+def test_sign_headers_v1_has_no_pubkey_header(make_key):
     w = make_key()
     headers = signing.sign_headers(w, **REQ)
-    assert headers[signing.H_VERSION] == '2'
-    assert 'GC-Public-Key' not in headers  # dropped in v2
+    assert headers[signing.H_VERSION] == '1'
+    assert 'GC-Public-Key' not in headers  # dropped in v1
     assert signing.verify(headers, **REQ) == w.address
 
 
-def test_verify_rejects_v1_pubkey_scheme(make_key):
+def test_verify_rejects_wrong_version(make_key):
     w = make_key()
     headers = signing.sign_headers(w, **REQ)
-    headers[signing.H_VERSION] = '1'  # old scheme
+    headers[signing.H_VERSION] = '2'  # a non-'1' (wrong) version is rejected
     with pytest.raises(signing.SignatureError):
         signing.verify(headers, **REQ)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -77,7 +77,7 @@ def test_split_endpoint_returns_unsigned_txn(
     r = client.get(
         '/api/transaction/split',
         params={
-            'public_key': transactor_signing_key.public_key_b64,
+            'signer': transactor_signing_key.address,
             'denomination': '100',
             'count': '3',
         },
@@ -96,7 +96,7 @@ def test_split_endpoint_rejects_count_over_49(
     r = ApiClient(host, transactor_signing_key).get(
         '/api/transaction/split',
         params={
-            'public_key': transactor_signing_key.public_key_b64,
+            'signer': transactor_signing_key.address,
             'denomination': '1',
             'count': '50',
         },
@@ -113,7 +113,7 @@ def test_split_endpoint_rejects_zero_denomination(
     r = ApiClient(host, transactor_signing_key).get(
         '/api/transaction/split',
         params={
-            'public_key': transactor_signing_key.public_key_b64,
+            'signer': transactor_signing_key.address,
             'denomination': '0',
             'count': '3',
         },
@@ -128,7 +128,7 @@ def test_api_client_get_split_transaction(
     with app.app_context():
         mill_block(transactor_signing_key)
     r = ApiClient(host, transactor_signing_key).get_split_transaction(
-        transactor_signing_key.public_key_b64, 100, 3
+        transactor_signing_key.address, 100, 3
     )
     assert r.status_code == 200
     chips = [o for o in r.json()['outflows'] if o.get('amount') == 100]


### PR DESCRIPTION
## Summary

Finishes the post-Ed25519 self-certifying cleanup. A `gc1…` address **is** the Ed25519 public key (`address = bech32m('gc', pubkey)`), so any separately-carried `public_key` is redundant — the verifier reconstructs the key from the address. This applies that simplification to the two places a pubkey blob still lived, normalizes the one wire scheme bumped to v2 pre-1.0 back to v1, and removes leftover RSA-era CLI surface.

**No chain/consensus change** — every group is off-chain (proofs, auth wire, build API, CLI). **Greenfield, no migration.**

### Group A — drop `public_key` from the gc-msg-v1 proof envelope
`message.py` / `gc-message.mjs` no longer emit `public_key`; `verify` reconstructs the key from `address` (`SigningKey.from_address` / `.fromAddress`) and the old address↔pubkey cross-check is gone (redundant — a tampered address reconstructs a different key and fails the signature). **Signature-preserving**: the gc-msg canonical signs over `address`, never the pubkey. Stays `gc-msg-v1`.

### Group B — revert `gc-sig-v2` → `gc-sig-v1`
Pre-1.0, bumping a wire version is the equivalent of stacking a migration (which our greenfield policy forbids). The version *field* stays, pinned at `'1'`; the verify gate now rejects anything `!= '1'`. Vectors regenerated; `docs/api-auth-protocol.md` reverted.

### Group C — txn-builder endpoints take the signer **address**, not `public_key`
`api.py` request models + views, `schema.py` (removed `PublicKeyType` / `validate_public_key`), `api_client.py`, `command.py`, `node_proxy.py` (relay body field `public_key` → `signer`, validated as an address for a clean 400), and `transact-glue.mjs` all send/derive from the address. The build endpoints derive a verify-only key from it.

### Group D — remove RSA-era surface
Dropped the no-op `--ed25519` flag from `signing-key create` (both branches already produced Ed25519); fixed the stale "RSA CryptoKey" comment in `signing-key-session.mjs`.

### Housekeeping
Swept comment/doc-only `gc-sig-v2` → `gc-sig-v1` residuals; bumped the JS SDK to **0.7.0** (consumer-visible proof + build-flow shape change); re-vendored `static/sdk` (byte-parity).

## Test plan
- `uv run pytest` — **710 passed, 1 skipped**
- `uv run mypy` (strict) — clean
- `uv run ruff check src tests` + `ruff format --check` — clean
- `uv run gumptionchain db check` — no new operations (unaffected)
- `clients/sdk` `node --test` — **151 passed**; `static/js` `node --test` — **71 passed**
- vendored byte-parity (`tests/test_sdk_vendored.py`) — passed
- Whole-branch independent code review — clean (signatures preserved, no missed stragglers, JS↔Python parity, address-reconstruction equivalent to the old carried-pubkey path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)