### PR TITLE
feat(browser): /signing-key offers the derive path — seamless identities (#330)

### DIFF
--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -14,6 +14,9 @@ import { exportEncrypted, importEncrypted } from '../sdk/gc-backup.mjs';
 import { session as defaultSession } from './signing-key-session.mjs';
 import { makePasskey } from './signing-key-passkey.mjs';
 import { decodeAddress } from '../sdk/gc-bech32.mjs';
+import { makeDerivedIdentity } from '../sdk/gc-derived-identity.mjs';
+import { deriveSigningKey } from '../sdk/gc-derive.mjs';
+import * as recoveryPhrase from './signing-key-recovery-phrase.mjs';
 
 // Re-exported so existing importers (and tests) of signing-key-glue keep working;
 // the implementation now lives in the shared signing-key-passkey module so /transact
@@ -158,6 +161,8 @@ export function init(
     win = typeof window !== 'undefined' ? window : undefined,
     doc = typeof document !== 'undefined' ? document : undefined,
     storage = typeof localStorage !== 'undefined' ? localStorage : undefined,
+    // Injectable for tests; when omitted it's resolved from makePasskey below.
+    passkey: injectedPasskey,
   } = {},
 ) {
   const $ = (sel) => root.querySelector(sel);
@@ -202,11 +207,20 @@ export function init(
     // forget
     forgetBtn: $('#forget-btn'),
     forgetStatus: $('#forget-status'),
+    // derive create + recognize (seamless, passkey-first)
+    createDeriveSection: $('#create-derive-section'),
+    createDeriveBtn: $('#create-derive-btn'),
+    createDeriveStatus: $('#create-derive-status'),
+    recognizeBtn: $('#recognize-btn'),
+    recognizeStatus: $('#recognize-status'),
+    // recovery-phrase surface (derived identity's only seed-bearing backup)
+    recoveryPhraseSection: $('#recovery-phrase-section'),
+    rpDoneBtn: $('#rp-done-btn'),
   };
 
   // Cached passkey capability (resolved once). Drives control visibility.
   let passkeyState = { secureContext: !!win?.isSecureContext, supported: false };
-  let passkey = null;
+  let passkey = injectedPasskey ?? null;
 
   function show(el, visible) {
     if (el) el.hidden = !visible;
@@ -231,6 +245,8 @@ export function init(
     show(els.addPasskeyBtn, c.showAddPasskey);
     show(els.addPasskeyPassphrase, c.showAddPasskey);
     show(els.backupBtn, c.showBackup);
+    show(els.createDeriveSection, c.showCreateDerive);
+    show(els.recognizeBtn, c.showRecognize);
     if (hasSigningKey && els.addressOut) {
       const rec = await store.get();
       els.addressOut.textContent = rec?.address ?? '';
@@ -260,6 +276,124 @@ export function init(
       'error',
     );
     return false;
+  }
+
+  // Reveal the recovery-phrase surface for a derived identity's seed-bearing
+  // backup, gating the "done" affordance on the saved-confirm.
+  function showRecoveryPhrase(mnemonic) {
+    show(els.recoveryPhraseSection, true);
+    if (els.rpDoneBtn) els.rpDoneBtn.hidden = true;
+    recoveryPhrase.init({
+      mnemonic,
+      onConfirm: () => {
+        if (els.rpDoneBtn) els.rpDoneBtn.hidden = false;
+      },
+      root: doc || document,
+    });
+  }
+  if (els.rpDoneBtn) {
+    els.rpDoneBtn.addEventListener('click', async () => {
+      show(els.recoveryPhraseSection, false);
+      await render();
+    });
+  }
+
+  // --- create (derived: seamless passkey, no passphrase) ---
+  if (els.createDeriveBtn) {
+    els.createDeriveBtn.addEventListener('click', async () => {
+      try {
+        if (!passkey) {
+          setStatus(
+            els.createDeriveStatus,
+            'Passkeys are not available here.',
+            'error',
+          );
+          return;
+        }
+        if (!trustGateOk(els.createDeriveStatus)) return;
+        if (!(await ensureEd25519(els.createDeriveStatus))) return;
+        const derived = makeDerivedIdentity({ passkey });
+        const { signing_key, address, mnemonic, credentialId } =
+          await derived.enroll({ userName: 'GumptionChain identity' });
+        await store.put({
+          version: keyring.VERSION,
+          kind: 'derived',
+          address,
+          credentialId,
+        });
+        session.setSigningKey(signing_key);
+        showRecoveryPhrase(mnemonic);
+        await render();
+      } catch (e) {
+        setStatus(
+          els.createDeriveStatus,
+          `Could not create with a passkey: ${msgOf(e)}. ` +
+            'Use a passphrase instead.',
+          'error',
+        );
+      }
+    });
+  }
+
+  // --- recognize (discover an existing passkey on this device) ---
+  if (els.recognizeBtn) {
+    els.recognizeBtn.addEventListener('click', async () => {
+      try {
+        if (!passkey) {
+          setStatus(
+            els.recognizeStatus,
+            'Passkeys are not available here.',
+            'error',
+          );
+          return;
+        }
+        const found = await passkey.discover();
+        if (!found) {
+          setStatus(
+            els.recognizeStatus,
+            'No Gumption passkey found on this device.',
+            'info',
+          );
+          return;
+        }
+        const sk = await deriveSigningKey(found.prfOutput);
+        const derivedAddress = await sk.address();
+        if (
+          classifyRecognition({
+            userHandle: found.userHandle,
+            derivedAddress,
+          }) === 'wrap'
+        ) {
+          setStatus(
+            els.recognizeStatus,
+            `Found ${found.userHandle.slice(0, 16)}… — it lives on its ` +
+              'original device. Restore it from your backup below.',
+            'info',
+          );
+          return;
+        }
+        if (!trustGateOk(els.recognizeStatus)) return;
+        await store.put({
+          version: keyring.VERSION,
+          kind: 'derived',
+          address: derivedAddress,
+          credentialId: found.credentialId,
+        });
+        session.setSigningKey(sk);
+        setStatus(
+          els.recognizeStatus,
+          `Signed in as ${derivedAddress}.`,
+          'ok',
+        );
+        await render();
+      } catch (e) {
+        setStatus(
+          els.recognizeStatus,
+          `Could not check for a passkey: ${msgOf(e)}`,
+          'error',
+        );
+      }
+    });
   }
 
   // --- create ---
@@ -516,6 +650,28 @@ export function init(
   if (els.backupBtn) {
     els.backupBtn.addEventListener('click', async () => {
       try {
+        // A derived identity has no encrypted artifact: its only seed-bearing
+        // backup is the recovery phrase, re-derived from the live passkey PRF.
+        const rec = await store.get();
+        if (rec?.kind === 'derived') {
+          if (!passkey) {
+            setStatus(
+              els.backupStatus,
+              'Connect your passkey to view the recovery phrase.',
+              'error',
+            );
+            return;
+          }
+          const found = await passkey.discover();
+          if (!found) {
+            setStatus(els.backupStatus, 'No passkey found.', 'error');
+            return;
+          }
+          const sk = await deriveSigningKey(found.prfOutput);
+          const mnemonic = await sk.mnemonic();
+          showRecoveryPhrase(mnemonic);
+          return;
+        }
         const passphrase = els.backupPassphrase
           ? els.backupPassphrase.value
           : '';
@@ -579,9 +735,9 @@ export function init(
   // Resolve passkey capability, install auto-lock, then render. Auto-lock
   // re-renders on lock so the controls reflect the locked state.
   (async () => {
-    passkey = await makePasskey({ window: win, rpName });
+    if (!passkey) passkey = await makePasskey({ window: win, rpName });
     passkeyState = {
-      secureContext: !!win?.isSecureContext,
+      secureContext: injectedPasskey ? true : !!win?.isSecureContext,
       supported: passkey != null,
     };
     session.onLock(() => {

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -13,6 +13,7 @@ import { makeIdbStore } from '../sdk/gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from '../sdk/gc-backup.mjs';
 import { session as defaultSession } from './signing-key-session.mjs';
 import { makePasskey } from './signing-key-passkey.mjs';
+import { decodeAddress } from '../sdk/gc-bech32.mjs';
 
 // Re-exported so existing importers (and tests) of signing-key-glue keep working;
 // the implementation now lives in the shared signing-key-passkey module so /transact
@@ -44,7 +45,37 @@ export function whichControls({
     showAddPasskey: !!hasSigningKey && !!unlocked && passkeyOk,
     showBackup: !!hasSigningKey,
     showForget: !!hasSigningKey,
+    // Keyless device with a usable passkey leads with the seamless derive
+    // create + recognize affordances; without a passkey it falls back to the
+    // passphrase create/import controls above.
+    showCreateDerive: !hasSigningKey && passkeyOk,
+    showRecognize: !hasSigningKey && passkeyOk,
   };
+}
+
+// Which create affordance a keyless device leads with: derive (seamless) when
+// passkeys work, else the passphrase wrap fallback.
+export function createPathFor(status) {
+  return status && status.passkeySupported ? 'derive' : 'wrap';
+}
+
+// Map a recognize verdict to the page action.
+export function recognitionOutcome(r) {
+  if (r && r.recognized && r.kind === 'derived') return 'rehydrated';
+  if (r && r.recognized && r.kind === 'wrap') return 'restore';
+  return 'none';
+}
+
+// The phantom guard (pure): a discovered passkey is a WRAP identity's passkey
+// iff its userHandle is a real gc address that disagrees with the PRF-derived
+// address (the PRF isn't this identity's seed). Otherwise it's DERIVED — adopt
+// the derived address. Mirrors onb.recognize()'s discriminator.
+export function classifyRecognition({ userHandle, derivedAddress }) {
+  if (userHandle != null && decodeAddress(userHandle) !== null
+      && userHandle !== derivedAddress) {
+    return 'wrap';
+  }
+  return 'derived';
 }
 
 // A stable, address-tagged filename for the downloaded encrypted backup.

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -473,3 +473,188 @@ test('whichControls shows derive + recognize only when a passkey is usable and n
   assert.equal(has.showCreateDerive, false);
   assert.equal(has.showRecognize, false);
 });
+
+// --- derive-create / recognize / kind-aware backup via init (#330) --------
+// These exercise the DOM wiring added to init(). They reuse the fakeElement /
+// memStorage helpers above, but extend the fake DOM with a getElementById()
+// (the recovery-phrase partial addresses its nodes by bare id) and a
+// createElement() so recoveryPhrase.init can render the words into the fake
+// #rp-words container. The same fake is passed as both `root` and `doc`.
+
+// A richer fake DOM: querySelector('#x') and getElementById('x') resolve to the
+// SAME cached node, so the glue ($('#rp-words')) and the recovery-phrase partial
+// ($('rp-words')) see one element. createElement returns append-able stubs.
+function fakeDom() {
+  const nodes = {};
+  const node = (key) => (nodes[key] ??= fakeElement());
+  const makeNode = () => {
+    const el = fakeElement();
+    el.className = '';
+    el.append = () => {};
+    el.replaceChildren = () => {};
+    return el;
+  };
+  return {
+    querySelector(sel) {
+      return node(sel.startsWith('#') ? sel.slice(1) : sel);
+    },
+    getElementById(id) {
+      return node(id);
+    },
+    querySelectorAll() {
+      return [];
+    },
+    createElement() {
+      return makeNode();
+    },
+    get body() {
+      return node('body');
+    },
+  };
+}
+
+function memStore(seed = null) {
+  let record = seed;
+  return {
+    get: async () => record,
+    put: async (rec) => {
+      record = rec;
+    },
+    delete: async () => {
+      record = null;
+    },
+  };
+}
+
+// A fake passkey matching the gc-passkey-webauthn surface the new flows need:
+// enroll()->{credentialId, prfOutput}, discover()->{credentialId, prfOutput,
+// userHandle}, isSupported()->true. prfOutput is a deterministic seed so the
+// derived address is reproducible across enroll/discover.
+function fakePasskey({ prfOutput, userHandle = null, credentialId = 'cred-1' } = {}) {
+  const prf = prfOutput ?? new Uint8Array(32).fill(7);
+  return {
+    isSupported: () => true,
+    enroll: async () => ({ credentialId, prfOutput: prf }),
+    discover: async () => ({ credentialId, prfOutput: prf, userHandle }),
+  };
+}
+
+test('init: derive-create persists a derived record (no ciphertext) + shows the recovery phrase', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const store = memStore();
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const prfOutput = new Uint8Array(32).fill(3);
+  const passkey = fakePasskey({ prfOutput });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+
+  dom.querySelector('#create-derive-btn');
+  await dom.querySelector('#create-derive-btn').click();
+
+  const rec = await store.get();
+  assert.notEqual(rec, null);
+  assert.equal(rec.kind, 'derived');
+  assert.equal(rec.version, 2);
+  // The derived address matches the seed-derived key's address.
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const sk = await deriveSigningKey(prfOutput);
+  assert.equal(rec.address, await sk.address());
+  assert.equal(rec.credentialId, 'cred-1');
+  // A derived record holds NO wrap ciphertext.
+  assert.equal(rec.signing_key_ct, undefined);
+  assert.equal(rec.wraps, undefined);
+  // The live key was handed to the session and the recovery section revealed.
+  assert.equal(session.isUnlocked(), true);
+  assert.equal(dom.querySelector('#recovery-phrase-section').hidden, false);
+});
+
+test('init: derive-create is blocked by the trust gate (no record, error status)', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const store = memStore();
+  // No trust-ack written and the checkbox is unchecked -> gate fails.
+  const storage = memStorage();
+  const passkey = fakePasskey();
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  // Ensure the trust-ack checkbox is unchecked.
+  dom.querySelector('#trust-ack').checked = false;
+  await dom.querySelector('#create-derive-btn').click();
+
+  assert.equal(await store.get(), null);
+  assert.equal(session.isUnlocked(), false);
+  assert.equal(dom.querySelector('#create-derive-status').dataset.kind, 'error');
+});
+
+test('init: recognize adopts a DERIVED passkey (random userHandle) into the session', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const store = memStore();
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const prfOutput = new Uint8Array(32).fill(9);
+  // A non-address userHandle -> classifyRecognition returns 'derived' -> adopt.
+  const passkey = fakePasskey({ prfOutput, userHandle: 'random-handle-xyz' });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await dom.querySelector('#recognize-btn').click();
+
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const expected = await (await deriveSigningKey(prfOutput)).address();
+  const rec = await store.get();
+  assert.notEqual(rec, null);
+  assert.equal(rec.kind, 'derived');
+  assert.equal(rec.address, expected);
+  assert.equal(session.isUnlocked(), true);
+  assert.match(dom.querySelector('#recognize-status').textContent, /Signed in as/);
+});
+
+test('init: recognize on a WRAP passkey (phantom guard) routes to restore, persists nothing', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const store = memStore();
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const prfOutput = new Uint8Array(32).fill(11);
+  // A real gc address as userHandle that DIFFERS from the PRF-derived address:
+  // this is a wrap identity's passkey discovered on a foreign device.
+  const otherAddress = await (await SigningKey.generate()).address();
+  const passkey = fakePasskey({ prfOutput, userHandle: otherAddress });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await dom.querySelector('#recognize-btn').click();
+
+  assert.equal(await store.get(), null);
+  assert.equal(session.isUnlocked(), false);
+  assert.match(dom.querySelector('#recognize-status').textContent, /restore/i);
+});
+
+test('init: backup on a DERIVED record shows the recovery phrase (no download)', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const prfOutput = new Uint8Array(32).fill(5);
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const derivedAddress = await (await deriveSigningKey(prfOutput)).address();
+  const store = memStore({
+    version: 2,
+    kind: 'derived',
+    address: derivedAddress,
+    credentialId: 'cred-1',
+  });
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const passkey = fakePasskey({ prfOutput });
+
+  // A doc whose createElement counts download attempts (there must be none).
+  let anchorsCreated = 0;
+  const baseCreate = dom.createElement.bind(dom);
+  dom.createElement = (tag) => {
+    if (tag === 'a') anchorsCreated += 1;
+    return baseCreate(tag);
+  };
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await dom.querySelector('#backup-btn').click();
+
+  // The derived branch reveals the recovery section and does NOT download.
+  assert.equal(dom.querySelector('#recovery-phrase-section').hidden, false);
+  assert.equal(anchorsCreated, 0);
+});

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -9,6 +9,11 @@ import {
   init,
   UNSUPPORTED_MSG,
 } from './signing-key-glue.mjs';
+import {
+  createPathFor,
+  recognitionOutcome,
+  classifyRecognition,
+} from './signing-key-glue.mjs';
 import { SigningKey } from '../sdk/gc-signing-key.mjs';
 import { makeSession } from './signing-key-session.mjs';
 
@@ -430,4 +435,41 @@ test('init: backup restore on an Ed25519-unsupported browser shows the update me
   } finally {
     SigningKey.isSupported = orig;
   }
+});
+
+// --- derive create + recognize phantom guard (#330) ----------------------
+
+test('createPathFor picks derive when passkeys are supported, else wrap', () => {
+  assert.equal(createPathFor({ passkeySupported: true }), 'derive');
+  assert.equal(createPathFor({ passkeySupported: false }), 'wrap');
+});
+
+test('recognitionOutcome maps the recognize verdict to a hub-style action', () => {
+  assert.equal(recognitionOutcome({ recognized: true, kind: 'derived' }), 'rehydrated');
+  assert.equal(recognitionOutcome({ recognized: true, kind: 'wrap' }), 'restore');
+  assert.equal(recognitionOutcome({ recognized: false }), 'none');
+  assert.equal(recognitionOutcome(null), 'none');
+});
+
+test('classifyRecognition is the phantom guard: wrap iff userHandle is a real address != D', async () => {
+  const { SigningKey } = await import('../sdk/gc-signing-key.mjs');
+  const D = await (await SigningKey.generate()).address();
+  const other = await (await SigningKey.generate()).address();
+  assert.equal(classifyRecognition({ userHandle: 'not-an-address', derivedAddress: D }), 'derived');
+  assert.equal(classifyRecognition({ userHandle: null, derivedAddress: D }), 'derived');
+  assert.equal(classifyRecognition({ userHandle: D, derivedAddress: D }), 'derived');
+  assert.equal(classifyRecognition({ userHandle: other, derivedAddress: D }), 'wrap');
+});
+
+test('whichControls shows derive + recognize only when a passkey is usable and no key', () => {
+  const keyless = whichControls({ hasSigningKey: false, unlocked: false, secureContext: true, passkeySupported: true });
+  assert.equal(keyless.showCreateDerive, true);
+  assert.equal(keyless.showRecognize, true);
+  const noPasskey = whichControls({ hasSigningKey: false, unlocked: false, secureContext: false, passkeySupported: false });
+  assert.equal(noPasskey.showCreateDerive, false);
+  assert.equal(noPasskey.showRecognize, false);
+  assert.equal(noPasskey.showCreate, true);
+  const has = whichControls({ hasSigningKey: true, unlocked: false, secureContext: true, passkeySupported: true });
+  assert.equal(has.showCreateDerive, false);
+  assert.equal(has.showRecognize, false);
 });

--- a/src/gumptionchain/static/js/signing-key-recovery-phrase.mjs
+++ b/src/gumptionchain/static/js/signing-key-recovery-phrase.mjs
@@ -1,0 +1,66 @@
+// The derived-identity recovery-phrase surface: chunk the 24-word BIP-39 phrase
+// for display, render it, and wire copy + "I've saved it" confirm. The phrase is
+// the derived identity's only seed-bearing backup (no encrypted artifact). DOM-free
+// pure logic up top; DOM wiring in init(). Mirrors the hub's recovery-phrase.mjs.
+const COLS = 4;
+
+export function chunkPhrase(mnemonic) {
+  const words = String(mnemonic || '').trim().split(/\s+/).filter(Boolean);
+  const rows = [];
+  for (let i = 0; i < words.length; i += COLS) {
+    rows.push(words.slice(i, i + COLS).map((word, j) => ({ n: i + j + 1, word })));
+  }
+  return rows;
+}
+
+export function renderPhrase(doc, container, mnemonic) {
+  container.replaceChildren?.();
+  for (const row of chunkPhrase(mnemonic)) {
+    const rowEl = doc.createElement('div');
+    rowEl.className = 'rp-row d-flex flex-wrap gap-2 mb-1';
+    for (const { n, word } of row) {
+      const cell = doc.createElement('span');
+      cell.className = 'rp-cell badge bg-light text-dark border';
+      const num = doc.createElement('span');
+      num.className = 'rp-num text-muted me-1';
+      num.textContent = String(n);
+      const w = doc.createElement('span');
+      w.className = 'rp-word fw-bold';
+      w.textContent = word;
+      cell.append(num, w);
+      rowEl.append(cell);
+    }
+    container.append(rowEl);
+  }
+}
+
+// Wire the partial: render the words, the Copy button, and the confirm that fires
+// onConfirm (the host uses it to reveal its continue affordance). root defaults to
+// document; ids: rp-words, rp-copy, rp-confirm, rp-status.
+export function init({ mnemonic, onConfirm, root = document } = {}) {
+  const $ = (id) => root.getElementById(id);
+  renderPhrase(root, $('rp-words'), mnemonic);
+  const copyBtn = $('rp-copy');
+  const confirmBox = $('rp-confirm');
+  const status = $('rp-status');
+  if (confirmBox) confirmBox.checked = false;
+  if (status) { status.textContent = ''; status.dataset.kind = 'info'; }
+  const setStatus = (text, ok) => {
+    if (!status) return;
+    status.textContent = text;
+    status.dataset.kind = ok ? 'ok' : 'error';
+  };
+  if (copyBtn) {
+    copyBtn.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(mnemonic);
+        setStatus('Copied — paste it somewhere safe, then clear your clipboard.', true);
+      } catch {
+        setStatus("Couldn't copy — write the words down instead.", false);
+      }
+    };
+  }
+  if (confirmBox) {
+    confirmBox.onchange = () => { if (confirmBox.checked) onConfirm?.(); };
+  }
+}

--- a/src/gumptionchain/static/js/signing-key-recovery-phrase.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-recovery-phrase.test.mjs
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chunkPhrase } from './signing-key-recovery-phrase.mjs';
+
+test('chunkPhrase splits 24 words into rows of 4 with 1-based numbers', () => {
+  const words = Array.from({ length: 24 }, (_, i) => `w${i + 1}`);
+  const rows = chunkPhrase(words.join(' '));
+  assert.equal(rows.length, 6);
+  assert.equal(rows[0].length, 4);
+  assert.deepEqual(rows[0][0], { n: 1, word: 'w1' });
+  assert.deepEqual(rows[5][3], { n: 24, word: 'w24' });
+});
+
+test('chunkPhrase tolerates extra whitespace and empty input', () => {
+  assert.deepEqual(chunkPhrase('  a   b '), [[{ n: 1, word: 'a' }, { n: 2, word: 'b' }]]);
+  assert.deepEqual(chunkPhrase(''), []);
+  assert.deepEqual(chunkPhrase(null), []);
+});

--- a/src/gumptionchain/templates/signing_key.html
+++ b/src/gumptionchain/templates/signing_key.html
@@ -43,6 +43,16 @@
           &mdash; to receive grit and spend later. Download an encrypted backup
           afterward: it is your only recovery.
         </p>
+        <!-- Passkey-primary create (derived = seamless across EGU apps) -->
+        <div id="create-derive-section" hidden>
+          <button id="create-derive-btn" class="btn btn-primary">Create with a passkey (recommended)</button>
+          <div class="form-text">A passkey makes a seamless identity — sign in on any Gumption app with one tap. Nothing to remember, nothing stored on this node.</div>
+          <div id="create-derive-status" class="mt-2 small"></div>
+          <button id="recognize-btn" class="btn btn-outline-primary mt-2" hidden>Sign in with your Gumption passkey</button>
+          <div id="recognize-status" class="mt-2 small"></div>
+          <hr>
+          <div class="text-muted small">or use a passphrase (this device only):</div>
+        </div>
         <div class="mb-2">
           <label for="create-passphrase" class="form-label">Passphrase</label>
           <input id="create-passphrase" type="password"
@@ -193,6 +203,22 @@
         </button>
         <div id="forget-status" class="mt-2 small"></div>
       </div>
+    </div></div>
+  </div></section>
+
+  <!-- Shared recovery-phrase surface (shown after derive-create / derived-backup). -->
+  <section id="recovery-phrase-section" class="row my-3" hidden><div class="col">
+    <div class="card"><div class="card-body">
+      <div class="card-title h5">Your recovery phrase</div>
+      <p class="small text-muted">These 24 words are the ONLY backup of a passkey identity. Write them down in order and keep them offline. Anyone with them controls the key.</p>
+      <div id="rp-words" class="mb-2"></div>
+      <button id="rp-copy" class="btn btn-sm btn-outline-secondary">Copy</button>
+      <div id="rp-status" class="mt-2 small"></div>
+      <div class="form-check mt-3">
+        <input id="rp-confirm" type="checkbox" class="form-check-input">
+        <label for="rp-confirm" class="form-check-label">I've saved my recovery phrase.</label>
+      </div>
+      <button id="rp-done-btn" class="btn btn-primary mt-2" hidden>Done</button>
     </div></div>
   </div></section>
 

--- a/tests/test_signing_key_page.py
+++ b/tests/test_signing_key_page.py
@@ -45,6 +45,17 @@ def test_signing_key_page_renders(app, test_client):
         assert 'bootstrap' in body
 
 
+def test_signing_key_page_offers_derive_and_recognize(app, test_client):
+    with app.app_context():
+        resp = test_client.get('/signing-key')
+        assert resp.status_code == httpx.codes.OK
+        body = str(resp.data)
+        assert 'create-derive-btn' in body
+        assert 'recognize-btn' in body
+        assert 'rp-words' in body  # recovery-phrase surface present
+        assert 'create-passphrase' in body  # passphrase fallback kept
+
+
 def test_signing_key_page_passes_rp_name(app, test_client):
     with app.app_context():
         resp = test_client.get('/signing-key')


### PR DESCRIPTION
Closes #330.

## Summary

Base's served `/signing-key` page could only mint **wrap** identities (random seed, encrypted locally), so base-born users never got the seamless "land in a new app, tap once, you're in" experience. This adds the **derive path** (passkey-primary → a derived `seed = KDF(PRF)` identity) with the passphrase **wrap** path as the explicit fallback, plus **recognition on entry** — mirroring the hub's #78/#79 UX.

**Approach:** built on the SDK's derive primitives (`makeDerivedIdentity` / `deriveSigningKey`), **keeping base's `session`** (auto-lock + cross-page key reuse), `keyring`, and trust-ack. Base hands the raw key to `session` — it does *not* compose `makeOnboarding`, which encapsulates the key and would fight base's reuse-the-key-across-pages model (see the issue discussion). All changes are base served JS (`static/js`) + the template — **not the vendored `clients/sdk`**, so no SDK version bump / no re-vendor.

## What's new
- **`signing-key-recovery-phrase.mjs`** (new) — the 24-word BIP-39 backup surface (`chunkPhrase`/`renderPhrase`/`init`), mirroring the hub's `recovery-phrase.mjs`, Bootstrap-styled.
- **Derive-primary create** — "Create with a passkey (recommended)" → `makeDerivedIdentity.enroll()` → persist `{version, kind:'derived', address, credentialId}` (byte-identical to the controller's derived record, no key material) → hand the key to `session` → show the recovery phrase. Passphrase wrap = explicit fallback; `createPathFor(status)` picks the primary by capability.
- **Recognize-on-entry** — "Sign in with your Gumption passkey" → discover → derive → **phantom guard** → adopt a derived identity (persist + session) or route a wrap passkey to restore (persist nothing).
- **Kind-aware backup** — derived record → re-derive via a passkey tap → show the recovery phrase (no download); wrap record → unchanged encrypted-artifact download.
- Kept intact: trust-ack gate (now also gating recognize-adopt), auto-lock `session`, `gcsec`/mnemonic/backup imports, unlock/lock/add-passkey/forget, Ed25519 feature-detect, all existing element ids.

## The phantom guard (security-critical)
A derived passkey's PRF *is* the seed; a wrap identity's convenience passkey PRF is the keyring *unlock* secret, so deriving it gives a phantom address. `classifyRecognition({userHandle, derivedAddress})` returns `wrap` iff `userHandle` is a real gc address **and ≠** the derived address → route to restore, persist **nothing**; else `derived` → adopt. Byte-identical to the merged `onb.recognize()` discriminator (re-implemented in base's glue because base hands the key to `session`, not the controller).

## Test plan
- `src/gumptionchain/static/js` `node --test` — **82 passed** (recovery-phrase chunking; pure helpers incl. the phantom guard; and `init`-driven glue tests: derive-create persists a no-key-material derived record + sets session + shows the phrase; recognize-derived adopts; recognize-wrap phantom guard writes **no record** + routes to restore; trust-gate blocks derive-create; kind-aware backup shows the phrase for a derived record)
- `uv run pytest` — **729 passed, 1 skipped** (incl. the new `/signing-key` page-render test); ruff + format + mypy clean; `gumptionchain db check` unaffected
- Independent whole-branch review — clean (phantom guard verified byte-identical, derived records carry no key material, all persists trust-gated, the injectable-passkey test seam doesn't change production behavior, kind-aware backup leaks nothing, no regressions)

**Needs a real-browser pass** (WebAuthn can't be unit-tested): derive-create (passkey enroll + recovery phrase), recognize-on-entry (cross-rpId discover → rehydrate / route-to-restore), and derived-backup (passkey tap → phrase). The unit tests cover the logic via fakes; the live passkey ceremony is manual.

## Out of scope
`/transact`'s create flow (separate stateless tier); any SDK change; the hub side (done: #78/#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)