### PR TITLE
feat(sdk): onb.recognize() — discover/derive/adopt an existing passkey identity (#328)

### DIFF
--- a/clients/sdk/gc-onboarding.mjs
+++ b/clients/sdk/gc-onboarding.mjs
@@ -15,6 +15,8 @@ import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
 import { makeDerivedIdentity } from './gc-derived-identity.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
+import { decodeAddress } from './gc-bech32.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -273,6 +275,45 @@ export function makeOnboarding({
     return pk.discover(opts);
   }
 
+  // Recognition on entry: discover an existing Gumption passkey on the rpId,
+  // derive its address, and ADOPT a derived identity (persist the record +
+  // hold the key) — or report a recognized wrap identity without adopting.
+  // For a device with NO local identity: adopting OVERWRITES the singleton
+  // store record, so callers must invoke this only when status().hasKey is
+  // false (the hub gates on exactly that). Never throws for the absent /
+  // cancel / unsupported / PRF-absent paths — they resolve to recognized:false.
+  async function recognize() {
+    let found;
+    try {
+      found = await discover();
+    } catch {
+      return { recognized: false };
+    }
+    if (!found) {
+      return { recognized: false };
+    }
+    const sk = await deriveSigningKey(found.prfOutput);
+    const derivedAddress = await sk.address();
+    const uh = found.userHandle;
+    if (uh != null && decodeAddress(uh) !== null && uh !== derivedAddress) {
+      // WRAP passkey: its PRF unlocks a keyring — it is NOT the signing seed,
+      // so deriving it yields a phantom address. Recognize WHO (the userHandle
+      // address), but adopt nothing (the real key isn't derivable here).
+      return { recognized: true, kind: 'wrap', address: uh };
+    }
+    // DERIVED passkey: userHandle is random (not an address), or it backs the
+    // derived address — adopt it (the same record create({withPasskey}) writes).
+    await store.put({
+      version: keyring.VERSION,
+      kind: 'derived',
+      address: derivedAddress,
+      credentialId: found.credentialId,
+    });
+    key = sk;
+    await notify();
+    return { recognized: true, kind: 'derived', address: derivedAddress };
+  }
+
   async function lock() {
     key = null;
     await notify();
@@ -286,6 +327,6 @@ export function makeOnboarding({
 
   return {
     status, onChange, create, unlock, restore, backup, addPasskey, discover,
-    signLogin, signTransaction, lock, forget,
+    recognize, signLogin, signTransaction, lock, forget,
   };
 }

--- a/clients/sdk/gc-onboarding.test.mjs
+++ b/clients/sdk/gc-onboarding.test.mjs
@@ -292,3 +292,79 @@ test('discover() delegates to the passkey adapter; null without one', async () =
   const onb2 = makeOnboarding({ store: fakeStore(), window: SECURE });
   assert.equal(await onb2.discover(), null);
 });
+
+// --- onb.recognize(): discover -> derive -> adopt on entry (#328) ----------
+
+// A passkey fake whose discover() returns a chosen userHandle. enroll/unlock
+// return the same PRF so the derived address is deterministic.
+function recognizePasskey({ prfFill = 7, credentialId = 'credR', userHandle = null } = {}) {
+  const PRF = new Uint8Array(32).fill(prfFill);
+  return {
+    PRF,
+    isSupported: async () => true,
+    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    unlock: async () => PRF,
+    discover: async () => ({ credentialId, prfOutput: PRF, userHandle }),
+  };
+}
+
+test('recognize() adopts a derived passkey (random non-address userHandle)', async () => {
+  const pk = recognizePasskey({ prfFill: 11, credentialId: 'credD', userHandle: 'not-an-address' });
+  const store = fakeStore();
+  const onb = makeOnboarding({ store, window: SECURE, passkey: pk });
+  const D = await (await deriveSigningKey(pk.PRF)).address();
+  const r = await onb.recognize();
+  assert.deepEqual(r, { recognized: true, kind: 'derived', address: D });
+  const rec = await store.get();
+  assert.equal(rec.version, 2);
+  assert.equal(rec.kind, 'derived');
+  assert.equal(rec.address, D);
+  assert.equal(rec.credentialId, 'credD');
+  assert.equal(rec.signing_key_ct, undefined);
+  assert.equal(rec.wraps, undefined);
+  assert.equal((await onb.status()).unlocked, true);
+});
+
+test('recognize() adopts when the userHandle equals the derived address', async () => {
+  const PRF_FILL = 13;
+  const D = await (await deriveSigningKey(new Uint8Array(32).fill(PRF_FILL))).address();
+  const pk = recognizePasskey({ prfFill: PRF_FILL, credentialId: 'credE', userHandle: D });
+  const store = fakeStore();
+  const onb = makeOnboarding({ store, window: SECURE, passkey: pk });
+  const r = await onb.recognize();
+  assert.deepEqual(r, { recognized: true, kind: 'derived', address: D });
+  assert.equal((await store.get()).kind, 'derived');
+});
+
+test('recognize() does NOT adopt a wrap passkey — phantom guard', async () => {
+  const wrapAddr = await (await SigningKey.generate()).address(); // a real address
+  const pk = recognizePasskey({ prfFill: 17, credentialId: 'credW', userHandle: wrapAddr });
+  const D = await (await deriveSigningKey(pk.PRF)).address();
+  assert.notEqual(wrapAddr, D); // sanity: the address claim differs from the derived one
+  const store = fakeStore();
+  const onb = makeOnboarding({ store, window: SECURE, passkey: pk });
+  const r = await onb.recognize();
+  assert.deepEqual(r, { recognized: true, kind: 'wrap', address: wrapAddr });
+  assert.equal(await store.get(), null);              // nothing persisted
+  assert.equal((await onb.status()).unlocked, false); // key not held
+});
+
+test('recognize() is recognized:false when discover finds nothing', async () => {
+  const pk = { isSupported: async () => true, discover: async () => null };
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: pk });
+  assert.deepEqual(await onb.recognize(), { recognized: false });
+});
+
+test('recognize() is recognized:false with no passkey adapter', async () => {
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE });
+  assert.deepEqual(await onb.recognize(), { recognized: false });
+});
+
+test('recognize() is recognized:false when discover throws (PRF absent / unsupported)', async () => {
+  const pk = {
+    isSupported: async () => true,
+    discover: async () => { throw new Error('passkey PRF not available'); },
+  };
+  const onb = makeOnboarding({ store: fakeStore(), window: SECURE, passkey: pk });
+  assert.deepEqual(await onb.recognize(), { recognized: false });
+});

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.9.0';
+export const version = '0.10.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-onboarding.mjs
+++ b/src/gumptionchain/static/sdk/gc-onboarding.mjs
@@ -15,6 +15,8 @@ import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
 import { makeDerivedIdentity } from './gc-derived-identity.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
