### PR TITLE
refactor(egu-342): harden canonical block-txn order outside the DB path

### DIFF
--- a/src/gumptionchain/block.py
+++ b/src/gumptionchain/block.py
@@ -87,9 +87,12 @@ def _block_from_model_data(data: dict[str, Any]) -> dict[str, Any]:
     """
     return {
         **data,
-        'txns': [
-            Transaction(**txn_from_model_data(t)) for t in data.get('txns', [])
-        ],
+        'txns': Block._canonical_order(
+            [
+                Transaction(**txn_from_model_data(t))
+                for t in data.get('txns', [])
+            ]
+        ),
     }
 
 
@@ -208,7 +211,9 @@ class Block:
 
     def in_merkle_tree(self, txid: str) -> bool:
         canonical = self.canonical_txns()
-        txids = [t.txid for t in canonical]
+        # Index over the SAME leaves build_merkle_tree appends — it skips txns
+        # with no txid, so a txid-less txn must not shift the leaf indices.
+        txids = [t.txid for t in canonical if t.txid is not None]
         if txid not in txids:
             return False
         tree = self.build_merkle_tree()

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -171,6 +172,61 @@ def test_from_dao_canonicalizes_transaction_order(
     assert reloaded.coinbase.txid == block.coinbase.txid
     assert not any(t.is_coinbase for t in reloaded.regular_txns)
     reloaded.validate()
+
+
+def test_from_dict_canonicalizes_transaction_order(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    # A serialized block whose txns array is NON-canonical (coinbase not last)
+    # must reconstruct in canonical order, so the position-based coinbase /
+    # regular_txns properties stay correct. (Block.__eq__ ignores txns order,
+    # so assert the order explicitly rather than via ==.)
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    block.validate()
+    d = block.to_dict()
+    d['txns'] = list(reversed(d['txns']))  # coinbase first — non-canonical
+    reconstructed = Block.from_dict(d)
+    assert reconstructed.txns[-1].is_coinbase
+    assert reconstructed.coinbase.txid == block.coinbase.txid
+    assert not any(t.is_coinbase for t in reconstructed.regular_txns)
+    reconstructed.validate()
+
+
+def test_from_json_canonicalizes_transaction_order(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    block.validate()
+    d = block.to_dict()
+    d['txns'] = list(reversed(d['txns']))  # coinbase first — non-canonical
+    reconstructed = Block.from_json(json.dumps(d))
+    assert reconstructed.txns[-1].is_coinbase
+    assert reconstructed.coinbase.txid == block.coinbase.txid
+    assert not any(t.is_coinbase for t in reconstructed.regular_txns)
+    reconstructed.validate()
+
+
+def test_in_merkle_tree_skips_untxid_leaf(
+    reward, single_block, signing_key, subject, txid, time_machine
+):
+    # in_merkle_tree's leaf index must be computed over the SAME leaves the
+    # tree is built from — build_merkle_tree skips txns with no txid. Inject a
+    # txid-less txn that sorts canonically first; pre-hardening its phantom
+    # slot shifted every real leaf index by one, breaking the inclusion proof.
+    block = _two_txn_block(
+        single_block, signing_key, subject, txid, reward, time_machine
+    )
+    real = block.regular_txns[0]
+    dummy = Transaction()  # unsealed → txid is None
+    dummy.timestamp = '2000-01-01T00:00:00Z'  # sorts before every real txn
+    block.txns.insert(0, dummy)
+    assert block.in_merkle_tree(real.txid)
+    assert block.in_merkle_tree(block.coinbase.txid)
+    assert not block.in_merkle_tree('nonexistent-txid')
 
 
 def test_add_txn(single_block, subject, time_machine, txid, signing_key):


### PR DESCRIPTION
Closes #342. Follow-up hardening to #340/#341 — two correct-by-construction tightenings, neither a live bug.

## 1. `from_json` / `from_dict` canonicalize txn order

#341 fixed the DB-reload path (`from_dao`), but the wire/storage deserialization paths still trusted input order. The merkle is already order-independent (computed over `canonical_txns()`), so a non-canonical txn array wouldn't cause a root mismatch — but it *would* corrupt the position-based `coinbase` / `last_txn` / `regular_txns` properties (a coinbase reconstructed mid-list → `coinbase` returns a regular txn → `validate()` raises `MissingCoinbaseError`/`OutOfOrderTransactionError`).

Fixed once at the shared `_block_from_model_data` choke point (both `from_json` and `from_dict` funnel through it), routing the reconstructed txns through `Block._canonical_order(...)` — same one-liner `from_dao` already uses.

## 2. `in_merkle_tree` leaf index over txid-bearing leaves only

`build_merkle_tree()` skips txns with `txid is None` when appending leaves, but `in_merkle_tree` built its 1-based index list over *all* canonical txns. A txid-less txn ahead of the target shifted every real leaf index by one → corrupt/`out-of-bounds` inclusion proof. Now the index is computed over `[t.txid for t in canonical if t.txid is not None]`, matching the tree exactly.

## Tests (all fail pre-fix, pass after)

- `test_from_dict_canonicalizes_transaction_order` / `test_from_json_canonicalizes_transaction_order` — reverse a sealed multi-txn block's serialized `txns` (coinbase first), reconstruct, assert coinbase lands last and `validate()` passes. (`Block.__eq__` ignores txn order, so order is asserted explicitly.)
- `test_in_merkle_tree_skips_untxid_leaf` — inject a txid-less txn that sorts canonically first; pre-fix the inclusion index went out of bounds, post-fix the real txns still prove.

## How to test
```
uv run pytest tests/test_block.py -q
uv run pytest -q   # full suite: 737 passed, 1 skipped
```

No consensus impact: no change to `seal()`, the stored merkle root, the block hash, or validation outcomes for well-formed blocks — only reconstruction/lookup robustness for non-DB paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)