### PR TITLE
feat(sdk): kind-aware identity controller — derived + wrap onboarding (#322)

### DIFF
--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -288,3 +288,28 @@ test('isConditionalAvailable() is false when isConditionalMediationAvailable is 
     restore();
   }
 });
+
+test('enroll() honors a residentKey preference and defaults to "required"', async () => {
+  let seenSelection = null;
+  const fakeNav = {
+    credentials: {
+      create: async (opts) => {
+        seenSelection = opts.publicKey.authenticatorSelection;
+        return {
+          rawId: new Uint8Array([1, 2, 3]).buffer,
+          getClientExtensionResults: () => ({ prf: { results: { first: new Uint8Array(32).fill(9).buffer } } }),
+        };
+      },
+    },
+  };
+  const restore = setGlobal('navigator', fakeNav);
+  try {
+    const pk = makeWebauthnPasskey({ rpId: 'gumption.com', rpName: 'G' });
+    await pk.enroll({ userName: 'a' });
+    assert.equal(seenSelection.residentKey, 'required');
+    await pk.enroll({ userName: 'a', residentKey: 'discouraged' });
+    assert.equal(seenSelection.residentKey, 'discouraged');
+  } finally {
+    restore();
+  }
+});

--- a/clients/sdk/gc-keyring.mjs
+++ b/clients/sdk/gc-keyring.mjs
@@ -89,6 +89,7 @@ export async function enroll(signing_key, { store }, { passphrase }) {
   const wraps = { passphrase: await passphraseWrap(passphrase, dekRaw) };
   await store.put({
     version: VERSION,
+    kind: 'wrap',
     address: await signing_key.address(),
     signing_key_ct,
     wraps,

--- a/clients/sdk/gc-keyring.mjs
+++ b/clients/sdk/gc-keyring.mjs
@@ -36,8 +36,11 @@ import { SigningKey } from './gc-signing-key.mjs';
 
 // VERSION 2: the encrypted-key field name changed in the signing-key rename.
 // Bumping the record version makes any pre-rename record fail
-// loudly on read rather than silently miss the renamed field.
-const VERSION = 2;
+// loudly on read rather than silently miss the renamed field. Exported so the
+// onboarding controller stamps the same record-schema version on derived
+// records (which don't go through this module), keeping both kinds' record
+// shapes forward-compatible for a future schema bump.
+export const VERSION = 2;
 const SALT_BYTES = 16;
 const DEK_BYTES = 32;
 const PBKDF2_ITERATIONS = 600000;

--- a/clients/sdk/gc-keyring.test.mjs
+++ b/clients/sdk/gc-keyring.test.mjs
@@ -63,6 +63,7 @@ test('the stored record is always ciphertext (no plaintext secret/DEK leaks)', a
   );
   assert.ok(!blob.includes(secret), 'plaintext secret must not appear in the record');
   assert.equal(rec.version, 2);
+  assert.equal(rec.kind, 'wrap');
   assert.equal(rec.address, await w.address());
   assert.ok(rec.signing_key_ct && rec.signing_key_ct.iv && rec.signing_key_ct.ciphertext);
   assert.ok(rec.wraps.passphrase.salt && rec.wraps.passphrase.iterations);

--- a/clients/sdk/gc-onboarding.mjs
+++ b/clients/sdk/gc-onboarding.mjs
@@ -131,7 +131,9 @@ export function makeOnboarding({
     if (withPasskey && (await passkeySupported())) {
       const { signing_key, address, mnemonic, credentialId } =
         await derived.enroll({ userName });
-      await store.put({ kind: 'derived', address, credentialId });
+      await store.put({
+        version: keyring.VERSION, kind: 'derived', address, credentialId,
+      });
       key = signing_key;
       await notify();
       return { kind: 'derived', address, mnemonic };

--- a/clients/sdk/gc-onboarding.mjs
+++ b/clients/sdk/gc-onboarding.mjs
@@ -2,11 +2,19 @@
 // low-level gc-* modules into create / back up / restore / unlock / sign-login
 // over a single in-memory unlocked-key holder. NO DOM, NO CSS, NO framework:
 // the consuming app owns all markup and renders from status() + onChange().
+//
+// Kind-aware (two identity kinds behind one surface):
+//   - 'derived' — a passkey identity whose seed = KDF(passkey-PRF) (No-2FA). The
+//     record holds { kind, address, credentialId } and NO key material; the key
+//     is re-derived from the passkey on demand (makeDerivedIdentity.resolve).
+//   - 'wrap'    — a random key encrypted in the keyring, unlockable by passphrase
+//     (and optionally a non-resident convenience passkey).
 import { SigningKey } from './gc-signing-key.mjs';
 import * as keyring from './gc-keyring.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { makeDerivedIdentity } from './gc-derived-identity.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -38,15 +46,14 @@ export function makeOnboarding({
   // A passkey adapter is built from rpId/rpName unless one is injected; absent
   // both, passkey features stay unavailable (status reports passkeySupported:false).
   const pk = passkey ?? ((rpId && rpName) ? makeWebauthnPasskey({ rpId, rpName }) : null);
+  // The derive flow (enroll/resolve) composes the same passkey adapter.
+  const derived = pk ? makeDerivedIdentity({ passkey: pk }) : null;
 
   let key = null; // the in-memory unlocked SigningKey, or null when locked
   const listeners = new Set();
 
   const secureContext = () => Boolean(win && win.isSecureContext);
 
-  // Feature-detect passkey support: an adapter must exist, the context must be
-  // secure, and the adapter must report support (guarded — a throwing adapter
-  // counts as unsupported). Reused by status() and create().
   async function passkeySupported() {
     if (!(pk && secureContext())) return false;
     try {
@@ -56,8 +63,16 @@ export function makeOnboarding({
     }
   }
 
-  // Which unlock methods the STORED record is enrolled under, read from its
-  // wraps without unlocking. Stable order: passphrase, then passkey.
+  // The stored record's identity kind. New records always carry `kind`; a stale
+  // record with keyring `wraps` and no `kind` reads as 'wrap' (a non-crashing
+  // default, NOT a migration path — greenfield recreates the dev DB).
+  function recordKind(rec) {
+    if (!rec) return null;
+    return rec.kind ?? (rec.wraps ? 'wrap' : null);
+  }
+
+  // Which unlock methods a WRAP record is enrolled under, read from its wraps
+  // without unlocking. Derived records have no wraps -> []. Stable order.
   function enrolledMethods(rec) {
     const wraps = (rec && rec.wraps) || {};
     return ['passphrase', 'passkey'].filter((m) => Boolean(wraps[m]));
@@ -65,16 +80,19 @@ export function makeOnboarding({
 
   async function status() {
     const rec = await store.get();
+    const kind = recordKind(rec);
     const address = key ? await key.address() : (rec ? rec.address : null);
     const methods = enrolledMethods(rec);
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
+      kind,
       address,
       // passkeySupported = device capability; passkeyEnrolled = stored state.
-      // Gate an "add a passkey" affordance on supported && !enrolled.
+      // A derived identity IS a passkey; a wrap identity is passkey-enrolled
+      // when it carries a passkey wrap.
       passkeySupported: await passkeySupported(),
-      passkeyEnrolled: methods.includes('passkey'),
+      passkeyEnrolled: kind === 'derived' || methods.includes('passkey'),
       methods,
       secureContext: secureContext(),
     };
@@ -97,25 +115,53 @@ export function makeOnboarding({
     return () => listeners.delete(fn);
   }
 
-  function passkeyIds(userName, address) {
-    return { userId: address, userName: userName || address };
+  // userId/userName + an optional residentKey preference for passkey enrollment.
+  function passkeyIds(userName, address, residentKey) {
+    return {
+      userId: address,
+      userName: userName || address,
+      ...(residentKey ? { residentKey } : {}),
+    };
   }
 
+  // A passkey at create time means DERIVE (seed = KDF(PRF), No-2FA). Without a
+  // (supported) passkey it's a passphrase-WRAP identity. An unsupported passkey
+  // falls back to wrap rather than throwing.
   async function create({ passphrase, withPasskey = false, userName } = {}) {
+    if (withPasskey && (await passkeySupported())) {
+      const { signing_key, address, mnemonic, credentialId } =
+        await derived.enroll({ userName });
+      await store.put({ kind: 'derived', address, credentialId });
+      key = signing_key;
+      await notify();
+      return { kind: 'derived', address, mnemonic };
+    }
     const sk = await SigningKey.generate();
     await keyring.enroll(sk, { store }, { passphrase });
-    const address = await sk.address();
-    if (withPasskey && (await passkeySupported())) {
-      await keyring.addPasskey(
-        { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
-      );
-    }
     key = sk;
     await notify();
-    return { address };
+    return { kind: 'wrap', address: await sk.address() };
   }
 
   async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    const rec = await store.get();
+    if (recordKind(rec) === 'derived') {
+      if (!derived) {
+        throw new NoSigningKeyError(
+          'no passkey adapter to rehydrate a derived identity',
+        );
+      }
+      // No-2FA: re-derive from the passkey PRF and match the stored address.
+      const r = await derived.resolve({ expectedAddress: rec.address });
+      if (r.status !== 'ok') {
+        // no-passkey / needs-passphrase / mismatch — can't rehydrate here. The
+        // hub treats this as "offer import", never a passphrase prompt.
+        throw new NoSigningKeyError('could not rehydrate this passkey identity');
+      }
+      key = r.signing_key;
+      await notify();
+      return { address: await key.address() };
+    }
     key = await keyring.unlock(
       { store, passkey: usePasskey ? pk : undefined },
       { passphrase },
@@ -124,16 +170,56 @@ export function makeOnboarding({
     return { address: await key.address() };
   }
 
-  async function restore({ backup, passphrase } = {}) {
-    const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
-    const sk = await importEncrypted(artifact, passphrase);
+  // A recovery phrase OR an encrypted backup both land as a WRAP identity —
+  // seamlessness can't follow a phrase (no new passkey reproduces an old
+  // passkey's PRF). Derived identities don't "restore"; a synced passkey just
+  // unlock()s them.
+  async function restore({ mnemonic, backup, passphrase } = {}) {
+    let sk;
+    if (mnemonic != null) {
+      sk = await SigningKey.fromMnemonic(mnemonic);
+    } else if (backup != null) {
+      const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
+      sk = await importEncrypted(artifact, passphrase);
+    } else {
+      throw new BadBackupError('restore requires a mnemonic or a backup');
+    }
+    if (passphrase == null || passphrase === '') {
+      throw new BadPassphraseError(
+        'a passphrase is required to store a restored identity',
+      );
+    }
     await keyring.enroll(sk, { store }, { passphrase });
     key = sk;
     await notify();
-    return { address: await sk.address() };
+    return { kind: 'wrap', address: await sk.address() };
   }
 
   async function backup({ passphrase } = {}) {
+    const rec = await store.get();
+    if (recordKind(rec) === 'derived') {
+      // Return the recovery phrase. Use the held key if unlocked, else tap the
+      // passkey to re-derive — without leaving a previously-locked id unlocked.
+      const wasLocked = !key;
+      let sk = key;
+      if (wasLocked) {
+        if (!derived) {
+          throw new NoSigningKeyError(
+            'no passkey adapter to back up a derived identity',
+          );
+        }
+        const r = await derived.resolve({ expectedAddress: rec.address });
+        if (r.status !== 'ok') {
+          throw new NoSigningKeyError(
+            'could not rehydrate this passkey identity',
+          );
+        }
+        sk = r.signing_key;
+      }
+      const mnemonic = await sk.mnemonic();
+      await notify();
+      return { kind: 'derived', mnemonic };
+    }
     const wasLocked = !key;
     if (wasLocked) {
       key = await keyring.unlock({ store }, { passphrase });
@@ -144,15 +230,19 @@ export function makeOnboarding({
       key = null; // a backup is a read; don't leave the key unlocked
     }
     await notify();
-    return { artifact, filename };
+    return { kind: 'wrap', artifact, filename };
   }
 
+  // Add a NON-RESIDENT convenience passkey to a wrap identity. Non-resident
+  // (residentKey:'discouraged') keeps it out of other origins' discover(), so it
+  // can't produce hollow cross-app recognition. (A preference, not a guarantee —
+  // some authenticators make it discoverable anyway; a strong mitigation.)
   async function addPasskey({ passphrase, userName } = {}) {
     const rec = await store.get();
     const address = await keyring.addPasskey(
       { store, passkey: pk },
       { passphrase },
-      passkeyIds(userName, rec ? rec.address : undefined),
+      passkeyIds(userName, rec ? rec.address : undefined, 'discouraged'),
     );
     await notify();
     return { address };

--- a/clients/sdk/gc-onboarding.test.mjs
+++ b/clients/sdk/gc-onboarding.test.mjs
@@ -145,8 +145,9 @@ test('create({withPasskey}) derives a passkey identity: returns kind+mnemonic, n
   assert.equal(kind, 'derived');
   assert.ok(address.startsWith('gc1'));
   assert.equal(mnemonic.split(' ').length, 24);
-  // record carries kind + credentialId, NO signing_key_ct / wraps
+  // record carries version + kind + credentialId, NO signing_key_ct / wraps
   const rec = await store.get();
+  assert.equal(rec.version, 2);
   assert.equal(rec.kind, 'derived');
   assert.equal(rec.credentialId, 'cred1');
   assert.equal(rec.signing_key_ct, undefined);
@@ -217,6 +218,11 @@ test('wrap backup yields an encrypted artifact (no raw key) + filename; restore 
   assert.equal(kind, 'wrap');
   assert.equal(artifact.kind, 'gc-signing-key-backup');
   assert.match(filename, /^gc-signing-key-backup-.*\.json$/);
+  // the artifact is exactly the encrypted envelope — no plaintext / extra fields
+  assert.deepEqual(
+    Object.keys(artifact).sort(),
+    ['address', 'ciphertext', 'iv', 'kdf', 'kind', 'version'],
+  );
 
   const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
   const r = await onb2.restore({ backup: JSON.stringify(artifact), passphrase: 'pw' });
@@ -242,6 +248,7 @@ test('signLogin requires unlocked and produces a verifiable gc-msg-v1 proof', as
   await onb.unlock({ passphrase: 'pw' });
   const proof = await onb.signLogin('login:abc');
   assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.message, 'login:abc');
   const v = await verifyMessage(proof, { maxAge: Number.MAX_SAFE_INTEGER });
   assert.equal(v.valid, true);
 });
@@ -252,6 +259,7 @@ test('forget deletes the device record', async () => {
   await onb.forget();
   const s = await onb.status();
   assert.equal(s.hasKey, false);
+  assert.equal(s.unlocked, false);
 });
 
 test('signTransaction: throws when locked; signs a node-built unsigned txn when unlocked', async () => {

--- a/clients/sdk/gc-onboarding.test.mjs
+++ b/clients/sdk/gc-onboarding.test.mjs
@@ -2,11 +2,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  makeOnboarding, NoSigningKeyError, BadPassphraseError,
+  makeOnboarding, NoSigningKeyError, BadPassphraseError, BadBackupError,
 } from './gc-onboarding.mjs';
 import { verifyMessage } from './gc-message.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 import { exportEncrypted } from './gc-backup.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
 import { txid as txnTxid, signingData } from './gc-transaction.mjs';
 
 function fakeStore() {
@@ -18,23 +19,31 @@ function fakeStore() {
   };
 }
 
+// A fake passkey adapter. enroll + discover return the SAME PRF so a derived
+// identity re-derives to the same address. enroll captures its options so a
+// test can assert residentKey. credentialId is stable.
 function fakePasskey(fill = 7, credentialId = 'cred1') {
   const PRF = new Uint8Array(32).fill(fill);
+  const calls = { enroll: [] };
   return {
+    calls,
     isSupported: async () => true,
-    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    enroll: async (ids = {}) => { calls.enroll.push(ids); return { credentialId, prfOutput: PRF }; },
     unlock: async () => PRF,
-    discover: async () => ({ credentialId, prfOutput: PRF }),
+    discover: async () => ({ credentialId, prfOutput: PRF, userHandle: null }),
   };
 }
 
 const SECURE = { isSecureContext: true };
 
-test('empty store: status reports no key, passkey off without an adapter', async () => {
+// --- status / empty -------------------------------------------------------
+
+test('empty store: status reports no key + null kind, passkey off without an adapter', async () => {
   const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
   const s = await onb.status();
   assert.equal(s.hasKey, false);
   assert.equal(s.unlocked, false);
+  assert.equal(s.kind, null);
   assert.equal(s.address, null);
   assert.equal(s.passkeySupported, false);
   assert.equal(s.secureContext, true);
@@ -42,24 +51,18 @@ test('empty store: status reports no key, passkey off without an adapter', async
   assert.equal(s.passkeyEnrolled, false);
 });
 
-test('status reports enrolled methods (passphrase-only) from the record, no unlock', async () => {
-  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
-  await onb.create({ passphrase: 'pw' });
-  await onb.lock(); // prove it reads wraps from the record, not the held key
-  const s = await onb.status();
-  assert.deepEqual(s.methods, ['passphrase']);
-  assert.equal(s.passkeyEnrolled, false);
-});
+// --- wrap kind ------------------------------------------------------------
 
-test('status reports passkeyEnrolled + both methods after create-with-passkey', async () => {
-  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
-  await onb.create({ passphrase: 'pw', withPasskey: true });
+test('create({passphrase}) makes a wrap identity; status reads kind+methods without unlocking', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const { kind, address } = await onb.create({ passphrase: 'pw' });
+  assert.equal(kind, 'wrap');
+  assert.ok(address.startsWith('gc1'));
   await onb.lock();
   const s = await onb.status();
-  assert.deepEqual(s.methods, ['passphrase', 'passkey']);
-  assert.equal(s.passkeyEnrolled, true);
-  // capability vs enrollment are distinct signals
-  assert.equal(s.passkeySupported, true);
+  assert.equal(s.kind, 'wrap');
+  assert.deepEqual(s.methods, ['passphrase']);
+  assert.equal(s.passkeyEnrolled, false);
 });
 
 test('create persists + holds unlocked, and onChange fires with fresh status', async () => {
@@ -67,7 +70,6 @@ test('create persists + holds unlocked, and onChange fires with fresh status', a
   let last = null;
   const off = onb.onChange((s) => { last = s; });
   const { address } = await onb.create({ passphrase: 'pw' });
-  assert.ok(address.startsWith('gc1'));
   const s = await onb.status();
   assert.equal(s.hasKey, true);
   assert.equal(s.unlocked, true);
@@ -94,52 +96,143 @@ test('unlock by passphrase re-holds the key; wrong passphrase rejects', async ()
   assert.equal(r.address, address);
   assert.equal((await onb.status()).unlocked, true);
   await onb.lock();
-  await assert.rejects(
-    () => onb.unlock({ passphrase: 'WRONG' }),
-    BadPassphraseError, // typed + catchable through the controller (#279)
-  );
+  await assert.rejects(() => onb.unlock({ passphrase: 'WRONG' }), BadPassphraseError);
 });
 
-test('passkey: create with passkey, unlock by passkey', async () => {
-  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
-  assert.equal((await onb.status()).passkeySupported, true);
-  const { address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+test('wrap + addPasskey: status shows both methods; unlock by passkey works', async () => {
+  const passkey = fakePasskey();
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey });
+  const { address } = await onb.create({ passphrase: 'pw' });
+  await onb.addPasskey({ passphrase: 'pw' });
   await onb.lock();
+  const s = await onb.status();
+  assert.equal(s.kind, 'wrap');
+  assert.deepEqual(s.methods, ['passphrase', 'passkey']);
+  assert.equal(s.passkeyEnrolled, true);
   const r = await onb.unlock({ passkey: true });
   assert.equal(r.address, address);
 });
 
-test('create with withPasskey silently skips the passkey when unsupported (no throw)', async () => {
-  // An adapter that reports unsupported must NOT be enrolled — create gates on
-  // the live support state, not merely the adapter's presence.
+test('addPasskey enrolls a NON-resident convenience passkey (residentKey discouraged)', async () => {
+  const passkey = fakePasskey();
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey });
+  await onb.create({ passphrase: 'pw' });
+  await onb.addPasskey({ passphrase: 'pw' });
+  // the convenience passkey enroll must request a discouraged (non-resident) key
+  assert.equal(passkey.calls.enroll.at(-1).residentKey, 'discouraged');
+});
+
+test('create with withPasskey but unsupported adapter falls back to wrap (no throw)', async () => {
   const passkey = {
     isSupported: async () => false,
     enroll: async () => { throw new Error('enroll must not run when unsupported'); },
     unlock: async () => { throw new Error('unlock must not run when unsupported'); },
+    discover: async () => { throw new Error('discover must not run when unsupported'); },
   };
   const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey });
-  assert.equal((await onb.status()).passkeySupported, false);
-  const { address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+  const { kind, address } = await onb.create({ passphrase: 'pw', withPasskey: true });
+  assert.equal(kind, 'wrap');
   assert.ok(address.startsWith('gc1'));
   assert.equal((await onb.status()).unlocked, true);
 });
 
-test('backup yields an encrypted artifact (no raw key) + filename; restore into a fresh store recovers the same address', async () => {
+// --- derived kind ---------------------------------------------------------
+
+test('create({withPasskey}) derives a passkey identity: returns kind+mnemonic, no key material stored', async () => {
+  const store = fakeStore();
+  const onb = makeOnboarding({ store, window: SECURE, passkey: fakePasskey() });
+  const { kind, address, mnemonic } = await onb.create({ withPasskey: true });
+  assert.equal(kind, 'derived');
+  assert.ok(address.startsWith('gc1'));
+  assert.equal(mnemonic.split(' ').length, 24);
+  // record carries kind + credentialId, NO signing_key_ct / wraps
+  const rec = await store.get();
+  assert.equal(rec.kind, 'derived');
+  assert.equal(rec.credentialId, 'cred1');
+  assert.equal(rec.signing_key_ct, undefined);
+  assert.equal(rec.wraps, undefined);
+  // unlocked in memory
+  assert.equal((await onb.status()).unlocked, true);
+});
+
+test('derived status reports kind+passkeyEnrolled without unlocking', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  await onb.create({ withPasskey: true });
+  await onb.lock();
+  const s = await onb.status();
+  assert.equal(s.kind, 'derived');
+  assert.equal(s.passkeyEnrolled, true);
+  assert.deepEqual(s.methods, []);
+});
+
+test('derived unlock re-derives via the passkey (No-2FA, empty creds) and matches the stored address', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  const { address } = await onb.create({ withPasskey: true });
+  await onb.lock();
+  const r = await onb.unlock();
+  assert.equal(r.address, address);
+  assert.equal((await onb.status()).unlocked, true);
+});
+
+test('derived unlock throws when the passkey re-derives a different address (wrong passkey)', async () => {
+  const store = fakeStore();
+  // enroll with one PRF...
+  const onb1 = makeOnboarding({ store, window: SECURE, passkey: fakePasskey(7) });
+  await onb1.create({ withPasskey: true });
+  await onb1.lock();
+  // ...then a different PRF on unlock derives a different address -> not 'ok'
+  const onb2 = makeOnboarding({ store, window: SECURE, passkey: fakePasskey(3) });
+  await assert.rejects(() => onb2.unlock(), NoSigningKeyError);
+});
+
+test('derived backup returns the recovery phrase; restoring it lands a WRAP identity at the same address', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  const { address } = await onb.create({ withPasskey: true });
+  const b = await onb.backup({});
+  assert.equal(b.kind, 'derived');
+  assert.equal(b.mnemonic.split(' ').length, 24);
+
+  const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  const r = await onb2.restore({ mnemonic: b.mnemonic, passphrase: 'pw' });
+  assert.equal(r.kind, 'wrap');
+  assert.equal(r.address, address);
+  assert.equal((await onb2.status()).kind, 'wrap');
+});
+
+test('derived backup while locked taps the passkey and does not leave it unlocked', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
+  await onb.create({ withPasskey: true });
+  await onb.lock();
+  const b = await onb.backup({});
+  assert.equal(b.kind, 'derived');
+  assert.equal((await onb.status()).unlocked, false);
+});
+
+// --- backup / restore (wrap) ---------------------------------------------
+
+test('wrap backup yields an encrypted artifact (no raw key) + filename; restore recovers the same address', async () => {
   const onb1 = makeOnboarding({ store: fakeStore(), window: SECURE });
   const { address } = await onb1.create({ passphrase: 'pw' });
-  const { artifact, filename } = await onb1.backup({ passphrase: 'pw' });
+  const { kind, artifact, filename } = await onb1.backup({ passphrase: 'pw' });
+  assert.equal(kind, 'wrap');
   assert.equal(artifact.kind, 'gc-signing-key-backup');
   assert.match(filename, /^gc-signing-key-backup-.*\.json$/);
-  assert.deepEqual(
-    Object.keys(artifact).sort(),
-    ['address', 'ciphertext', 'iv', 'kdf', 'kind', 'version'],
-  );
 
   const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
   const r = await onb2.restore({ backup: JSON.stringify(artifact), passphrase: 'pw' });
+  assert.equal(r.kind, 'wrap');
   assert.equal(r.address, address);
   assert.equal((await onb2.status()).hasKey, true);
 });
+
+test('restore requires a mnemonic or a backup, and a passphrase', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  await assert.rejects(() => onb.restore({ passphrase: 'pw' }), BadBackupError);
+  const k = await SigningKey.generate();
+  await assert.rejects(async () => onb.restore({ mnemonic: await k.mnemonic() }), BadPassphraseError);
+});
+
+// --- signing / lifecycle (unchanged behavior) ----------------------------
 
 test('signLogin requires unlocked and produces a verifiable gc-msg-v1 proof', async () => {
   const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
@@ -149,7 +242,6 @@ test('signLogin requires unlocked and produces a verifiable gc-msg-v1 proof', as
   await onb.unlock({ passphrase: 'pw' });
   const proof = await onb.signLogin('login:abc');
   assert.equal(proof.scheme, 'gc-msg-v1');
-  assert.equal(proof.message, 'login:abc');
   const v = await verifyMessage(proof, { maxAge: Number.MAX_SAFE_INTEGER });
   assert.equal(v.valid, true);
 });
@@ -160,19 +252,16 @@ test('forget deletes the device record', async () => {
   await onb.forget();
   const s = await onb.status();
   assert.equal(s.hasKey, false);
-  assert.equal(s.unlocked, false);
 });
 
 test('signTransaction: throws when locked; signs a node-built unsigned txn when unlocked', async () => {
   const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
   await assert.rejects(() => onb.signTransaction({ txid: 'x' }), NoSigningKeyError);
 
-  // Inject a KNOWN key via restore so the test controls address/public_key.
   const k = await SigningKey.generate();
   const backup = await exportEncrypted(k, 'pw');
   await onb.restore({ backup, passphrase: 'pw' });
 
-  // Build a self-consistent unsigned support txn, as the node would return one.
   const base = {
     timestamp: '1700000000',
     address: await k.address(),
@@ -183,23 +272,15 @@ test('signTransaction: throws when locked; signs a node-built unsigned txn when 
     prev_hash: null,
   };
   const unsigned = { ...base, txid: await txnTxid(base) };
-
   const signed = await onb.signTransaction(unsigned);
   assert.equal(signed.address, await k.address());
-  assert.equal(signed.txid, unsigned.txid);
-  assert.equal(typeof signed.signature, 'string');
-  // The signature is real: it verifies over the canonical signing data.
   assert.equal(await k.verify(signingData(signed), signed.signature), true);
 });
 
-test('discover() delegates to the passkey adapter', async () => {
+test('discover() delegates to the passkey adapter; null without one', async () => {
   const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: fakePasskey() });
   const r = await onb.discover();
   assert.equal(r.credentialId, 'cred1');
-  assert.ok(r.prfOutput instanceof Uint8Array);
-});
-
-test('discover() returns null when no passkey adapter is configured', async () => {
-  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
-  assert.equal(await onb.discover(), null);
+  const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
+  assert.equal(await onb2.discover(), null);
 });

--- a/clients/sdk/gc-passkey-webauthn.mjs
+++ b/clients/sdk/gc-passkey-webauthn.mjs
@@ -111,7 +111,7 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
       );
     },
 
-    async enroll({ userId, userName } = {}) {
+    async enroll({ userId, userName, residentKey = 'required' } = {}) {
       const idBytes =
         typeof userId === 'string'
           ? new TextEncoder().encode(userId)
@@ -125,7 +125,7 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
             { type: 'public-key', alg: -7 },
             { type: 'public-key', alg: -257 },
           ],
-          authenticatorSelection: { residentKey: 'required', userVerification },
+          authenticatorSelection: { residentKey, userVerification },
           extensions: { prf: { eval: { first: PRF_SALT } } },
         },
       });

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.8.0';
+export const version = '0.9.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-keyring.mjs
+++ b/src/gumptionchain/static/sdk/gc-keyring.mjs
@@ -89,6 +89,7 @@ export async function enroll(signing_key, { store }, { passphrase }) {
   const wraps = { passphrase: await passphraseWrap(passphrase, dekRaw) };
   await store.put({
     version: VERSION,
+    kind: 'wrap',
     address: await signing_key.address(),
     signing_key_ct,
     wraps,

--- a/src/gumptionchain/static/sdk/gc-keyring.mjs
+++ b/src/gumptionchain/static/sdk/gc-keyring.mjs
@@ -36,8 +36,11 @@ import { SigningKey } from './gc-signing-key.mjs';
 
 // VERSION 2: the encrypted-key field name changed in the signing-key rename.
 // Bumping the record version makes any pre-rename record fail
-// loudly on read rather than silently miss the renamed field.
-const VERSION = 2;
+// loudly on read rather than silently miss the renamed field. Exported so the
+// onboarding controller stamps the same record-schema version on derived
+// records (which don't go through this module), keeping both kinds' record
+// shapes forward-compatible for a future schema bump.
+export const VERSION = 2;
 const SALT_BYTES = 16;
 const DEK_BYTES = 32;
 const PBKDF2_ITERATIONS = 600000;

--- a/src/gumptionchain/static/sdk/gc-onboarding.mjs
+++ b/src/gumptionchain/static/sdk/gc-onboarding.mjs
@@ -131,7 +131,9 @@ export function makeOnboarding({
     if (withPasskey && (await passkeySupported())) {
       const { signing_key, address, mnemonic, credentialId } =
         await derived.enroll({ userName });
-      await store.put({ kind: 'derived', address, credentialId });
+      await store.put({
+        version: keyring.VERSION, kind: 'derived', address, credentialId,
+      });
       key = signing_key;
       await notify();
       return { kind: 'derived', address, mnemonic };

--- a/src/gumptionchain/static/sdk/gc-onboarding.mjs
+++ b/src/gumptionchain/static/sdk/gc-onboarding.mjs
@@ -2,11 +2,19 @@
 // low-level gc-* modules into create / back up / restore / unlock / sign-login
 // over a single in-memory unlocked-key holder. NO DOM, NO CSS, NO framework:
 // the consuming app owns all markup and renders from status() + onChange().
+//
+// Kind-aware (two identity kinds behind one surface):
+//   - 'derived' — a passkey identity whose seed = KDF(passkey-PRF) (No-2FA). The
+//     record holds { kind, address, credentialId } and NO key material; the key
+//     is re-derived from the passkey on demand (makeDerivedIdentity.resolve).
+//   - 'wrap'    — a random key encrypted in the keyring, unlockable by passphrase
+//     (and optionally a non-resident convenience passkey).
 import { SigningKey } from './gc-signing-key.mjs';
 import * as keyring from './gc-keyring.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
+import { makeDerivedIdentity } from './gc-derived-identity.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -38,15 +46,14 @@ export function makeOnboarding({
   // A passkey adapter is built from rpId/rpName unless one is injected; absent
   // both, passkey features stay unavailable (status reports passkeySupported:false).
   const pk = passkey ?? ((rpId && rpName) ? makeWebauthnPasskey({ rpId, rpName }) : null);
+  // The derive flow (enroll/resolve) composes the same passkey adapter.
+  const derived = pk ? makeDerivedIdentity({ passkey: pk }) : null;
 
   let key = null; // the in-memory unlocked SigningKey, or null when locked
   const listeners = new Set();
 
   const secureContext = () => Boolean(win && win.isSecureContext);
 
-  // Feature-detect passkey support: an adapter must exist, the context must be
-  // secure, and the adapter must report support (guarded — a throwing adapter
-  // counts as unsupported). Reused by status() and create().
   async function passkeySupported() {
     if (!(pk && secureContext())) return false;
     try {
@@ -56,8 +63,16 @@ export function makeOnboarding({
     }
   }
 
-  // Which unlock methods the STORED record is enrolled under, read from its
-  // wraps without unlocking. Stable order: passphrase, then passkey.
+  // The stored record's identity kind. New records always carry `kind`; a stale
+  // record with keyring `wraps` and no `kind` reads as 'wrap' (a non-crashing
+  // default, NOT a migration path — greenfield recreates the dev DB).
+  function recordKind(rec) {
+    if (!rec) return null;
+    return rec.kind ?? (rec.wraps ? 'wrap' : null);
+  }
+
+  // Which unlock methods a WRAP record is enrolled under, read from its wraps
+  // without unlocking. Derived records have no wraps -> []. Stable order.
   function enrolledMethods(rec) {
     const wraps = (rec && rec.wraps) || {};
     return ['passphrase', 'passkey'].filter((m) => Boolean(wraps[m]));
@@ -65,16 +80,19 @@ export function makeOnboarding({
 
   async function status() {
     const rec = await store.get();
+    const kind = recordKind(rec);
     const address = key ? await key.address() : (rec ? rec.address : null);
     const methods = enrolledMethods(rec);
     return {
       hasKey: Boolean(rec),
       unlocked: Boolean(key),
+      kind,
       address,
       // passkeySupported = device capability; passkeyEnrolled = stored state.
-      // Gate an "add a passkey" affordance on supported && !enrolled.
+      // A derived identity IS a passkey; a wrap identity is passkey-enrolled
+      // when it carries a passkey wrap.
       passkeySupported: await passkeySupported(),
-      passkeyEnrolled: methods.includes('passkey'),
+      passkeyEnrolled: kind === 'derived' || methods.includes('passkey'),
       methods,
       secureContext: secureContext(),
     };
@@ -97,25 +115,53 @@ export function makeOnboarding({
     return () => listeners.delete(fn);
   }
 
-  function passkeyIds(userName, address) {
-    return { userId: address, userName: userName || address };
+  // userId/userName + an optional residentKey preference for passkey enrollment.
+  function passkeyIds(userName, address, residentKey) {
+    return {
+      userId: address,
+      userName: userName || address,
+      ...(residentKey ? { residentKey } : {}),
+    };
   }
 
+  // A passkey at create time means DERIVE (seed = KDF(PRF), No-2FA). Without a
+  // (supported) passkey it's a passphrase-WRAP identity. An unsupported passkey
+  // falls back to wrap rather than throwing.
   async function create({ passphrase, withPasskey = false, userName } = {}) {
+    if (withPasskey && (await passkeySupported())) {
+      const { signing_key, address, mnemonic, credentialId } =
+        await derived.enroll({ userName });
+      await store.put({ kind: 'derived', address, credentialId });
+      key = signing_key;
+      await notify();
+      return { kind: 'derived', address, mnemonic };
+    }
     const sk = await SigningKey.generate();
     await keyring.enroll(sk, { store }, { passphrase });
-    const address = await sk.address();
-    if (withPasskey && (await passkeySupported())) {
-      await keyring.addPasskey(
-        { store, passkey: pk }, { passphrase }, passkeyIds(userName, address),
-      );
-    }
     key = sk;
     await notify();
-    return { address };
+    return { kind: 'wrap', address: await sk.address() };
   }
 
   async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    const rec = await store.get();
+    if (recordKind(rec) === 'derived') {
+      if (!derived) {
+        throw new NoSigningKeyError(
+          'no passkey adapter to rehydrate a derived identity',
+        );
+      }
+      // No-2FA: re-derive from the passkey PRF and match the stored address.
+      const r = await derived.resolve({ expectedAddress: rec.address });
+      if (r.status !== 'ok') {
+        // no-passkey / needs-passphrase / mismatch — can't rehydrate here. The
+        // hub treats this as "offer import", never a passphrase prompt.
+        throw new NoSigningKeyError('could not rehydrate this passkey identity');
+      }
+      key = r.signing_key;
+      await notify();
+      return { address: await key.address() };
+    }
     key = await keyring.unlock(
       { store, passkey: usePasskey ? pk : undefined },
       { passphrase },
@@ -124,16 +170,56 @@ export function makeOnboarding({
     return { address: await key.address() };
   }
 
-  async function restore({ backup, passphrase } = {}) {
-    const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
-    const sk = await importEncrypted(artifact, passphrase);
+  // A recovery phrase OR an encrypted backup both land as a WRAP identity —
+  // seamlessness can't follow a phrase (no new passkey reproduces an old
+  // passkey's PRF). Derived identities don't "restore"; a synced passkey just
+  // unlock()s them.
+  async function restore({ mnemonic, backup, passphrase } = {}) {
+    let sk;
+    if (mnemonic != null) {
+      sk = await SigningKey.fromMnemonic(mnemonic);
+    } else if (backup != null) {
+      const artifact = typeof backup === 'string' ? JSON.parse(backup) : backup;
+      sk = await importEncrypted(artifact, passphrase);
+    } else {
+      throw new BadBackupError('restore requires a mnemonic or a backup');
+    }
+    if (passphrase == null || passphrase === '') {
+      throw new BadPassphraseError(
+        'a passphrase is required to store a restored identity',
+      );
+    }
     await keyring.enroll(sk, { store }, { passphrase });
     key = sk;
     await notify();
-    return { address: await sk.address() };
+    return { kind: 'wrap', address: await sk.address() };
   }
 
   async function backup({ passphrase } = {}) {
+    const rec = await store.get();
+    if (recordKind(rec) === 'derived') {
+      // Return the recovery phrase. Use the held key if unlocked, else tap the
+      // passkey to re-derive — without leaving a previously-locked id unlocked.
+      const wasLocked = !key;
+      let sk = key;
+      if (wasLocked) {
+        if (!derived) {
+          throw new NoSigningKeyError(
+            'no passkey adapter to back up a derived identity',
+          );
+        }
+        const r = await derived.resolve({ expectedAddress: rec.address });
+        if (r.status !== 'ok') {
+          throw new NoSigningKeyError(
+            'could not rehydrate this passkey identity',
+          );
+        }
+        sk = r.signing_key;
+      }
+      const mnemonic = await sk.mnemonic();
+      await notify();
+      return { kind: 'derived', mnemonic };
+    }
     const wasLocked = !key;
     if (wasLocked) {
       key = await keyring.unlock({ store }, { passphrase });
@@ -144,15 +230,19 @@ export function makeOnboarding({
       key = null; // a backup is a read; don't leave the key unlocked
     }
     await notify();
-    return { artifact, filename };
+    return { kind: 'wrap', artifact, filename };
   }
 
+  // Add a NON-RESIDENT convenience passkey to a wrap identity. Non-resident
+  // (residentKey:'discouraged') keeps it out of other origins' discover(), so it
+  // can't produce hollow cross-app recognition. (A preference, not a guarantee —
+  // some authenticators make it discoverable anyway; a strong mitigation.)
   async function addPasskey({ passphrase, userName } = {}) {
     const rec = await store.get();
     const address = await keyring.addPasskey(
       { store, passkey: pk },
       { passphrase },
-      passkeyIds(userName, rec ? rec.address : undefined),
+      passkeyIds(userName, rec ? rec.address : undefined, 'discouraged'),
     );
     await notify();
     return { address };

--- a/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
+++ b/src/gumptionchain/static/sdk/gc-passkey-webauthn.mjs
@@ -111,7 +111,7 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
       );
     },
 
-    async enroll({ userId, userName } = {}) {
+    async enroll({ userId, userName, residentKey = 'required' } = {}) {
       const idBytes =
         typeof userId === 'string'
           ? new TextEncoder().encode(userId)
@@ -125,7 +125,7 @@ export function makeWebauthnPasskey({ rpId, rpName, userVerification = 'preferre
             { type: 'public-key', alg: -7 },
             { type: 'public-key', alg: -257 },
           ],
-          authenticatorSelection: { residentKey: 'required', userVerification },
+          authenticatorSelection: { residentKey, userVerification },
           extensions: { prf: { eval: { first: PRF_SALT } } },
         },
       });

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.8.0';
+export const version = '0.9.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Closes #322.

## Summary

Evolves the SDK onboarding controller (`gc-onboarding.mjs`) to be **kind-aware**, so the hub can serve both identity kinds behind one surface (gump-hub#67 "Sign in with Gumption", `feat/derive-path-onboarding`):

- **derived** — a passkey user; `seed = KDF(passkey-PRF)`, No-2FA (the seamless cross-origin path; builds on the #320 derive primitives). The stored record is `{ kind:'derived', address, credentialId }` with **no key material** — the key is re-derived from the passkey PRF on demand.
- **wrap** — passphrase-only fallback; a random seed encrypted in the keyring (today's behavior), now stamped `kind:'wrap'`.

**No chain/consensus change** — pure SDK (browser) + Node tests. Zero new deps. Greenfield (no migration; recreate the dev DB).

## What changed

- **`create({ withPasskey })` — semantic shift:** a passkey at create time now means **derive** (No-2FA; returns the 24-word `mnemonic` for the hub's backup step), not "wrap + passkey-unlock." The wrap-plus-convenience-passkey case is reached via `addPasskey` after a passphrase create. An unsupported passkey falls back to wrap (no throw).
- **`unlock` routes on kind** — derived → `makeDerivedIdentity.resolve({ expectedAddress })` (re-derives and matches the stored address; throws on non-`ok`); wrap → `keyring.unlock` (unchanged).
- **`backup` per kind** — derived → `{ kind:'derived', mnemonic }` (taps the passkey to re-derive if locked, without leaving it unlocked); wrap → encrypted artifact (unchanged).
- **`restore`** — a recovery phrase **or** an encrypted backup both land as a **wrap** identity (seamlessness can't follow a phrase). Derived identities don't restore; a synced passkey just `unlock`s them.
- **`status()`** adds `kind`, read without unlocking.
- **`addPasskey` enrolls a NON-resident convenience passkey** (`residentKey:'discouraged'`) so a wrap identity's convenience passkey stays out of other origins' `discover()` and can't produce hollow cross-app recognition. The derive passkey stays `'required'`. Threaded via the `ids` object — no keyring signature change. (A preference, not a guarantee — documented in-code; the hub keeps the defensive member-guide rule.)
- `gc-passkey-webauthn.mjs` `enroll` gains `residentKey='required'`; `gc-keyring.mjs` `enroll` stamps `kind:'wrap'`.

## Out of scope (per the issue + hub spec)
Recognition directory, 2FA, server-verified recognition, `largeBlob`/remote key store — all hub-side / future. Base's served `/signing-key` + `/transact` pages use `keyring.enroll`/`fromMnemonic` directly (not `makeOnboarding`), so they're unaffected beyond the backward-compatible `kind` stamp + `residentKey` default.

## Test plan
- `clients/sdk` `node --test` — **167 passed** (rewritten `gc-onboarding.test.mjs` covers both kinds: derived create/unlock/backup, wrap create/unlock/addPasskey, restore-mnemonic→wrap, restore-backup→wrap, unsupported fallback, wrong-passkey rejection, `residentKey:'discouraged'` assertion)
- `uv run pytest` — **710 passed, 1 skipped**; vendored byte-parity (`tests/test_sdk_vendored.py`) green
- `uv run ruff check src tests` + `ruff format --check` — clean
- Independent whole-branch review — clean (kind routing, no-key-material derived records, non-resident threading end-to-end, restore semantics, byte-parity all verified)
- SDK bumped 0.8.0 → 0.9.0; `static/sdk` re-vendored

🤖 Generated with [Claude Code](https://claude.com/claude-code)