### PR TITLE
fix(browser): kind-aware /signing-key management — derived identities crashed the wrap-only controls (#338)

### DIFF
--- a/clients/sdk/gc-keyring.mjs
+++ b/clients/sdk/gc-keyring.mjs
@@ -104,7 +104,12 @@ export async function enroll(signing_key, { store }, { passphrase }) {
 // explicitly-supplied passphrase is preferred; otherwise the passkey is used.
 // Wrong secret -> GCM auth-tag failure -> openWithKey rejects (fails closed).
 async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
-  const { wraps } = rec;
+  const wraps = rec.wraps;
+  if (!wraps) {
+    throw new NoSigningKeyError(
+      'this identity has no keyring wraps (a derived identity?) — unlock it with its passkey',
+    );
+  }
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);

--- a/clients/sdk/gc-keyring.test.mjs
+++ b/clients/sdk/gc-keyring.test.mjs
@@ -166,3 +166,11 @@ test('unlock prefers an explicitly-supplied passphrase over the passkey', async 
     addr,
   );
 });
+
+test('unlock/addPasskey on a wraps-less (derived) record throw a clean NoSigningKeyError', async () => {
+  const { NoSigningKeyError } = await import('./gc-errors.mjs');
+  let r = { version: 2, kind: 'derived', address: 'gc1x', credentialId: 'c' };
+  const store = { get: async () => r, put: async (x) => { r = x; }, delete: async () => { r = null; } };
+  await assert.rejects(() => keyring.unlock({ store }, { passphrase: 'pw' }), NoSigningKeyError);
+  await assert.rejects(() => keyring.addPasskey({ store, passkey: {} }, { passphrase: 'pw' }, {}), NoSigningKeyError);
+});

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -191,6 +191,7 @@ export function init(
     trustAck: $('#trust-ack'),
     // unlock
     unlockSection: $('#unlock-section'),
+    unlockPassphraseRow: $('#unlock-passphrase-row'),
     unlockPassphrase: $('#unlock-passphrase'),
     unlockBtn: $('#unlock-btn'),
     unlockPasskeyBtn: $('#unlock-passkey-btn'),
@@ -203,6 +204,8 @@ export function init(
     addPasskeyStatus: $('#add-passkey-status'),
     // backup
     backupHeading: $('#backup-heading'),
+    backupDesc: $('#backup-desc'),
+    backupPassphraseRow: $('#backup-passphrase-row'),
     backupPassphrase: $('#backup-passphrase'),
     backupBtn: $('#backup-btn'),
     backupStatus: $('#backup-status'),
@@ -246,7 +249,9 @@ export function init(
     show(els.noSigningKey, c.showCreate || c.showImport);
     show(els.hasSigningKey, c.showHasSigningKey);
     show(els.unlockSection, c.showUnlock);
-    show(els.unlockPassphrase, c.showUnlockPassphrase);
+    // Hide the whole passphrase row (label + input), not just the input, so a
+    // derived identity's unlock shows only the passkey button — no dangling label.
+    show(els.unlockPassphraseRow, c.showUnlockPassphrase);
     show(els.unlockBtn, c.showUnlockPassphrase);
     show(els.unlockPasskeyBtn, c.showUnlockPasskey);
     show(els.lockBtn, c.showLock);
@@ -257,7 +262,10 @@ export function init(
     show(els.createDeriveSection, c.showCreateDerive);
     show(els.recognizeBtn, c.showRecognize);
     const derived = kind === 'derived';
-    show(els.backupPassphrase, c.showBackup && !derived);
+    // Backup is kind-aware: a derived identity has no passphrase/encrypted blob —
+    // its backup IS the recovery phrase. Hide the whole passphrase row (label +
+    // input) and reword the heading + description.
+    show(els.backupPassphraseRow, c.showBackup && !derived);
     if (els.backupBtn) {
       els.backupBtn.textContent = derived
         ? 'Show recovery phrase'
@@ -267,6 +275,15 @@ export function init(
       els.backupHeading.textContent = derived
         ? 'Your recovery phrase'
         : 'Download an encrypted backup';
+    }
+    if (els.backupDesc) {
+      els.backupDesc.textContent = derived
+        ? 'Your 24-word recovery phrase is the only backup of this passkey '
+          + 'identity — it re-derives the key on any device. Write it down and '
+          + 'keep it offline; anyone with it controls the signing key.'
+        : 'Exports the encrypted backup blob (safe to store). This is your '
+          + 'recovery, cross-device, and cross-method path. Lose both the '
+          + 'passphrase and the backup and the signing key is unrecoverable.';
     }
     if (hasSigningKey && els.addressOut) {
       els.addressOut.textContent = rec.address ?? '';

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -202,6 +202,7 @@ export function init(
     addPasskeyPassphrase: $('#add-passkey-passphrase'),
     addPasskeyStatus: $('#add-passkey-status'),
     // backup
+    backupHeading: $('#backup-heading'),
     backupPassphrase: $('#backup-passphrase'),
     backupBtn: $('#backup-btn'),
     backupStatus: $('#backup-status'),
@@ -227,19 +228,26 @@ export function init(
     if (el) el.hidden = !visible;
   }
 
-  // Re-render which controls are visible from the current state.
+  // Re-render which controls are visible from the current state. Reads the
+  // record + kind once at the top and threads kind through whichControls so a
+  // saved derived identity gets passkey-unlock / recovery-phrase backup / no
+  // add-passkey, while a wrap keeps the passphrase affordances.
   async function render() {
-    const hasSigningKey = await keyring.hasSigningKey(store);
+    const rec = await store.get();
+    const hasSigningKey = rec !== null;
+    const kind = rec ? (rec.kind ?? (rec.wraps ? 'wrap' : null)) : null;
     const unlocked = session.isUnlocked();
     const c = whichControls({
-      hasSigningKey,
-      unlocked,
+      hasSigningKey, unlocked,
       secureContext: passkeyState.secureContext,
       passkeySupported: passkeyState.supported,
+      kind,
     });
     show(els.noSigningKey, c.showCreate || c.showImport);
     show(els.hasSigningKey, c.showHasSigningKey);
     show(els.unlockSection, c.showUnlock);
+    show(els.unlockPassphrase, c.showUnlockPassphrase);
+    show(els.unlockBtn, c.showUnlockPassphrase);
     show(els.unlockPasskeyBtn, c.showUnlockPasskey);
     show(els.lockBtn, c.showLock);
     show(els.addPasskeySection, c.showAddPasskey);
@@ -248,9 +256,20 @@ export function init(
     show(els.backupBtn, c.showBackup);
     show(els.createDeriveSection, c.showCreateDerive);
     show(els.recognizeBtn, c.showRecognize);
+    const derived = kind === 'derived';
+    show(els.backupPassphrase, c.showBackup && !derived);
+    if (els.backupBtn) {
+      els.backupBtn.textContent = derived
+        ? 'Show recovery phrase'
+        : 'Download backup';
+    }
+    if (els.backupHeading) {
+      els.backupHeading.textContent = derived
+        ? 'Your recovery phrase'
+        : 'Download an encrypted backup';
+    }
     if (hasSigningKey && els.addressOut) {
-      const rec = await store.get();
-      els.addressOut.textContent = rec?.address ?? '';
+      els.addressOut.textContent = rec.address ?? '';
     }
   }
 
@@ -573,6 +592,39 @@ export function init(
             'Passkeys are not available here.',
             'error',
           );
+          return;
+        }
+        // A derived identity has no keyring wraps: re-derive its key from the
+        // live passkey PRF and confirm it matches the saved address (an unknown
+        // passkey on this device must not silently adopt a different identity).
+        const rec = await store.get();
+        const kind = rec ? (rec.kind ?? (rec.wraps ? 'wrap' : null)) : null;
+        if (kind === 'derived') {
+          const found = await passkey.discover();
+          if (!found) {
+            setStatus(
+              els.unlockStatus,
+              'No passkey found on this device.',
+              'error',
+            );
+            return;
+          }
+          const sk = await deriveSigningKey(found.prfOutput);
+          if ((await sk.address()) !== rec.address) {
+            setStatus(
+              els.unlockStatus,
+              "That passkey isn't this identity.",
+              'error',
+            );
+            return;
+          }
+          session.setSigningKey(sk);
+          setStatus(
+            els.unlockStatus,
+            'Unlocked with your passkey for this page session.',
+            'ok',
+          );
+          await render();
           return;
         }
         const signing_key = await keyring.unlock({ store, passkey }, {});

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -39,19 +39,26 @@ export function whichControls({
   unlocked,
   secureContext,
   passkeySupported,
+  kind,
 }) {
   const passkeyOk = !!secureContext && !!passkeySupported;
+  // A derived identity has no keyring wraps: passphrase-unlock and add-passkey
+  // are wrap-only operations, so they have no meaning here. It unlocks with its
+  // passkey only.
+  const derived = kind === 'derived';
+  const locked = !!hasSigningKey && !unlocked;
   return {
     // No-signing_key section.
     showCreate: !hasSigningKey,
     showImport: !hasSigningKey,
     // Has-signing_key section.
     showHasSigningKey: !!hasSigningKey,
-    showUnlock: !!hasSigningKey && !unlocked,
-    showUnlockPasskey: !!hasSigningKey && !unlocked && passkeyOk,
+    showUnlock: locked,
+    showUnlockPassphrase: locked && !derived,
+    showUnlockPasskey: locked && passkeyOk,
     showLock: !!hasSigningKey && !!unlocked,
     // Add-passkey is an unlocked-only action (it re-wraps the live DEK).
-    showAddPasskey: !!hasSigningKey && !!unlocked && passkeyOk,
+    showAddPasskey: !!hasSigningKey && !!unlocked && passkeyOk && !derived,
     showBackup: !!hasSigningKey,
     showForget: !!hasSigningKey,
     // Keyless device with a usable passkey leads with the seamless derive

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -658,3 +658,17 @@ test('init: backup on a DERIVED record shows the recovery phrase (no download)',
   assert.equal(dom.querySelector('#recovery-phrase-section').hidden, false);
   assert.equal(anchorsCreated, 0);
 });
+
+test('whichControls is kind-aware: derived hides passphrase-unlock + add-passkey', () => {
+  const locked = whichControls({ hasSigningKey: true, unlocked: false, secureContext: true, passkeySupported: true, kind: 'derived' });
+  assert.equal(locked.showUnlock, true);
+  assert.equal(locked.showUnlockPassphrase, false);
+  assert.equal(locked.showUnlockPasskey, true);
+  const unlocked = whichControls({ hasSigningKey: true, unlocked: true, secureContext: true, passkeySupported: true, kind: 'derived' });
+  assert.equal(unlocked.showAddPasskey, false);
+  assert.equal(unlocked.showBackup, true);
+  const wrapLocked = whichControls({ hasSigningKey: true, unlocked: false, secureContext: true, passkeySupported: true, kind: 'wrap' });
+  assert.equal(wrapLocked.showUnlockPassphrase, true);
+  const wrapUnlocked = whichControls({ hasSigningKey: true, unlocked: true, secureContext: true, passkeySupported: true, kind: 'wrap' });
+  assert.equal(wrapUnlocked.showAddPasskey, true);
+});

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -694,18 +694,20 @@ test('init: a saved DERIVED record renders passkey-unlock, no passphrase, no add
   // Let the async init IIFE (passkey resolve + first render) settle.
   await new Promise((r) => setTimeout(r, 0));
 
-  // Passphrase-unlock controls are hidden; passkey-unlock is shown.
-  assert.equal(dom.querySelector('#unlock-passphrase').hidden, true);
+  // The whole passphrase row (label + input) is hidden, not just the input —
+  // no dangling "Passphrase" label; passkey-unlock is shown.
+  assert.equal(dom.querySelector('#unlock-passphrase-row').hidden, true);
   assert.equal(dom.querySelector('#unlock-btn').hidden, true);
   assert.equal(dom.querySelector('#unlock-passkey-btn').hidden, false);
   // Add-passkey is hidden for a derived identity (wrap-only operation).
   assert.equal(dom.querySelector('#add-passkey-section').hidden, true);
   assert.equal(dom.querySelector('#add-passkey-btn').hidden, true);
-  // The backup heading + button are relabeled for the recovery-phrase path.
+  // The backup heading + button + description are relabeled for the phrase path.
   assert.equal(dom.querySelector('#backup-btn').textContent, 'Show recovery phrase');
   assert.equal(dom.querySelector('#backup-heading').textContent, 'Your recovery phrase');
-  // No passphrase field for a derived backup.
-  assert.equal(dom.querySelector('#backup-passphrase').hidden, true);
+  assert.match(dom.querySelector('#backup-desc').textContent, /recovery phrase/i);
+  // No passphrase row (label + input) for a derived backup.
+  assert.equal(dom.querySelector('#backup-passphrase-row').hidden, true);
 });
 
 test('init: derived passkey-unlock with the matching passkey unlocks the session', async () => {
@@ -765,11 +767,11 @@ test('init: a saved WRAP record keeps passphrase-unlock + add-passkey', async ()
   init(dom, { store, session, storage, doc: dom, passkey });
   await new Promise((r) => setTimeout(r, 0));
 
-  // Locked wrap: passphrase-unlock input + unlock button shown.
-  assert.equal(dom.querySelector('#unlock-passphrase').hidden, false);
+  // Locked wrap: passphrase-unlock row + unlock button shown.
+  assert.equal(dom.querySelector('#unlock-passphrase-row').hidden, false);
   assert.equal(dom.querySelector('#unlock-btn').hidden, false);
-  // The backup keeps the encrypted-download labels + passphrase field.
+  // The backup keeps the encrypted-download labels + passphrase row.
   assert.equal(dom.querySelector('#backup-btn').textContent, 'Download backup');
   assert.equal(dom.querySelector('#backup-heading').textContent, 'Download an encrypted backup');
-  assert.equal(dom.querySelector('#backup-passphrase').hidden, false);
+  assert.equal(dom.querySelector('#backup-passphrase-row').hidden, false);
 });

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -672,3 +672,104 @@ test('whichControls is kind-aware: derived hides passphrase-unlock + add-passkey
   const wrapUnlocked = whichControls({ hasSigningKey: true, unlocked: true, secureContext: true, passkeySupported: true, kind: 'wrap' });
   assert.equal(wrapUnlocked.showAddPasskey, true);
 });
+
+// --- kind-aware management render + unlock via init (#338) ----------------
+// A saved DERIVED identity gets passkey-unlock (no passphrase field), a
+// recovery-phrase backup (relabeled), and NO add-passkey. A saved WRAP record
+// keeps the passphrase-unlock + add-passkey affordances. These exercise the
+// kind-threaded render() and the derived branch of #unlock-passkey-btn,
+// reusing the fakeDom / memStore / memStorage / fakePasskey helpers above.
+
+test('init: a saved DERIVED record renders passkey-unlock, no passphrase, no add-passkey', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const prfOutput = new Uint8Array(32).fill(13);
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const D = await (await deriveSigningKey(prfOutput)).address();
+  const store = memStore({ version: 2, kind: 'derived', address: D, credentialId: 'c' });
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const passkey = fakePasskey({ prfOutput });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  // Let the async init IIFE (passkey resolve + first render) settle.
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Passphrase-unlock controls are hidden; passkey-unlock is shown.
+  assert.equal(dom.querySelector('#unlock-passphrase').hidden, true);
+  assert.equal(dom.querySelector('#unlock-btn').hidden, true);
+  assert.equal(dom.querySelector('#unlock-passkey-btn').hidden, false);
+  // Add-passkey is hidden for a derived identity (wrap-only operation).
+  assert.equal(dom.querySelector('#add-passkey-section').hidden, true);
+  assert.equal(dom.querySelector('#add-passkey-btn').hidden, true);
+  // The backup heading + button are relabeled for the recovery-phrase path.
+  assert.equal(dom.querySelector('#backup-btn').textContent, 'Show recovery phrase');
+  assert.equal(dom.querySelector('#backup-heading').textContent, 'Your recovery phrase');
+  // No passphrase field for a derived backup.
+  assert.equal(dom.querySelector('#backup-passphrase').hidden, true);
+});
+
+test('init: derived passkey-unlock with the matching passkey unlocks the session', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const prfOutput = new Uint8Array(32).fill(17);
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const D = await (await deriveSigningKey(prfOutput)).address();
+  const store = memStore({ version: 2, kind: 'derived', address: D, credentialId: 'c' });
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const passkey = fakePasskey({ prfOutput });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await new Promise((r) => setTimeout(r, 0));
+
+  await dom.querySelector('#unlock-passkey-btn').click();
+
+  assert.equal(session.isUnlocked(), true);
+  assert.equal((await session.getSigningKey().address()), D);
+  assert.equal(dom.querySelector('#unlock-status').dataset.kind, 'ok');
+});
+
+test('init: derived passkey-unlock with a MISMATCHED passkey does not unlock, errors', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  // Saved record is for the address derived from one PRF...
+  const savedPrf = new Uint8Array(32).fill(19);
+  const { deriveSigningKey } = await import('../sdk/gc-derive.mjs');
+  const D = await (await deriveSigningKey(savedPrf)).address();
+  const store = memStore({ version: 2, kind: 'derived', address: D, credentialId: 'c' });
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  // ...but the passkey on this device derives a DIFFERENT address.
+  const otherPrf = new Uint8Array(32).fill(23);
+  const passkey = fakePasskey({ prfOutput: otherPrf });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await new Promise((r) => setTimeout(r, 0));
+
+  await dom.querySelector('#unlock-passkey-btn').click();
+
+  assert.equal(session.isUnlocked(), false);
+  assert.equal(dom.querySelector('#unlock-status').dataset.kind, 'error');
+});
+
+test('init: a saved WRAP record keeps passphrase-unlock + add-passkey', async () => {
+  const dom = fakeDom();
+  const session = makeSession();
+  const store = memStore();
+  const storage = memStorage({ [TRUST_ACK_KEY]: '1' });
+  const passkey = fakePasskey();
+
+  // Enroll a real wrap record (version-tagged ciphertext under a passphrase).
+  const sk = await SigningKey.generate();
+  const { enroll } = await import('../sdk/gc-keyring.mjs');
+  await enroll(sk, { store }, { passphrase: 'correct horse battery' });
+
+  init(dom, { store, session, storage, doc: dom, passkey });
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Locked wrap: passphrase-unlock input + unlock button shown.
+  assert.equal(dom.querySelector('#unlock-passphrase').hidden, false);
+  assert.equal(dom.querySelector('#unlock-btn').hidden, false);
+  // The backup keeps the encrypted-download labels + passphrase field.
+  assert.equal(dom.querySelector('#backup-btn').textContent, 'Download backup');
+  assert.equal(dom.querySelector('#backup-heading').textContent, 'Download an encrypted backup');
+  assert.equal(dom.querySelector('#backup-passphrase').hidden, false);
+});

--- a/src/gumptionchain/static/sdk/gc-keyring.mjs
+++ b/src/gumptionchain/static/sdk/gc-keyring.mjs
@@ -104,7 +104,12 @@ export async function enroll(signing_key, { store }, { passphrase }) {
 // explicitly-supplied passphrase is preferred; otherwise the passkey is used.
 // Wrong secret -> GCM auth-tag failure -> openWithKey rejects (fails closed).
 async function unwrapDek(rec, { passkey } = {}, { passphrase } = {}) {
-  const { wraps } = rec;
+  const wraps = rec.wraps;
+  if (!wraps) {
+    throw new NoSigningKeyError(
+      'this identity has no keyring wraps (a derived identity?) — unlock it with its passkey',
+    );
+  }
   if (passphrase != null && wraps.passphrase) {
     const w = wraps.passphrase;
     const kek = await deriveKey(passphrase, w.salt, w.iterations);

--- a/src/gumptionchain/templates/signing_key.html
+++ b/src/gumptionchain/templates/signing_key.html
@@ -171,7 +171,7 @@
 
       <!-- Backup -->
       <div class="mb-4">
-        <div class="h6">Download an encrypted backup</div>
+        <div id="backup-heading" class="h6">Download an encrypted backup</div>
         <p class="small text-muted">
           Exports the encrypted backup blob (safe to store). This is your
           recovery, cross-device, and cross-method path. Lose both the

--- a/src/gumptionchain/templates/signing_key.html
+++ b/src/gumptionchain/templates/signing_key.html
@@ -126,7 +126,7 @@
       <!-- Unlock (passphrase + optional passkey) -->
       <div id="unlock-section" class="mb-4" hidden>
         <div class="h6">Unlock</div>
-        <div class="mb-2">
+        <div id="unlock-passphrase-row" class="mb-2">
           <label for="unlock-passphrase" class="form-label">Passphrase</label>
           <input id="unlock-passphrase" type="password"
                  class="form-control" autocomplete="current-password"
@@ -172,12 +172,12 @@
       <!-- Backup -->
       <div class="mb-4">
         <div id="backup-heading" class="h6">Download an encrypted backup</div>
-        <p class="small text-muted">
+        <p id="backup-desc" class="small text-muted">
           Exports the encrypted backup blob (safe to store). This is your
           recovery, cross-device, and cross-method path. Lose both the
           passphrase and the backup and the signing key is unrecoverable.
         </p>
-        <div class="mb-2">
+        <div id="backup-passphrase-row" class="mb-2">
           <label for="backup-passphrase" class="form-label">Passphrase</label>
           <input id="backup-passphrase" type="password"
                  class="form-control" autocomplete="current-password"


### PR DESCRIPTION
Closes #338.

## The bug

On `/signing-key`, a **derived** identity (record `{ kind:'derived', address, credentialId }`, **no keyring `wraps`**) crashed the wrap-only management controls:

> Could not add a passkey: Cannot read properties of undefined (reading 'passphrase')

#330 made the page's *create* and *backup* kind-aware, but the **has-saved-key management controls weren't** — so for a derived identity `whichControls` offered Add-a-passkey / passphrase-unlock, which call `keyring.unlock`/`addPasskey → unwrapDek`, which read `wraps.passphrase` off the missing `wraps`. (Reachable on **both** add-passkey and a post-reload passphrase-unlock; a derived identity also had **no way to unlock** on the page.)

## The fix — kind-aware has-key management (3 commits)

1. **Keyring defense-in-depth** (`gc-keyring.mjs`, re-vendored): `unwrapDek` guards a `wraps`-less record → throws a clean `NoSigningKeyError` instead of a `TypeError`.
2. **`whichControls` kind-aware**: a `kind` param; `showUnlockPassphrase = locked && !derived`; `showAddPasskey` now `&& !derived`.
3. **`render()` + the passkey-unlock handler + a one-line template tweak**: render threads the record's `kind`; for a **derived** identity it hides the passphrase input + add-passkey and relabels backup to "recovery phrase"; the `#unlock-passkey-btn` handler branches — **derived** does `discover → deriveSigningKey(prf) → verify the re-derived address equals the saved record's address → session.setSigningKey`, **wrap** keeps `keyring.unlock`.

So a saved derived identity now unlocks with its passkey (verifying it's *that* identity — a different passkey is rejected), backs up via its recovery phrase, and never reaches a wrap-keyring op. Wrap identities are unchanged.

## Not the Bitwarden angle
Surfaced while testing Bitwarden passkey sync, but that's a separate known limitation (Bitwarden returns `prf: undefined` to external RPs, so it can't anchor a PRF-derived *or* keyring convenience passkey). This PR is purely the derived-management crash.

## Test plan
- `src/gumptionchain/static/js` `node --test` — **87 pass, EXIT 0** (derived-locked render hides passphrase-unlock + add-passkey and shows passkey-unlock; derived passkey-unlock success on a matching address; **mismatch** → not unlocked + error; wrap unchanged)
- `clients/sdk` `node --test` — **195 pass** (keyring `NoSigningKeyError` guard for `unlock` + `addPasskey` on a wraps-less record)
- `uv run pytest` — **729 passed, 1 skipped** (incl. the `/signing-key` page render); vendored byte-parity green; ruff + mypy + `db check` clean
- Independent whole-branch review — clean (crash fixed on two layers, derived-unlock address verification, no wrap regression, byte-parity)

## Out of scope (follow-up)
Migrating `/signing-key` to the SDK session-signer (#335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)