### PR TITLE
feat(browser): canonical WebAuthn rpId for passkey pages — Sign in with Gumption Phase 2 (base half)

### DIFF
--- a/src/gumptionchain/browser.py
+++ b/src/gumptionchain/browser.py
@@ -501,6 +501,7 @@ def advanced_view() -> Any:
         title='Advanced',
         node_host=current_app.config['NODE_HOST'],
         rp_name='GumptionChain',
+        rp_id=current_app.config.get('RP_ID') or '',
     )
 
 
@@ -518,6 +519,7 @@ def transact_view() -> Any:
         # rp_name labels the WebAuthn passkey (RP name) for the saved key
         # passkey unlock path; gc-sig is node-bound so node_host stays too.
         rp_name='GumptionChain',
+        rp_id=current_app.config.get('RP_ID') or '',
     )
 
 
@@ -532,4 +534,5 @@ def signing_key_view() -> Any:
         'signing_key.html',
         title='SigningKey',
         rp_name='GumptionChain',
+        rp_id=current_app.config.get('RP_ID') or '',
     )

--- a/src/gumptionchain/config.py
+++ b/src/gumptionchain/config.py
@@ -32,6 +32,11 @@ class EnvAppSettings(EnvironSettings):
     _prefix: ClassVar[str] = 'GC_'
 
     NODE_HOST: str | None = field(default=None)
+    # Canonical WebAuthn RP ID for passkey ceremonies on the browser pages.
+    # None → the page falls back to its origin hostname (self-scoped). Set to a
+    # shared EGU rpId (e.g. the hub domain) to federate one passkey identity
+    # across distinct origins via Related Origin Requests (gump-hub#67).
+    RP_ID: str | None = field(default=None)
     PEERS: list[str] = field(default_factory=list)
     API_CLIENT_TIMEOUT: int = field(default=10)
     MAX_CHAIN_FILL_DEPTH: int = field(default=50000)

--- a/src/gumptionchain/static/js/signing-key-glue.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.mjs
@@ -12,7 +12,7 @@ import * as keyring from '../sdk/gc-keyring.mjs';
 import { makeIdbStore } from '../sdk/gc-store-idb.mjs';
 import { exportEncrypted, importEncrypted } from '../sdk/gc-backup.mjs';
 import { session as defaultSession } from './signing-key-session.mjs';
-import { makePasskey } from './signing-key-passkey.mjs';
+import { makePasskey, resolveRpId } from './signing-key-passkey.mjs';
 import {
   classifyRecognition, makeDerivedIdentity,
 } from '../sdk/gc-derived-identity.mjs';
@@ -26,8 +26,8 @@ export { classifyRecognition };
 
 // Re-exported so existing importers (and tests) of signing-key-glue keep working;
 // the implementation now lives in the shared signing-key-passkey module so /transact
-// can reuse the same secure-context gating.
-export { makePasskey };
+// can reuse the same secure-context gating. resolveRpId travels with it.
+export { makePasskey, resolveRpId };
 
 // --- pure helpers ---------------------------------------------------------
 
@@ -151,12 +151,15 @@ function downloadText(doc, filename, text) {
 }
 
 // init wires the page. root defaults to document. rpName labels the passkey
