### PR TITLE
fix(egu-340): reproducible block merkle root — compute over canonical coinbase-last order

### DIFF
--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -414,9 +414,9 @@ class Block:
             target=dao.target,
             proof_of_work=dao.proof_of_work,
             merkle_root=dao.merkle_root,
-            txns=[
-                Transaction.from_dao(txn_dao) for txn_dao in dao.transactions
-            ],
+            txns=cls._canonical_order(
+                [Transaction.from_dao(txn_dao) for txn_dao in dao.transactions]
+            ),
             version=dao.version,
         )
 

--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -182,9 +182,22 @@ class Block:
         potential_header = self.potential_header(proof_of_work)
         return validate_hash_diff(mill_hash_str(potential_header), self.target)
 
+    @staticmethod
+    def _canonical_order(txns: list[Transaction]) -> list[Transaction]:
+        # One canonical block order: regular txns by (timestamp, txid),
+        # then the coinbase LAST. is_coinbase (prev_hash is not None) is
+        # position-independent and survives to_dao/from_dao, so the order is
+        # reproducible from any starting permutation (DB load, wire JSON).
+        return sorted(
+            txns, key=lambda t: (t.is_coinbase, t.timestamp, t.txid or '')
+        )
+
+    def canonical_txns(self) -> list[Transaction]:
+        return self._canonical_order(self.txns)
+
     def build_merkle_tree(self) -> InmemoryTree:
         tree = InmemoryTree()
-        for txn in self.txns:
+        for txn in self.canonical_txns():
             if txn.txid is not None:
                 tree.append_entry(txn.txid.encode())
         return tree
@@ -194,7 +207,8 @@ class Block:
         return root.digest.hex() if root else None
 
     def in_merkle_tree(self, txid: str) -> bool:
-        txids = [t.txid for t in self.txns]
+        canonical = self.canonical_txns()
+        txids = [t.txid for t in canonical]
         if txid not in txids:
             return False
         tree = self.build_merkle_tree()

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -17,7 +17,7 @@ from gumptionchain.exceptions import (
     SealedBlockError,
     UnlinkedBlockError,
 )
-from gumptionchain.payload import Inflow, Outflow
+from gumptionchain.payload import Inflow, Outflow, encode_subject
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
 from gumptionchain.util import dt_2_iso, now
 
@@ -79,6 +79,67 @@ def test_in_merkle_tree(reward, single_block, single_txn, signing_key):
     single_block.mill()
     single_block.validate()
     assert single_block.in_merkle_tree(single_txn.txid)
