### PR TITLE
docs(sdk): document recognize() + its enrolled-only caveat (#325)

### DIFF
--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -148,6 +148,7 @@ mapping, *not* BIP-39's PBKDF2 seed-stretching — the words **are** the seed.)
 | `canonical`, `signHeaders` | `gc-sig-v1` request signing |
 | `enroll`, `unlock`, `hasSigningKey`, `clear` | passkey-anchored storage orchestration |
 | `makeWebauthnPasskey`, `makeIdbStore` | real WebAuthn + IndexedDB adapters; the passkey adapter also exposes `discover({ mediation, signal })` / `isConditionalAvailable()` |
+| `recognize` | `recognize({ rpId })` → `{ recognized, address }` — a "who's here?" hint over `discover()` (enrolled identities only; see caveat) |
 | `deriveSeed`, `deriveSigningKey` | passkey-PRF → 32-byte seed / `SigningKey` (no stored key; optional `passphrase` 2FA) |
 | `seedToMnemonic`, `mnemonicToSeed` | BIP-39 24-word recovery-phrase codec over the raw seed |
 | `exportEncrypted`, `importEncrypted`, `exportPlain`, `importPlain` | backup/recovery |
@@ -179,6 +180,24 @@ the *wrap* model the encrypted key blob is origin-scoped and not re-derivable
 from the PRF, so the material itself still comes from the hub-served store or a
 user backup. (In the *derive* model below, the PRF **is** the key — see the
 federation boundary.)
+
+### `recognize()` — the "who's here?" hint
+
+`recognize({ rpId, mediation = 'optional', signal })` is a thin convenience over
+`discover()` for the member-kit: it answers "is a returning EGU user here, and who
+are they?" in one call, resolving `{ recognized: true, address }` when a passkey is
+picked, or `{ recognized: false, address: null }` on every absent / cancelled /
+unsupported / no-`userHandle` path. It **never throws** for those cases, so a caller
+always falls through to "create".
+
+> **Caveat — enrolled identities only.** The returned `address` is the credential's
+> decoded `userHandle`, which equals the GC address **only for enrolled (wrap-keyring)
+> identities**, where `user.id === address`. A **derived** identity (`create({ withPasskey })`
+> / `makeDerivedIdentity`) has a **random** `userHandle` — its address isn't known at
+> `create()` time, before the PRF exists — so `recognize()` would report a confidently
+> **wrong** address for it. Recognize/rehydrate derived identities with
+> `makeDerivedIdentity.resolve({ expectedAddress })` (which re-derives the real address
+> from the PRF), **not** `recognize()`. Route the two identity kinds accordingly.
 
 ### Derived-identity flow (`gc-derived-identity.mjs`)
 


### PR DESCRIPTION
Closes #325 (base-repo side).

## Context

#325 is the follow-up the #324 review flagged: `recognize()` (#315) returns the credential's `userHandle` as `address`, which is correct **only for enrolled (wrap-keyring) identities**. Now that #324 made **derived** identities real (their `userHandle` is a random value, not the address), pointing `recognize()` at a derived identity would return a confidently wrong address — derived recognition must go through `makeDerivedIdentity.resolve()`.

## What this does

**Ask 1 (the in-code doc-comment on `recognize()`) is already on `main`** — it landed proactively in #323 (commit `5cfe054`) when the #323 hub review raised the same point. This PR closes the remaining base-repo gap: `recognize()` was a shipped public barrel export but **absent from the SDK README**, while its sibling `discover()` and the derived-identity flow were both documented — so a consumer reading the README never saw the caveat.

- Adds a `recognize` row to the Public API table.
- Adds a dedicated **`recognize()` — the "who's here?" hint** subsection (next to the discovery + derived-identity docs) carrying the same enrolled-vs-derived caveat as the source doc-comment, and explicitly routing derived recognition to `makeDerivedIdentity.resolve({ expectedAddress })`.

## Scope

- Doc-only; no code/behavior change (the issue explicitly says **not** a change to `recognize()`'s behavior — it's correct for its #315 enrolled-user scope). The README is not vendored, so no `static/sdk` re-vendor.
- **Ask 2 (the member-kit integration guide) is hub-side** — gump-hub `docs/integrate-sign-in-with-gumption.md` (gump-hub#67) — and out of scope for this repo.

## Test plan
- Doc-only change; no tests affected. `git diff` touches `clients/sdk/README.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)