### PR TITLE
feat(egu-351): complete the node-proxy relay — add /txn/rescind

### DIFF
--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -179,6 +179,30 @@ def node_proxy_blueprint(
     def txn_oppose() -> Response:
         return _build('get_opposition_transaction')
 
+    @bp.post('/txn/rescind')
+    def txn_rescind() -> Response:
+        # Build an unsigned rescind: un-stake the signer's own support or
+        # opposition on a subject. `kind` selects which stake to undo
+        # (the node re-validates it; we 400 early on a bad value).
+        data = request.get_json(silent=True) or {}
+        signer = _signer(data)
+        subject = _require_subject(data.get('subject'))
+        grains = _grit_to_grains(data.get('amount_grit'))
+        kind = data.get('kind')
+        if kind not in ('opposition', 'support'):
+            raise _ProxyError(400, "kind must be 'opposition' or 'support'")
+        return jsonify(
+            _ok(
+                _call(
+                    make_client().get_rescind_transaction,
+                    signer,
+                    grains,
+                    subject,
+                    kind,
+                )
+            ).json()
+        )
+
     @bp.post('/txn/transfer')
     def txn_transfer() -> Response:
         # Build an unsigned player->address GRIT transfer. Same shape as the

--- a/tests/test_node_proxy.py
+++ b/tests/test_node_proxy.py
@@ -67,6 +67,11 @@ class FakeClient:
     ):
         return self._resp('build_split', signer, denomination, count)
 
+    def get_rescind_transaction(
+        self, signer, amount, subject, kind, *, raise_for_status=True
+    ):
+        return self._resp('build_rescind', signer, amount, subject, kind)
+
     def get(self, path, *, raise_for_status=True):
         return self._resp('status', path)
 
@@ -213,6 +218,37 @@ def test_build_transfer_rejects_bad_address():
         json={'signer': SIGNER, 'amount_grit': 20, 'to_address': 'nope'},
     )
     assert resp.status_code == 400
+
+
+def test_build_rescind_converts_grit_and_passes_kind():
+    unsigned = {'txid': 'r1', 'outflows': [{'amount': 500, 'rescind': 'enc'}]}
+    client = FakeClient(build_rescind=FakeResponse(200, unsigned))
+    resp = _app(client).post(
+        '/api/node/txn/rescind',
+        json={
+            'signer': SIGNER,
+            'amount_grit': 5,
+            'subject': 'goblins',
+            'kind': 'support',
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == unsigned
+    name, args, _ = client.calls[0]
+    assert name == 'build_rescind'
+    assert args == (SIGNER, 500, 'goblins', 'support')
+
+
+def test_build_rescind_rejects_bad_kind():
+    client = FakeClient()
+    for bad in ({}, {'kind': ''}, {'kind': 'nope'}, {'kind': 'Support'}):
+        resp = _app(client).post(
+            '/api/node/txn/rescind',
+            json={'signer': SIGNER, 'amount_grit': 5, 'subject': 'x', **bad},
+        )
+        assert resp.status_code == 400, bad
+        assert 'kind' in resp.get_json()['error']
+    assert client.calls == []
 
 
 def test_build_split_converts_grit_and_passes_count():


### PR DESCRIPTION
Closes #351.

## Audit first

Issue #351 asked to ship a **complete, batteries-included node-proxy relay** (so the next EGU member mounts one blueprint and isn't missing routes), and to **verify the build routes use the `signer = <gc1 address>` shape, not the pre-Ed25519 `public_key`**.

Audited the current `node_proxy_blueprint`:

- **Signer shape — verified ✓.** Every build route resolves the signer via `_signer()` → `validate_address_format(signer)`; there is **no `public_key`** anywhere in `node_proxy.py`. The transfer route (and support/oppose/split) all forward `signer`.
- **Surface — one genuine gap.** The relay already had `balance`, `subject/balances`, `subject/search`, build `support`/`oppose`/`transfer`/`split`, `submit`, and `txn/<txid>/status` — but **no `rescind`**, despite `ApiClient.get_rescind_transaction` existing and rescind being a core player op (un-stake). That's exactly the "discover a missing route one at a time" friction #351 exists to eliminate.

## Change

Add `POST /txn/rescind` — `{signer, amount_grit, subject, kind}` → unsigned rescind, with `kind ∈ {opposition, support}` validated early for a clean 400. Mirrors the existing support/oppose build pattern and the `signer`-address shape.

**The build surface is now complete: support · oppose · rescind · transfer · split.**

## Tests

- `test_build_rescind_converts_grit_and_passes_kind` — GRIT→grains, raw subject + kind passed through to `get_rescind_transaction(signer, grains, subject, kind)`.
- `test_build_rescind_rejects_bad_kind` — missing/empty/unknown/wrong-case `kind` → 400, node not called.

```
uv run pytest tests/test_node_proxy.py -q   # 25 pass
uv run pytest -q                             # full suite: 746 passed, 1 skipped
```

Non-consensus (browser-facing relay only). The EGU member-app guide (gumption-hub `docs/build-an-egu-member-app.md`) can now point members at the full chain-ops surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