+import { decodeAddress } from './gc-bech32.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -273,6 +275,45 @@ export function makeOnboarding({
     return pk.discover(opts);
   }
 
+  // Recognition on entry: discover an existing Gumption passkey on the rpId,
+  // derive its address, and ADOPT a derived identity (persist the record +
+  // hold the key) — or report a recognized wrap identity without adopting.
+  // For a device with NO local identity: adopting OVERWRITES the singleton
+  // store record, so callers must invoke this only when status().hasKey is
+  // false (the hub gates on exactly that). Never throws for the absent /
+  // cancel / unsupported / PRF-absent paths — they resolve to recognized:false.
+  async function recognize() {
+    let found;
+    try {
+      found = await discover();
+    } catch {
+      return { recognized: false };
+    }
+    if (!found) {
+      return { recognized: false };
+    }
+    const sk = await deriveSigningKey(found.prfOutput);
+    const derivedAddress = await sk.address();
+    const uh = found.userHandle;
+    if (uh != null && decodeAddress(uh) !== null && uh !== derivedAddress) {
+      // WRAP passkey: its PRF unlocks a keyring — it is NOT the signing seed,
+      // so deriving it yields a phantom address. Recognize WHO (the userHandle
+      // address), but adopt nothing (the real key isn't derivable here).
+      return { recognized: true, kind: 'wrap', address: uh };
+    }
+    // DERIVED passkey: userHandle is random (not an address), or it backs the
+    // derived address — adopt it (the same record create({withPasskey}) writes).
+    await store.put({
+      version: keyring.VERSION,
+      kind: 'derived',
+      address: derivedAddress,
+      credentialId: found.credentialId,
+    });
+    key = sk;
+    await notify();
+    return { recognized: true, kind: 'derived', address: derivedAddress };
+  }
+
   async function lock() {
     key = null;
     await notify();
@@ -286,6 +327,6 @@ export function makeOnboarding({
 
   return {
     status, onChange, create, unlock, restore, backup, addPasskey, discover,
-    signLogin, signTransaction, lock, forget,
+    recognize, signLogin, signTransaction, lock, forget,
   };
 }

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.9.0';
+export const version = '0.10.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Closes #328.

## Summary

Adds a controller method **`onb.recognize()`** for the hub's "recognition on entry" feature (gump-hub#79, under "Sign in with Gumption" #67): a device with **no local identity** but a Gumption passkey on the shared rpId — created in another EGU app — recognizes and rehydrates that identity in one tap. Builds on #324 (kind-aware controller) + #312/#320 (derive primitives).

This is **distinct** from the #315 standalone `recognize()` export (same verb, two layers): that one is a low-level "who's here?" hint; this is the full **discover → derive → adopt** entry flow. It holds `discover()`'s raw result, so it closes the `credentialId` gap that `makeDerivedIdentity.resolve()` can't, and writes the derived record where the controller already writes it.

```js
onb.recognize() → { recognized: false }
               | { recognized: true, kind: 'derived', address }   // adopted (persisted + key held)
               | { recognized: true, kind: 'wrap',    address }    // recognized who, not adopted
```

## The phantom guard (load-bearing)

A **derived** passkey's PRF *is* the signing seed; a **wrap** identity's convenience passkey PRF is the keyring *unlock* secret, **not** the seed — so `deriveSigningKey(wrapPrf)` yields a *phantom* address. The discriminator:

- `userHandle` is a real gc address (`decodeAddress !== null`) **and ≠** the derived address `D` → **wrap passkey** → return `kind:'wrap'` with the *userHandle* (true address), persist **nothing**.
- otherwise (userHandle random/not-an-address, or `=== D` so the PRF backs the claim) → **derived** → adopt `D`: persist `{ version, kind:'derived', address, credentialId }` (byte-identical to `create({withPasskey})`'s record) and hold the key.

So a wrap passkey can never be wrongly adopted (would persist a phantom identity), and a derived identity is never wrongly rejected. In practice wrap convenience passkeys are non-resident (#324) so they rarely surface in `discover()` — the guard makes `recognize()` safe regardless.

## Data-safety note

`recognize()` persists into the **singleton** store, so it overwrites any existing record. The intended caller (hub gump-hub#79) invokes it **only when `status().hasKey === false`**; the method's doc-comment warns callers to gate on no-local-identity. The wrap branch persists nothing and holds no key, so it can never clobber a stored key.

## Test plan
- `clients/sdk` `node --test` — **173 passed** (6 new: derived-adopt via random userHandle, derived-adopt via `userHandle === D`, the wrap phantom-guard — asserting **no record written** + key not held, `discover` returns null, no adapter, and `discover` throws → `recognized:false`)
- `uv run pytest` — **728 passed, 1 skipped**; vendored byte-parity green
- `uv run ruff check src tests` + `ruff format --check` — clean
- Independent whole-branch review — clean (all four guard branches traced, never-throws confirmed, adopted record byte-identical, key handling correct)
- SDK bumped 0.9.0 → 0.10.0; `static/sdk` re-vendored

## Out of scope
The hub entry button + member-kit guide collapse to "call `onb.recognize()`" — hub-side (gump-hub#79). No change to the #315 standalone `recognize()`; both coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)