### PR TITLE
feat(explorer): sortable Subjects + Stats leaderboard columns (#297, #298)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -27,6 +27,7 @@ from gumptionchain.models import (
 from gumptionchain.node import Node
 from gumptionchain.payload import decode_subject
 from gumptionchain.provenance import lookup_provenance
+from gumptionchain.sortable import parse_sort
 from gumptionchain.transaction import Transaction
 from gumptionchain.util import now
 
@@ -161,10 +162,21 @@ def blocks_view() -> Any:
 
 @blueprint.route('/subjects')
 def subjects_view() -> Any:
+    spec = parse_sort(
+        request.args,
+        allowed={'subject', 'opposition', 'support', 'net', 'total'},
+        default_key='total',
+    )
     try:
         lc = longest_chain()
         subjects_page = (
-            paginate_rows(lc.subject_leaderboard()) if lc is not None else None
+            paginate_rows(
+                lc.subject_leaderboard(
+                    sort_by=spec.key, direction=spec.direction
+                )
+            )
+            if lc is not None
+            else None
         )
     except HTTPException as e:
         return e
@@ -176,21 +188,36 @@ def subjects_view() -> Any:
         current_app.logger.exception(e)
         abort(500)
     return render_template(
-        'subjects.html', title='Subjects', subjects_page=subjects_page
+        'subjects.html',
+        title='Subjects',
+        subjects_page=subjects_page,
+        sort=spec,
     )
 
 
 @blueprint.route('/stats')
 def stats_view() -> Any:
+    spec = parse_sort(
+        request.args,
+        allowed={'address', 'count', 'last'},
+        default_key='count',
+    )
     try:
-        stats_page = paginate_rows(SubmissionDAO.transactor_leaderboard())
+        stats_page = paginate_rows(
+            SubmissionDAO.transactor_leaderboard(
+                sort_by=spec.key, direction=spec.direction
+            )
+        )
     except HTTPException as e:
         return e
     except Exception as e:
         current_app.logger.exception(e)
         abort(500)
     return render_template(
-        'stats.html', title='Submission stats', stats_page=stats_page
+        'stats.html',
+        title='Submission stats',
+        stats_page=stats_page,
+        sort=spec,
     )
 
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -556,8 +556,13 @@ class Chain:
     def support_balance(self, subject: str) -> int:
         return int(self.to_dao().support_balance(subject))
 
-    def subject_leaderboard(self, limit: int | None = None) -> Select[Any]:
-        return self.to_dao().subject_leaderboard(limit)
+    def subject_leaderboard(
+        self,
+        sort_by: str = 'total',
+        direction: str = 'desc',
+        limit: int | None = None,
+    ) -> Select[Any]:
+        return self.to_dao().subject_leaderboard(sort_by, direction, limit)
 
     def search_subjects(
         self, query: str, limit: int | None = None

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1507,14 +1507,25 @@ class SubmissionDAO(Base):
         return db.session.scalar(stmt) or 0
 
     @classmethod
-    def transactor_leaderboard(cls) -> Select[Any]:
+    def transactor_leaderboard(
+        cls, sort_by: str = 'count', direction: str = 'desc'
+    ) -> Select[Any]:
+        count_expr = db.func.count()
+        last_expr = db.func.max(cls.submitted_at)
         stmt = db.select(
             cls.transactor_address.label('address'),
-            db.func.count().label('count'),
-            db.func.max(cls.submitted_at).label('last_submit_at'),
+            count_expr.label('count'),
+            last_expr.label('last_submit_at'),
         )
         stmt = stmt.group_by(cls.transactor_address)
-        stmt = stmt.order_by(db.desc('count'), cls.transactor_address)
+        order_map: dict[str, Any] = {
+            'address': cls.transactor_address,
+            'count': count_expr,
+            'last': last_expr,
+        }
+        col = order_map.get(sort_by, count_expr)
+        col = col.asc() if direction == 'asc' else col.desc()
+        stmt = stmt.order_by(col, cls.transactor_address)
         return stmt  # type: ignore[no-any-return]
 
 

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -889,6 +889,8 @@ class ChainDAO(Base):
 
     def subject_leaderboard(
         self,
+        sort_by: str = 'total',
+        direction: str = 'desc',
         limit: int | None = None,
     ) -> Select[Any]:
         def _leg(column: Any, kind: StakeKind) -> Select[Any]:
@@ -907,18 +909,38 @@ class ChainDAO(Base):
         opp = _leg(OutflowDAO.opposition, 'opposition')
         sup = _leg(OutflowDAO.support, 'support')
         union = opp.union_all(sup).subquery()
+        # Build the aggregate expressions once and reuse them in BOTH the
+        # SELECT and the ORDER BY map, so ordering never relies on label-name
+        # resolution (SQLite-safe) and net is a real column.
+        opp_sum = db.func.sum(
+            db.case((union.c.kind == 'opposition', union.c.amount), else_=0)
+        )
+        sup_sum = db.func.sum(
+            db.case((union.c.kind == 'support', union.c.amount), else_=0)
+        )
+        tot_sum = db.func.sum(union.c.amount)
+        net_expr = sup_sum - opp_sum
         stmt = db.select(
             union.c.subject,
-            db.func.sum(
-                db.case((union.c.kind == 'opposition', union.c.amount), else_=0)
-            ).label('opposition'),
-            db.func.sum(
-                db.case((union.c.kind == 'support', union.c.amount), else_=0)
-            ).label('support'),
-            db.func.sum(union.c.amount).label('total'),
+            opp_sum.label('opposition'),
+            sup_sum.label('support'),
+            net_expr.label('net'),
+            tot_sum.label('total'),
         )
         stmt = stmt.group_by(union.c.subject)
-        stmt = stmt.order_by(db.desc('total'), union.c.subject)
+        # Allowlist: a validated key -> the real column expression. Never
+        # interpolate ORDER BY from raw input.
+        order_map: dict[str, Any] = {
+            'subject': union.c.subject,
+            'opposition': opp_sum,
+            'support': sup_sum,
+            'net': net_expr,
+            'total': tot_sum,
+        }
+        col = order_map.get(sort_by, tot_sum)
+        col = col.asc() if direction == 'asc' else col.desc()
+        # Stable tiebreak by subject so pagination is deterministic.
+        stmt = stmt.order_by(col, union.c.subject)
         if limit is not None:
             stmt = stmt.limit(limit)
             return db.select(db.aliased(stmt.subquery()))  # type: ignore[no-any-return]

--- a/src/gumptionchain/sortable.py
+++ b/src/gumptionchain/sortable.py
@@ -1,0 +1,49 @@
+"""Shared server-side sort helper for the paginated explorer leaderboards.
+
+The URL `?sort` key is validated against a per-view allowlist and `?dir`
+against asc/desc; the DAO maps the validated key to an actual column
+expression. The ORDER BY column is NEVER interpolated from raw request input
+— that mapping is the whole security surface.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SortSpec:
+    """A validated (column key, direction) pair + template helpers."""
+
+    key: str
+    direction: str  # 'asc' | 'desc'
+
+    def toggled(self, col_key: str) -> str:
+        """The direction a header link for `col_key` should request: flip if
+        it's the active column, else the column's default ('desc' — the
+        leaderboards lead with 'most')."""
+        if col_key == self.key:
+            return 'asc' if self.direction == 'desc' else 'desc'
+        return 'desc'
+
+    def indicator(self, col_key: str) -> str:
+        """'▼'/'▲' on the active column, '' otherwise."""
+        if col_key != self.key:
+            return ''
+        return '▼' if self.direction == 'desc' else '▲'
+
+
+def parse_sort(
+    args: Mapping[str, str],
+    *,
+    allowed: set[str],
+    default_key: str,
+    default_dir: str = 'desc',
+) -> SortSpec:
+    """Validate `?sort`/`?dir` against the allowlist; fall back to defaults."""
+    key = args.get('sort')
+    if key not in allowed:
+        key = default_key
+    direction = args.get('dir')
+    if direction not in ('asc', 'desc'):
+        direction = default_dir
+    return SortSpec(key=key, direction=direction)

--- a/src/gumptionchain/templates/_sort.html
+++ b/src/gumptionchain/templates/_sort.html
@@ -1,0 +1,10 @@
+{# A sortable column header: a link that toggles sort/direction, preserving
+   every other query arg; `page` is dropped so a re-sort returns to page 1.
+   `spec` is a sortable.SortSpec; `endpoint` the view's url_for target. #}
+{% macro sort_header(label, key, spec, endpoint) -%}
+{%- set args = request.args.to_dict() -%}
+{%- set _ = args.pop('page', none) -%}
+{%- set _ = args.update(request.view_args | default({}, true)) -%}
+{%- set _ = args.update({'sort': key, 'dir': spec.toggled(key)}) -%}
+<th><a class="text-dark text-decoration-none" href="{{ url_for(endpoint, **args) }}">{{ label }} {{ spec.indicator(key) }}</a></th>
+{%- endmacro %}

--- a/src/gumptionchain/templates/stats.html
+++ b/src/gumptionchain/templates/stats.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_pagination.html" import render_pagination %}
+{% from "_sort.html" import sort_header %}
 
 {% block content -%}
 <div class="container-fluid">
@@ -8,7 +9,11 @@
       <div class="card-title h5">Submission stats</div>
       {%- if stats_page and stats_page.total %}
       <table class="table table-hover">
-        <thead><tr><th>#</th><th>Transactor</th><th>Submissions</th><th>Last submit</th></tr></thead>
+        <thead><tr><th>#</th>
+          {{ sort_header('Transactor', 'address', sort, 'browser.stats_view') }}
+          {{ sort_header('Submissions', 'count', sort, 'browser.stats_view') }}
+          {{ sort_header('Last submit', 'last', sort, 'browser.stats_view') }}
+        </tr></thead>
         <tbody>
         {%- for row in stats_page.items %}
           <tr>

--- a/src/gumptionchain/templates/subjects.html
+++ b/src/gumptionchain/templates/subjects.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from "_pagination.html" import render_pagination %}
 {% from "_net.html" import net_stance %}
+{% from "_sort.html" import sort_header %}
 
 {% block content -%}
 <div class="container-fluid">
@@ -10,7 +11,13 @@
       {% include "subjects/extra.html" ignore missing %}
       {%- if subjects_page and subjects_page.total %}
       <table class="table table-hover subjects">
-        <thead><tr><th>#</th><th>Subject</th><th>Opposition</th><th>Support</th><th>Net</th><th>Total</th></tr></thead>
+        <thead><tr><th>#</th>
+          {{ sort_header('Subject', 'subject', sort, 'browser.subjects_view') }}
+          {{ sort_header('Opposition', 'opposition', sort, 'browser.subjects_view') }}
+          {{ sort_header('Support', 'support', sort, 'browser.subjects_view') }}
+          {{ sort_header('Net', 'net', sort, 'browser.subjects_view') }}
+          {{ sort_header('Total', 'total', sort, 'browser.subjects_view') }}
+        </tr></thead>
         <tbody>
         {%- for row in subjects_page.items %}
           <tr class="clickable" style="cursor: pointer;" onclick="window.location='{{ url_for('browser.subject_view', subject=row.subject) }}'">

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1649,8 +1649,8 @@ def test_antijoin_equivalence_all_methods(
         wl = db.session.execute(dao_a.signing_key_leaderboard()).all()
         assert wl == [(signing_key.address, reward + mint)]
         sl = db.session.execute(dao_a.subject_leaderboard()).all()
-        # (subject, opposition, support, total)
-        assert sl == [(subject, cb_1_amount, 0, cb_1_amount)]
+        # (subject, opposition, support, net, total); net = support - opposition
+        assert sl == [(subject, cb_1_amount, 0, -cb_1_amount, cb_1_amount)]
 
         # On chain_b (ancestry routing): t_2a is NOT in chain_b, so cb_1 is
         # UNSPENT; block_2b's coinbase is a single unspent reward (no stake →

--- a/tests/test_sortable.py
+++ b/tests/test_sortable.py
@@ -1,0 +1,45 @@
+from gumptionchain.sortable import SortSpec, parse_sort
+
+
+def test_parse_sort_defaults_when_absent():
+    spec = parse_sort({}, allowed={'a', 'b'}, default_key='b')
+    assert spec.key == 'b'
+    assert spec.direction == 'desc'
+
+
+def test_parse_sort_rejects_unknown_key_falls_back_to_default():
+    spec = parse_sort({'sort': 'evil'}, allowed={'a', 'b'}, default_key='a')
+    assert spec.key == 'a'
+
+
+def test_parse_sort_accepts_allowed_key_and_direction():
+    spec = parse_sort(
+        {'sort': 'a', 'dir': 'asc'}, allowed={'a', 'b'}, default_key='b'
+    )
+    assert spec.key == 'a'
+    assert spec.direction == 'asc'
+
+
+def test_parse_sort_rejects_bad_direction():
+    spec = parse_sort(
+        {'sort': 'a', 'dir': 'sideways'}, allowed={'a'}, default_key='a'
+    )
+    assert spec.direction == 'desc'
+
+
+def test_parse_sort_honors_default_dir():
+    spec = parse_sort({}, allowed={'a'}, default_key='a', default_dir='asc')
+    assert spec.direction == 'asc'
+
+
+def test_toggled_flips_only_the_active_column():
+    spec = SortSpec(key='a', direction='desc')
+    assert spec.toggled('a') == 'asc'
+    assert spec.toggled('b') == 'desc'
+    assert SortSpec(key='a', direction='asc').toggled('a') == 'desc'
+
+
+def test_indicator_marks_only_the_active_column():
+    assert SortSpec(key='a', direction='desc').indicator('a') == '▼'
+    assert SortSpec(key='a', direction='asc').indicator('a') == '▲'
+    assert SortSpec(key='a', direction='desc').indicator('b') == ''

--- a/tests/test_stats_page.py
+++ b/tests/test_stats_page.py
@@ -1,4 +1,5 @@
 from gumptionchain.api_client import ApiClient
+from gumptionchain.models import SubmissionDAO
 
 
 def test_stats_page_lists_transactors(
@@ -25,3 +26,35 @@ def test_stats_page_lists_transactors(
     resp = test_client.get('/stats')
     assert resp.status_code == 200
     assert transactor_signing_key.address.encode() in resp.data
+
+
+def _seed_two_transactors(app):
+    with app.app_context():
+        # 'GCfewGC' has one submission, 'GCmanyGC' has three.
+        SubmissionDAO.record('txF1', 'GCfewGC')
+        SubmissionDAO.record('txM1', 'GCmanyGC')
+        SubmissionDAO.record('txM2', 'GCmanyGC')
+        SubmissionDAO.record('txM3', 'GCmanyGC')
+
+
+def test_stats_sort_count_asc_orders_few_before_many(app, test_client):
+    _seed_two_transactors(app)
+    resp = test_client.get('/stats?sort=count&dir=asc')
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert body.index('GCfewGC') < body.index('GCmanyGC')
+
+
+def test_stats_sort_bogus_key_falls_back_to_default(app, test_client):
+    _seed_two_transactors(app)
+    resp = test_client.get('/stats?sort=bogus')
+    assert resp.status_code == 200
+
+
+def test_stats_active_count_header_toggles_and_indicates(app, test_client):
+    _seed_two_transactors(app)
+    resp = test_client.get('/stats?sort=count&dir=desc')
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert 'sort=count&amp;dir=asc' in body or 'sort=count&dir=asc' in body
+    assert '▼' in body

--- a/tests/test_subject_leaderboard.py
+++ b/tests/test_subject_leaderboard.py
@@ -160,3 +160,45 @@ def test_stake_stats_empty_chain(
         count, staked = m.longest_chain.stake_stats()
         assert count == 0
         assert staked == 0
+
+
+def test_subject_leaderboard_net_column_and_sorting(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    a = encode_subject('alpha')
+    b = encode_subject('bravo')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        lc = m.longest_chain
+        # alpha: 300 opp + 150 sup -> net -150, total 450
+        _stake(host, lc, signing_key, oppose=(a, 300))
+        mill_block(signing_key)
+        lc = m.longest_chain
+        _stake(host, lc, signing_key, support=(a, 150))
+        mill_block(signing_key)
+        lc = m.longest_chain
+        # bravo: 50 opp + 250 sup -> net +200, total 300
+        _stake(host, lc, signing_key, oppose=(b, 50))
+        mill_block(signing_key)
+        lc = m.longest_chain
+        _stake(host, lc, signing_key, support=(b, 250))
+        mill_block(signing_key)
+
+        dao = m.longest_chain.to_dao()
+
+        def order(sort_by, direction):
+            rows = db.session.execute(
+                dao.subject_leaderboard(sort_by=sort_by, direction=direction)
+            ).all()
+            return [r.subject for r in rows]
+
+        rows = db.session.execute(dao.subject_leaderboard()).all()
+        by = {r.subject: r for r in rows}
+        assert by[a].net == -150
+        assert by[b].net == 200
+
+        assert order('total', 'desc') == [a, b]
+        assert order('net', 'desc') == [b, a]
+        assert order('support', 'asc') == [a, b]
+        assert order('opposition', 'desc') == [a, b]
+        assert order('bogus', 'desc') == [a, b]

--- a/tests/test_subjects_page.py
+++ b/tests/test_subjects_page.py
@@ -83,6 +83,54 @@ def test_subjects_index_paginates_across_pages(
         assert f'/subject/{mid}'.encode() not in page2.data
 
 
+# ---- sortable headers --------------------------------------------------
+
+
+def test_subjects_sort_support_asc_orders_low_before_high(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    high = encode_subject('high-support')
+    low = encode_subject('low-support')
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake_support(host, m.longest_chain, signing_key, 300, high)
+        mill_block(signing_key)
+        _stake_support(host, m.longest_chain, signing_key, 100, low)
+        mill_block(signing_key)
+
+        resp = app.test_client().get('/subjects?sort=support&dir=asc')
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert body.index(low) < body.index(high)
+
+
+def test_subjects_sort_bogus_key_falls_back_to_default(
+    app, host, mill_block, requests_proxy, subject, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake_support(host, m.longest_chain, signing_key, 100, subject)
+        mill_block(signing_key)
+
+        resp = app.test_client().get('/subjects?sort=bogus')
+        assert resp.status_code == 200
+
+
+def test_subjects_active_total_header_toggles_and_indicates(
+    app, host, mill_block, requests_proxy, subject, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        _stake_support(host, m.longest_chain, signing_key, 100, subject)
+        mill_block(signing_key)
+
+        resp = app.test_client().get('/subjects?sort=total&dir=desc')
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert 'sort=total&amp;dir=asc' in body or 'sort=total&dir=asc' in body
+        assert '▼' in body
+
+
 # ---- subject detail ----------------------------------------------------
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -60,3 +60,78 @@ def test_transactor_leaderboard_ranks_by_count(app):
         assert by_addr['GCquietGC'].count == 1
         assert rows[0].address == 'GCbusyGC'
         assert by_addr['GCbusyGC'].last_submit_at is not None
+
+
+def _seed_sortable(app):
+    # Distinct counts so count ordering is unambiguous; addresses chosen so
+    # their lexical order (alpha < bravo < charlie) differs from BOTH the
+    # count-desc (bravo:3, alpha:2, charlie:1) and count-asc orders, making
+    # the address sort a meaningful, independent assertion.
+    counts = {'GCalphaGC': 2, 'GCbravoGC': 3, 'GCcharlieGC': 1}
+    n = 0
+    for address, ct in counts.items():
+        for _ in range(ct):
+            n += 1
+            SubmissionDAO.record(f'tx{n}', address)
+
+
+def test_transactor_leaderboard_sort_by_count_desc(app):
+    with app.app_context():
+        _seed_sortable(app)
+        rows = db.session.execute(
+            SubmissionDAO.transactor_leaderboard(
+                sort_by='count', direction='desc'
+            )
+        ).all()
+        assert [r.address for r in rows] == [
+            'GCbravoGC',
+            'GCalphaGC',
+            'GCcharlieGC',
+        ]
+        assert rows[0].count == 3
+
+
+def test_transactor_leaderboard_sort_by_count_asc(app):
+    with app.app_context():
+        _seed_sortable(app)
+        rows = db.session.execute(
+            SubmissionDAO.transactor_leaderboard(
+                sort_by='count', direction='asc'
+            )
+        ).all()
+        assert [r.address for r in rows] == [
+            'GCcharlieGC',
+            'GCalphaGC',
+            'GCbravoGC',
+        ]
+        assert rows[0].count == 1
+
+
+def test_transactor_leaderboard_sort_by_address_asc(app):
+    with app.app_context():
+        _seed_sortable(app)
+        rows = db.session.execute(
+            SubmissionDAO.transactor_leaderboard(
+                sort_by='address', direction='asc'
+            )
+        ).all()
+        assert [r.address for r in rows] == [
+            'GCalphaGC',
+            'GCbravoGC',
+            'GCcharlieGC',
+        ]
+
+
+def test_transactor_leaderboard_bogus_sort_falls_back_to_count_desc(app):
+    with app.app_context():
+        _seed_sortable(app)
+        rows = db.session.execute(
+            SubmissionDAO.transactor_leaderboard(
+                sort_by='bogus', direction='desc'
+            )
+        ).all()
+        assert [r.address for r in rows] == [
+            'GCbravoGC',
+            'GCalphaGC',
+            'GCcharlieGC',
+        ]


### PR DESCRIPTION
Closes #297, closes #298.

## Summary

Makes the `/subjects` and `/stats` explorer leaderboard columns **server-side sortable** — correct across all pages of a paginated table. (A client-JS sort would only reorder the current page, and dodges the repo's npm-aversion.) Both pages share one helper + one header macro.

## The safety rule (the whole security surface)

The `ORDER BY` column is **never** interpolated from raw request input. The URL `?sort` key is validated against a per-view **allowlist** and mapped to an actual SQLAlchemy column expression *inside the DAO* (`order_map.get(sort_by, default)`); `?dir` is validated to `asc`/`desc` (→ `.asc()`/`.desc()`). Unknown/absent values fall back to the column default with a stable tiebreak.

## What changed

- **`src/gumptionchain/sortable.py`** (new, pure, unit-tested) — `parse_sort(args, *, allowed, default_key, default_dir='desc') → SortSpec`. `SortSpec.toggled(col)` / `.indicator(col)` drive the toggling header links + ▲/▼.
- **`templates/_sort.html`** (new) — a `sort_header(label, key, spec, endpoint)` macro; preserves other query args, drops `page` so a re-sort returns to page 1.
- **`ChainDAO.subject_leaderboard(sort_by='total', direction='desc', limit=None)`** — adds a `net` column (`sum(support) − sum(opposition)`) so Net is sortable (display unchanged via `net_stance`); orders by an allowlisted column with a `subject` tiebreak. Aggregate exprs are built once and reused in both the SELECT and the order map (SQLite-safe, no label-name reliance). `Chain.subject_leaderboard` passes through; the no-arg callers (`subject_count`/`total_staked`/`stake_stats`) keep today's behavior.
- **`SubmissionDAO.transactor_leaderboard(sort_by='count', direction='desc')`** — same pattern (address/count/last).
- **`browser.py`** — `subjects_view`/`stats_view` parse the sort and thread it to the DAO + template.

**Columns:** Subjects = Subject / Opposition / Support / Net / Total (default **Total ↓**); Stats = Transactor / Submissions / Last submit (default **Submissions ↓**). `?sort`/`?dir` persist across pages for free (`render_pagination` already carries `request.args`).

## Out of scope
`/addresses` (no issue — a trivial follow-up now the helper exists); client-side JS; multi-column / persisted-preference sort.

## Test plan
- `uv run pytest` — **728 passed, 1 skipped**
- New: `tests/test_sortable.py` (helper unit), DAO ordering for every column incl. net (`tests/test_subject_leaderboard.py`, `tests/test_submission.py`), and view tests asserting rendered order + toggled-dir links + ▲/▼ (`tests/test_subjects_page.py`, `tests/test_stats_page.py`)
- `uv run ruff check src tests` + `ruff format --check` — clean; `uv run mypy` — clean (`sortable.py` fully typed)
- `gumptionchain db check` — unaffected (no schema change)
- Independent whole-branch review — clean (ORDER BY never interpolated, net + tiebreaks correct, limit-subquery callers unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)