### PR TITLE
feat(egu-362): relay-glue.mjs — browser client for the node-proxy relay

### DIFF
--- a/docs/client-sdk-reference.md
+++ b/docs/client-sdk-reference.md
@@ -248,6 +248,29 @@ Lower-level txid primitives live in `gc-transaction.mjs` (internal):
 `dataCsv(txn)`, `txid(txn)`, `signingData(txn)`, `signUnsignedTxn(unsigned,
 signing_key)` — byte-identical to the Python implementation.
 
+### `relay-glue.mjs` — the relay path
+
+`transact-glue` above is **direct-to-node**: the browser gc-sig-signs each API
+request *as the user*, so the user's address must be a `TRANSACTOR`. For a
+**closed-transactor** node where end users transact through a **relay** (the
+node-proxy `node_proxy_blueprint`; the *relay's* service key is the only
+authorized caller), use `relay-glue.mjs`
+(`/static/gumptionchain/js/relay-glue.mjs`). The browser→relay hop is a plain
+JSON POST (no GC-* headers — the relay signs the node call); the user still signs
+only their own tx payload.
+
+| Export | Signature → returns | Purpose |
+|---|---|---|
+| `buildUnsigned({ relayBase, type, fields, fetchImpl? })` | → `{ unsigned }` | POST `relayBase/txn/<type>` (`fields` use the relay's wire names: `signer`, `subject`, `amount_grit`, `kind`/`to_address`/`denomination_grit`+`count`). `type` ∈ `support\|oppose\|rescind\|transfer\|split`. |
+| `signAndSubmit({ relayBase, unsigned, signing_key, fetchImpl? })` | → `{ unsigned, signed, txid }` | Sign a pre-built unsigned txn (`signUnsignedTxn`) and POST `relayBase/txn/submit` (confirm-then-sign). |
+| `submit({ relayBase, signed, fetchImpl? })` | → `{ txid }` | POST an already-signed txn to the relay. |
+| `buildSignSubmit({ relayBase, type, fields, signing_key, fetchImpl? })` | → `{ unsigned, signed, txid }` | The full relay round-trip in one call. |
+| `buildBody` / `normalizeGrit` / `relayMessage` / `relayUrl` | (pure helpers) | Request-body assembly, whole-GRIT validation (sub-grain rejected, mirrors `gumptionchain.units`), and relay status→message mapping. |
+
+Amounts cross as **whole GRIT** (`amount_grit`/`denomination_grit`, ≤ 2 decimals);
+the relay converts to grains. `relayBase` is the prefix the consuming app mounts
+the relay at (e.g. `/relay`).
+
 ---
 
 ## 7. Backup, recovery & derivation

--- a/src/gumptionchain/static/js/relay-glue.mjs
+++ b/src/gumptionchain/static/js/relay-glue.mjs
@@ -59,9 +59,11 @@ export function normalizeGrit(value, field = 'amount_grit') {
   if (decimals > 2) {
     throw new Error(`${field} precision finer than one grain (0.01)`);
   }
-  // Canonicalize (drop a leading + / insignificant forms) via Number, but keep
-  // exactness for <= 2 decimals.
-  return String(num);
+  // Return the validated decimal string as-is (the regex guarantees a plain
+  // [-]digits[.digits] form). Don't round-trip through Number — that would
+  // emit exponential notation for very large values; the relay parses the
+  // string with Decimal, so leading/trailing zeros are harmless.
+  return str;
 }
 
 // Build the relay request body for a transaction type from caller-supplied

--- a/src/gumptionchain/static/js/relay-glue.mjs
+++ b/src/gumptionchain/static/js/relay-glue.mjs
@@ -1,0 +1,230 @@
+// Browser client for the node-proxy RELAY (gumptionchain `node_proxy_blueprint`).
+//
+// This is the relay counterpart to transact-glue.mjs. transact-glue is the
+// DIRECT-to-node path: the browser gc-sig-signs each API request AS the user, so
+// the user's address must be a TRANSACTOR on the node. relay-glue is the RELAY
+// path for a CLOSED-transactor node: the relay's service key is the only
+// authorized caller, and the relay (server-side) gc-sig-signs the node calls.
+// The user only signs their OWN transaction payload (proving they hold the key);
+// the node validates that signature for balance/ownership. So the browser->relay
+// hop here is a plain JSON POST — no GC-* headers.
+//
+// Flow: build (POST relayBase/txn/<type>) -> sign (the user's key, reusing the
+// shared signUnsignedTxn primitive) -> submit (POST relayBase/txn/submit).
+//
+// Whole-GRIT at the boundary: amounts are sent as `amount_grit`/`denomination_
+// grit` (whole/decimal GRIT, max 2 places = one grain); the relay converts to
+// grains. normalizeGrit mirrors gumptionchain.units — sub-grain precision is
+// rejected client-side before the round-trip.
+
+import { signUnsignedTxn } from '../sdk/gc-transaction.mjs';
+
+// type -> { path on the relay, required body fields }. amount_grit /
+// denomination_grit are grit-normalized; `count` is an integer; `kind` is
+// constrained for rescind.
+const TYPE_SPECS = {
+  support: { path: 'support', fields: ['signer', 'subject', 'amount_grit'] },
+  oppose: { path: 'oppose', fields: ['signer', 'subject', 'amount_grit'] },
+  rescind: {
+    path: 'rescind',
+    fields: ['signer', 'subject', 'amount_grit', 'kind'],
+  },
+  transfer: {
+    path: 'transfer',
+    fields: ['signer', 'to_address', 'amount_grit'],
+  },
+  split: {
+    path: 'split',
+    fields: ['signer', 'denomination_grit', 'count'],
+  },
+};
+
+const GRIT_FIELDS = new Set(['amount_grit', 'denomination_grit']);
+
+// Validate a GRIT amount and return its canonical string. Mirrors
+// gumptionchain.units.grit_to_grains: positive, at most one-grain (0.01)
+// precision. Throws (fail loud) on a finer-than-grain or non-numeric value
+// rather than silently truncating. Returns a string so no float drift crosses
+// the wire (the relay parses it with Decimal).
+export function normalizeGrit(value, field = 'amount_grit') {
+  const str = String(value).trim();
+  if (!/^-?\d+(\.\d+)?$/.test(str)) {
+    throw new Error(`${field} must be a number`);
+  }
+  const num = Number(str);
+  if (!(num > 0)) {
+    throw new Error(`${field} must be positive`);
+  }
+  const decimals = str.includes('.') ? str.split('.')[1].length : 0;
+  if (decimals > 2) {
+    throw new Error(`${field} precision finer than one grain (0.01)`);
+  }
+  // Canonicalize (drop a leading + / insignificant forms) via Number, but keep
+  // exactness for <= 2 decimals.
+  return String(num);
+}
+
+// Build the relay request body for a transaction type from caller-supplied
+// fields (using the relay's wire names). Validates required fields, normalizes
+// grit amounts, and constrains rescind's kind. Throws on an unknown type or a
+// missing/invalid field — before any network call.
+export function buildBody(type, fields = {}) {
+  const spec = TYPE_SPECS[type];
+  if (!spec) {
+    throw new Error(`unknown transaction type: ${type}`);
+  }
+  const body = {};
+  for (const name of spec.fields) {
+    const value = fields[name];
+    if (value === undefined || value === null || value === '') {
+      throw new Error(`${type} requires ${name}`);
+    }
+    if (GRIT_FIELDS.has(name)) {
+      body[name] = normalizeGrit(value, name);
+    } else if (name === 'count') {
+      if (!Number.isInteger(value) || value < 1) {
+        throw new Error('count must be a positive integer');
+      }
+      body[name] = value;
+    } else if (name === 'kind') {
+      if (value !== 'opposition' && value !== 'support') {
+        throw new Error("kind must be 'opposition' or 'support'");
+      }
+      body[name] = value;
+    } else {
+      body[name] = value;
+    }
+  }
+  return body;
+}
+
+// Join a relay base (origin/prefix the consuming app mounts, e.g. '/relay' or
+// 'https://hub.example/relay') with a relay path, without a double slash.
+export function relayUrl(relayBase, path) {
+  return `${String(relayBase).replace(/\/$/, '')}/${path}`;
+}
+
+// Map a relay response to a user-facing message. The relay translates node
+// statuses (node 5xx -> 502; node 4xx pass through), so the cases differ from
+// the direct-to-node transact-glue: a 403 here means the RELAY's service key is
+// not authorized, not the end user's address.
+export function relayMessage(status, body = {}, phase = 'submit') {
+  const detail =
+    body && typeof body === 'object' && typeof body.error === 'string'
+      ? body.error
+      : '';
+  const building = phase === 'build';
+  if (status >= 200 && status < 300) {
+    return 'Transaction submitted and received by the node.';
+  }
+  if (status === 403) {
+    return (
+      'This app is not authorized to submit transactions on your behalf ' +
+      '(its relay key is not a TRANSACTOR on the node).'
+    );
+  }
+  if (status === 404) {
+    return `Transaction not found${detail ? `: ${detail}` : ''}.`;
+  }
+  if (status === 429) {
+    return 'The relay is rate-limiting submissions. Try again shortly.';
+  }
+  if (status === 400) {
+    return building
+      ? `Couldn't build the transaction: ${detail || 'invalid request'}.`
+      : `The node rejected the transaction: ${detail || 'validation error'}.`;
+  }
+  if (status >= 500) {
+    return `The node is unavailable (HTTP ${status})${detail ? `: ${detail}` : ''}. Try again shortly.`;
+  }
+  const lead = building
+    ? "Couldn't build the transaction"
+    : 'Unexpected response from the relay';
+  return `${lead} (HTTP ${status})${detail ? `: ${detail}` : ''}.`;
+}
+
+// Read a fetch Response's JSON, tolerating an empty/non-JSON body.
+async function readBody(resp) {
+  try {
+    const text = await resp.text();
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function postJson(url, payload, fetchImpl) {
+  return fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+// build: POST relayBase/txn/<type> with the validated body; return the
+// node-built UNSIGNED transaction. Throws a mapped message on a non-OK relay
+// response (e.g. insufficient funds surfaces here, before anything is signed).
+export async function buildUnsigned({
+  relayBase,
+  type,
+  fields,
+  fetchImpl = globalThis.fetch,
+}) {
+  const spec = TYPE_SPECS[type];
+  if (!spec) {
+    throw new Error(`unknown transaction type: ${type}`);
+  }
+  const body = buildBody(type, fields);
+  const resp = await postJson(relayUrl(relayBase, `txn/${spec.path}`), body, fetchImpl);
+  const data = await readBody(resp);
+  if (!resp.ok) {
+    throw new Error(relayMessage(resp.status, data, 'build'));
+  }
+  return { unsigned: data };
+}
+
+// submit: POST relayBase/txn/submit { signed }; return { txid }. Throws a mapped
+// message on a non-OK relay response.
+export async function submit({
+  relayBase,
+  signed,
+  fetchImpl = globalThis.fetch,
+}) {
+  const resp = await postJson(relayUrl(relayBase, 'txn/submit'), { signed }, fetchImpl);
+  const data = await readBody(resp);
+  if (!resp.ok) {
+    throw new Error(relayMessage(resp.status, data, 'submit'));
+  }
+  return { txid: data.txid };
+}
+
+// sign (the user's key) + submit a pre-built unsigned txn. Split from
+// buildSignSubmit so an app can confirm with the user between build and sign.
+export async function signAndSubmit({
+  relayBase,
+  unsigned,
+  signing_key,
+  fetchImpl = globalThis.fetch,
+}) {
+  const signed = await signUnsignedTxn(unsigned, signing_key);
+  const { txid } = await submit({ relayBase, signed, fetchImpl });
+  return { unsigned, signed, txid };
+}
+
+// The full relay round-trip: build -> sign -> submit. Returns the unsigned and
+// signed txns plus the confirmed txid.
+export async function buildSignSubmit({
+  relayBase,
+  type,
+  fields,
+  signing_key,
+  fetchImpl = globalThis.fetch,
+}) {
+  const { unsigned } = await buildUnsigned({
+    relayBase,
+    type,
+    fields,
+    fetchImpl,
+  });
+  return signAndSubmit({ relayBase, unsigned, signing_key, fetchImpl });
+}

--- a/src/gumptionchain/static/js/relay-glue.test.mjs
+++ b/src/gumptionchain/static/js/relay-glue.test.mjs
@@ -1,0 +1,236 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildBody,
+  normalizeGrit,
+  relayMessage,
+  relayUrl,
+  buildUnsigned,
+  submit,
+  buildSignSubmit,
+} from './relay-glue.mjs';
+import { SigningKey } from '../sdk/gc-signing-key.mjs';
+import { txid as computeTxid } from '../sdk/gc-transaction.mjs';
+
+const SIGNER = 'gc13sqcx509fwu3mkceq4hmll0xcufszhzajp8seuvdy22z872tn6sqxlqndc';
+
+// A fetch stand-in: records the call, returns a fake Response (.ok/.status/
+// .text()). One per assertion so we can inspect the request it received.
+function fakeFetch(status, body) {
+  const calls = [];
+  const fn = (url, init) => {
+    calls.push({ url, init });
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      text: () => Promise.resolve(JSON.stringify(body)),
+    });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// --- buildBody: type -> relay request body, validated + grit-normalized ------
+
+test('buildBody support/oppose carry signer, subject, amount_grit', () => {
+  for (const type of ['support', 'oppose']) {
+    const body = buildBody(type, {
+      signer: SIGNER,
+      subject: 'pineapple belongs on pizza',
+      amount_grit: 5,
+    });
+    assert.deepEqual(body, {
+      signer: SIGNER,
+      subject: 'pineapple belongs on pizza',
+      amount_grit: '5',
+    });
+  }
+});
+
+test('buildBody rescind also carries kind', () => {
+  const body = buildBody('rescind', {
+    signer: SIGNER,
+    subject: 'x',
+    amount_grit: 1,
+    kind: 'support',
+  });
+  assert.equal(body.kind, 'support');
+});
+
+test('buildBody transfer carries to_address; split carries denomination+count', () => {
+  const t = buildBody('transfer', {
+    signer: SIGNER,
+    to_address: SIGNER,
+    amount_grit: 2,
+  });
+  assert.equal(t.to_address, SIGNER);
+  const s = buildBody('split', {
+    signer: SIGNER,
+    denomination_grit: 1,
+    count: 4,
+  });
+  assert.deepEqual(s, {
+    signer: SIGNER,
+    denomination_grit: '1',
+    count: 4,
+  });
+});
+
+test('buildBody rejects an unknown type', () => {
+  assert.throws(() => buildBody('mint', { signer: SIGNER }), /unknown.*type/i);
+});
+
+test('buildBody rejects a missing required field', () => {
+  assert.throws(
+    () => buildBody('support', { signer: SIGNER, amount_grit: 1 }),
+    /subject/,
+  );
+});
+
+test('buildBody rejects a bad rescind kind', () => {
+  assert.throws(
+    () =>
+      buildBody('rescind', {
+        signer: SIGNER,
+        subject: 'x',
+        amount_grit: 1,
+        kind: 'nope',
+      }),
+    /kind/,
+  );
+});
+
+// --- normalizeGrit: whole-GRIT boundary, sub-grain rejected (mirror units) ---
+
+test('normalizeGrit accepts whole + 2-decimal amounts (exact)', () => {
+  assert.equal(normalizeGrit(5), '5');
+  assert.equal(normalizeGrit('1.5'), '1.5');
+  assert.equal(normalizeGrit('0.07'), '0.07');
+  assert.equal(normalizeGrit(12.34), '12.34');
+});
+
+test('normalizeGrit rejects sub-grain precision', () => {
+  assert.throws(() => normalizeGrit('0.001'), /grain/i);
+});
+
+test('normalizeGrit rejects non-positive and non-numeric', () => {
+  assert.throws(() => normalizeGrit(0), /positive/i);
+  assert.throws(() => normalizeGrit(-1), /positive/i);
+  assert.throws(() => normalizeGrit('abc'), /number|amount/i);
+});
+
+// --- relayMessage: relay status -> user-facing string ------------------------
+
+test('relayMessage maps success', () => {
+  assert.match(relayMessage(200, { txid: 't' }), /submitted|received/i);
+});
+
+test('relayMessage 403 is the relay-not-authorized message', () => {
+  assert.match(relayMessage(403, { error: '...' }), /authorized|relay/i);
+});
+
+test('relayMessage 400 surfaces the relay error detail', () => {
+  assert.match(relayMessage(400, { error: 'invalid subject' }), /invalid subject/);
+});
+
+test('relayMessage 404 is unknown-txid', () => {
+  assert.match(relayMessage(404, { error: 'unknown txid' }), /unknown|not found/i);
+});
+
+// --- relayUrl: joins base + path without a double slash ----------------------
+
+test('relayUrl joins base and path, trimming a trailing slash', () => {
+  assert.equal(relayUrl('/relay', 'txn/support'), '/relay/txn/support');
+  assert.equal(relayUrl('/relay/', 'txn/submit'), '/relay/txn/submit');
+});
+
+// --- buildUnsigned: POST relayBase/txn/<type>, return { unsigned } -----------
+
+test('buildUnsigned POSTs the body to the relay and returns the unsigned txn', async () => {
+  const unsigned = { txid: 't1', outflows: [{ amount: 500, support: 'enc' }] };
+  const fetchImpl = fakeFetch(200, unsigned);
+  const out = await buildUnsigned({
+    relayBase: '/relay',
+    type: 'support',
+    fields: { signer: SIGNER, subject: 'goblins', amount_grit: 5 },
+    fetchImpl,
+  });
+  assert.deepEqual(out, { unsigned });
+  const { url, init } = fetchImpl.calls[0];
+  assert.equal(url, '/relay/txn/support');
+  assert.equal(init.method, 'POST');
+  assert.equal(JSON.parse(init.body).amount_grit, '5');
+});
+
+test('buildUnsigned throws a mapped message on a non-OK relay response', async () => {
+  const fetchImpl = fakeFetch(403, { error: 'relay key not authorized' });
+  await assert.rejects(
+    buildUnsigned({
+      relayBase: '/relay',
+      type: 'support',
+      fields: { signer: SIGNER, subject: 'g', amount_grit: 1 },
+      fetchImpl,
+    }),
+    /authorized|relay/i,
+  );
+});
+
+// --- submit: POST relayBase/txn/submit { signed } -> { txid } ----------------
+
+test('submit POSTs the signed txn and returns the txid', async () => {
+  const fetchImpl = fakeFetch(200, { txid: 'abc123' });
+  const out = await submit({
+    relayBase: '/relay',
+    signed: { txid: 'abc123', signature: 'sig', address: SIGNER },
+    fetchImpl,
+  });
+  assert.deepEqual(out, { txid: 'abc123' });
+  const { url, init } = fetchImpl.calls[0];
+  assert.equal(url, '/relay/txn/submit');
+  assert.equal(JSON.parse(init.body).signed.txid, 'abc123');
+});
+
+// --- buildSignSubmit: end-to-end build -> sign (real key) -> submit ----------
+
+test('buildSignSubmit signs the unsigned txn with the user key and submits', async () => {
+  const key = await SigningKey.generate();
+  const address = await key.address();
+  // A node-built unsigned txn with a correct txid (so signUnsignedTxn agrees).
+  const draft = {
+    timestamp: '2026-06-27T00:00:00Z',
+    address,
+    inflows: [{ outflow_txid: 'a'.repeat(64), outflow_idx: 0 }],
+    outflows: [{ amount: 500, support: 'enc' }],
+    version: '2',
+  };
+  const unsigned = { ...draft, txid: await computeTxid(draft) };
+
+  // build returns the unsigned txn; submit returns the txid.
+  let call = 0;
+  const fetchImpl = (url, init) => {
+    call += 1;
+    const body = call === 1 ? unsigned : { txid: unsigned.txid };
+    fetchImpl.last = { url, init };
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(body)),
+    });
+  };
+
+  const out = await buildSignSubmit({
+    relayBase: '/relay',
+    type: 'support',
+    fields: { signer: address, subject: 'goblins', amount_grit: 5 },
+    signing_key: key,
+    fetchImpl,
+  });
+
+  assert.equal(out.txid, unsigned.txid);
+  assert.equal(out.signed.address, address);
+  assert.ok(out.signed.signature, 'the signed txn carries a signature');
+  // last call was the submit, carrying the signed txn.
+  assert.equal(fetchImpl.last.url, '/relay/txn/submit');
+  assert.equal(JSON.parse(fetchImpl.last.init.body).signed.signature, out.signed.signature);
+});


