### PR TITLE
feat(egu-353/354): lightweight entry point + canonical GRIT⇄grains helper

### DIFF
--- a/src/gumptionchain/__init__.py
+++ b/src/gumptionchain/__init__.py
@@ -17,21 +17,21 @@
 
 from __future__ import annotations
 
+from functools import cache as _cache
 from importlib.metadata import version as _pkg_version
 from pathlib import Path as _Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import click
-from flask import Flask
-from flask.cli import FlaskGroup
-from flask_migrate import Migrate
+if TYPE_CHECKING:
+    from flask import Flask
 
-from gumptionchain.node_proxy import (
-    node_proxy_blueprint as node_proxy_blueprint,
-)
-from gumptionchain.static_assets import (
-    static_assets_blueprint as static_assets_blueprint,
-)
+# Lightweight entry point (egu-354): this package's __init__ must NOT eagerly
+# import Flask / Click / the node DB layer, so a member app can
+# `from gumptionchain.units import grit_to_grains` or
+# `from gumptionchain.signing_key import SigningKey` at module top without
+# paying the node's startup cost. The heavy public names (create_app, cli, the
+# blueprints) are exposed lazily via PEP 562 module __getattr__ below; each
+# imports Flask only when actually accessed.
 
 __version__ = _pkg_version('gumptionchain')
 
@@ -47,6 +47,8 @@ def create_app(
     config_map: dict[str, Any] | None = None,
     register_browser: bool = True,  # noqa: FBT001
 ) -> Flask:
+    from flask import Flask  # noqa: PLC0415 — deferred to keep import light
+
     from .application import (  # noqa: PLC0415 — circular: application imports gumptionchain
         init_app,
     )