-// (WebAuthn RP name). store/session/win are injectable for completeness but
-// default to the real IndexedDB store / shared session / window.
+// (WebAuthn RP name); rpId overrides the origin hostname as the WebAuthn RP ID
+// (the canonical EGU rpId when configured, else the hostname). store/session/win
+// are injectable for completeness but default to the real IndexedDB store /
+// shared session / window.
 export function init(
   root = document,
   {
     rpName = 'GumptionChain',
+    rpId,
     store = makeIdbStore({}),
     session = defaultSession,
     win = typeof window !== 'undefined' ? window : undefined,
@@ -805,7 +808,7 @@ export function init(
   // Resolve passkey capability, install auto-lock, then render. Auto-lock
   // re-renders on lock so the controls reflect the locked state.
   (async () => {
-    if (!passkey) passkey = await makePasskey({ window: win, rpName });
+    if (!passkey) passkey = await makePasskey({ window: win, rpName, rpId });
     passkeyState = {
       secureContext: injectedPasskey ? true : !!win?.isSecureContext,
       supported: passkey != null,

--- a/src/gumptionchain/static/js/signing-key-glue.test.mjs
+++ b/src/gumptionchain/static/js/signing-key-glue.test.mjs
@@ -13,6 +13,7 @@ import {
   createPathFor,
   recognitionOutcome,
   classifyRecognition,
+  resolveRpId,
 } from './signing-key-glue.mjs';
 import { SigningKey } from '../sdk/gc-signing-key.mjs';
 import { makeSession } from './signing-key-session.mjs';
@@ -774,4 +775,16 @@ test('init: a saved WRAP record keeps passphrase-unlock + add-passkey', async ()
   assert.equal(dom.querySelector('#backup-btn').textContent, 'Download backup');
   assert.equal(dom.querySelector('#backup-heading').textContent, 'Download an encrypted backup');
   assert.equal(dom.querySelector('#backup-passphrase-row').hidden, false);
+});
+
+// --- resolveRpId: explicit (server-configured) rpId wins, else hostname ----
+test('resolveRpId returns an explicit rpId when provided', () => {
+  const win = { location: { hostname: 'chain.example' } };
+  assert.equal(resolveRpId({ window: win, rpId: 'gumption.com' }), 'gumption.com');
+});
+
+test('resolveRpId falls back to the origin hostname when rpId is empty/absent', () => {
+  const win = { location: { hostname: 'chain.example' } };
+  assert.equal(resolveRpId({ window: win }), 'chain.example');
+  assert.equal(resolveRpId({ window: win, rpId: '' }), 'chain.example');
 });

--- a/src/gumptionchain/static/js/signing-key-passkey.mjs
+++ b/src/gumptionchain/static/js/signing-key-passkey.mjs
@@ -4,15 +4,27 @@
 // in one place rather than being duplicated per page.
 import { makeWebauthnPasskey } from '../sdk/gc-passkey-webauthn.mjs';
 
+// Resolve the WebAuthn RP ID for a passkey ceremony: an explicit
+// (server-configured) rpId wins; otherwise fall back to this origin's hostname
+// (the historical behaviour). Pure + DOM-free so it can be unit-tested with a
+// fake window. A shared, canonical rpId across distinct EGU origins is what
+// lets one passkey identity federate via Related Origin Requests (gump-hub#67);
+// leaving it unset keeps each origin self-scoped (non-breaking default).
+export function resolveRpId({ window: win = window, rpId } = {}) {
+  return rpId || win?.location?.hostname;
+}
+
 // Build a passkey adapter for THIS origin, but only on a secure context where
 // PRF is actually supported. Returns null (not a half-working adapter) when
-// passkeys aren't usable here, so the UI degrades to passphrase-only.
-export async function makePasskey({ window: win = window, rpName } = {}) {
+// passkeys aren't usable here, so the UI degrades to passphrase-only. rpId
+// overrides the origin hostname (see resolveRpId) so the page can enroll/unlock
+// under a canonical EGU rpId; it MUST be identical across enroll and unlock.
+export async function makePasskey({ window: win = window, rpName, rpId } = {}) {
   if (!win?.isSecureContext) {
     return null;
   }
   const passkey = makeWebauthnPasskey({
-    rpId: win.location.hostname,
+    rpId: resolveRpId({ window: win, rpId }),
     rpName,
   });
   if (!(await passkey.isSupported())) {

--- a/src/gumptionchain/static/js/transact-glue.mjs
+++ b/src/gumptionchain/static/js/transact-glue.mjs
@@ -389,6 +389,7 @@ export function init(
   {
     nodeHost,
     rpName = 'GumptionChain',
+    rpId,
     store = makeIdbStore({}),
     session = defaultSession,
     win = typeof window !== 'undefined' ? window : undefined,
@@ -835,7 +836,7 @@ export function init(
   // the shared auto-lock policy so an unlocked key (saved OR session) is dropped
   // on idle / tab-hide / page-unload. A lock re-renders the panel.
   (async () => {
-    passkey = await makePasskey({ window: win, rpName });
+    passkey = await makePasskey({ window: win, rpName, rpId });
     session.onLock(() => {
       if (wasUnlocked && keyStatus) {
         setStatus(keyStatus, 'Key locked — cleared from memory.', 'info');

--- a/src/gumptionchain/templates/advanced.html
+++ b/src/gumptionchain/templates/advanced.html
@@ -4,7 +4,7 @@
 
 {% block content -%}
 <div class="container-fluid" data-node-host="{{ node_host }}"
-     data-rp-name="{{ rp_name }}">
+     data-rp-name="{{ rp_name }}" data-rp-id="{{ rp_id }}">
 
   <div class="row my-3"><div class="col">
     <div class="alert alert-warning" role="alert">
@@ -118,6 +118,7 @@
   init(root, {
     nodeHost: root.dataset.nodeHost,
     rpName: root.dataset.rpName,
+    rpId: root.dataset.rpId,
   });
 </script>
 {%- endblock %}

--- a/src/gumptionchain/templates/signing_key.html
+++ b/src/gumptionchain/templates/signing_key.html
@@ -3,7 +3,7 @@
 {% block title %}Signing key{% endblock %}
 
 {% block content -%}
-<div class="container-fluid" data-rp-name="{{ rp_name }}">
+<div class="container-fluid" data-rp-name="{{ rp_name }}" data-rp-id="{{ rp_id }}">
 
   <!-- Security banner: persistence is a trust decision in this node. -->
   <div class="row my-3"><div class="col">
@@ -231,6 +231,6 @@
 <script type="module">
   import { init } from "{{ url_for('browser.static', filename='js/signing-key-glue.mjs') }}";
   const root = document.querySelector('[data-rp-name]');
-  init(root, { rpName: root.dataset.rpName });
+  init(root, { rpName: root.dataset.rpName, rpId: root.dataset.rpId });
 </script>
 {%- endblock %}

--- a/src/gumptionchain/templates/transact.html
+++ b/src/gumptionchain/templates/transact.html
@@ -4,7 +4,7 @@
 
 {% block content -%}
 <div class="container-fluid" data-node-host="{{ node_host }}"
-     data-rp-name="{{ rp_name }}">
+     data-rp-name="{{ rp_name }}" data-rp-id="{{ rp_id }}">
 
   <div class="row my-3"><div class="col">
     <div class="alert alert-warning" role="alert">
@@ -99,6 +99,7 @@
   init(root, {
     nodeHost: root.dataset.nodeHost,
     rpName: root.dataset.rpName,
+    rpId: root.dataset.rpId,
   });
 </script>
 {%- endblock %}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -53,3 +53,23 @@ def test_transaction(app, add_chain_block, subject, test_client, signing_key):
         response = test_client.get(f'/transaction/{t.txid}')
         assert response.status_code == httpx.codes.OK
         assert t.txid in str(response.data)
+
+
+def test_signing_key_rp_id_default_empty(app, test_client):
+    # Unconfigured: data-rp-id renders empty, so the page glue falls back to the
+    # origin hostname as the WebAuthn RP ID (self-scoped, non-breaking default).
+    with app.app_context():
+        response = test_client.get('/signing-key')
+        assert response.status_code == httpx.codes.OK
+        assert 'data-rp-id=""' in str(response.data)
+
+
+def test_browser_pages_render_configured_rp_id(app, test_client):
+    # A configured canonical RP_ID reaches every passkey page's data-rp-id, so
+    # the glue threads it into makePasskey for a federated EGU rpId.
+    app.config['RP_ID'] = 'gumption.example'
+    with app.app_context():
+        for path in ('/signing-key', '/transact', '/advanced'):
+            response = test_client.get(path)
+            assert response.status_code == httpx.codes.OK
+            assert 'data-rp-id="gumption.example"' in str(response.data), path


### PR DESCRIPTION
The base half of **"Sign in with Gumption" Phase 2** rpId threading (gumption-hub#67). Hub Phase 1 (the `/.well-known/webauthn` RP-ID authority) already shipped; this makes base able to enroll/unlock passkeys under a **canonical, server-configured rpId** instead of always `location.hostname`.

## Why

Base's passkey ceremonies hardcoded `rpId: win.location.hostname` (`signing-key-passkey.mjs`), so a derived identity created on base was permanently self-scoped — it could never federate to another EGU origin. WebAuthn only resolves a passkey when the rpId is **byte-identical** across enroll and unlock, and federating one identity across **distinct domains** requires all of them to assert one shared rpId via Related Origin Requests. This adds the override that makes base a participant.

## What

- **`makePasskey` gains an `rpId` param**, resolved by a new pure, DOM-free `resolveRpId({ window, rpId })` helper: an explicit (configured) rpId wins, else fall back to the origin hostname.
- **Threaded through both passkey chokepoints** — `signing-key-glue` (`/signing-key`) and `transact-glue` (`/transact`, `/advanced`) `init()`. Base funnels *every* ceremony (create / recognize / unlock / add-passkey) through this single adapter, so there's no partial-threading risk — they all share one rpId.
- **Sourced from a new `GC_RP_ID` config** → `data-rp-id` on each page, mirroring the existing `rp_name` plumbing exactly. **Unset → empty → hostname fallback, so it's fully non-breaking** — current deployments behave identically until an operator sets `GC_RP_ID`.

## Scope / out of scope

This is only the **rpId threading** slice of Phase 2. The rest of Phase 2 — `discover()` cross-origin recognition, the "Sign in with Gumption" endpoint, and the hub pin bump — is separate and untouched. No consensus impact (client/config only).

> Note: once a real `GC_RP_ID` is adopted and differs from a page's prior rpId, passkeys enrolled under the old rpId stop resolving — an rpId flip is a re-enroll event, to be sequenced with user comms. This PR changes no rpId by default.

## Tests

- `resolveRpId` unit tests (node:test) — explicit rpId wins; empty/absent falls back to hostname.
- `test_signing_key_rp_id_default_empty` — unconfigured renders `data-rp-id=""` (hostname fallback).
- `test_browser_pages_render_configured_rp_id` — a configured `RP_ID` reaches `data-rp-id` on all three passkey pages.

## How to test
```
node --test src/gumptionchain/static/js/*.test.mjs   # 284 pass
uv run pytest -q                                      # 739 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
