### PR TITLE
ci: add Python 3.14 to the test matrix + classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ When `GC_API_ASYNC_PROCESSING=true`, block/txn POSTs return `202` without doing 
 
 - `ruff` config in `pyproject.toml`: `[tool.ruff]` holds top-level settings (target Python 3.12, `line-length = 80`), `[tool.ruff.lint]` holds the rule selection — large rule set enabled (`A,B,C,DTZ,E,EM,F,FBT,I,ICN,ISC,N,PLC,PLE,PLR,PLW,Q,RUF,S,SIM,T,TID,UP,W,YTT`). Quote style: `[tool.ruff.lint.flake8-quotes] inline-quotes = "single"` + `[tool.ruff.format] quote-style = "single"` keep linter and formatter aligned. Project-wide ignores include `S101` (assert allowed in tests). Both `ruff check` and `ruff format --check` are hard CI gates as of Phase 3 / PR 8.
 - `mypy` runs under `[tool.mypy] strict = true` and is a hard CI gate as of Phase 3. Target paths come from the `files = ["src/gumptionchain"]` setting; invoke with `uv run mypy` (no positional args) so config and CI agree.
-- Python ≥ 3.12 (CI matrix: 3.12, 3.13). 3.13 is the highest actively tested version.
+- Python ≥ 3.12 (CI matrix: 3.12, 3.13, 3.14). 3.14 is the highest actively tested version. `ruff target-version`/`mypy python_version` stay pinned to the 3.12 floor for back-compat checking.
 - SQLAlchemy is `>=2.0` with `Mapped[]` annotations on every DAO in `models.py`. Flask-SQLAlchemy 3.1+ preserves the legacy `Model.query` / `db.session.query(...)` API; modernization to `db.session.execute(db.select(...))` is Phase 6 work, not Phase 3.
 - pymerkle is `>=5` (currently resolves to 6.1.0) with the v5/v6 `InmemoryTree` API in `block.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Sociology",
   "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Adds **Python 3.14** as a supported, CI-tested version (it went final Oct 2025; we were on 3.12/3.13).

## Verified locally on 3.14 before adding

- `uv sync --group dev --python 3.14` — **deps resolve cleanly, no `uv.lock` change** (resolves identically to 3.12/3.13).
- `pytest` — **767 passed, 1 skipped** (only pre-existing deprecation warnings).
- `ruff check` / `ruff format --check` — clean.
- `mypy` — clean (37 files).
- `gumptionchain db upgrade` + `db check` — "No new upgrade operations detected" (migration-drift gate green).

So the full per-matrix gate passes on 3.14; this PR's own matrix run is the live proof.

## Changes

- `tests.yml`: matrix → `['3.12', '3.13', '3.14']`.
- `pyproject.toml`: add the `Programming Language :: Python :: 3.14` classifier.
- `CLAUDE.md`: note 3.14 is now the highest actively tested version.

## Deliberately unchanged

- `ruff target-version = py312` / `mypy python_version = 3.12` — these pin the **minimum** supported version for back-compat checking, independent of the runtime; adding 3.14 support doesn't raise the floor.
- `requires-python = ">=3.12"` already permits 3.14.
- `security.yml` pip-audit pin stays `3.13` — CVE scanning is interpreter-agnostic, no need to churn it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)