### PR TITLE
feat(sdk): session-signer — cross-document sign-only identity reuse without key ownership (#332)

### DIFF
--- a/clients/sdk/MANUAL-VERIFICATION.md
+++ b/clients/sdk/MANUAL-VERIFICATION.md
@@ -193,3 +193,26 @@ path by hand:
    (not a throw).
 5. On a browser exposing `PublicKeyCredential.isConditionalMediationAvailable`,
    confirm `isConditionalAvailable()` resolves `true`; on one without it, `false`.
+
+## Session-signer cross-document reuse + cross-tab lock (#332)
+
+`makeSessionSigner` persists a **non-extractable** Ed25519 signing handle in
+IndexedDB so the identity is reusable across a multi-document app's pages without
+re-unlocking, and without ever exposing the seed. The unit tests cover the logic
+with a shared fake store + a fake `BroadcastChannel`; the real browser behaviors
+below can't be unit-tested:
+
+1. **Cross-document reuse.** Sign in (`recognize()` / `createDerived()` /
+   `unlock()`) on page A, then hard-navigate to page B (a separate document).
+   Confirm `status()` reports `signedIn: true` on B and `signLogin` / `signTransaction`
+   work **without** a re-unlock prompt — the handle was hydrated from IndexedDB.
+2. **No seed at rest.** In DevTools → Application → IndexedDB → `gc-session-signer`,
+   confirm the stored record holds a `CryptoKey` whose `extractable === false`
+   (the seed cannot be exported), and that `exportSecret()` on a hydrated key
+   throws `NoSeedError`.
+3. **Auto-lock.** Leave the page idle past the idle timeout (or hide the tab /
+   `pagehide`) and confirm the session locks (`status().signedIn === false`, the
+   IndexedDB record cleared).
+4. **Cross-tab lock-sync.** Open the app in two tabs (both signed in), `lock()` in
+   one, and confirm the other signs out (its in-memory cache cleared via the
+   `BroadcastChannel` `lock` message).

--- a/clients/sdk/gc-adapters.test.mjs
+++ b/clients/sdk/gc-adapters.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 import { makeIdbStore } from './gc-store-idb.mjs';
+import { makeSessionStore } from './gc-session-store-idb.mjs';
 
 test('webauthn passkey adapter exposes the passkey interface', async () => {
   const pk = makeWebauthnPasskey({ rpId: 'example.com', rpName: 'Demo' });
@@ -14,6 +15,13 @@ test('webauthn passkey adapter exposes the passkey interface', async () => {
 
 test('idb store adapter exposes the store interface', () => {
   const store = makeIdbStore({ dbName: 'gc-signing-key-test' });
+  for (const m of ['get', 'put', 'delete']) {
+    assert.equal(typeof store[m], 'function');
+  }
+});
+
+test('session store adapter exposes the store interface', () => {
+  const store = makeSessionStore({ dbName: 'gc-session-signer-test' });
   for (const m of ['get', 'put', 'delete']) {
     assert.equal(typeof store[m], 'function');
   }

--- a/clients/sdk/gc-errors.mjs
+++ b/clients/sdk/gc-errors.mjs
@@ -24,3 +24,7 @@ export class BadProofError extends Error {}
 // Input is not a structurally valid stake attestation (bad claim shape or a
 // proof whose message is not a parseable claim).
 export class BadAttestationError extends Error {}
+
+// A sign-only key (non-extractable private key, e.g. a session-signer handle):
+// it can sign but cannot produce the seed. Thrown by exportSecret()/mnemonic().
+export class NoSeedError extends Error {}

--- a/clients/sdk/gc-session-signer.mjs
+++ b/clients/sdk/gc-session-signer.mjs
@@ -1,8 +1,13 @@
 // Cross-document, non-extractable, auto-locking sign-only session. Holds a sign-only
 // SigningKey handle in an injected session store (cross-document) + an in-memory cache;
-// exposes signLogin/signTransaction; never exposes the seed. Populate methods
-// (recognize/unlock/createDerived) and auto-lock are added in later tasks. DOM-free;
+// exposes signLogin/signTransaction; never exposes the seed. DOM-free;
 // store/passkey/clock/broadcast are injected.
+//
+// Auto-lock mirrors base's signing-key-session.mjs: an idle timeout (default
+// ~15 min, reset on user activity via touch()), plus the page being hidden
+// (visibilitychange -> hidden) or unloaded (pagehide) when installAutoLock wires
+// the DOM lifecycle. A lock in one tab/document is broadcast over an injected
+// BroadcastChannel-like object so the other tabs drop their in-memory cache too.
 import { SigningKey } from './gc-signing-key.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
@@ -11,9 +16,50 @@ import * as keyring from './gc-keyring.mjs';
 import { makeDerivedIdentity, classifyRecognition } from './gc-derived-identity.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
 
-export function makeSessionSigner({ store, durableStore, passkey } = {}) {
+export const DEFAULT_IDLE_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'scroll', 'touchstart'];
+
+export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAULT_IDLE_MS, broadcast, clock } = {}) {
   let cached = null; // in-memory sign-only SigningKey for this document
   const lockCbs = [];
+
+  // Idle-timer deps (injectable clock/timer). Defaults reference the real
+  // globals only here, inside the function, guarded — never at module top level.
+  const timerDeps = {
+    now: clock?.now ?? (() => Date.now()),
+    setTimer: clock?.setTimer ?? ((cb, t) => setTimeout(cb, t)),
+    clearTimer: clock?.clearTimer ?? ((id) => clearTimeout(id)),
+  };
+  let timerHandle = null;
+  // Auto-lock is OFF until installAutoLock() turns it on. Until then touch()
+  // (called by adopt() when a session begins) is a no-op — so a signer with no
+  // auto-lock installed never arms a timer (mirrors base's signing-key-session,
+  // where touch() is a no-op until armIdle has run). Without this, every adopt()
+  // would leak a real 15-min setTimeout that keeps the process/event loop alive.
+  let autoLockArmed = false;
+
+  function clearTimerHandle() {
+    if (timerHandle != null) timerDeps.clearTimer(timerHandle);
+    timerHandle = null;
+  }
+
+  // Arm (or re-arm) the idle timer toward an auto-lock. now() is threaded for
+  // parity with base (deadline math may use it); the lock on expiry is the point.
+  function armIdle(ms = idleMs) {
+    autoLockArmed = true;
+    clearTimerHandle();
+    timerHandle = timerDeps.setTimer(() => {
+      timerHandle = null;
+      lock();
+    }, ms);
+  }
+
+  // Reset the idle countdown on activity / on a session beginning. A no-op
+  // until auto-lock has been armed (installAutoLock / an explicit armIdle).
+  function touch() {
+    if (!autoLockArmed) return;
+    armIdle(idleMs);
+  }
 
   async function held() {
     if (cached) return cached;
@@ -27,6 +73,10 @@ export function makeSessionSigner({ store, durableStore, passkey } = {}) {
     const handle = await key.toSignOnlyHandle(); // always non-extractable
     await store.put(handle);
     cached = SigningKey.fromSignOnlyHandle(handle);
+    // A session is beginning: (re)start the idle countdown — mirrors base's
+    // setSigningKey -> touch(). A no-op effect on behavior until the timer is
+    // wired, but with an injected clock it arms immediately.
+    touch();
     return { address: handle.address };
   }
 
@@ -84,11 +134,62 @@ export function makeSessionSigner({ store, durableStore, passkey } = {}) {
 
   function onLock(cb) { lockCbs.push(cb); }
 
-  async function lock() {
+  // Drop the in-memory key + idle timer and fire onLock callbacks. Shared by
+  // lock() and the cross-tab broadcast handler. Does NOT touch the store or
+  // re-broadcast — those are lock()'s responsibility (the originating tab).
+  function clearLocal() {
     cached = null;
-    await store.delete();
+    clearTimerHandle();
     for (const cb of lockCbs) cb();
   }
 
-  return { adopt, status, signLogin, signTransaction, recognize, createDerived, unlock, onLock, lock };
+  async function lock() {
+    clearLocal();
+    await store.delete();
+    broadcast?.postMessage({ type: 'lock' });
+  }
+
+  // Wire the page lifecycle + activity handlers. Thin: registers listeners that
+  // delegate to lock()/touch(), keeping the timer logic unit-testable without a
+  // DOM. The clock/timer fall back to the injected `clock` when absent.
+  function installAutoLock({
+    document,
+    window,
+    idleMs: ms = idleMs,
+    activityEvents = DEFAULT_ACTIVITY_EVENTS,
+    now,
+    setTimer,
+    clearTimer,
+  } = {}) {
+    if (now) timerDeps.now = now;
+    if (setTimer) timerDeps.setTimer = setTimer;
+    if (clearTimer) timerDeps.clearTimer = clearTimer;
+
+    if (document) {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') lock();
+      });
+    }
+    if (window) {
+      window.addEventListener('pagehide', () => lock());
+      for (const type of activityEvents) {
+        window.addEventListener(type, () => touch());
+      }
+    }
+    armIdle(ms);
+  }
+
+  // Cross-tab lock-sync: a lock in another document drops our local cache too.
+  // Only clear local state — the originating tab already cleared the store and
+  // broadcast, so we must NOT re-delete or re-broadcast (avoid a loop).
+  if (broadcast) {
+    broadcast.onmessage = (ev) => {
+      if (ev?.data?.type === 'lock') clearLocal();
+    };
+  }
+
+  return {
+    adopt, status, signLogin, signTransaction, recognize, createDerived,
+    unlock, onLock, lock, armIdle, touch, installAutoLock,
+  };
 }

--- a/clients/sdk/gc-session-signer.mjs
+++ b/clients/sdk/gc-session-signer.mjs
@@ -1,0 +1,56 @@
+// Cross-document, non-extractable, auto-locking sign-only session. Holds a sign-only
+// SigningKey handle in an injected session store (cross-document) + an in-memory cache;
+// exposes signLogin/signTransaction; never exposes the seed. Populate methods
+// (recognize/unlock/createDerived) and auto-lock are added in later tasks. DOM-free;
+// store/passkey/clock/broadcast are injected.
+import { SigningKey } from './gc-signing-key.mjs';
+import { signMessage } from './gc-message.mjs';
+import { signUnsignedTxn } from './gc-transaction.mjs';
+import { NoSigningKeyError } from './gc-errors.mjs';
+
+export function makeSessionSigner({ store } = {}) {
+  let cached = null; // in-memory sign-only SigningKey for this document
+  const lockCbs = [];
+
+  async function held() {
+    if (cached) return cached;
+    const rec = await store.get();
+    if (!rec) return null;
+    cached = SigningKey.fromSignOnlyHandle(rec);
+    return cached;
+  }
+
+  async function adopt(key) {
+    const handle = await key.toSignOnlyHandle(); // always non-extractable
+    await store.put(handle);
+    cached = SigningKey.fromSignOnlyHandle(handle);
+    return { address: handle.address };
+  }
+
+  async function status() {
+    const k = await held();
+    return { signedIn: Boolean(k), address: k ? await k.address() : null };
+  }
+
+  async function signLogin(challenge, { timestamp } = {}) {
+    const k = await held();
+    if (!k) throw new NoSigningKeyError('locked: no session signer');
+    return signMessage(k, challenge, { timestamp });
+  }
+
+  async function signTransaction(unsigned) {
+    const k = await held();
+    if (!k) throw new NoSigningKeyError('locked: no session signer');
+    return signUnsignedTxn(unsigned, k);
+  }
+
+  function onLock(cb) { lockCbs.push(cb); }
+
+  async function lock() {
+    cached = null;
+    await store.delete();
+    for (const cb of lockCbs) cb();
+  }
+
+  return { adopt, status, signLogin, signTransaction, onLock, lock };
+}

--- a/clients/sdk/gc-session-signer.mjs
+++ b/clients/sdk/gc-session-signer.mjs
@@ -7,8 +7,11 @@ import { SigningKey } from './gc-signing-key.mjs';
 import { signMessage } from './gc-message.mjs';
 import { signUnsignedTxn } from './gc-transaction.mjs';
 import { NoSigningKeyError } from './gc-errors.mjs';
+import * as keyring from './gc-keyring.mjs';
+import { makeDerivedIdentity, classifyRecognition } from './gc-derived-identity.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
 
-export function makeSessionSigner({ store } = {}) {
+export function makeSessionSigner({ store, durableStore, passkey } = {}) {
   let cached = null; // in-memory sign-only SigningKey for this document
   const lockCbs = [];
 
@@ -44,6 +47,41 @@ export function makeSessionSigner({ store } = {}) {
     return signUnsignedTxn(unsigned, k);
   }
 
+  async function recognize() {
+    if (!passkey || typeof passkey.discover !== 'function') return { verdict: 'none' };
+    let found;
+    try { found = await passkey.discover(); } catch { return { verdict: 'none' }; }
+    if (!found) return { verdict: 'none' };
+    const sk = await deriveSigningKey(found.prfOutput);
+    const derivedAddress = await sk.address();
+    if (classifyRecognition({ userHandle: found.userHandle, derivedAddress }) === 'wrap') {
+      return { verdict: 'wrap', address: found.userHandle };
+    }
+    await durableStore.put({
+      version: keyring.VERSION, kind: 'derived', address: derivedAddress,
+      credentialId: found.credentialId,
+    });
+    await adopt(sk);
+    return { verdict: 'derived', address: derivedAddress };
+  }
+
+  async function createDerived({ userName } = {}) {
+    const derived = makeDerivedIdentity({ passkey });
+    const { signing_key, address, mnemonic, credentialId } = await derived.enroll({ userName });
+    await durableStore.put({
+      version: keyring.VERSION, kind: 'derived', address, credentialId,
+    });
+    await adopt(signing_key);
+    return { address, mnemonic };
+  }
+
+  async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    const key = await keyring.unlock(
+      { store: durableStore, passkey: usePasskey ? passkey : undefined }, { passphrase },
+    );
+    return adopt(key);
+  }
+
   function onLock(cb) { lockCbs.push(cb); }
 
   async function lock() {
@@ -52,5 +90,5 @@ export function makeSessionSigner({ store } = {}) {
     for (const cb of lockCbs) cb();
   }
 
-  return { adopt, status, signLogin, signTransaction, onLock, lock };
+  return { adopt, status, signLogin, signTransaction, recognize, createDerived, unlock, onLock, lock };
 }

--- a/clients/sdk/gc-session-signer.test.mjs
+++ b/clients/sdk/gc-session-signer.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { makeSessionSigner } from './gc-session-signer.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 import { verifyMessage } from './gc-message.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
 
 function fakeStore() {
   let rec = null;
@@ -42,4 +43,68 @@ test('signLogin/signTransaction reject when signed out', async () => {
   const s = makeSessionSigner({ store: fakeStore() });
   await assert.rejects(() => s.signLogin('x'), NoSigningKeyError);
   await assert.rejects(() => s.signTransaction({ txid: 'x' }), NoSigningKeyError);
+});
+
+function fakeDerivePasskey({ prfFill = 9, credentialId = 'credS', userHandle = null } = {}) {
+  const PRF = new Uint8Array(32).fill(prfFill);
+  return {
+    PRF,
+    isSupported: async () => true,
+    enroll: async () => ({ credentialId, prfOutput: PRF }),
+    discover: async () => ({ credentialId, prfOutput: PRF, userHandle }),
+  };
+}
+
+test('recognize(): derived passkey -> signed in + derived record persisted', async () => {
+  const store = fakeStore(); const durableStore = fakeStore();
+  const passkey = fakeDerivePasskey({ prfFill: 11, credentialId: 'credD', userHandle: 'not-an-address' });
+  const D = await (await deriveSigningKey(passkey.PRF)).address();
+  const s = makeSessionSigner({ store, durableStore, passkey });
+  const r = await s.recognize();
+  assert.deepEqual(r, { verdict: 'derived', address: D });
+  assert.deepEqual(await s.status(), { signedIn: true, address: D });
+  const rec = await durableStore.get();
+  assert.equal(rec.version, 2);
+  assert.equal(rec.kind, 'derived');
+  assert.equal(rec.address, D);
+  assert.equal(rec.credentialId, 'credD');
+});
+
+test('recognize(): wrap passkey (phantom guard) -> verdict wrap, NOT signed in, nothing persisted', async () => {
+  const store = fakeStore(); const durableStore = fakeStore();
+  const wrapAddr = await (await SigningKey.generate()).address();
+  const passkey = fakeDerivePasskey({ prfFill: 17, userHandle: wrapAddr });
+  const D = await (await deriveSigningKey(passkey.PRF)).address();
+  assert.notEqual(wrapAddr, D);
+  const s = makeSessionSigner({ store, durableStore, passkey });
+  assert.deepEqual(await s.recognize(), { verdict: 'wrap', address: wrapAddr });
+  assert.deepEqual(await s.status(), { signedIn: false, address: null });
+  assert.equal(await durableStore.get(), null);
+});
+
+test('recognize(): no passkey -> verdict none, no throw', async () => {
+  const s = makeSessionSigner({ store: fakeStore(), durableStore: fakeStore() });
+  assert.deepEqual(await s.recognize(), { verdict: 'none' });
+});
+
+test('createDerived(): returns address + 24-word mnemonic, signs in, persists derived record', async () => {
+  const store = fakeStore(); const durableStore = fakeStore();
+  const passkey = fakeDerivePasskey({ prfFill: 5, credentialId: 'credC' });
+  const s = makeSessionSigner({ store, durableStore, passkey });
+  const { address, mnemonic } = await s.createDerived({ userName: 'x' });
+  assert.ok(address.startsWith('gc1'));
+  assert.equal(mnemonic.split(' ').length, 24);
+  assert.deepEqual(await s.status(), { signedIn: true, address });
+  assert.equal((await durableStore.get()).kind, 'derived');
+});
+
+test('unlock(): a wrap identity in the keyring signs in', async () => {
+  const keyring = await import('./gc-keyring.mjs');
+  const store = fakeStore(); const durableStore = fakeStore();
+  const w = await SigningKey.generate();
+  await keyring.enroll(w, { store: durableStore }, { passphrase: 'pw' });
+  const s = makeSessionSigner({ store, durableStore });
+  const r = await s.unlock({ passphrase: 'pw' });
+  assert.equal(r.address, await w.address());
+  assert.deepEqual(await s.status(), { signedIn: true, address: await w.address() });
 });

--- a/clients/sdk/gc-session-signer.test.mjs
+++ b/clients/sdk/gc-session-signer.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeSessionSigner } from './gc-session-signer.mjs';
+import { SigningKey } from './gc-signing-key.mjs';
+import { verifyMessage } from './gc-message.mjs';
+
+function fakeStore() {
+  let rec = null;
+  return { get: async () => rec, put: async (r) => { rec = r; }, delete: async () => { rec = null; } };
+}
+
+test('adopt persists a sign-only handle; a FRESH signer on the same store is signed in', async () => {
+  const store = fakeStore();
+  const key = await SigningKey.generate();
+  const addr = await key.address();
+  const s1 = makeSessionSigner({ store });
+  await s1.adopt(key);
+  assert.deepEqual(await s1.status(), { signedIn: true, address: addr });
+  const s2 = makeSessionSigner({ store }); // a new document hydrates from the same store
+  assert.deepEqual(await s2.status(), { signedIn: true, address: addr });
+  const proof = await s2.signLogin('login:abc');
+  const v = await verifyMessage(proof, { maxAge: Number.MAX_SAFE_INTEGER });
+  assert.equal(v.valid, true);
+  assert.equal((await store.get()).privateKey.extractable, false); // persisted handle non-extractable
+});
+
+test('lock clears the store + memory; a fresh signer is signed out', async () => {
+  const store = fakeStore();
+  const s1 = makeSessionSigner({ store });
+  await s1.adopt(await SigningKey.generate());
+  let locked = false;
+  s1.onLock(() => { locked = true; });
+  await s1.lock();
+  assert.equal(locked, true);
+  assert.equal(await store.get(), null);
+  assert.deepEqual(await s1.status(), { signedIn: false, address: null });
+  assert.deepEqual(await makeSessionSigner({ store }).status(), { signedIn: false, address: null });
+});
+
+test('signLogin/signTransaction reject when signed out', async () => {
+  const { NoSigningKeyError } = await import('./gc-errors.mjs');
+  const s = makeSessionSigner({ store: fakeStore() });
+  await assert.rejects(() => s.signLogin('x'), NoSigningKeyError);
+  await assert.rejects(() => s.signTransaction({ txid: 'x' }), NoSigningKeyError);
+});

--- a/clients/sdk/gc-session-signer.test.mjs
+++ b/clients/sdk/gc-session-signer.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { makeSessionSigner } from './gc-session-signer.mjs';
+import { makeSessionSigner, DEFAULT_IDLE_MS } from './gc-session-signer.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 import { verifyMessage } from './gc-message.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
@@ -8,6 +8,28 @@ import { deriveSigningKey } from './gc-derive.mjs';
 function fakeStore() {
   let rec = null;
   return { get: async () => rec, put: async (r) => { rec = r; }, delete: async () => { rec = null; } };
+}
+
+// A connected fake BroadcastChannel pair: postMessage on A delivers to B.onmessage
+// (as a MessageEvent-shaped { data }) and vice versa.
+function fakeChannelPair() {
+  const a = { onmessage: null, postMessage: (m) => b.onmessage && b.onmessage({ data: m }) };
+  const b = { onmessage: null, postMessage: (m) => a.onmessage && a.onmessage({ data: m }) };
+  return [a, b];
+}
+
+// A fake injectable clock that captures the most recent armed timer callback so
+// tests can fire it deterministically and count set/clear invocations.
+function fakeClock() {
+  let cb = null;
+  const calls = { set: 0, clear: 0 };
+  return {
+    now: () => 0,
+    setTimer: (fn) => { cb = fn; calls.set++; return 1; },
+    clearTimer: () => { calls.clear++; },
+    fire: () => cb && cb(),
+    calls,
+  };
 }
 
 test('adopt persists a sign-only handle; a FRESH signer on the same store is signed in', async () => {
@@ -107,4 +129,99 @@ test('unlock(): a wrap identity in the keyring signs in', async () => {
   const r = await s.unlock({ passphrase: 'pw' });
   assert.equal(r.address, await w.address());
   assert.deepEqual(await s.status(), { signedIn: true, address: await w.address() });
+});
+
+test('idle timeout fires lock: signed out + store cleared', async () => {
+  const store = fakeStore();
+  const clock = fakeClock();
+  const s = makeSessionSigner({ store, clock });
+  let locked = false;
+  s.onLock(() => { locked = true; });
+  const key = await SigningKey.generate();
+  await s.adopt(key);
+  // Auto-lock is off until installAutoLock; it arms with the injected fake clock
+  // (so no real setTimeout leaks and keeps the process alive). adopt() before
+  // this is a no-op for the timer.
+  s.installAutoLock({});
+  assert.equal(clock.calls.set > 0, true);
+  assert.deepEqual(await s.status(), { signedIn: true, address: await key.address() });
+  clock.fire(); // simulate the idle deadline elapsing
+  assert.equal(locked, true);
+  assert.equal(await store.get(), null);
+  assert.deepEqual(await s.status(), { signedIn: false, address: null });
+});
+
+test('installAutoLock: visibilitychange -> hidden locks', async () => {
+  const store = fakeStore();
+  const clock = fakeClock();
+  const s = makeSessionSigner({ store, clock });
+  await s.adopt(await SigningKey.generate());
+  let locked = false;
+  s.onLock(() => { locked = true; });
+
+  const docListeners = {};
+  const winListeners = {};
+  const document = {
+    visibilityState: 'visible',
+    addEventListener: (type, fn) => { docListeners[type] = fn; },
+  };
+  const window = {
+    addEventListener: (type, fn) => { winListeners[type] = fn; },
+  };
+  s.installAutoLock({ document, window });
+  document.visibilityState = 'hidden';
+  docListeners.visibilitychange();
+  assert.equal(locked, true);
+  assert.equal(await store.get(), null);
+});
+
+test('installAutoLock: pagehide locks', async () => {
+  const store = fakeStore();
+  const clock = fakeClock();
+  const s = makeSessionSigner({ store, clock });
+  await s.adopt(await SigningKey.generate());
+  let locked = false;
+  s.onLock(() => { locked = true; });
+
+  const docListeners = {};
+  const winListeners = {};
+  const document = { visibilityState: 'visible', addEventListener: (type, fn) => { docListeners[type] = fn; } };
+  const window = { addEventListener: (type, fn) => { winListeners[type] = fn; } };
+  s.installAutoLock({ document, window });
+  winListeners.pagehide();
+  assert.equal(locked, true);
+  assert.equal(await store.get(), null);
+});
+
+test('cross-tab: lock in tab A clears tab B in-memory cache + fires B onLock', async () => {
+  const store = fakeStore();
+  const [chA, chB] = fakeChannelPair();
+  const A = makeSessionSigner({ store, broadcast: chA });
+  const B = makeSessionSigner({ store, broadcast: chB });
+  await A.adopt(await SigningKey.generate());
+  // adopt on B first to give B a live in-memory cache (so we can assert it clears)
+  await B.status(); // hydrate B's cache from the shared store
+  assert.equal((await B.status()).signedIn, true);
+  let bLocked = false;
+  B.onLock(() => { bLocked = true; });
+  await A.lock();
+  assert.equal(bLocked, true); // B fired onLock from the broadcast
+  assert.deepEqual(await B.status(), { signedIn: false, address: null });
+});
+
+test('touch re-arms the idle timer (clear + set)', async () => {
+  const store = fakeStore();
+  const clock = fakeClock();
+  const s = makeSessionSigner({ store, clock });
+  await s.adopt(await SigningKey.generate());
+  s.installAutoLock({}); // arm auto-lock (touch is a no-op until then)
+  const setAfterArm = clock.calls.set;
+  const clearAfterArm = clock.calls.clear;
+  s.touch();
+  assert.equal(clock.calls.clear > clearAfterArm, true);
+  assert.equal(clock.calls.set > setAfterArm, true);
+});
+
+test('DEFAULT_IDLE_MS is 15 minutes', () => {
+  assert.equal(DEFAULT_IDLE_MS, 15 * 60 * 1000);
 });

--- a/clients/sdk/gc-session-store-idb.mjs
+++ b/clients/sdk/gc-session-store-idb.mjs
@@ -1,0 +1,62 @@
+// Real IndexedDB session store adapter (browser-only). Implements the `store`
+// interface for the session-signer: one DB, one object store, a single fixed-key
+// record. Uses a DISTINCT dbName from the durable keyring store so the
+// auto-locking session lives in its own database. The stored record holds
+// structured-cloneable values including non-extractable CryptoKeys — IndexedDB
+// structured-clones them natively, so no special handling is needed. Touches
+// `indexedDB` only inside functions so it imports cleanly in Node.
+const STORE = 'signing_key';
+const KEY = 'singleton';
+
+function openDb(dbName) {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx(db, mode, fn) {
+  return new Promise((resolve, reject) => {
+    const t = db.transaction(STORE, mode);
+    const req = fn(t.objectStore(STORE));
+    t.oncomplete = () => resolve(req ? req.result : undefined);
+    t.onerror = () => reject(t.error);
+    t.onabort = () => reject(t.error);
+  });
+}
+
+export function makeSessionStore({ dbName = 'gc-session-signer' } = {}) {
+  return {
+    async get() {
+      const db = await openDb(dbName);
+      try {
+        const rec = await tx(db, 'readonly', (s) => s.get(KEY));
+        return rec ?? null;
+      } finally {
+        db.close();
+      }
+    },
+    async put(record) {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.put(record, KEY));
+      } finally {
+        db.close();
+      }
+    },
+    async delete() {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.delete(KEY));
+      } finally {
+        db.close();
+      }
+    },
+  };
+}

--- a/clients/sdk/gc-signing-key.mjs
+++ b/clients/sdk/gc-signing-key.mjs
@@ -3,6 +3,7 @@
 // dependencies. Browser + Node 20+.
 import { base64encode, base64decode, base64urlDecode } from './gc-crypto.mjs';
 import { encodeAddress, decodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
+import { NoSeedError } from './gc-errors.mjs';
 
 const ALG = 'Ed25519';
 // RFC 8410 Ed25519 PKCS8 prefix for a bare 32-byte seed (16 bytes); WebCrypto
@@ -11,6 +12,13 @@ const PKCS8_PREFIX = Uint8Array.of(
   0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
   0x04, 0x22, 0x04, 0x20,
 );
+
+function pkcs8FromSeed(seed) {
+  const pkcs8 = new Uint8Array(PKCS8_PREFIX.length + 32);
+  pkcs8.set(PKCS8_PREFIX, 0);
+  pkcs8.set(seed, PKCS8_PREFIX.length);
+  return pkcs8;
+}
 
 export class SigningKey {
   #privateKey;
@@ -44,9 +52,7 @@ export class SigningKey {
     if (seed === null) {
       throw new Error('invalid gcsec secret (bad checksum or HRP)');
     }
-    const pkcs8 = new Uint8Array(PKCS8_PREFIX.length + 32);
-    pkcs8.set(PKCS8_PREFIX, 0);
-    pkcs8.set(seed, PKCS8_PREFIX.length);
+    const pkcs8 = pkcs8FromSeed(seed);
     const priv = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, true, [
       'sign',
     ]);
@@ -58,6 +64,24 @@ export class SigningKey {
       ALG,
       true,
       ['verify'],
+    );
+    return new SigningKey(priv, pub);
+  }
+
+  // A non-extractable, sign-only key: the private CryptoKey can sign but cannot be
+  // exported, so exportSecret()/mnemonic() throw NoSeedError. The public key is
+  // derived via a transient extractable import (the seed is in hand here anyway).
+  static async fromSecretSignOnly(gcsec) {
+    const seed = decodeSecret(gcsec);
+    if (seed === null) {
+      throw new Error('invalid gcsec secret (bad checksum or HRP)');
+    }
+    const pkcs8 = pkcs8FromSeed(seed);
+    const priv = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, false, ['sign']);
+    const tmp = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, true, ['sign']);
+    const jwk = await crypto.subtle.exportKey('jwk', tmp);
+    const pub = await crypto.subtle.importKey(
+      'jwk', { kty: 'OKP', crv: 'Ed25519', x: jwk.x, ext: true }, ALG, true, ['verify'],
     );
     return new SigningKey(priv, pub);
   }
@@ -98,8 +122,35 @@ export class SigningKey {
 
   async exportSecret() {
     if (!this.#privateKey) throw new Error('no private key');
+    if (!this.#privateKey.extractable) {
+      throw new NoSeedError('sign-only key: the seed is not extractable');
+    }
     const jwk = await crypto.subtle.exportKey('jwk', this.#privateKey);
     return encodeSecret(base64urlDecode(jwk.d));
+  }
+
+  // A structured-cloneable, NON-EXTRACTABLE handle for cross-document session reuse
+  // (persist via IndexedDB). Always sign-only: if this key is extractable, re-import
+  // its seed non-extractable first, so the persisted handle can never leak the seed.
+  async toSignOnlyHandle() {
+    if (!this.#privateKey) throw new Error('no private key');
+    if (this.#privateKey.extractable) {
+      const signOnly = await SigningKey.fromSecretSignOnly(await this.exportSecret());
+      return {
+        address: await this.address(),
+        privateKey: signOnly.#privateKey,
+        publicKey: signOnly.#publicKey,
+      };
+    }
+    return {
+      address: await this.address(),
+      privateKey: this.#privateKey,
+      publicKey: this.#publicKey,
+    };
+  }
+
+  static fromSignOnlyHandle({ privateKey, publicKey }) {
+    return new SigningKey(privateKey, publicKey);
   }
 
   async #rawPublic() {

--- a/clients/sdk/gc-signing-key.test.mjs
+++ b/clients/sdk/gc-signing-key.test.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { SigningKey } from './gc-signing-key.mjs';
+import { NoSeedError } from './gc-errors.mjs';
+import { signMessage } from './gc-message.mjs';
 
 test('isSupported() returns true on a runtime with WebCrypto Ed25519', async () => {
   // Node 20+ (and current browsers) support Ed25519, so the probe succeeds.
@@ -78,4 +80,34 @@ test('fromAddress rejects a corrupted address', async () => {
   const addr = await (await SigningKey.generate()).address();
   const bad = addr.slice(0, -1) + (addr.at(-1) === 'q' ? 'p' : 'q');
   await assert.rejects(() => SigningKey.fromAddress(bad), /address/);
+});
+
+test('fromSecretSignOnly: signs + correct address, but the seed is non-extractable', async () => {
+  const full = await SigningKey.generate();
+  const gcsec = await full.exportSecret();
+  const addr = await full.address();
+  const signOnly = await SigningKey.fromSecretSignOnly(gcsec);
+  assert.equal(await signOnly.address(), addr);
+  const sig = await signOnly.sign(new TextEncoder().encode('hi'));
+  assert.equal(await full.verify(new TextEncoder().encode('hi'), sig), true);
+  await assert.rejects(() => signOnly.exportSecret(), NoSeedError);
+  await assert.rejects(() => signOnly.mnemonic(), NoSeedError);
+});
+
+test('signMessage works with a sign-only key', async () => {
+  const full = await SigningKey.generate();
+  const signOnly = await SigningKey.fromSecretSignOnly(await full.exportSecret());
+  const proof = await signMessage(signOnly, 'login:abc');
+  assert.equal(proof.scheme, 'gc-msg-v1');
+  assert.equal(proof.address, await full.address());
+});
+
+test('toSignOnlyHandle round-trips and is non-extractable; a normal key still exports', async () => {
+  const full = await SigningKey.generate();
+  const handle = await full.toSignOnlyHandle();
+  assert.equal(handle.privateKey.extractable, false);
+  const rehydrated = SigningKey.fromSignOnlyHandle(handle);
+  assert.equal(await rehydrated.address(), handle.address);
+  await assert.rejects(() => rehydrated.exportSecret(), NoSeedError);
+  assert.ok((await full.exportSecret()).startsWith('gcsec1'));
 });

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.11.0';
+export const version = '0.12.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -20,6 +20,8 @@ export { canonical, signHeaders } from './gc-sig.mjs';
 export { enroll, unlock, hasSigningKey, clear } from './gc-store.mjs';
 export { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 export { makeIdbStore } from './gc-store-idb.mjs';
+export { makeSessionSigner } from './gc-session-signer.mjs';
+export { makeSessionStore } from './gc-session-store-idb.mjs';
 
 // Backup / recovery
 export {

--- a/clients/sdk/index.test.mjs
+++ b/clients/sdk/index.test.mjs
@@ -7,6 +7,7 @@ const FUNCTIONS = [
   'canonical', 'signHeaders',
   'enroll', 'unlock', 'hasSigningKey', 'clear',
   'makeWebauthnPasskey', 'makeIdbStore',
+  'makeSessionSigner', 'makeSessionStore',
   'exportEncrypted', 'importEncrypted', 'exportPlain', 'importPlain',
   'deriveSeed', 'deriveSigningKey', 'seedToMnemonic', 'mnemonicToSeed',
   'signMessage', 'verifyMessage', 'toArmored', 'fromArmored',

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-errors.mjs
+++ b/src/gumptionchain/static/sdk/gc-errors.mjs
@@ -24,3 +24,7 @@ export class BadProofError extends Error {}
 // Input is not a structurally valid stake attestation (bad claim shape or a
 // proof whose message is not a parseable claim).
 export class BadAttestationError extends Error {}
+
+// A sign-only key (non-extractable private key, e.g. a session-signer handle):
+// it can sign but cannot produce the seed. Thrown by exportSecret()/mnemonic().
+export class NoSeedError extends Error {}

--- a/src/gumptionchain/static/sdk/gc-session-signer.mjs
+++ b/src/gumptionchain/static/sdk/gc-session-signer.mjs
@@ -1,0 +1,195 @@
+// Cross-document, non-extractable, auto-locking sign-only session. Holds a sign-only
+// SigningKey handle in an injected session store (cross-document) + an in-memory cache;
+// exposes signLogin/signTransaction; never exposes the seed. DOM-free;
+// store/passkey/clock/broadcast are injected.
+//
+// Auto-lock mirrors base's signing-key-session.mjs: an idle timeout (default
+// ~15 min, reset on user activity via touch()), plus the page being hidden
+// (visibilitychange -> hidden) or unloaded (pagehide) when installAutoLock wires
+// the DOM lifecycle. A lock in one tab/document is broadcast over an injected
+// BroadcastChannel-like object so the other tabs drop their in-memory cache too.
+import { SigningKey } from './gc-signing-key.mjs';
+import { signMessage } from './gc-message.mjs';
+import { signUnsignedTxn } from './gc-transaction.mjs';
+import { NoSigningKeyError } from './gc-errors.mjs';
+import * as keyring from './gc-keyring.mjs';
+import { makeDerivedIdentity, classifyRecognition } from './gc-derived-identity.mjs';
+import { deriveSigningKey } from './gc-derive.mjs';
+
+export const DEFAULT_IDLE_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'scroll', 'touchstart'];
+
+export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAULT_IDLE_MS, broadcast, clock } = {}) {
+  let cached = null; // in-memory sign-only SigningKey for this document
+  const lockCbs = [];
+
+  // Idle-timer deps (injectable clock/timer). Defaults reference the real
+  // globals only here, inside the function, guarded — never at module top level.
+  const timerDeps = {
+    now: clock?.now ?? (() => Date.now()),
+    setTimer: clock?.setTimer ?? ((cb, t) => setTimeout(cb, t)),
+    clearTimer: clock?.clearTimer ?? ((id) => clearTimeout(id)),
+  };
+  let timerHandle = null;
+  // Auto-lock is OFF until installAutoLock() turns it on. Until then touch()
+  // (called by adopt() when a session begins) is a no-op — so a signer with no
+  // auto-lock installed never arms a timer (mirrors base's signing-key-session,
+  // where touch() is a no-op until armIdle has run). Without this, every adopt()
+  // would leak a real 15-min setTimeout that keeps the process/event loop alive.
+  let autoLockArmed = false;
+
+  function clearTimerHandle() {
+    if (timerHandle != null) timerDeps.clearTimer(timerHandle);
+    timerHandle = null;
+  }
+
+  // Arm (or re-arm) the idle timer toward an auto-lock. now() is threaded for
+  // parity with base (deadline math may use it); the lock on expiry is the point.
+  function armIdle(ms = idleMs) {
+    autoLockArmed = true;
+    clearTimerHandle();
+    timerHandle = timerDeps.setTimer(() => {
+      timerHandle = null;
+      lock();
+    }, ms);
+  }
+
+  // Reset the idle countdown on activity / on a session beginning. A no-op
+  // until auto-lock has been armed (installAutoLock / an explicit armIdle).
+  function touch() {
+    if (!autoLockArmed) return;
+    armIdle(idleMs);
+  }
+
+  async function held() {
+    if (cached) return cached;
+    const rec = await store.get();
+    if (!rec) return null;
+    cached = SigningKey.fromSignOnlyHandle(rec);
+    return cached;
+  }
+
+  async function adopt(key) {
+    const handle = await key.toSignOnlyHandle(); // always non-extractable
+    await store.put(handle);
+    cached = SigningKey.fromSignOnlyHandle(handle);
+    // A session is beginning: (re)start the idle countdown — mirrors base's
+    // setSigningKey -> touch(). A no-op effect on behavior until the timer is
+    // wired, but with an injected clock it arms immediately.
+    touch();
+    return { address: handle.address };
+  }
+
+  async function status() {
+    const k = await held();
+    return { signedIn: Boolean(k), address: k ? await k.address() : null };
+  }
+
+  async function signLogin(challenge, { timestamp } = {}) {
+    const k = await held();
+    if (!k) throw new NoSigningKeyError('locked: no session signer');
+    return signMessage(k, challenge, { timestamp });
+  }
+
+  async function signTransaction(unsigned) {
+    const k = await held();
+    if (!k) throw new NoSigningKeyError('locked: no session signer');
+    return signUnsignedTxn(unsigned, k);
+  }
+
+  async function recognize() {
+    if (!passkey || typeof passkey.discover !== 'function') return { verdict: 'none' };
+    let found;
+    try { found = await passkey.discover(); } catch { return { verdict: 'none' }; }
+    if (!found) return { verdict: 'none' };
+    const sk = await deriveSigningKey(found.prfOutput);
+    const derivedAddress = await sk.address();
+    if (classifyRecognition({ userHandle: found.userHandle, derivedAddress }) === 'wrap') {
+      return { verdict: 'wrap', address: found.userHandle };
+    }
+    await durableStore.put({
+      version: keyring.VERSION, kind: 'derived', address: derivedAddress,
+      credentialId: found.credentialId,
+    });
+    await adopt(sk);
+    return { verdict: 'derived', address: derivedAddress };
+  }
+
+  async function createDerived({ userName } = {}) {
+    const derived = makeDerivedIdentity({ passkey });
+    const { signing_key, address, mnemonic, credentialId } = await derived.enroll({ userName });
+    await durableStore.put({
+      version: keyring.VERSION, kind: 'derived', address, credentialId,
+    });
+    await adopt(signing_key);
+    return { address, mnemonic };
+  }
+
+  async function unlock({ passphrase, passkey: usePasskey } = {}) {
+    const key = await keyring.unlock(
+      { store: durableStore, passkey: usePasskey ? passkey : undefined }, { passphrase },
+    );
+    return adopt(key);
+  }
+
+  function onLock(cb) { lockCbs.push(cb); }
+
+  // Drop the in-memory key + idle timer and fire onLock callbacks. Shared by
+  // lock() and the cross-tab broadcast handler. Does NOT touch the store or
+  // re-broadcast — those are lock()'s responsibility (the originating tab).
+  function clearLocal() {
+    cached = null;
+    clearTimerHandle();
+    for (const cb of lockCbs) cb();
+  }
+
+  async function lock() {
+    clearLocal();
+    await store.delete();
+    broadcast?.postMessage({ type: 'lock' });
+  }
+
+  // Wire the page lifecycle + activity handlers. Thin: registers listeners that
+  // delegate to lock()/touch(), keeping the timer logic unit-testable without a
+  // DOM. The clock/timer fall back to the injected `clock` when absent.
+  function installAutoLock({
+    document,
+    window,
+    idleMs: ms = idleMs,
+    activityEvents = DEFAULT_ACTIVITY_EVENTS,
+    now,
+    setTimer,
+    clearTimer,
+  } = {}) {
+    if (now) timerDeps.now = now;
+    if (setTimer) timerDeps.setTimer = setTimer;
+    if (clearTimer) timerDeps.clearTimer = clearTimer;
+
+    if (document) {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') lock();
+      });
+    }
+    if (window) {
+      window.addEventListener('pagehide', () => lock());
+      for (const type of activityEvents) {
+        window.addEventListener(type, () => touch());
+      }
+    }
+    armIdle(ms);
+  }
+
+  // Cross-tab lock-sync: a lock in another document drops our local cache too.
+  // Only clear local state — the originating tab already cleared the store and
+  // broadcast, so we must NOT re-delete or re-broadcast (avoid a loop).
+  if (broadcast) {
+    broadcast.onmessage = (ev) => {
+      if (ev?.data?.type === 'lock') clearLocal();
+    };
+  }
+
+  return {
+    adopt, status, signLogin, signTransaction, recognize, createDerived,
+    unlock, onLock, lock, armIdle, touch, installAutoLock,
+  };
+}

--- a/src/gumptionchain/static/sdk/gc-session-store-idb.mjs
+++ b/src/gumptionchain/static/sdk/gc-session-store-idb.mjs
@@ -1,0 +1,62 @@
+// Real IndexedDB session store adapter (browser-only). Implements the `store`
+// interface for the session-signer: one DB, one object store, a single fixed-key
+// record. Uses a DISTINCT dbName from the durable keyring store so the
+// auto-locking session lives in its own database. The stored record holds
+// structured-cloneable values including non-extractable CryptoKeys — IndexedDB
+// structured-clones them natively, so no special handling is needed. Touches
+// `indexedDB` only inside functions so it imports cleanly in Node.
+const STORE = 'signing_key';
+const KEY = 'singleton';
+
+function openDb(dbName) {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx(db, mode, fn) {
+  return new Promise((resolve, reject) => {
+    const t = db.transaction(STORE, mode);
+    const req = fn(t.objectStore(STORE));
+    t.oncomplete = () => resolve(req ? req.result : undefined);
+    t.onerror = () => reject(t.error);
+    t.onabort = () => reject(t.error);
+  });
+}
+
+export function makeSessionStore({ dbName = 'gc-session-signer' } = {}) {
+  return {
+    async get() {
+      const db = await openDb(dbName);
+      try {
+        const rec = await tx(db, 'readonly', (s) => s.get(KEY));
+        return rec ?? null;
+      } finally {
+        db.close();
+      }
+    },
+    async put(record) {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.put(record, KEY));
+      } finally {
+        db.close();
+      }
+    },
+    async delete() {
+      const db = await openDb(dbName);
+      try {
+        await tx(db, 'readwrite', (s) => s.delete(KEY));
+      } finally {
+        db.close();
+      }
+    },
+  };
+}

--- a/src/gumptionchain/static/sdk/gc-signing-key.mjs
+++ b/src/gumptionchain/static/sdk/gc-signing-key.mjs
@@ -3,6 +3,7 @@
 // dependencies. Browser + Node 20+.
 import { base64encode, base64decode, base64urlDecode } from './gc-crypto.mjs';
 import { encodeAddress, decodeAddress, encodeSecret, decodeSecret } from './gc-bech32.mjs';
+import { NoSeedError } from './gc-errors.mjs';
 
 const ALG = 'Ed25519';
 // RFC 8410 Ed25519 PKCS8 prefix for a bare 32-byte seed (16 bytes); WebCrypto
@@ -11,6 +12,13 @@ const PKCS8_PREFIX = Uint8Array.of(
   0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
   0x04, 0x22, 0x04, 0x20,
 );
+
+function pkcs8FromSeed(seed) {
+  const pkcs8 = new Uint8Array(PKCS8_PREFIX.length + 32);
+  pkcs8.set(PKCS8_PREFIX, 0);
+  pkcs8.set(seed, PKCS8_PREFIX.length);
+  return pkcs8;
+}
 
 export class SigningKey {
   #privateKey;
@@ -44,9 +52,7 @@ export class SigningKey {
     if (seed === null) {
       throw new Error('invalid gcsec secret (bad checksum or HRP)');
     }
-    const pkcs8 = new Uint8Array(PKCS8_PREFIX.length + 32);
-    pkcs8.set(PKCS8_PREFIX, 0);
-    pkcs8.set(seed, PKCS8_PREFIX.length);
+    const pkcs8 = pkcs8FromSeed(seed);
     const priv = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, true, [
       'sign',
     ]);
@@ -58,6 +64,24 @@ export class SigningKey {
       ALG,
       true,
       ['verify'],
+    );
+    return new SigningKey(priv, pub);
+  }
+
+  // A non-extractable, sign-only key: the private CryptoKey can sign but cannot be
+  // exported, so exportSecret()/mnemonic() throw NoSeedError. The public key is
+  // derived via a transient extractable import (the seed is in hand here anyway).
+  static async fromSecretSignOnly(gcsec) {
+    const seed = decodeSecret(gcsec);
+    if (seed === null) {
+      throw new Error('invalid gcsec secret (bad checksum or HRP)');
+    }
+    const pkcs8 = pkcs8FromSeed(seed);
+    const priv = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, false, ['sign']);
+    const tmp = await crypto.subtle.importKey('pkcs8', pkcs8, ALG, true, ['sign']);
+    const jwk = await crypto.subtle.exportKey('jwk', tmp);
+    const pub = await crypto.subtle.importKey(
+      'jwk', { kty: 'OKP', crv: 'Ed25519', x: jwk.x, ext: true }, ALG, true, ['verify'],
     );
     return new SigningKey(priv, pub);
   }
@@ -98,8 +122,35 @@ export class SigningKey {
 
   async exportSecret() {
     if (!this.#privateKey) throw new Error('no private key');
+    if (!this.#privateKey.extractable) {
+      throw new NoSeedError('sign-only key: the seed is not extractable');
+    }
     const jwk = await crypto.subtle.exportKey('jwk', this.#privateKey);
     return encodeSecret(base64urlDecode(jwk.d));
+  }
+
+  // A structured-cloneable, NON-EXTRACTABLE handle for cross-document session reuse
+  // (persist via IndexedDB). Always sign-only: if this key is extractable, re-import
+  // its seed non-extractable first, so the persisted handle can never leak the seed.
+  async toSignOnlyHandle() {
+    if (!this.#privateKey) throw new Error('no private key');
+    if (this.#privateKey.extractable) {
+      const signOnly = await SigningKey.fromSecretSignOnly(await this.exportSecret());
+      return {
+        address: await this.address(),
+        privateKey: signOnly.#privateKey,
+        publicKey: signOnly.#publicKey,
+      };
+    }
+    return {
+      address: await this.address(),
+      privateKey: this.#privateKey,
+      publicKey: this.#publicKey,
+    };
+  }
+
+  static fromSignOnlyHandle({ privateKey, publicKey }) {
+    return new SigningKey(privateKey, publicKey);
   }
 
   async #rawPublic() {

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.11.0';
+export const version = '0.12.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';
@@ -20,6 +20,8 @@ export { canonical, signHeaders } from './gc-sig.mjs';
 export { enroll, unlock, hasSigningKey, clear } from './gc-store.mjs';
 export { makeWebauthnPasskey, recognize } from './gc-passkey-webauthn.mjs';
 export { makeIdbStore } from './gc-store-idb.mjs';
+export { makeSessionSigner } from './gc-session-signer.mjs';
+export { makeSessionStore } from './gc-session-store-idb.mjs';
 
 // Backup / recovery
 export {


### PR DESCRIPTION
Closes #332.

## Summary

A **cross-document, non-extractable, auto-locking session-signer** so "Sign in with Gumption" member apps (gumptactoe, acquire-llm, and a 5th post-launch) reuse an unlocked Gumption identity across the pages of a multi-document app **without taking custody of the seed**. Neither prior surface gave that combination: `makeOnboarding` encapsulates the key but is per-page; base's `signing-key-session.mjs` is cross-page but holds the *extractable* key (= ownership). This adds the missing third option.

SDK-only (`clients/sdk`, vendored to `static/sdk`); no chain/consensus change; zero new deps. Composes the existing primitives (`keyring`, `makeDerivedIdentity`, `deriveSigningKey`, the #333 `classifyRecognition` guard) — single-sourcing, not re-implementing.

## What's new

- **Sign-only `SigningKey`** — "sign-only" = a non-extractable private CryptoKey (detected via `CryptoKey.extractable`). `fromSecretSignOnly(gcsec)` imports the private key non-extractable (public derived via a transient, non-retained extractable import); `exportSecret()`/`mnemonic()` throw a new `NoSeedError`; `toSignOnlyHandle()` → a structured-cloneable `{address, privateKey (non-extractable), publicKey}` for IndexedDB persistence; `fromSignOnlyHandle()` rehydrates.
- **`makeSessionSigner({ store, durableStore, passkey, idleMs, broadcast, clock })`** —
  - **populate:** `recognize()` (discover → derive → phantom-guard → adopt-if-derived / route-wrap-to-restore), `unlock({passphrase|passkey})`, `createDerived({userName}) → {address, mnemonic}`.
  - **use (cross-document, sign-only):** `status() → {signedIn, address}` (hydrates from the IDB store on a fresh document), `signLogin`, `signTransaction`. **No backup** — the seed isn't here.
  - **session:** `lock()`, `onLock`, `installAutoLock` (idle / visibility / pagehide, mirroring base), and **cross-tab lock-sync** via `BroadcastChannel`.
- **`gc-session-store-idb.mjs`** — a separate IndexedDB store (`dbName: gc-session-signer`) for the non-extractable handle record (distinct from the durable keyring DB).
- Barrel exports (`makeSessionSigner`, `makeSessionStore`); SDK **0.11.0 → 0.12.0**; re-vendored.

## Security posture

The only persisted/reused material is a **non-extractable** handle — no seed at rest, ever; the seed exists in JS only transiently at the populate moment. The handle is **sign-capable at rest** for the session window (the deliberate "stay signed in" tradeoff), bounded by auto-lock, shared across same-origin tabs (lock propagates). The phantom guard (#333) is baked into the only `recognize()` path, so a member app can't adopt a phantom identity via the turnkey surface.

## Notable fix during build
The auto-lock `touch()` initially armed a real 15-min `setTimeout` on every `adopt()` even without `installAutoLock`, which leaks a timer and hangs Node's test runner. Fixed to match base: `touch()` is a no-op until auto-lock is armed (`installAutoLock`/`armIdle`), so a signer with no auto-lock never arms a timer. The suite now exits cleanly.

## Test plan
- `clients/sdk` `node --test` — **192 passed, clean exit** (sign-only key incl. NoSeedError + signMessage parity; session-signer core with two instances sharing a store = cross-document sim; recognize/unlock/createDerived; auto-lock via injected clock; visibility/pagehide; cross-tab lock via fake BroadcastChannel; the no-leak/clean-exit check)
- `uv run pytest` — **729 passed, 1 skipped**; vendored byte-parity green
- `uv run ruff check` + `format --check` + `mypy` + `gumptionchain db check` — clean
- Independent whole-branch review — clean (no-seed-at-rest invariant, phantom guard, timer-leak fix, cross-tab loop-safety, sign-only correctness, byte-parity, DOM-freedom all verified)

**Needs a real-browser pass** (added to `MANUAL-VERIFICATION.md`): cross-document handle reuse, no-seed-at-rest in DevTools (`extractable === false`), auto-lock, and cross-tab lock — WebCrypto + IndexedDB + BroadcastChannel across real documents/tabs can't be unit-tested.

## Out of scope (follow-ups)
base `/transact` migration to the session-signer (sheds its extractable-key exposure); `makeOnboarding` consolidation; the hub member-kit guide pointing apps at `makeSessionSigner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)