### PR TITLE
refactor(sdk): single-source the recognize phantom guard (#331 follow-up)

### DIFF
--- a/clients/sdk/gc-derived-identity.mjs
+++ b/clients/sdk/gc-derived-identity.mjs
@@ -10,7 +10,25 @@
 // gc-passkey-webauthn). The hub + the /signing-key page compose this. No deps.
 import { deriveSigningKey } from './gc-derive.mjs';
 import { seedToMnemonic } from './gc-bip39.mjs';
-import { decodeSecret } from './gc-bech32.mjs';
+import { decodeAddress, decodeSecret } from './gc-bech32.mjs';
+
+// The phantom guard (pure, single-sourced): classify a discovered passkey from
+// its userHandle against the address its PRF derives to. A DERIVED passkey's PRF
+// IS the signing seed (so it derives to the identity's address); a WRAP
+// identity's convenience passkey PRF is the keyring UNLOCK secret, NOT the seed,
+// so deriving it yields a phantom address unrelated to the real key. The guard:
+// a userHandle that is a real gc address AND disagrees with the derived address
+// → 'wrap' (recognize WHO, but do NOT adopt — the real key isn't derivable);
+// otherwise (userHandle random/non-address, or it equals the derived address) →
+// 'derived' (adopt). Used by both makeOnboarding.recognize() and key-needing
+// glue (base /signing-key) so the security-critical check can't drift.
+export function classifyRecognition({ userHandle, derivedAddress }) {
+  if (userHandle != null && decodeAddress(userHandle) !== null
+      && userHandle !== derivedAddress) {
+    return 'wrap';
+  }
+  return 'derived';
+}
 
 export function makeDerivedIdentity({ passkey }) {
   // Create a passkey, derive the seed from its PRF, and return the key + its

--- a/clients/sdk/gc-derived-identity.test.mjs
+++ b/clients/sdk/gc-derived-identity.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { makeDerivedIdentity } from './gc-derived-identity.mjs';
+import {
+  classifyRecognition, makeDerivedIdentity,
+} from './gc-derived-identity.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
+import { SigningKey } from './gc-signing-key.mjs';
 
 const PRF = Uint8Array.from({ length: 32 }, (_, i) => i + 5);
 
@@ -60,4 +63,19 @@ test('resolve: no passkey discovered -> no-passkey', async () => {
     passkey: { async discover() { return null; } },
   });
   assert.equal((await id.resolve({})).status, 'no-passkey');
+});
+
+// The single-sourced phantom guard (shared by makeOnboarding.recognize() + base
+// /signing-key glue). Adopt unless a real-address userHandle contradicts the
+// derived address.
+test('classifyRecognition: wrap iff userHandle is a real gc address != the derived address', async () => {
+  const D = await (await SigningKey.generate()).address();
+  const other = await (await SigningKey.generate()).address();
+  // random / non-address userHandle -> derived (adopt)
+  assert.equal(classifyRecognition({ userHandle: 'not-an-address', derivedAddress: D }), 'derived');
+  assert.equal(classifyRecognition({ userHandle: null, derivedAddress: D }), 'derived');
+  // a real address that equals the derived address -> derived (PRF backs it)
+  assert.equal(classifyRecognition({ userHandle: D, derivedAddress: D }), 'derived');
+  // a real address that disagrees with the derived address -> wrap (phantom guard)
+  assert.equal(classifyRecognition({ userHandle: other, derivedAddress: D }), 'wrap');
 });

--- a/clients/sdk/gc-onboarding.mjs
+++ b/clients/sdk/gc-onboarding.mjs
@@ -14,9 +14,10 @@ import * as keyring from './gc-keyring.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
-import { makeDerivedIdentity } from './gc-derived-identity.mjs';
+import {
+  classifyRecognition, makeDerivedIdentity,
+} from './gc-derived-identity.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
-import { decodeAddress } from './gc-bech32.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -295,7 +296,7 @@ export function makeOnboarding({
     const sk = await deriveSigningKey(found.prfOutput);
     const derivedAddress = await sk.address();
     const uh = found.userHandle;
