### PR TITLE
feat(mempool): PendingTxnDAO.incoming_grains — pending incoming reads (gump-hub#115)

### DIFF
--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1458,6 +1458,40 @@ class PendingTxnDAO(Base):
             yield json_data
 
     @classmethod
+    def incoming_grains(
+        cls, address: str, expired: datetime.datetime | None = None
+    ) -> int:
+        """Total grains paid TO `address` by OTHER signers across the live
+        mempool (unconfirmed + unexpired). Excludes txns signed by `address`
+        itself — that pending change is already reflected by the spendable-now
+        balance (signing_key_balance(filter_pending=True)). Stake outflows carry
+        a NULL payee, so only payment/reward outflows count. Returns 0 when
+        nothing matches; a row that fails to parse is skipped, never raised."""
+        # Lazy import: transaction.py imports this module, so a top-level import
+        # would be circular.
+        from gumptionchain.exceptions import (  # noqa: PLC0415 — circular
+            InvalidTransactionError,
+        )
+        from gumptionchain.transaction import (  # noqa: PLC0415 — circular
+            Transaction,
+        )
+
+        total = 0
+        for json_data in cls.json_datas(
+            expired=expired, exclude_confirmed=True
+        ):
+            try:
+                txn = Transaction.from_json(json_data)
+            except InvalidTransactionError:
+                continue  # a corrupt mempool row must not break the read
+            if txn.address == address:
+                continue  # the signer's own change is counted elsewhere
+            for outflow in txn.outflows:
+                if outflow.address == address:
+                    total += outflow.amount or 0
+        return total
+
+    @classmethod
     def pending_q(
         cls,
         expired: datetime.datetime | None = None,

--- a/src/gumptionchain/models.py
+++ b/src/gumptionchain/models.py
@@ -1461,12 +1461,16 @@ class PendingTxnDAO(Base):
     def incoming_grains(
         cls, address: str, expired: datetime.datetime | None = None
     ) -> int:
-        """Total grains paid TO `address` by OTHER signers across the live
-        mempool (unconfirmed + unexpired). Excludes txns signed by `address`
-        itself — that pending change is already reflected by the spendable-now
-        balance (signing_key_balance(filter_pending=True)). Stake outflows carry
-        a NULL payee, so only payment/reward outflows count. Returns 0 when
-        nothing matches; a row that fails to parse is skipped, never raised."""
+        """Total grains paid TO `address` by OTHER signers across the pending
+        pool. Measures credits arriving FROM OTHERS (e.g. an unmilled reward),
+        not your own change: txns signed by `address` are skipped, so a consumer
+        can pair this with the spendable-now balance
+        (signing_key_balance(filter_pending=True)) without double-showing your
+        own pending outputs as "incoming". Stake outflows carry a NULL payee, so
+        only payment outflows count. Pass `expired` (a cutoff datetime, e.g.
+        expiry_cutoff(now())) to drop rows older than it; the default None
+        counts all pending rows regardless of expiry. Returns 0 when nothing
+        matches; a row that fails to parse is skipped, never raised."""
         # Lazy import: transaction.py imports this module, so a top-level import
         # would be circular.
         from gumptionchain.exceptions import (  # noqa: PLC0415 — circular
@@ -1476,6 +1480,11 @@ class PendingTxnDAO(Base):
             Transaction,
         )
 
+        # Scale: O(N) json parse over the whole pending pool per call. Fine
+        # while MAX_PENDING_TXNS keeps the pool small; if this ever becomes a
+        # hot path, project pending OUTFLOWS (payee, amount, signer) into a
+        # queryable table on admission and SUM in SQL — the pool only indexes
+        # consumed INFLOWS today (PendingIOflowDAO), not outputs.
         total = 0
         for json_data in cls.json_datas(
             expired=expired, exclude_confirmed=True
@@ -1485,7 +1494,7 @@ class PendingTxnDAO(Base):
             except InvalidTransactionError:
                 continue  # a corrupt mempool row must not break the read
             if txn.address == address:
-                continue  # the signer's own change is counted elsewhere
+                continue  # credits FROM OTHERS only — own change isn't incoming
             for outflow in txn.outflows:
                 if outflow.address == address:
                     total += outflow.amount or 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 
 from _sa_helpers import _count, _count_select
 
-from gumptionchain.block import Block
+from gumptionchain.api_client import ApiClient
+from gumptionchain.block import Block, expiry_cutoff
 from gumptionchain.chain import Chain
 from gumptionchain.database import db
 from gumptionchain.models import (
@@ -12,10 +13,13 @@ from gumptionchain.models import (
     InflowDAO,
     LongestChainBlockDAO,
     OutflowDAO,
+    PendingTxnDAO,
     TransactionDAO,
 )
 from gumptionchain.payload import Inflow, Outflow
+from gumptionchain.signing_key import SigningKey
 from gumptionchain.transaction import CoinbaseMetrics, Transaction
+from gumptionchain.util import now
 
 
 def _pythonic_ancestry_ids(block_dao):
@@ -1800,3 +1804,125 @@ def test_antijoin_no_materialization(app, subject, time_stepper, signing_key):
                 if 'AUTOMATIC' in row and 'OUTFLOW_ID' in row
             ]
             assert not automatic_over_inflow, text
+
+
+def test_incoming_grains_counts_payment_and_skips_self(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)  # signing_key holds a coinbase UTXO
+        dest = SigningKey().address
+        txn = m.longest_chain.create_transfer(signing_key, 400, dest)
+        txn.sign()
+        ApiClient(host, signing_key).post_transaction(txn)  # pending
+        cutoff = expiry_cutoff(now())
+        # the recipient sees the incoming payment
+        assert PendingTxnDAO.incoming_grains(dest, expired=cutoff) == 400
+        # the signer's own change output is NOT counted (self-skip)
+        assert (
+            PendingTxnDAO.incoming_grains(signing_key.address, expired=cutoff)
+            == 0
+        )
+
+
+def test_incoming_grains_sums_across_pending_txns(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        # Two DIFFERENT signers, each funded by its own coinbase, each paying
+        # dest -> two independent pending payments. (A single signer can't make
+        # two concurrent pending transfers: create_transfer's gather would tie
+        # up its funds on the first.)
+        signer2 = SigningKey()
+        m, _b = mill_block(signing_key)  # signer1's coinbase
+        m, _b = mill_block(signer2)  # signer2's coinbase
+        chain = m.longest_chain
+        dest = SigningKey().address
+        t1 = chain.create_transfer(signing_key, 300, dest)
+        t1.sign()
+        ApiClient(host, signing_key).post_transaction(t1)
+        t2 = chain.create_transfer(signer2, 200, dest)
+        t2.sign()
+        # t2 is signed by signer2 (an arbitrary key with no node role); post it
+        # through the authorized poster so it lands in the mempool. The parsed
+        # mempool row's signer is still signer2 — an "other signer" vs. dest.
+        ApiClient(host, signing_key).post_transaction(t2)
+        assert (
+            PendingTxnDAO.incoming_grains(dest, expired=expiry_cutoff(now()))
+            == 500
+        )
+
+
+def test_incoming_grains_excludes_confirmed(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        dest = SigningKey().address
+        txn = m.longest_chain.create_transfer(signing_key, 400, dest)
+        txn.sign()
+        ApiClient(host, signing_key).post_transaction(txn)  # pending
+        m, _b = mill_block(signing_key)  # confirms + prunes it
+        # re-insert as a re-gossiped row; it's still confirmed in the chain
+        PendingTxnDAO(
+            txid=txn.txid,
+            timestamp=txn.timestamp_dt,
+            json_data=txn.to_json(),
+        ).commit()
+        assert (
+            PendingTxnDAO.incoming_grains(dest, expired=expiry_cutoff(now()))
+            == 0
+        )
+
+
+def test_incoming_grains_excludes_expired(
+    app, host, mill_block, requests_proxy, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        dest = SigningKey().address
+        txn = m.longest_chain.create_transfer(signing_key, 400, dest)
+        txn.sign()
+        # insert directly with an EXPIRED row timestamp (don't post)
+        PendingTxnDAO(
+            txid=txn.txid,
+            timestamp=now() - datetime.timedelta(hours=8),
+            json_data=txn.to_json(),
+        ).commit()
+        # with the expiry cutoff it is filtered out...
+        assert (
+            PendingTxnDAO.incoming_grains(dest, expired=expiry_cutoff(now()))
+            == 0
+        )
+        # ...without it (the default), it still counts
+        assert PendingTxnDAO.incoming_grains(dest) == 400
+
+
+def test_incoming_grains_ignores_stakes(
+    app, host, mill_block, requests_proxy, subject, signing_key
+):
+    with app.app_context():
+        m, _b = mill_block(signing_key)
+        txn = m.longest_chain.create_opposition(signing_key, 400, subject)
+        txn.sign()
+        ApiClient(host, signing_key).post_transaction(txn)  # pending stake
+        other = SigningKey().address
+        # a stake outflow has a NULL payee -> credits nobody
+        assert (
+            PendingTxnDAO.incoming_grains(other, expired=expiry_cutoff(now()))
+            == 0
+        )
+
+
+def test_incoming_grains_empty_mempool(app, signing_key):
+    with app.app_context():
+        assert PendingTxnDAO.incoming_grains(signing_key.address) == 0
+
+
+def test_incoming_grains_skips_unparseable_row(app, signing_key):
+    with app.app_context():
+        PendingTxnDAO(
+            txid='b' * 64, timestamp=now(), json_data='{not valid json}'
+        ).commit()
+        # a corrupt mempool row must not raise — it's skipped, contributes 0
+        assert PendingTxnDAO.incoming_grains(signing_key.address) == 0


### PR DESCRIPTION
## `PendingTxnDAO.incoming_grains` — pending incoming reads

Adds a read-only mempool primitive: **the total grains paid TO an address by
OTHER signers across the live mempool** (unconfirmed + unexpired). The chain knew
confirmed balance (`balance()`) and pending *outgoing* consumption
(`signing_key_balance(filter_pending=True)`), but had no way to see pending
*incoming* credits.

```python
PendingTxnDAO.incoming_grains(address: str, expired: datetime | None = None) -> int
```

- Iterates the canonical live-mempool iterator
  `json_datas(expired=…, exclude_confirmed=True)` (open-boundary expiry +
  reorg-safe unconfirmed clause — no new filter logic).
- Parses each row with `Transaction.from_json`; a row that fails to parse is
  skipped, never raised.
- **Skips txns the address itself signed** — a signer's own change is already
  netted out of `signing_key_balance(filter_pending=True)`, so counting it here
  would double-count.
- Sums `outflow.amount` for outflows paying the address. Stake outflows carry a
  NULL payee, so only payment/reward outflows count.
- `Transaction`/`InvalidTransactionError` are imported lazily inside the method
  (`transaction.py` imports this module — a top-level import would be circular).

### Why
Driven by **gump-hub#115**: the hub's stake modal tells a member who just *won*
GRIT (a GumpTacToe reward sitting unmilled in the mempool) to "go win GRIT",
because it can't see the incoming credit. With this primitive the hub can instead
say "your GRIT is on its way — ready after the next block." (The hub wiring —
`/balance` field + the modal's third state — is a follow-up after a pin bump to
this change.)

### Tests (`tests/test_models.py`)
Seven cases: counts an incoming payment + skips the signer's own change; sums
across two distinct-signer pending payments; excludes a confirmed (re-gossiped)
row via the unconfirmed clause; excludes an expired row (and counts it without
the cutoff, proving the 0 comes from expiry); ignores a stake's NULL payee; empty
mempool → 0; an unparseable row → 0 (exercises the defensive skip).

Read-only — no write path, gossip, or consensus change.

Gates green: full suite 788 passed, ruff check + format, mypy `src` clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
