### PR TITLE
fix(egu-364): link mempool txids + contextual transaction-view back-link

### DIFF
--- a/src/gumptionchain/templates/mempool.html
+++ b/src/gumptionchain/templates/mempool.html
@@ -13,7 +13,7 @@
         <tbody class="font-monospace">
         {%- for entry in entries %}
           <tr>
-            <td>{{ entry.txid }}</td>
+            <td><a href="{{ url_for('browser.transaction_view', txid=entry.txid) }}">{{ entry.txid }}</a></td>
             <td>{{ entry.timestamp | utc_datetime }}</td>
             <td>{{ entry.inflows }}</td>
             <td>{{ entry.outflows }}</td>

--- a/src/gumptionchain/templates/transaction.html
+++ b/src/gumptionchain/templates/transaction.html
@@ -4,7 +4,7 @@
 {% block content -%}
   <div class="container-fluid">
     <div class="row my-3"><div class="col">
-      <p class="mb-1"><a href="{{ url_for('browser.blocks_view') }}">&larr; Blocks</a></p>
+      <p class="mb-1">{% if status == 'pending' %}<a href="{{ url_for('browser.mempool_view') }}">&larr; Mempool</a>{% else %}<a href="{{ url_for('browser.blocks_view') }}">&larr; Blocks</a>{% endif %}</p>
       <div class="card bg-light"><div class="card-body">
         <div class="h5">Transaction{% if transaction.is_coinbase %} <span class="badge bg-info text-dark">Coinbase</span>{% endif %}</div>
         <table class="table table-hover" style="table-layout:fixed;">

--- a/tests/test_mempool_page.py
+++ b/tests/test_mempool_page.py
@@ -82,8 +82,8 @@ def test_mempool_shows_pending_txn(
         assert txn.txid.encode() in body
         # the numeric total-out is shown
         assert str(total_out).encode() in body
-        # link-free: no /transaction/<txid> link rendered for it
-        assert f'/transaction/{txn.txid}'.encode() not in body
+        # the txid links to its transaction view (egu-364)
+        assert f'/transaction/{txn.txid}'.encode() in body
 
 
 def _reinsert_pending(txn):

--- a/tests/test_transaction_view.py
+++ b/tests/test_transaction_view.py
@@ -113,6 +113,10 @@ def test_transaction_view_pending_txn(
         assert 'opposition' in page
         # the spent coinbase outflow's amount resolves from the chain
         assert 'None (pending)' in page  # block row placeholder
+        # back-link is contextual: a pending txn came from the mempool, not
+        # the blocks index (egu-364)
+        assert '&larr; Mempool' in page
+        assert '&larr; Blocks' not in page
 
 
 def test_transaction_view_confirmed_shows_status(


### PR DESCRIPTION
Closes #364. Two small browser-template correctness fixes (in base templates, so all nodes benefit).

## 1. Mempool txids now link to the transaction view

`mempool.html` rendered each `entry.txid` as plain text, unlike the block view (where confirmed txns link to their detail page). Now wrapped in a link to `browser.transaction_view`.

## 2. Contextual back-link on the transaction view

`transaction.html`'s back-link was unconditionally "← Blocks" — wrong for a **pending** (mempool) txn, which has no block (the page even shows "None (pending)"). `status` is already in scope, so: pending → **"← Mempool"**, otherwise → "← Blocks" (confirmed/orphaned keep the blocks link).

## Tests

- `test_mempool_shows_pending_txn`: the old assertion explicitly checked the txid was **link-free** (`/transaction/<txid>` *not* in body) — that codified the bug. Flipped to assert the link **is** rendered.
- `test_transaction_view_pending_txn`: added `assert '← Mempool' in page` and `'← Blocks' not in page`.
- The confirmed/coinbase tests (`test_transaction_view_marks_coinbase`, `..._confirmed_shows_status`) still assert "← Blocks" — unaffected.

```
uv run pytest -q   # 767 passed, 1 skipped
```

Templates + tests only; no `src/*.py` touched (no consensus/API surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)