### PR TITLE
feat(sdk): recognize() — who's-here passkey hint for the member-kit (#315)

### DIFF
--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -210,6 +210,29 @@ test('recognize() is false+null when the assertion has no PRF (UnsupportedError)
   );
 });
 
+test('recognize() is false+null when discovery is aborted (AbortError)', async () => {
+  await withFakeWebauthn(
+    { getImpl: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; } },
+    async () => {
+      const ac = new AbortController();
+      ac.abort();
+      assert.deepEqual(
+        await recognize({ rpId: 'gumption.com', signal: ac.signal }),
+        { recognized: false, address: null },
+      );
+    },
+  );
+});
+
+test('recognize() called with no arguments is false+null (unsupported navigator)', async () => {
+  const restore = setGlobal('navigator', undefined);
+  try {
+    assert.deepEqual(await recognize(), { recognized: false, address: null });
+  } finally {
+    restore();
+  }
+});
+
 test('isConditionalAvailable() reflects platform support and never throws', async () => {
   await withFakeWebauthn({ getImpl: async () => null, conditional: true }, async () => {
     const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
 
 test('webauthn passkey adapter exposes the passkey interface', async () => {
@@ -135,6 +135,79 @@ test('discover() throws UnsupportedError when the assertion has no PRF', async (
     const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
     await assert.rejects(() => pk.discover(), /PRF/);
   });
+});
+
+// --- recognize(): thin wrapper over discover() → { recognized, address } (#315)
+
+test('recognize() returns recognized+address when a passkey carries a userHandle', async () => {
+  await withFakeWebauthn(
+    { getImpl: async () => fakeAssertion({ userHandle: 'gc1alice' }) },
+    async () => {
+      const r = await recognize({ rpId: 'gumption.com' });
+      assert.deepEqual(r, { recognized: true, address: 'gc1alice' });
+    },
+  );
+});
+
+test('recognize() forwards mediation and signal to the discovery call', async () => {
+  let seen = null;
+  await withFakeWebauthn(
+    { getImpl: async (opts) => { seen = opts; return fakeAssertion({ userHandle: 'gc1bob' }); } },
+    async () => {
+      const signal = new AbortController().signal;
+      const r = await recognize({ rpId: 'gumption.com', mediation: 'conditional', signal });
+      assert.equal(r.recognized, true);
+      assert.equal(seen.mediation, 'conditional');
+      assert.equal(seen.signal, signal);
+    },
+  );
+});
+
+test('recognize() is false+null when the user dismisses (NotAllowedError)', async () => {
+  await withFakeWebauthn(
+    { getImpl: async () => { const e = new Error('no'); e.name = 'NotAllowedError'; throw e; } },
+    async () => {
+      assert.deepEqual(await recognize({ rpId: 'gumption.com' }), { recognized: false, address: null });
+    },
+  );
+});
+
+test('recognize() is false+null when navigator is unavailable', async () => {
+  const restore = setGlobal('navigator', undefined);
+  try {
+    assert.deepEqual(await recognize({ rpId: 'gumption.com' }), { recognized: false, address: null });
+  } finally {
+    restore();
+  }
+});
+
+test('recognize() is false+null when a credential carries no userHandle', async () => {
+  await withFakeWebauthn(
+    { getImpl: async () => fakeAssertion({ userHandle: null }) },
+    async () => {
+      assert.deepEqual(await recognize({ rpId: 'gumption.com' }), { recognized: false, address: null });
+    },
+  );
+});
+
+test('recognize() defaults mediation to "optional"', async () => {
+  let seen = null;
+  await withFakeWebauthn(
+    { getImpl: async (opts) => { seen = opts; return fakeAssertion({ userHandle: 'gc1dave' }); } },
+    async () => {
+      await recognize({ rpId: 'gumption.com' });
+      assert.equal(seen.mediation, 'optional');
+    },
+  );
+});
+
+test('recognize() is false+null when the assertion has no PRF (UnsupportedError)', async () => {
+  await withFakeWebauthn(
+    { getImpl: async () => fakeAssertion({ prf: null }) },
+    async () => {
+      assert.deepEqual(await recognize({ rpId: 'gumption.com' }), { recognized: false, address: null });
+    },
+  );
 });
 
 test('isConditionalAvailable() reflects platform support and never throws', async () => {

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -145,3 +145,27 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     isConditionalAvailable,
   };
 }
+
+// Member-kit recognition: "is a returning EGU user here, and who are they?"
+// A thin convenience over discover() — build a discover-only adapter for rpId,
+// run discovery, and map to { recognized, address }. NEVER throws for the
+// absent / cancelled / unsupported paths (discover() returns null for dismissal
+// and an unsupported navigator; PRF-absent throws UnsupportedError, caught here);
+// any unexpected error also resolves to { recognized: false } so a "who's here?"
+// hint always lets the caller fall through to "create". address is the decoded
+// userHandle (the enrolled userId; the EGU convention is that this is the GC
+// address) — generic at the SDK layer. rpName is unused by discover(), so rpId
+// is passed as a harmless placeholder.
+export async function recognize({ rpId, mediation = 'optional', signal } = {}) {
+  const pk = makeWebauthnPasskey({ rpId, rpName: rpId });
+  let found;
+  try {
+    found = await pk.discover({ mediation, signal });
+  } catch {
+    return { recognized: false, address: null };
+  }
+  if (!found || !found.userHandle) {
+    return { recognized: false, address: null };
+  }
+  return { recognized: true, address: found.userHandle };
+}

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -156,12 +156,23 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
 // userHandle (the enrolled userId; the EGU convention is that this is the GC
 // address) — generic at the SDK layer. rpName is unused by discover(), so rpId
 // is passed as a harmless placeholder.
+//
+// IMPORTANT: the returned address equals the GC address ONLY for ENROLLED
+// (wrap-keyring) identities, where user.id === address. DERIVED (passkey-PRF)
+// identities have a NON-address userHandle — their address isn't known at
+// create() time, before the PRF exists — so recognize() would report a
+// confidently wrong address for them. Recognize derived identities via
+// makeDerivedIdentity.resolve() (which re-derives the real address from the
+// PRF), not this helper. The member-kit guide routes the two kinds accordingly.
 export async function recognize({ rpId, mediation = 'optional', signal } = {}) {
   const pk = makeWebauthnPasskey({ rpId, rpName: rpId });
   let found;
   try {
     found = await pk.discover({ mediation, signal });
   } catch {
+    // Deliberate fail-open: a signal abort or any unexpected error maps to
+    // "not recognized" (this is a UX hint, never an auth gate) — do NOT
+    // "fix" this into a throw.
     return { recognized: false, address: null };
   }
   if (!found || !found.userHandle) {

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.7.0';
+export const version = '0.8.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -18,7 +18,7 @@ export { canonical, signHeaders } from './gc-sig.mjs';
 
 // Passkey-anchored storage
 export { enroll, unlock, hasSigningKey, clear } from './gc-store.mjs';
-export { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+export { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 export { makeIdbStore } from './gc-store-idb.mjs';
 
 // Backup / recovery

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -145,3 +145,27 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
     isConditionalAvailable,
   };
 }
+
+// Member-kit recognition: "is a returning EGU user here, and who are they?"
+// A thin convenience over discover() — build a discover-only adapter for rpId,
+// run discovery, and map to { recognized, address }. NEVER throws for the
+// absent / cancelled / unsupported paths (discover() returns null for dismissal
+// and an unsupported navigator; PRF-absent throws UnsupportedError, caught here);
+// any unexpected error also resolves to { recognized: false } so a "who's here?"
+// hint always lets the caller fall through to "create". address is the decoded
+// userHandle (the enrolled userId; the EGU convention is that this is the GC
+// address) — generic at the SDK layer. rpName is unused by discover(), so rpId
+// is passed as a harmless placeholder.
+export async function recognize({ rpId, mediation = 'optional', signal } = {}) {
+  const pk = makeWebauthnPasskey({ rpId, rpName: rpId });
+  let found;
+  try {
+    found = await pk.discover({ mediation, signal });
+  } catch {
+    return { recognized: false, address: null };
+  }
+  if (!found || !found.userHandle) {
+    return { recognized: false, address: null };
+  }
+  return { recognized: true, address: found.userHandle };
+}

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -156,12 +156,23 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
 // userHandle (the enrolled userId; the EGU convention is that this is the GC
 // address) — generic at the SDK layer. rpName is unused by discover(), so rpId
 // is passed as a harmless placeholder.
+//
+// IMPORTANT: the returned address equals the GC address ONLY for ENROLLED
+// (wrap-keyring) identities, where user.id === address. DERIVED (passkey-PRF)
+// identities have a NON-address userHandle — their address isn't known at
+// create() time, before the PRF exists — so recognize() would report a
+// confidently wrong address for them. Recognize derived identities via
+// makeDerivedIdentity.resolve() (which re-derives the real address from the
+// PRF), not this helper. The member-kit guide routes the two kinds accordingly.
 export async function recognize({ rpId, mediation = 'optional', signal } = {}) {
   const pk = makeWebauthnPasskey({ rpId, rpName: rpId });
   let found;
   try {
     found = await pk.discover({ mediation, signal });
   } catch {
+    // Deliberate fail-open: a signal abort or any unexpected error maps to
+    // "not recognized" (this is a UX hint, never an auth gate) — do NOT
+    // "fix" this into a throw.
     return { recognized: false, address: null };
   }
   if (!found || !found.userHandle) {

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.7.0';
+export const version = '0.8.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -18,7 +18,7 @@ export { canonical, signHeaders } from './gc-sig.mjs';
 
 // Passkey-anchored storage
 export { enroll, unlock, hasSigningKey, clear } from './gc-store.mjs';
-export { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+export { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 export { makeIdbStore } from './gc-store-idb.mjs';
 
 // Backup / recovery


### PR DESCRIPTION
Closes #315.

## Summary

Adds a small, member-facing **`recognize()`** helper to the browser SDK — a thin convenience over `discover()` that answers "is a returning EGU user here, and who are they?" in one call. It's the entry point the hub recognition member-kit (gump-hub#67) points every member site at.

Pairs with #313 (`discover()` → `userHandle`), already merged — so this is purely the wrapper on top.

```js
import { recognize } from '@gumptionchain/sdk';

recognize({ rpId, mediation = 'optional', signal })
  // → { recognized: true,  address: '<userHandle>' }   a passkey was picked
  // → { recognized: false, address: null }              absent / cancel / unsupported / no-userHandle
```

## Design notes

- **Standalone export** in `gc-passkey-webauthn.mjs` (beside `discover()`), re-exported from the barrel. Its signature takes `rpId`, so members call it without constructing an adapter; internally it builds a discover-only adapter (`rpName` is unused by `discover()`, so `rpId` is a harmless placeholder) and maps the result.
- **Never throws** for the absent/cancel/unsupported/no-userHandle paths — `discover()` already returns `null` for dismissal and an unsupported navigator; the PRF-absent `UnsupportedError` (and any other unexpected error) is caught and mapped to `{ recognized: false, address: null }`, so a "who's here?" hint always lets the caller fall through to "create".
- `address` is the already-decoded `userHandle` (the enrolled `userId`; the EGU convention is that this is the GC address). Generic at the SDK layer — a **UX branch hint only**, no server verification implied.
- Out of scope (per the issue): the recognition directory, server-verified recognition, 2FA, `largeBlob`.

## Test plan
- `clients/sdk` `node --test` — **158 passed** (incl. 7 new `recognize()` cases: recognized+address, mediation default + mediation/signal passthrough, dismissal, unsupported navigator, no-PRF, no-userHandle; and the version/package.json semver-agreement check at 0.8.0)
- `uv run pytest` — **710 passed, 1 skipped**; vendored byte-parity (`tests/test_sdk_vendored.py`) green
- `uv run ruff check src tests` + `ruff format --check` — clean
- SDK bumped 0.7.0 → 0.8.0 (new public export); `static/sdk` re-vendored

🤖 Generated with [Claude Code](https://claude.com/claude-code)