### PR TITLE
feat(egu-357): public pending-aware balance — balance(address, filter_pending=False)

### DIFF
--- a/src/gumptionchain/chain.py
+++ b/src/gumptionchain/chain.py
@@ -519,8 +519,18 @@ class Chain:
             if limit is not None and amount >= limit:
                 break
 
-    def balance(self, address: str) -> int:
-        return int(self.to_dao().signing_key_balance(address))
+    def balance(
+        self,
+        address: str,
+        filter_pending: bool = False,  # noqa: FBT001
+    ) -> int:
+        # filter_pending=True -> spendable-now balance (excludes outputs already
+        # consumed by mempool txns); default False -> confirmed (egu-357).
+        return int(
+            self.to_dao().signing_key_balance(
+                address, filter_pending=filter_pending
+            )
+        )
 
     def _funds_error(self, address: str, amount: int) -> InsufficientFundsError:
         # Distinguish a genuine shortfall from funds tied up in an unconfirmed

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -815,9 +815,15 @@ class ChainDAO(Base):
             stmt = stmt.where(~OutflowDAO.pending.any())
         return stmt
 
-    def signing_key_balance(self, address: str) -> int:
-        stmt = self.outflows.where(OutflowDAO.address == address)
-        stmt = stmt.where(self._unspent_clause())
+    def signing_key_balance(
+        self,
+        address: str,
+        filter_pending: bool = False,  # noqa: FBT001
+    ) -> int:
+        # filter_pending=True returns the spendable-now total: confirmed-unspent
+        # minus outputs already consumed by mempool txns (egu-357). Reuses
+        # unspent_outflows so the unspent + pending logic lives in one place.
+        stmt = self.unspent_outflows(address, filter_pending=filter_pending)
         outflows_alias = db.aliased(OutflowDAO, stmt.subquery())
         sum_stmt = db.select(db.func.sum(OutflowDAO.amount)).join(
             outflows_alias, OutflowDAO.id == outflows_alias.id

--- a/tests/test_miller.py
+++ b/tests/test_miller.py
@@ -100,6 +100,52 @@ def test_miller_create_block(app, time_machine, time_stepper, signing_key):
         assert m.longest_chain.get_block(b2.block_hash)
 
 
+def test_balance_filter_pending_excludes_pending_spend(
+    app, time_machine, time_stepper, signing_key
+):
+    # egu-357: balance(address, filter_pending=True) is the spendable-now total
+    # (confirmed-unspent minus outputs already consumed by mempool txns), so a
+    # UI can gate compose-time. Default False keeps confirmed-balance semantics.
+    with app.app_context():
+        now_dt = now()
+        time_step = time_stepper(start=now_dt - datetime.timedelta(hours=1))
+        m = Miller(milling_signing_key=signing_key)
+        _ = next(time_step)
+        b0 = m.create_block()
+        m.mill_block(b0)  # coinbase cb0 -> REWARD
+        _ = next(time_step)
+        b1 = m.create_block()
+        m.mill_block(b1)  # coinbase cb1 -> REWARD
+        _ = next(time_step)
+        addr = signing_key.address
+        lc = m.longest_chain
+        assert lc.balance(addr) == 2 * REWARD
+        # Nothing pending yet: available == confirmed.
+        assert lc.balance(addr, filter_pending=True) == 2 * REWARD
+
+        # Spend ONE confirmed coinbase output (cb0) via a PENDING, unmilled txn.
+        cb0 = b0.coinbase
+        cb0_amount = next(iter(cb0.outflows)).amount
+        w2 = SigningKey()
+        remit = 2 * GPG
+        t0 = Transaction()
+        t0.add_inflow(Inflow(outflow_txid=cb0.txid, outflow_idx=0))
+        t0.add_outflow(Outflow(amount=remit, address=w2.address))
+        t0.add_outflow(Outflow(amount=cb0_amount - remit, address=addr))
+        t0.set_signing_key(signing_key)
+        t0.seal()
+        t0.sign()
+        m.receive_transaction(t0.txid, t0.to_json())  # -> mempool, not milled
+
+        lc = m.longest_chain
+        # Confirmed balance ignores pending consumption (unchanged behavior).
+        assert lc.balance(addr) == 2 * REWARD
+        # Available excludes cb0 (consumed by the pending txn); the pending
+        # change isn't confirmed, so only the untouched cb1 remains spendable.
+        assert lc.balance(addr, filter_pending=True) == REWARD
+        time_machine.move_to(now_dt)
+
+
 def test_expired_transaction(app, time_machine, signing_key):
     with app.app_context():
         m = Miller(milling_signing_key=signing_key)


### PR DESCRIPTION
Closes #357.

## What

`Chain.balance` and `MoltenLeavesDAO.signing_key_balance` gain an optional **`filter_pending`** flag (default `False`). `True` returns the **spendable-now** total — confirmed-unspent minus outputs already consumed by mempool transactions — by threading the flag that already exists on `unspent_outflows`.

## Why

`balance(address)` counts confirmed-unspent outputs and ignores pending consumption. The builders gather with `filter_pending=True` so they never double-spend, but there was no *public* way to read the pending-aware total. Downstream (gumption-hub#94, C3) wants to gate **compose-time** — so a member never starts a second action spending GRIT still tied up in an unmilled txn — instead of only finding out at submit-time via `_funds_error`. This lets the UI say "X available (Y awaiting the mill)" before the user composes.

## Change (minimal, backward-compatible)

- `signing_key_balance(address, filter_pending=False)` — now sums over `unspent_outflows(address, filter_pending=...)` instead of re-deriving the unspent query, so the unspent + pending logic lives in one place.
- `Chain.balance(address, filter_pending=False)` — passes it through.

Default `False` preserves today's semantics for every existing caller (api, browser, command, `create_*`). The default path is query-equivalent — the `test_query_plans` EXPLAIN/no-materialization guards still pass.

## Tests

`test_balance_filter_pending_excludes_pending_spend`: mill two coinbase outputs (2×REWARD confirmed), then spend one via a **pending, unmilled** transfer. Asserts:
- `balance(addr)` == 2×REWARD (confirmed, unchanged).
- `balance(addr, filter_pending=True)` == 2×REWARD with nothing pending, and == REWARD after the pending spend (excludes the consumed output; pending change isn't confirmed).

```
uv run pytest -q   # 767 passed, 1 skipped
uv run mypy src    # clean
```

Non-consensus (read accessor over node-local mempool state). Same base→hub sequence as the #345→#346 enabler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