### PR DESCRIPTION
Closes #362. Ships `relay-glue.mjs`, the served browser ESM client for the **node-proxy relay** path — so member apps stop hand-rolling `/txn/*` fetches.

## Direct-to-node vs. relay (why this is a separate glue)

- `transact-glue.mjs` is **direct-to-node**: the browser gc-sig-signs each API request *as the user*, so the user's address must be in `TRANSACTOR_ADDRESSES`.
- `relay-glue.mjs` is the **relay** path for a **closed-transactor** node: the relay's service key (`node_proxy_blueprint`) is the only authorized caller. The browser→relay hop is a **plain JSON POST** (no GC-* headers — the relay signs the node call server-side); the user signs only their own tx payload. This is the proxy-as-transactor pattern.

## Contract / API

build → sign → submit over a configurable `relayBase`:

- `buildUnsigned({ relayBase, type, fields, fetchImpl? })` → `{ unsigned }` — POST `relayBase/txn/<type>` (`type` ∈ `support|oppose|rescind|transfer|split`; `fields` use the relay wire names `signer`/`subject`/`amount_grit`/`kind`/`to_address`/`denomination_grit`+`count`).
- `signAndSubmit({ relayBase, unsigned, signing_key, fetchImpl? })` → `{ unsigned, signed, txid }` — reuses the shared `signUnsignedTxn` primitive (confirm-then-sign).
- `submit({ relayBase, signed, fetchImpl? })` → `{ txid }`.
- `buildSignSubmit(...)` → the full round-trip in one call.
- Pure helpers `buildBody` / `normalizeGrit` / `relayMessage` / `relayUrl`.

**Whole-GRIT at the boundary:** `amount_grit`/`denomination_grit` are sent as strings; `normalizeGrit` rejects sub-grain precision **client-side** (mirrors `gumptionchain.units`) before the round-trip; the relay converts to grains. `relayMessage` maps statuses to user-facing strings (incl. **403** "relay key not authorized to transact").

## Tests

18 `node --test` cases (no DOM), incl. an **end-to-end build→sign→submit with a real `SigningKey`** (a correctly-txid'd unsigned txn so `signUnsignedTxn` agrees), request-shape assertions via a mocked `fetch`, the whole-GRIT/sub-grain rules, and the status→message mapping.

```
node --test src/gumptionchain/static/js/*.test.mjs   # 302 pass (+18)
```

Also documented in `docs/client-sdk-reference.md` §6 (relay vs direct-to-node). No Python touched (served `static/js` glue, like transact-glue; not a vendored SDK module).

## Consumers

gump-hub (relay-adoption) and gumptactoe (migrating off its hand-rolled relay calls). Same base→consumer sequence as the GC_SIGNING_KEY / pending-balance enablers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)