### PR TITLE
feat(sdk): session-signer.signingKey() — sign attestations with the sign-only key (#336)

### DIFF
--- a/clients/sdk/gc-session-signer.mjs
+++ b/clients/sdk/gc-session-signer.mjs
@@ -85,6 +85,19 @@ export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAU
     return { signedIn: Boolean(k), address: k ? await k.address() : null };
   }
 
+  // The session's sign-only SigningKey (or null when locked) — for composing
+  // signing the session-signer doesn't wrap, e.g. attestations via the
+  // gc-attestation helpers (signStakeAttestation / signSocialBinding), or any
+  // signMessage. The key is NON-EXTRACTABLE: it signs, but exportSecret() /
+  // mnemonic() throw NoSeedError — so this grants exactly the signing capability
+  // signLogin/signTransaction already imply, with no new seed-leak surface.
+  // CONTRACT: call this fresh per operation and do NOT retain the reference —
+  // lock() clears the session but cannot revoke a handle a caller already
+  // captured (a retained handle can still sign until GC).
+  async function signingKey() {
+    return held();
+  }
+
   async function signLogin(challenge, { timestamp } = {}) {
     const k = await held();
     if (!k) throw new NoSigningKeyError('locked: no session signer');
@@ -189,7 +202,7 @@ export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAU
   }
 
   return {
-    adopt, status, signLogin, signTransaction, recognize, createDerived,
-    unlock, onLock, lock, armIdle, touch, installAutoLock,
+    adopt, status, signingKey, signLogin, signTransaction, recognize,
+    createDerived, unlock, onLock, lock, armIdle, touch, installAutoLock,
   };
 }

--- a/clients/sdk/gc-session-signer.test.mjs
+++ b/clients/sdk/gc-session-signer.test.mjs
@@ -4,6 +4,8 @@ import { makeSessionSigner, DEFAULT_IDLE_MS } from './gc-session-signer.mjs';
 import { SigningKey } from './gc-signing-key.mjs';
 import { verifyMessage } from './gc-message.mjs';
 import { deriveSigningKey } from './gc-derive.mjs';