+
+
+def _two_txn_block(
+    single_block, signing_key, subject, txid, reward, time_machine
+):
+    """A sealed+milled block: two regular txns + coinbase (coinbase last)."""
+    base = now()
+    time_machine.move_to(base + datetime.timedelta(seconds=1))
+    single_block.add_txn(new_txn(txid, subject, signing_key))
+    time_machine.move_to(base + datetime.timedelta(seconds=2))
+    single_block.add_txn(
+        new_txn(txid[::-1], encode_subject('a second subject'), signing_key)
+    )
+    single_block.link(0, GENESIS_HASH, TEST_TARGET)
+    single_block.seal(signing_key, reward, CoinbaseMetrics())
+    single_block.mill()
+    return single_block
+
+
+def test_merkle_root_order_independent(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    block.validate()
+    root = block.get_merkle_root()
+    assert root == block.merkle_root
+    # Simulate a non-canonical reload: coinbase no longer last.
+    block.txns = [block.txns[-1], *block.txns[:-1]]
+    assert block.get_merkle_root() == root
+    block.validate_merkle_root()  # must not raise
+
+
+def test_canonical_txns_orders_coinbase_last(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    shuffled = [block.txns[-1], *reversed(block.txns[:-1])]
+    block.txns = shuffled
+    canonical = block.canonical_txns()
+    assert canonical[-1].is_coinbase
+    assert not any(t.is_coinbase for t in canonical[:-1])
+    regulars = canonical[:-1]
+    assert regulars == sorted(
+        regulars, key=lambda t: (t.timestamp, t.txid or '')
+    )
+
+
+def test_in_merkle_tree_multi_txn(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    block.validate()
+    for t in block.txns:
+        assert block.in_merkle_tree(t.txid)
+    assert not block.in_merkle_tree('nonexistent-txid')
 
 
 def test_add_txn(single_block, subject, time_machine, txid, signing_key):

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,4 +1,5 @@
 import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,7 +20,7 @@ from gumptionchain.exceptions import (
 )
 from gumptionchain.payload import Inflow, Outflow, encode_subject
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
-from gumptionchain.util import dt_2_iso, now
+from gumptionchain.util import dt_2_iso, iso_2_dt, now
 
 TEST_TARGET = 'F' * 64
 
@@ -140,6 +141,36 @@ def test_in_merkle_tree_multi_txn(
     for t in block.txns:
         assert block.in_merkle_tree(t.txid)
     assert not block.in_merkle_tree('nonexistent-txid')
+
+
+def test_from_dao_canonicalizes_transaction_order(
+    app, reward, single_block, signing_key, subject, txid, time_machine
+):
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    block.validate()
+    # DB presents transactions coinbase-FIRST (the (timestamp,txid)
+    # tie-break flip).
+    with app.app_context():
+        cb_dao = block.coinbase.to_dao()
+        reg_daos = [t.to_dao() for t in block.regular_txns]
+    fake_dao = SimpleNamespace(
+        idx=block.idx,
+        timestamp=iso_2_dt(block.timestamp),
+        block_hash=block.block_hash,
+        prev_hash=block.prev_hash,
+        target=block.target,
+        proof_of_work=block.proof_of_work,
+        merkle_root=block.merkle_root,
+        version=block.version,
+        transactions=[cb_dao, *reg_daos],
+    )
+    reloaded = Block.from_dao(fake_dao)
+    assert reloaded.coinbase.is_coinbase
+    assert reloaded.coinbase.txid == block.coinbase.txid
+    assert not any(t.is_coinbase for t in reloaded.regular_txns)
+    reloaded.validate()
 
 
 def test_add_txn(single_block, subject, time_machine, txid, signing_key):

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -30,7 +30,7 @@ from gumptionchain.exceptions import (
     SpentTransactionError,
 )
 from gumptionchain.milling import mill_hash_str
-from gumptionchain.models import ChainDAO, TransactionDAO
+from gumptionchain.models import BlockDAO, ChainDAO, TransactionDAO
 from gumptionchain.payload import Inflow, Outflow
 from gumptionchain.signing_key import SigningKey
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
@@ -289,6 +289,127 @@ def test_db(add_chain_block, app, time_machine, signing_key):
         chain.to_db()
         chain_copy = Chain.from_db(chain.cid)
         assert chain == chain_copy
+
+
+def test_reloaded_multi_txn_chain_validates(
+    add_chain_block, app, time_machine, signing_key, subject
+):
+    # Regression for egu-340: a block carrying regular txns alongside its
+    # coinbase must validate after being reloaded from the DB. The merkle root
+    # is sealed over a CANONICAL order (regular txns by (timestamp, txid), then
+    # the coinbase LAST). The DB association order, however, is plain
+    # (timestamp, txid) over ALL txns — so when a regular txn shares the
+    # coinbase's timestamp and its txid sorts before the coinbase's, the DB
+    # presents the coinbase NOT-last. Pre-fix, Block.from_dao reconstructed
+    # txns in that raw DB order, the recomputed merkle root mismatched the
+    # sealed header, and Chain.validate() raised InvalidMerkleRootError. This
+    # mirrors `gumptionchain validate` and the peer-sync path.
+    with app.app_context():
+        # Both split outputs go to signing_key's own address so signing_key can
+        # spend each independently in block 2 (an inflow's outflow address must
+        # match the spender's address).
+        addr = signing_key.address
+        # A FIXED instant (not now()) so every txid — and thus the
+        # (timestamp, txid) sort that drives both add_txn ordering and the DB
+        # association order — is fully deterministic across runs. With a
+        # wall-clock now() the txids reshuffle every run, intermittently
+        # tripping OutOfOrderTransactionError on the two same-timestamp spends
+        # and flipping the coinbase-not-last divergence this test relies on.
+        # The seconds field is chosen so the coinbase's txid does NOT sort last
+        # under (timestamp, txid) — i.e. the DB presents the coinbase not-last,
+        # which is what surfaces the merkle bug (asserted by the guard below). A
+        # broad majority of values diverge, so this is robust; the guard fails
+        # loud if a future txid-format change ever removes the divergence.
+        now_dt = datetime.datetime(2026, 6, 15, 12, 0, 2, tzinfo=datetime.UTC)
+        t0 = now_dt - datetime.timedelta(hours=2)
+        t1 = now_dt - datetime.timedelta(hours=1)
+
+        # Genesis block (coinbase only) — its coinbase reward funds the chain.
+        time_machine.move_to(t0)
+        chain, block0 = add_chain_block()
+        cb0 = block0.coinbase
+        cb0_amount = next(iter(cb0.outflows)).amount
+
+        # Block 1: one regular txn that splits the genesis reward into two
+        # spendable outputs (idx 0 and idx 1), so block 2 can carry two
+        # independent regular txns.
+        half = cb0_amount // 2
+        time_machine.move_to(t1)
+        split = Transaction()
+        split.add_inflow(Inflow(outflow_txid=cb0.txid, outflow_idx=0))
+        split.add_outflow(Outflow(amount=half, address=addr))
+        split.add_outflow(Outflow(amount=cb0_amount - half, address=addr))
+        split.set_signing_key(signing_key)
+        split.seal()
+        split.sign()
+        split.to_db()
+        block1 = Block()
+        block1.add_txn(split)
+        _, block1 = add_chain_block(chain=chain, block=block1)
+
+        # Block 2: TWO regular txns, each spending one of block 1's outputs and
+        # each timestamped at now_dt — the same instant the block (and its
+        # coinbase) is sealed. With the canonical test key's deterministic
+        # txids, the coinbase ties on timestamp and the (timestamp, txid)
+        # tie-break leaves it NOT-last in DB order.
+        time_machine.move_to(now_dt)
+        spend_a = Transaction()
+        spend_a.add_inflow(Inflow(outflow_txid=split.txid, outflow_idx=0))
+        spend_a.add_outflow(Outflow(amount=half, opposition=subject))
+        spend_a.set_signing_key(signing_key)
+        spend_a.seal()
+        spend_a.sign()
+        spend_a.to_db()
+        spend_b = Transaction()
+        spend_b.add_inflow(Inflow(outflow_txid=split.txid, outflow_idx=1))
+        spend_b.add_outflow(Outflow(amount=cb0_amount - half, support=subject))
+        spend_b.set_signing_key(signing_key)
+        spend_b.seal()
+        spend_b.sign()
+        spend_b.to_db()
+        block2 = Block()
+        # add_txn enforces non-decreasing (timestamp, txid) order; spend_a and
+        # spend_b share a timestamp, so add them in their sorted order (mirrors
+        # the mempool, which yields pending txns ordered by (timestamp, txid)).
+        for txn in sorted([spend_a, spend_b]):
+            block2.add_txn(txn)
+        # add_chain_block seals the block (appending the coinbase), mills, and
+        # persists it. The block now carries 3 txns: two regular + coinbase.
+        _, block2 = add_chain_block(chain=chain, block=block2)
+        chain.to_db()
+
+        # Confirm the raw DB association order genuinely diverges from the
+        # canonical order — i.e. the coinbase is NOT last as the DB presents
+        # it. Without this divergence the test would not exercise the bug.
+        # A coinbase DAO is discriminated by a non-null prev_hash (it binds
+        # its block's prev_hash into the txid); regular txns leave it unset.
+        block2_dao = BlockDAO.get(block2.block_hash)
+        db_order = list(block2_dao.transactions)
+        assert db_order[-1].prev_hash is None, (
+            'expected the DB association order to present the coinbase '
+            'NOT-last (the (timestamp, txid) tie-break flip that surfaces '
+            'the merkle bug); got coinbase last so the bug is not exercised'
+        )
+
+        # Reload the whole chain from the DB by its tip hash and validate it
+        # end-to-end — the from_db/from_dao path that surfaced the bug.
+        reloaded = Chain.from_db(block_hash=chain.block_hash)
+        assert reloaded is not None
+        # Sanity-check that a reloaded block genuinely has >1 txn (here, 3),
+        # so this actually exercises a multi-txn block — a coinbase-only block
+        # would not.
+        reloaded_blocks = list(reloaded.blocks)
+        multi_txn_blocks = [b for b in reloaded_blocks if len(b.txns) > 1]
+        assert multi_txn_blocks, 'expected a reloaded block with >1 txn'
+        assert any(len(b.txns) == 3 for b in multi_txn_blocks)
+        # On reload, each multi-txn block's recomputed merkle root must still
+        # match its sealed header. Pre-fix, from_dao kept the raw DB order and
+        # the recomputed root diverged from the stored one (InvalidMerkleRoot).
+        for b in multi_txn_blocks:
+            assert b.get_merkle_root() == b.merkle_root
+        # And the chain validates end-to-end (must not raise — e.g.
+        # InvalidMerkleRootError / OutOfOrderTransactionError before the fix).
+        assert reloaded.validate() is True
 
 
 def test_dao(add_chain_block, app, time_machine, time_stepper, signing_key):


### PR DESCRIPTION
Fixes #340.

## Problem

A block's merkle root could not be recomputed after the block was reloaded from the DB for any block with **>1 transaction**, so `validate()` raised `InvalidMerkleRootError` and **peer sync rejected the block** (a peer 400 on `/api/block/<hash>` during `fill_peer`). Balances were unaffected (they never recompute the merkle), so it stayed latent until a multi-tx chain was validated/synced.

**Root cause:** `seal()` builds the merkle with the coinbase appended **last**, but `BlockDAO.transactions` reloads ordered by `(timestamp, txid)`. The coinbase is minted at seal time, so its timestamp **ties** the just-milled txns and the tie breaks on `txid` — a per-block coin flip. When the coinbase's txid sorts it ahead of a regular txn, the reloaded order ≠ the sealed order, and `build_merkle_tree()` (which iterated raw `self.txns`) produced a different root.

## NOT a consensus change — no rebuild

The sealed order **is** canonical (`[regular by (timestamp,txid), coinbase LAST]`), so the **stored roots are already correct** — only the recompute on reload used the wrong order. Verified on the dev chain: recomputing every multi-tx block's merkle over canonical coinbase-last order reproduces the stored root exactly (11/11 match; 5 of those fail only under the raw DB load order). The coinbase has been appended last since the initial commit — the convention never flipped.

## Fix

Define one canonical order and compute the merkle + inclusion proofs over it everywhere:

- **`Block.canonical_txns()`** (new, via `_canonical_order`): regular txns by `(timestamp, txid)`, coinbase **LAST**. Coinbase identity is position-independent (`is_coinbase` = `prev_hash is not None`, survives `to_dao`/`from_dao`).
- **`build_merkle_tree()` + `in_merkle_tree()`** compute over `canonical_txns()` — order-independent.
- **`from_dao()`** reconstructs `txns` in canonical order, so a reloaded block's `coinbase`/`last_txn`/`regular_txns` are correct too.

No change to `seal()`, `get_merkle_root()`'s byte computation, the header, the block hash, or `models.py` `order_by`.

## Tests

- `test_merkle_root_order_independent` — shuffling `self.txns` doesn't change the root.
- `test_canonical_txns_orders_coinbase_last` — sort key puts regulars first (by `(timestamp,txid)`), coinbase last.
- `test_in_merkle_tree_multi_txn` — inclusion proofs hold on a multi-txn block.
- `test_from_dao_canonicalizes_transaction_order` — a coinbase-first DB presentation reloads canonical and validates.
- `test_reloaded_multi_txn_chain_validates` (`tests/test_chain.py`) — the end-to-end regression: persist a 3-txn-tip chain, reload via `Chain.from_db`, `validate()`. Verified to **fail at the pre-fix baseline** (`InvalidMerkleRootError`) and pass after. Uses a fixed instant + sorted same-timestamp spends so the `(timestamp, txid)` ordering that surfaces the bug is deterministic, with a self-guard that fails loud if a future txid-format change ever stops exercising it.

## How to test
```
uv run pytest tests/test_block.py tests/test_chain.py -q
uv run pytest -q   # full suite: 734 passed, 1 skipped
```

Went through the consensus-critical cycle (brainstorm → spec → plan → subagent build → whole-branch review, verdict PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)