### PR TITLE
docs(egu-352): served SDK barrel as the stable import surface + CI guard

### DIFF
--- a/clients/sdk/README.md
+++ b/clients/sdk/README.md
@@ -34,10 +34,25 @@ import { SigningKey, signMessage } from './clients/sdk/index.mjs';
 // @<tag-or-sha> segment so you track a fixed version, not the default branch:
 // import { SigningKey } from
 //   'https://cdn.jsdelivr.net/gh/gumptionthomas/gumptionchain@<tag-or-sha>/clients/sdk/index.mjs';
+
+// Or, when a base gumptionchain node serves the package (member apps embedding
+// the node's static assets), import the SERVED barrel:
+// import { SigningKey } from '/static/gumptionchain/sdk/index.mjs';
 ```
 
 Only symbols re-exported from `index.mjs` are the supported public API. Other
 files (`gc-crypto.mjs`, `gc-envelope.mjs`, …) are internal and may change.
+
+**Importing the served package (member apps).** When you consume the SDK from a
+base node's static assets, import **only the served barrel** —
+`/static/gumptionchain/sdk/index.mjs` — never an individual file URL
+(`…/sdk/gc-keyring.mjs`). The barrel path is the stable contract; individual
+served filenames are internal and may be renamed or moved, which would 404 a
+direct import only **after** you bump the node pin (invisible until runtime —
+see issue #352). Read the `version` export to gate on the embedder-API semver.
+A base node serves `index.mjs` with a `text/javascript` MIME type (required for
+`import`); `tests/test_static_assets.py` guards that path so a base-side break
+fails CI rather than your deploy.
 
 ## Quickstart
 

--- a/tests/test_static_assets.py
+++ b/tests/test_static_assets.py
@@ -15,6 +15,26 @@ def test_static_assets_blueprint_serves_a_signing_key_module():
     assert b'export' in resp.data  # it served the real module, not a 404 page
 
 
+def test_served_barrel_is_the_stable_import_surface():
+    # The served barrel (index.mjs) is THE documented stable import surface for
+    # member apps consuming base's SDK over HTTP. A rename/move that breaks this
+    # served path — or a wrong MIME that breaks ESM `import` — must fail base CI
+    # HERE, not silently at a consumer's deploy/runtime (the egu-352 404 trap).
+    app = Flask(__name__)
+    app.register_blueprint(static_assets_blueprint())
+    client = app.test_client()
+
+    resp = client.get('/static/gumptionchain/sdk/index.mjs')
+    assert resp.status_code == 200
+    # A JS MIME type is required for the browser to evaluate it as an ES module.
+    assert 'javascript' in resp.headers.get('Content-Type', '').lower()
+    body = resp.get_data(as_text=True)
+    # It's the public-API barrel (carries the embedder-API version +
+    # re-exports), not a 404 page or some other file.
+    assert 'export const version' in body
+    assert 'SigningKey' in body
+
+
 def test_static_assets_blueprint_url_path_is_overridable():
     app = Flask(__name__)
     app.register_blueprint(static_assets_blueprint(url_path='/assets/gc'))


### PR DESCRIPTION
Closes #352.

## The trap

Member apps consuming base's SDK over HTTP imported **individual served file URLs** (`/static/gumptionchain/sdk/gc-*.mjs`). A base-side rename keeps resolving at the old SHA, so nothing breaks **until the node pin is bumped** — then the ESM import 404s at the consumer's runtime, invisible until deploy.

## Finding: the stable surface already exists

The `index.mjs` **barrel** is already the documented public API (with a `version` semver), vendored by `sync_sdk.py`, served at `/static/gumptionchain/sdk/index.mjs` (`text/javascript`, verified), and guarded by `test_sdk_vendored.py`. The README documented importing it for the **relative** and **CDN** cases — but **not the served case**, which is exactly how members consume it. So the fix is to point the served case at the barrel and guard it, not build anything new.

(Approach chosen over a redirect/alias: the served URL *prefix* is stable; the fragility was importing individual *files*, which the barrel eliminates. A redirect is reactive per-rename — lower value here.)

## Change

1. **README** — add the served import case: import **only** `/static/gumptionchain/sdk/index.mjs`; individual served filenames are internal/movable; gate on the `version` export.
2. **`test_static_assets.py`** — guard that the served barrel resolves (`200`) with a `text/javascript` MIME (required for ESM `import`) and is the real barrel (`version` + re-exports). A base-side path/MIME break now fails **base CI**, not a consumer's deploy — directly closing the "invisible until runtime" complaint.

## Scope

Base-only (per the chosen scope). The member-facing how-to belongs in the hub member-app guide (`gumption-hub docs/build-an-egu-member-app.md`) and should reference the served barrel path separately — I'll note that on the issue.

```
uv run pytest tests/test_static_assets.py -q   # 3 pass
uv run pytest -q                                # full suite: 747 passed, 1 skipped
```

No `src/` change (README + guard test only). Non-consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