+import { signSocialBinding, verifyBinding } from './gc-attestation.mjs';
+import { NoSeedError } from './gc-errors.mjs';
 
 function fakeStore() {
   let rec = null;
@@ -224,4 +226,27 @@ test('touch re-arms the idle timer (clear + set)', async () => {
 
 test('DEFAULT_IDLE_MS is 15 minutes', () => {
   assert.equal(DEFAULT_IDLE_MS, 15 * 60 * 1000);
+});
+
+test('signingKey() yields a sign-only key usable with the gc-attestation helpers (#336)', async () => {
+  const store = fakeStore();
+  const s = makeSessionSigner({ store });
+  await s.adopt(await SigningKey.generate());
+  const k = await s.signingKey();
+  assert.ok(k);
+  await assert.rejects(() => k.exportSecret(), NoSeedError); // non-extractable: no seed leak
+  // the gc-attestation helpers take a raw SigningKey and work UNCHANGED
+  const proof = await signSocialBinding(k, { platform: 'github', handle: 'octocat' });
+  const r = await verifyBinding(proof, { maxAge: Number.MAX_SAFE_INTEGER });
+  assert.equal(r.valid, true);
+  assert.equal(r.claim.handle, 'octocat');
+});
+
+test('signingKey() is null when locked (#336)', async () => {
+  const store = fakeStore();
+  const s = makeSessionSigner({ store });
+  await s.adopt(await SigningKey.generate());
+  assert.ok(await s.signingKey());
+  await s.lock();
+  assert.equal(await s.signingKey(), null);
 });

--- a/clients/sdk/index.mjs
+++ b/clients/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.12.0';
+export const version = '0.13.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';

--- a/clients/sdk/package.json
+++ b/clients/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gumptionchain/sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "GumptionChain browser SDK — Ed25519 signing (gc-sig-v1), bech32m addresses, passkey PRF key derivation, BIP-39 recovery, backup, message signing.",
   "type": "module",
   "exports": {

--- a/src/gumptionchain/static/sdk/gc-session-signer.mjs
+++ b/src/gumptionchain/static/sdk/gc-session-signer.mjs
@@ -85,6 +85,19 @@ export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAU
     return { signedIn: Boolean(k), address: k ? await k.address() : null };
   }
 
+  // The session's sign-only SigningKey (or null when locked) — for composing
+  // signing the session-signer doesn't wrap, e.g. attestations via the
+  // gc-attestation helpers (signStakeAttestation / signSocialBinding), or any
+  // signMessage. The key is NON-EXTRACTABLE: it signs, but exportSecret() /
+  // mnemonic() throw NoSeedError — so this grants exactly the signing capability
+  // signLogin/signTransaction already imply, with no new seed-leak surface.
+  // CONTRACT: call this fresh per operation and do NOT retain the reference —
+  // lock() clears the session but cannot revoke a handle a caller already
+  // captured (a retained handle can still sign until GC).
+  async function signingKey() {
+    return held();
+  }
+
   async function signLogin(challenge, { timestamp } = {}) {
     const k = await held();
     if (!k) throw new NoSigningKeyError('locked: no session signer');
@@ -189,7 +202,7 @@ export function makeSessionSigner({ store, durableStore, passkey, idleMs = DEFAU
   }
 
   return {
-    adopt, status, signLogin, signTransaction, recognize, createDerived,
-    unlock, onLock, lock, armIdle, touch, installAutoLock,
+    adopt, status, signingKey, signLogin, signTransaction, recognize,
+    createDerived, unlock, onLock, lock, armIdle, touch, installAutoLock,
   };
 }

--- a/src/gumptionchain/static/sdk/index.mjs
+++ b/src/gumptionchain/static/sdk/index.mjs
@@ -5,7 +5,7 @@
 //
 // The package `version` is the embedder-API semver; it is INDEPENDENT of the
 // wire scheme ids gc-sig-v1 / gc-msg-v1 bound into signatures.
-export const version = '0.12.0';
+export const version = '0.13.0';
 
 // Identity / keys
 export { SigningKey } from './gc-signing-key.mjs';


### PR DESCRIPTION
Closes #336. Needed by the hub's session-signer adoption (gump-hub#82).

## The gap

`makeSessionSigner`'s use surface was `signLogin` + `signTransaction`. But a member app's signing is often **attestations** — `signStakeAttestation` (share a stake) / `signSocialBinding` (bind a GitHub handle) — whose `gc-attestation` helpers take a raw `SigningKey`. The session-signer deliberately doesn't hand out its key, so an app that adopts it for cross-document signing **couldn't produce its attestations** without falling back to an extractable-key unlock — defeating the point.

## The change

Add **`sessionSigner.signingKey() → SigningKey | null`** — the session's sign-only key (or `null` when locked). The existing `gc-attestation` helpers then work **unchanged**: the consumer passes `await sessionSigner.signingKey()` where it passed an unlocked key.

```js
const k = await sessionSigner.signingKey();
const proof = await signSocialBinding(k, { platform: 'github', handle: 'octocat' });
```

This is option 1 from the issue (the recommended one): smallest addition, no message-builder duplication, no `gc-attestation` coupling in the session-signer.

## Why it's safe

The session-signer's invariant is *"never exposes the **seed**,"* not "never exposes a signing handle" — it already grants signing via `signLogin`/`signTransaction`. The returned key is **non-extractable** (`exportSecret()`/`mnemonic()` throw `NoSeedError`), so `signingKey()` grants exactly the signing capability the session already implies, with **no new seed-leak surface**.

**Documented contract:** call `signingKey()` fresh per operation and **don't retain** the reference — `lock()` clears the session but can't revoke a handle a caller already captured (it returns `null` when locked).

## Test plan
- `clients/sdk` `node --test` — **194 passed, clean exit** (2 new: `signingKey()` produces a sign-only key that verifies through `signSocialBinding`/`verifyBinding` and whose `exportSecret()` throws `NoSeedError`; and `signingKey()` is `null` after `lock()`)
- `uv run pytest` — **729 passed, 1 skipped**; vendored byte-parity green; ruff + mypy clean
- SDK 0.12.0 → 0.13.0; re-vendored

🤖 Generated with [Claude Code](https://claude.com/claude-code)