@@ -81,6 +83,10 @@ def create_app(
     init_app(app, register_browser=register_browser)
 
     try:
+        from flask_migrate import (  # noqa: PLC0415 — deferred so `import gumptionchain` stays light
+            Migrate,
+        )
+
         db.init_app(app)
         Migrate(app, db, directory=_MIGRATIONS_DIR)
     except RuntimeError as e:
@@ -103,7 +109,41 @@ def create_app(
     return app
 
 
-@click.version_option(package_name='gumptionchain')
-@click.group(cls=FlaskGroup, create_app=create_app, add_version_option=False)
-def cli() -> None:
-    pass
+@_cache
+def _make_cli() -> Any:
+    # Built lazily (not at module import) so `import gumptionchain` doesn't pull
+    # in Click + Flask's CLI. @cache makes `gumptionchain.cli` a stable
+    # singleton; the console-script entry point is unchanged.
+    import click  # noqa: PLC0415 — deferred to keep package import light
+    from flask.cli import FlaskGroup  # noqa: PLC0415 — deferred (keep light)
+
+    @click.version_option(package_name='gumptionchain')
+    @click.group(
+        cls=FlaskGroup, create_app=create_app, add_version_option=False
+    )
+    def cli() -> None:
+        pass
+
+    return cli
+
+
+def __getattr__(name: str) -> Any:
+    # PEP 562 lazy attributes: keep the public surface
+    # (`from gumptionchain import cli / node_proxy_blueprint / ...`) working
+    # while importing Flask/Click/the blueprints only on first access.
+    if name == 'cli':
+        return _make_cli()
+    if name == 'node_proxy_blueprint':
+        from gumptionchain.node_proxy import (  # noqa: PLC0415 — lazy
+            node_proxy_blueprint,
+        )
+
+        return node_proxy_blueprint
+    if name == 'static_assets_blueprint':
+        from gumptionchain.static_assets import (  # noqa: PLC0415 — lazy
+            static_assets_blueprint,
+        )
+
+        return static_assets_blueprint
+    msg = f'module {__name__!r} has no attribute {name!r}'
+    raise AttributeError(msg)

--- a/src/gumptionchain/application.py
+++ b/src/gumptionchain/application.py
@@ -11,10 +11,10 @@ from werkzeug.routing import BaseConverter, ValidationError
 
 from gumptionchain import __version__, api, browser, command
 from gumptionchain.api_client import ApiClient
-from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.payload import decode_subject, validate_subject
 from gumptionchain.schema import validate_address_format, validate_base64
 from gumptionchain.signing_key import SigningKey
+from gumptionchain.units import GRAIN_PER_GRIT
 from gumptionchain.util import host_address
 
 

--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -45,9 +45,12 @@ from gumptionchain.models import (
 from gumptionchain.payload import Inflow, Outflow, StakeKind
 from gumptionchain.signing_key import SigningKey
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
+from gumptionchain.units import GRAIN_PER_GRIT
 from gumptionchain.util import dt_2_iso, now
 
-GRAIN_PER_GRIT = 100
+# GRAIN_PER_GRIT is defined in the dependency-free gumptionchain.units and
+# re-exported here so existing `from gumptionchain.chain import GRAIN_PER_GRIT`
+# imports keep working (single source of truth — egu-353).
 GENESIS_HASH = mill_hash_str('GENESIS')
 # MAX_TARGET is the difficulty floor (easiest target) and genesis/initial
 # target. Benchmarked on the target hardware (#169): Pi 3 B+ single-core

--- a/src/gumptionchain/command.py
+++ b/src/gumptionchain/command.py
@@ -32,7 +32,6 @@ from rich.text import Text
 
 from gumptionchain.api_client import ApiClient
 from gumptionchain.block import Block
-from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.console import console
 from gumptionchain.database import db
 from gumptionchain.miller import Miller
@@ -40,6 +39,7 @@ from gumptionchain.node import Node
 from gumptionchain.payload import StakeKind, encode_subject
 from gumptionchain.signing_key import SigningKey
 from gumptionchain.transaction import Transaction
+from gumptionchain.units import GRAIN_PER_GRIT
 from gumptionchain.util import host_address, now_iso
 
 REFRESH_PER_SECOND = 8

--- a/src/gumptionchain/node_proxy.py
+++ b/src/gumptionchain/node_proxy.py
@@ -9,9 +9,9 @@ import httpx
 from flask import Blueprint, Request, Response, jsonify, request
 
 from gumptionchain.api_client import ApiClient
-from gumptionchain.chain import GRAIN_PER_GRIT
 from gumptionchain.payload import encode_subject, validate_raw_subject
 from gumptionchain.schema import validate_address_format
+from gumptionchain.units import GRAIN_PER_GRIT
 
 
 class _ProxyError(Exception):
@@ -89,7 +89,15 @@ def node_proxy_blueprint(
     """A browser-facing JSON relay over ``ApiClient`` for GRIT support/oppose
     spending, keeping the node host server-side. ``make_client`` supplies a
     configured client (node host + a TRANSACTOR/READER key). The relay holds no
-    key; it converts GRIT<->grains, validates subjects, and maps errors."""
+    key; it converts GRIT<->grains, validates subjects, and maps errors.
+
+    **Whole-GRIT at the proxy (the canonical conversion boundary).** Every
+    amount crossing this relay is **whole/decimal GRIT** (``amount_grit``,
+    ``denomination_grit``; reads return ``{grit, grains}``). The proxy is the
+    *one* place GRIT<->grains conversion happens (via ``gumptionchain.units``),
+    so a member app speaking to it never handles grains and never re-declares
+    the 100:1 factor (egu-353). One grain (0.01 GRIT) is the finest amount;
+    finer precision is a 400, not a silent truncation."""
     bp = Blueprint(name, __name__, url_prefix=url_path)
 
     @bp.errorhandler(_ProxyError)

--- a/src/gumptionchain/units.py
+++ b/src/gumptionchain/units.py
@@ -1,0 +1,52 @@
+"""GRIT <-> grains conversion — the single canonical boundary.
+
+1 **GRIT** = 100 **grains** (`GRAIN_PER_GRIT`). The node always works in integer
+grains; humans and member apps think in whole/decimal GRIT. This module is the
+one place that conversion lives, so consumers never re-declare ``100`` locally
+(an off-by-100 waiting to happen).
+
+It is deliberately **dependency-free** — pure stdlib (``decimal``), importing
+nothing from the node DB / Flask / chain layer — so a member app can
+``from gumptionchain.units import grit_to_grains`` at module top without paying
+the node's import cost (see the lightweight entry point, egu-354).
+
+The node-proxy relay is the canonical conversion boundary for browser/member
+traffic: it accepts and returns **whole GRIT**, converting to/from grains here,
+so a member speaking to the proxy never handles grains at all.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+# 1 GRIT = 100 grains. The smallest amount is one grain (0.01 GRIT).
+GRAIN_PER_GRIT = 100
+
+
+def grit_to_grains(grit: str | int | float | Decimal) -> int:
+    """Convert a GRIT amount to integer grains, exactly.
+
+    Uses ``Decimal`` (not float) so e.g. ``0.07`` GRIT is exactly 7 grains.
+    Raises ``ValueError`` for a non-numeric value or for finer-than-grain
+    precision (more than 2 decimal places) — failing loud beats silently
+    truncating a sub-grain amount to the wrong number of grains.
+    """
+    try:
+        amount = Decimal(str(grit))
+    except (InvalidOperation, ValueError):
+        msg = f'not a valid GRIT amount: {grit!r}'
+        raise ValueError(msg) from None
+    grains = amount * GRAIN_PER_GRIT
+    if grains != grains.to_integral_value():
+        msg = f'GRIT precision finer than one grain (0.01): {grit!r}'
+        raise ValueError(msg)
+    return int(grains)
+
+
+def grains_to_grit(grains: int) -> Decimal:
+    """Convert integer grains to a GRIT ``Decimal`` (exact; e.g. 7 -> 0.07).
+
+    Returns a ``Decimal`` so callers control display rounding without inheriting
+    float error. ``str(grains_to_grit(n))`` is a faithful GRIT string.
+    """
+    return Decimal(int(grains)) / GRAIN_PER_GRIT

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -69,7 +69,7 @@ def test_lightweight_surface_does_not_import_db_or_flask():
         'import gumptionchain.signing_key\n'
         'from gumptionchain.units import grit_to_grains, GRAIN_PER_GRIT\n'
         'from gumptionchain.signing_key import SigningKey\n'
-        "heavy = [m for m in ('sqlalchemy', 'flask', 'flask_migrate') "
+        "heavy = [m for m in ('sqlalchemy', 'flask', 'flask_migrate', 'click') "
         'if m in sys.modules]\n'
         "print(','.join(heavy))\n"
     )

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,94 @@
+import subprocess
+import sys
+from decimal import Decimal
+
+import pytest
+
+import gumptionchain
+from gumptionchain.units import (
+    GRAIN_PER_GRIT,
+    grains_to_grit,
+    grit_to_grains,
+)
+
+
+def test_grain_per_grit_is_100():
+    assert GRAIN_PER_GRIT == 100
+
+
+@pytest.mark.parametrize(
+    ('grit', 'grains'),
+    [
+        (1, 100),
+        ('1', 100),
+        (5, 500),
+        (0, 0),
+        ('0.07', 7),  # exact via Decimal — float 0.07*100 != 7 exactly
+        (Decimal('0.01'), 1),
+        (1.5, 150),
+        ('12.34', 1234),
+    ],
+)
+def test_grit_to_grains_exact(grit, grains):
+    assert grit_to_grains(grit) == grains
+
+
+def test_grit_to_grains_rejects_sub_grain_precision():
+    # Finer than one grain (0.01) must fail loud, not silently truncate.
+    with pytest.raises(ValueError, match='precision'):
+        grit_to_grains('0.001')
+
+
+def test_grit_to_grains_rejects_non_numeric():
+    with pytest.raises(ValueError, match='not a valid GRIT amount'):
+        grit_to_grains('not-a-number')
+
+
+@pytest.mark.parametrize(
+    ('grains', 'grit'),
+    [(100, '1'), (7, '0.07'), (0, '0'), (1, '0.01'), (1234, '12.34')],
+)
+def test_grains_to_grit_exact(grains, grit):
+    assert grains_to_grit(grains) == Decimal(grit)
+
+
+def test_round_trip():
+    for grains in (0, 1, 7, 100, 12345):
+        assert grit_to_grains(grains_to_grit(grains)) == grains
+
+
+def test_lightweight_surface_does_not_import_db_or_flask():
+    # The whole point of the lightweight entry point (egu-354): a member app can
+    # import the constants + client crypto + GRIT helper at module top WITHOUT
+    # transitively dragging in the node DB / Flask layer. Run in a fresh
+    # subprocess because the pytest process already has flask/sqlalchemy loaded.
+    code = (
+        'import sys\n'
+        'import gumptionchain\n'
+        'import gumptionchain.units\n'
+        'import gumptionchain.signing_key\n'
+        'from gumptionchain.units import grit_to_grains, GRAIN_PER_GRIT\n'
+        'from gumptionchain.signing_key import SigningKey\n'
+        "heavy = [m for m in ('sqlalchemy', 'flask', 'flask_migrate') "
+        'if m in sys.modules]\n'
+        "print(','.join(heavy))\n"
+    )
+    result = subprocess.run(  # noqa: S603 — fixed argv, our own interpreter
+        [sys.executable, '-c', code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == '', (
+        f'lightweight import transitively loaded: {result.stdout.strip()!r}'
+    )
+
+
+def test_lazy_init_still_exposes_create_app_cli_and_blueprints():
+    # PEP 562 lazy __getattr__ must keep the public surface importable.
+    assert callable(gumptionchain.create_app)
+    assert gumptionchain.cli is not None
+    assert callable(gumptionchain.node_proxy_blueprint)
+    assert callable(gumptionchain.static_assets_blueprint)
+    with pytest.raises(AttributeError):
+        _ = gumptionchain.does_not_exist


### PR DESCRIPTION
Closes #353 and #354 (they're one piece of work — #354 says the GRIT⇄grains helper should live in the lightweight surface, and #353's "importable without the DB layer" is impossible until that surface exists).

## Problem

A member app embedding `gumptionchain` paid a full **node-DB + Flask import cost** just to read a constant or sign a transaction — `import gumptionchain` eagerly loaded `sqlalchemy` and `flask`. So GTT deferred `from gumptionchain…` imports into function bodies *and* re-declared `GRAINS_PER_GRIT = 100` locally (an off-by-100 waiting to happen), each new member re-litigating both.

## Change

**`gumptionchain.units` — canonical GRIT⇄grains (#353).** Dependency-free (stdlib `Decimal` only): `GRAIN_PER_GRIT`, `grit_to_grains`, `grains_to_grit`. Exact via Decimal (`0.07` GRIT → exactly 7 grains); finer-than-grain precision **raises** rather than silently truncating. `chain.py`, `node_proxy`, `command`, `application` all source the constant here (single source of truth; `chain` re-exports it so existing `from gumptionchain.chain import GRAIN_PER_GRIT` keeps working).

**Lazy package `__init__` (#354).** PEP 562 module `__getattr__` defers Flask / Click / the blueprints, so `import gumptionchain`, `gumptionchain.units`, and `gumptionchain.signing_key` no longer transitively load `sqlalchemy`/`flask`. `create_app` / `cli` / `node_proxy_blueprint` / `static_assets_blueprint` are unchanged for callers (`cli` is a cached singleton; the `gumptionchain`/`gc` console-script entry points are intact — verified).

**`node_proxy` docstring** now documents the **"whole-GRIT at the proxy"** contract: the relay is the *one* conversion boundary; members speak whole GRIT and never handle grains.

## Tests

- `test_units.py`: exactness + sub-grain rejection + round-trip for the helper.
- **Guard (the #354 contract):** a subprocess (clean module state) imports `gumptionchain`, `.units`, `.signing_key` and asserts **no** `sqlalchemy`/`flask`/`flask_migrate` got loaded.
- A second test asserts the lazy surface still exposes `create_app`/`cli`/both blueprints (and raises `AttributeError` for unknown names).

```
uv run pytest -q          # 766 passed, 1 skipped
uv run mypy src           # clean (37 files)
uv run gumptionchain --version   # entry point intact
```

Non-consensus (import-graph + a pure-stdlib helper). The member-facing how-to + the proxy contract belong in the hub member-app guide (gumption-hub) — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