-    if (uh != null && decodeAddress(uh) !== null && uh !== derivedAddress) {
+    if (classifyRecognition({ userHandle: uh, derivedAddress }) === 'wrap') {
       // WRAP passkey: its PRF unlocks a keyring — it is NOT the signing seed,
       // so deriving it yields a phantom address. Recognize WHO (the userHandle
       // address), but adopt nothing (the real key isn't derivable here).

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.10.0';
+export const version = '0.11.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -13,10 +13,16 @@ import { makeIdbStore } from '../sdk/gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from '../sdk/gc-backup.mjs';
 import { session as defaultSession } from './signing-key-session.mjs';
 import { makePasskey } from './signing-key-passkey.mjs';
-import { decodeAddress } from '../sdk/gc-bech32.mjs';
-import { makeDerivedIdentity } from '../sdk/gc-derived-identity.mjs';
+import {
+  classifyRecognition, makeDerivedIdentity,
+} from '../sdk/gc-derived-identity.mjs';
 import { deriveSigningKey } from '../sdk/gc-derive.mjs';
 import * as recoveryPhrase from './signing-key-recovery-phrase.mjs';
+
+// Re-exported so the page glue + existing tests import the phantom guard from
+// here, while the implementation is single-sourced in the SDK (shared with
+// makeOnboarding.recognize() — the security-critical check can't drift).
+export { classifyRecognition };
 
 // Re-exported so existing importers (and tests) of signing-key-glue keep working;
 // the implementation now lives in the shared signing-key-passkey module so /transact
@@ -67,18 +73,6 @@ export function recognitionOutcome(r) {
   if (r && r.recognized && r.kind === 'derived') return 'rehydrated';
   if (r && r.recognized && r.kind === 'wrap') return 'restore';
   return 'none';
-}
-
-// The phantom guard (pure): a discovered passkey is a WRAP identity's passkey
-// iff its userHandle is a real gc address that disagrees with the PRF-derived
-// address (the PRF isn't this identity's seed). Otherwise it's DERIVED — adopt
-// the derived address. Mirrors onb.recognize()'s discriminator.
-export function classifyRecognition({ userHandle, derivedAddress }) {
-  if (userHandle != null && decodeAddress(userHandle) !== null
-      && userHandle !== derivedAddress) {
-    return 'wrap';
-  }
-  return 'derived';
 }
 
 // A stable, address-tagged filename for the downloaded encrypted backup.

--- a/src/gumptionchain/static/sdk/gc-derived-identity.mjs
+++ b/src/gumptionchain/static/sdk/gc-derived-identity.mjs
@@ -10,7 +10,25 @@
 // gc-passkey-webauthn). The hub + the /signing-key page compose this. No deps.
 import { deriveSigningKey } from './gc-derive.mjs';
 import { seedToMnemonic } from './gc-bip39.mjs';
-import { decodeSecret } from './gc-bech32.mjs';
+import { decodeAddress, decodeSecret } from './gc-bech32.mjs';
+
+// The phantom guard (pure, single-sourced): classify a discovered passkey from
+// its userHandle against the address its PRF derives to. A DERIVED passkey's PRF
+// IS the signing seed (so it derives to the identity's address); a WRAP
+// identity's convenience passkey PRF is the keyring UNLOCK secret, NOT the seed,
+// so deriving it yields a phantom address unrelated to the real key. The guard:
+// a userHandle that is a real gc address AND disagrees with the derived address
+// → 'wrap' (recognize WHO, but do NOT adopt — the real key isn't derivable);
+// otherwise (userHandle random/non-address, or it equals the derived address) →
+// 'derived' (adopt). Used by both makeOnboarding.recognize() and key-needing
+// glue (base /signing-key) so the security-critical check can't drift.
+export function classifyRecognition({ userHandle, derivedAddress }) {
+  if (userHandle != null && decodeAddress(userHandle) !== null
+      && userHandle !== derivedAddress) {
+    return 'wrap';
+  }
+  return 'derived';
+}
 
 export function makeDerivedIdentity({ passkey }) {
   // Create a passkey, derive the seed from its PRF, and return the key + its

--- a/src/gumptionchain/static/sdk/gc-onboarding.mjs
+++ b/src/gumptionchain/static/sdk/gc-onboarding.mjs
@@ -14,9 +14,10 @@ import * as keyring from './gc-keyring.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from './gc-backup.mjs';
 import { makeWebauthnPasskey } from './gc-passkey-webauthn.mjs';
-import { makeDerivedIdentity } from './gc-derived-identity.mjs';
+import {
+  classifyRecognition, makeDerivedIdentity,
+} from './gc-derived-identity.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
-import { decodeAddress } from './gc-bech32.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import {
@@ -295,7 +296,7 @@ export function makeOnboarding({
     const sk = await deriveSigningKey(found.prfOutput);
     const derivedAddress = await sk.address();
     const uh = found.userHandle;
-    if (uh != null && decodeAddress(uh) !== null && uh !== derivedAddress) {
+    if (classifyRecognition({ userHandle: uh, derivedAddress }) === 'wrap') {
       // WRAP passkey: its PRF unlocks a keyring — it is NOT the signing seed,
       // so deriving it yields a phantom address. Recognize WHO (the userHandle
       // address), but adopt nothing (the real key isn't derivable here).

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.10.0';
+export const version = '0.11.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Follow-up to #331, per the hub-you review. Refs #332.

## Summary

The security-critical **phantom-guard** discriminator existed as **two independent, byte-identical copies**:
- inline in `makeOnboarding.recognize()` (SDK `gc-onboarding.mjs`, from #328)
- as `classifyRecognition()` in base's `signing-key-glue.mjs` (from #330/#331)

For a check whose whole job is *"don't adopt a phantom identity"*, two copies are a real **drift risk** — harden or fix one and the other silently stays vulnerable. This single-sources it.

## What changed
- **Promoted** `classifyRecognition({ userHandle, derivedAddress })` into `clients/sdk/gc-derived-identity.mjs` (next to `makeDerivedIdentity`), with a focused unit test — the **one** place the guard is defined and tested.
- `makeOnboarding.recognize()` now calls `classifyRecognition(...)` instead of its inline check.
- Base's `signing-key-glue.mjs` imports it from the SDK and **re-exports** it, so the page glue + base's existing tests are unchanged.
- The now-unused `decodeAddress` imports drop from both call sites.
- Re-vendored `static/sdk`; SDK **0.10.0 → 0.11.0**.

The logic is unchanged (it was byte-identical) — this is purely de-duplication, so the merged behavior of both `onb.recognize()` and base's `/signing-key` recognize is identical.

## Test plan
- `clients/sdk` `node --test` — **174 passed** (incl. the new `classifyRecognition` unit test + the existing `onb.recognize()` tests, now exercising the shared guard)
- `src/gumptionchain/static/js` `node --test` — **82 passed** (base's recognize tests, now via the re-exported shared guard)
- `uv run pytest` — **729 passed, 1 skipped**; vendored byte-parity green
- `uv run ruff check` + `format --check` + `mypy` — clean
- Confirmed no stray `decodeAddress` / local guard copy remains

## Deeper fix tracked separately
#332 — a shared `recognize → { key, credentialId, verdict }` primitive so key-needing consumers (base's `session`, the hub's `signing.mjs`) stop re-implementing derive/recognize outside the controller. This PR just kills the immediate drift risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)